### PR TITLE
refactor: signal and timeout + remove Client requestTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ Options:
   transport latency.
   Default: `1e3` milliseconds (1s).
 
-- `requestTimeout: Number`, the timeout after which a request will time out.
-  Monitors time between request is dispatched on socket and receiving
-  a response. Use `0` to disable it entirely.
-  Default: `30e3` milliseconds (30s).
-
 - `pipelining: Number`, the amount of concurrent requests to be sent over the
   single TCP/TLS connection according to
   [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2).
@@ -425,7 +420,19 @@ This is the low level API which all the preceeding API's are implemented on top 
 
 Options:
 
-* ... same as [`client.request(opts[, callback])`][request].
+* `path: String`
+* `method: String`
+* `opaque: Any`
+* `body: String|Buffer|Uint8Array|stream.Readable|Null`
+  Default: `null`.
+* `headers: Object|Null`, an object with header-value pairs.
+  Default: `null`.
+* `signal: AbortController|EventEmitter|Null`
+  Default: `null`.
+* `idempotent: Boolean`, whether the requests can be safely retried or not.
+  If `false` the request won't be sent until all preceeding
+  requests in the pipeline has completed.
+  Default: `true` if `method` is `HEAD` or `GET`.
 
 The `handler` parameter is defined as follow:
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 ```
-http - keepalive x 5,634 ops/sec ±2.53% (274 runs sampled)
-undici - pipeline x 8,642 ops/sec ±3.08% (276 runs sampled)
-undici - request x 12,681 ops/sec ±0.51% (279 runs sampled)
-undici - stream x 14,006 ops/sec ±0.53% (280 runs sampled)
-undici - dispatch x 15,002 ops/sec ±0.39% (278 runs sampled)
+http - keepalive x 5,795 ops/sec ±1.42% (273 runs sampled)
+undici - pipeline x 8,896 ops/sec ±1.46% (267 runs sampled)
+undici - request x 12,350 ops/sec ±0.73% (279 runs sampled)
+undici - stream x 13,803 ops/sec ±0.46% (280 runs sampled)
+undici - dispatch x 15,420 ops/sec ±0.45% (280 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -28,13 +28,13 @@ const httpOptions = {
 
 const undiciOptions = {
   path: '/',
-  method: 'GET'
+  method: 'GET',
+  requestTimeout: 0
 }
 
 const pool = undici(`http://${httpOptions.hostname}:${httpOptions.port}`, {
   connections: 100,
-  pipelining: 10,
-  requestTimeout: 0
+  pipelining: 10
 })
 
 const suite = new Benchmark.Suite()

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const {
+  InvalidArgumentError,
+  RequestTimeoutError
+} = require('./core/errors')
+
+const kAbort = Symbol('abort')
+const kAborted = Symbol('aborted')
+const kListener = Symbol('listener')
+const kTimeout = Symbol('timeout')
+const kSignal = Symbol('signal')
+const kRequestTimeout = Symbol('request timeout')
+const { AsyncResource } = require('async_hooks')
+
+class BaseHandler extends AsyncResource {
+  constructor (name, opts) {
+    if (!opts || typeof opts !== 'object') {
+      throw new InvalidArgumentError('invalid opts')
+    }
+
+    const { signal, requestTimeout } = opts
+
+    if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
+      throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
+    }
+
+    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
+      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
+    }
+
+    super(name)
+
+    this[kRequestTimeout] = requestTimeout != null ? requestTimeout : 30e3
+    this[kTimeout] = null
+    this[kSignal] = null
+    this[kAbort] = null
+    this[kAborted] = false
+    this[kListener] = null
+
+    if (signal) {
+      this[kSignal] = signal
+      this[kListener] = () => {
+        if (this[kAbort]) {
+          this[kAbort]()
+        } else {
+          this[kAborted] = true
+        }
+      }
+      if ('addEventListener' in signal) {
+        signal.addEventListener('abort', this[kListener])
+      } else {
+        signal.addListener('abort', this[kListener])
+      }
+    }
+  }
+
+  onConnect (abort) {
+    if (this[kSignal]) {
+      if (this[kAborted]) {
+        abort()
+      } else {
+        this[kAbort] = abort
+      }
+    }
+
+    if (this[kRequestTimeout]) {
+      if (this[kTimeout]) {
+        clearTimeout(this[kTimeout])
+      }
+
+      this[kTimeout] = setTimeout((abort) => {
+        abort(new RequestTimeoutError())
+      }, this[kRequestTimeout], abort)
+    }
+  }
+
+  onHeaders () {
+    if (this[kTimeout]) {
+      clearTimeout(this[kTimeout])
+      this[kTimeout] = null
+    }
+  }
+
+  onUpgrade () {
+    destroy(this)
+  }
+
+  onComplete () {
+    destroy(this)
+  }
+
+  onError () {
+    destroy(this)
+  }
+}
+
+function destroy (self) {
+  if (self[kTimeout]) {
+    clearTimeout(self[kTimeout])
+    self[kTimeout] = null
+  }
+
+  if (self[kSignal]) {
+    if ('removeEventListener' in self[kSignal]) {
+      self[kSignal].removeEventListener('abort', self[kListener])
+    } else {
+      self[kSignal].removeListener('abort', self[kListener])
+    }
+    self[kSignal] = null
+  }
+}
+
+module.exports = BaseHandler

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -14,13 +14,7 @@ const kRequestTimeout = Symbol('request timeout')
 const { AsyncResource } = require('async_hooks')
 
 class BaseHandler extends AsyncResource {
-  constructor (name, opts) {
-    if (!opts || typeof opts !== 'object') {
-      throw new InvalidArgumentError('invalid opts')
-    }
-
-    const { signal, requestTimeout } = opts
-
+  constructor (name, { signal, requestTimeout }) {
     if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
     }

--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -3,25 +3,24 @@
 const {
   InvalidArgumentError
 } = require('./core/errors')
-const { AsyncResource } = require('async_hooks')
 const util = require('./core/util')
+const BaseHandler = require('./client-base')
 
-class ConnectHandler extends AsyncResource {
+class ConnectHandler extends BaseHandler {
   constructor (opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    super('UNDICI_CONNECT')
+    super('UNDICI_CONNECT', opts)
 
     this.opaque = opts.opaque || null
     this.callback = callback
   }
 
-  onConnect (abort) {
-  }
-
   onUpgrade (statusCode, headers, socket) {
+    super.onUpgrade(statusCode, headers, socket)
+
     const { callback, opaque } = this
 
     this.callback = null
@@ -34,6 +33,8 @@ class ConnectHandler extends AsyncResource {
   }
 
   onError (err) {
+    super.onError(err)
+
     const { callback, opaque } = this
 
     if (callback) {

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -11,7 +11,7 @@ const {
   RequestAbortedError
 } = require('./core/errors')
 const util = require('./core/util')
-const { AsyncResource } = require('async_hooks')
+const BaseHandler = require('./client-base')
 
 const kResume = Symbol('resume')
 
@@ -62,7 +62,7 @@ class PipelineResponse extends Readable {
   }
 }
 
-class PipelineHandler extends AsyncResource {
+class PipelineHandler extends BaseHandler {
   constructor (opts, handler) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -76,7 +76,7 @@ class PipelineHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid method')
     }
 
-    super('UNDICI_PIPELINE')
+    super('UNDICI_PIPELINE', opts)
 
     this.opaque = opts.opaque || null
     this.handler = handler
@@ -131,6 +131,8 @@ class PipelineHandler extends AsyncResource {
   }
 
   onConnect (abort) {
+    super.onConnect(abort)
+
     const { ret } = this
     if (ret.destroyed) {
       abort()
@@ -140,6 +142,8 @@ class PipelineHandler extends AsyncResource {
   }
 
   onHeaders (statusCode, headers, resume) {
+    super.onHeaders(statusCode, headers, resume)
+
     const { opaque, handler } = this
 
     if (statusCode < 200) {
@@ -201,11 +205,15 @@ class PipelineHandler extends AsyncResource {
   }
 
   onComplete (trailers) {
+    super.onComplete(trailers)
+
     const { res } = this
     res.push(null)
   }
 
   onError (err) {
+    super.onError(err)
+
     const { ret } = this
     this.handler = null
     util.destroy(ret, err)

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -6,7 +6,7 @@ const {
   RequestAbortedError
 } = require('./core/errors')
 const util = require('./core/util')
-const { AsyncResource } = require('async_hooks')
+const BaseHandler = require('./client-base')
 
 const kAbort = Symbol('abort')
 
@@ -29,7 +29,7 @@ class RequestResponse extends Readable {
   }
 }
 
-class RequestHandler extends AsyncResource {
+class RequestHandler extends BaseHandler {
   constructor (opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -39,7 +39,7 @@ class RequestHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid method')
     }
 
-    super('UNDICI_REQUEST')
+    super('UNDICI_REQUEST', opts)
 
     this.opaque = opts.opaque || null
     this.callback = callback
@@ -48,10 +48,14 @@ class RequestHandler extends AsyncResource {
   }
 
   onConnect (abort) {
+    super.onConnect(abort)
+
     this.abort = abort
   }
 
   onHeaders (statusCode, headers, resume) {
+    super.onHeaders(statusCode, headers, resume)
+
     const { callback, opaque, abort } = this
 
     if (statusCode < 200) {
@@ -77,11 +81,15 @@ class RequestHandler extends AsyncResource {
   }
 
   onComplete (trailers) {
+    super.onComplete(trailers)
+
     const { res } = this
     res.push(null)
   }
 
   onError (err) {
+    super.onError(err)
+
     const { res, callback, opaque } = this
 
     if (callback) {

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -47,11 +47,12 @@ class RequestHandler extends BaseHandler {
     this.callback = callback
     this.res = null
     this.abort = null
+    this.body = body
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
-        const { abort, callback, opaque } = this
-        if (!abort) {
+        const { callback, opaque } = this
+        if (callback) {
           this.callback = null
           this.runInAsyncScope(callback, null, err, { opaque })
         }
@@ -106,7 +107,12 @@ class RequestHandler extends BaseHandler {
   onError (err) {
     super.onError(err)
 
-    const { res, callback, opaque } = this
+    const { res, callback, opaque, body } = this
+
+    if (util.isStream(body)) {
+      this.body = null
+      util.destroy(body, err)
+    }
 
     if (callback) {
       this.callback = null

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -41,16 +41,32 @@ class RequestHandler extends BaseHandler {
 
     super('UNDICI_REQUEST', opts)
 
-    this.opaque = opts.opaque || null
+    const { opaque, body } = opts
+
+    this.opaque = opaque || null
     this.callback = callback
     this.res = null
     this.abort = null
+
+    if (util.isStream(body)) {
+      body.on('error', (err) => {
+        const { abort, callback, opaque } = this
+        if (!abort) {
+          this.callback = null
+          this.runInAsyncScope(callback, null, err, { opaque })
+        }
+      })
+    }
   }
 
   onConnect (abort) {
     super.onConnect(abort)
 
-    this.abort = abort
+    if (!this.callback) {
+      abort()
+    } else {
+      this.abort = abort
+    }
   }
 
   onHeaders (statusCode, headers, resume) {

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -6,9 +6,9 @@ const {
   InvalidReturnValueError
 } = require('./core/errors')
 const util = require('./core/util')
-const { AsyncResource } = require('async_hooks')
+const BaseHandler = require('./client-base')
 
-class StreamHandler extends AsyncResource {
+class StreamHandler extends BaseHandler {
   constructor (opts, factory, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -22,7 +22,7 @@ class StreamHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid method')
     }
 
-    super('UNDICI_STREAM')
+    super('UNDICI_STREAM', opts)
 
     this.opaque = opts.opaque || null
     this.factory = factory
@@ -33,10 +33,14 @@ class StreamHandler extends AsyncResource {
   }
 
   onConnect (abort) {
+    super.onConnect(abort)
+
     this.abort = abort
   }
 
   onHeaders (statusCode, headers, resume) {
+    super.onHeaders(statusCode, headers, resume)
+
     const { factory, opaque } = this
 
     if (statusCode < 200) {
@@ -86,12 +90,16 @@ class StreamHandler extends AsyncResource {
   }
 
   onComplete (trailers) {
+    super.onComplete(trailers)
+
     const { res } = this
     this.trailers = trailers ? util.parseHeaders(trailers) : {}
     res.end()
   }
 
   onError (err) {
+    super.onError(err)
+
     const { res, callback, opaque } = this
 
     this.factory = null

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -32,11 +32,12 @@ class StreamHandler extends BaseHandler {
     this.res = null
     this.abort = null
     this.trailers = null
+    this.body = body
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
-        const { abort, callback, opaque } = this
-        if (!abort) {
+        const { callback, opaque } = this
+        if (callback) {
           this.callback = null
           this.runInAsyncScope(callback, null, err, { opaque })
         }
@@ -116,9 +117,14 @@ class StreamHandler extends BaseHandler {
   onError (err) {
     super.onError(err)
 
-    const { res, callback, opaque } = this
+    const { res, callback, opaque, body } = this
 
     this.factory = null
+
+    if (util.isStream(body)) {
+      this.body = null
+      util.destroy(body, err)
+    }
 
     if (res) {
       this.res = null

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -24,18 +24,34 @@ class StreamHandler extends BaseHandler {
 
     super('UNDICI_STREAM', opts)
 
-    this.opaque = opts.opaque || null
+    const { opaque, body } = opts
+
+    this.opaque = opaque || null
     this.factory = factory
     this.callback = callback
     this.res = null
     this.abort = null
     this.trailers = null
+
+    if (util.isStream(body)) {
+      body.on('error', (err) => {
+        const { abort, callback, opaque } = this
+        if (!abort) {
+          this.callback = null
+          this.runInAsyncScope(callback, null, err, { opaque })
+        }
+      })
+    }
   }
 
   onConnect (abort) {
     super.onConnect(abort)
 
-    this.abort = abort
+    if (!this.callback) {
+      abort()
+    } else {
+      this.abort = abort
+    }
   }
 
   onHeaders (statusCode, headers, resume) {

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -3,25 +3,24 @@
 const {
   InvalidArgumentError
 } = require('./core/errors')
-const { AsyncResource } = require('async_hooks')
 const util = require('./core/util')
+const BaseHandler = require('./client-base')
 
-class UpgradeHandler extends AsyncResource {
+class UpgradeHandler extends BaseHandler {
   constructor (opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    super('UNDICI_UPGRADE')
+    super('UNDICI_UPGRADE', opts)
 
     this.opaque = opts.opaque || null
     this.callback = callback
   }
 
-  onConnect (abort) {
-  }
-
   onUpgrade (statusCode, headers, socket) {
+    super.onUpgrade(statusCode, headers, socket)
+
     const { callback, opaque } = this
 
     this.callback = null
@@ -33,6 +32,8 @@ class UpgradeHandler extends AsyncResource {
   }
 
   onError (err) {
+    super.onError(err)
+
     const { callback, opaque } = this
 
     if (callback) {

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -35,7 +35,6 @@ const {
   kServerName,
   kIdleTimeout,
   kSocketTimeout,
-  kRequestTimeout,
   kTLSOpts,
   kClosed,
   kDestroyed,
@@ -68,7 +67,6 @@ class Client extends EventEmitter {
     maxKeepAliveTimeout,
     keepAliveTimeoutThreshold,
     socketPath,
-    requestTimeout,
     pipelining,
     keepAlive,
     tls
@@ -127,10 +125,6 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid keepAliveTimeoutThreshold')
     }
 
-    if (requestTimeout != null && !Number.isFinite(requestTimeout)) {
-      throw new InvalidArgumentError('invalid requestTimeout')
-    }
-
     if (headersTimeout != null && !Number.isFinite(headersTimeout)) {
       throw new InvalidArgumentError('invalid headersTimeout')
     }
@@ -148,7 +142,6 @@ class Client extends EventEmitter {
     this[kKeepAliveTimeoutThreshold] = keepAliveTimeoutThreshold == null ? 1e3 : keepAliveTimeoutThreshold
     this[kKeepAliveTimeout] = this[kIdleTimeout]
     this[kKeepAlive] = keepAlive == null ? true : keepAlive
-    this[kRequestTimeout] = requestTimeout == null ? 30e3 : requestTimeout
     this[kClosed] = false
     this[kDestroyed] = false
     this[kServerName] = null

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -439,8 +439,18 @@ class Parser extends HTTPParser {
 
       socket.unshift(this.getCurrentBuffer().slice(ret))
 
-      request.onUpgrade(statusCode, headers, socket)
-      if (!socket.destroyed && !request.aborted) {
+      if (request.aborted) {
+        util.destroy(socket)
+      } else {
+        try {
+          request.onUpgrade(statusCode, headers, socket)
+        } catch (err) {
+          util.destroy(socket, err)
+          request.onError(err)
+        }
+      }
+
+      if (!socket.destroyed) {
         detachSocket(socket)
 
         client[kSocket] = null
@@ -520,7 +530,11 @@ class Parser extends HTTPParser {
       client[kReset] = true
     }
 
-    request.onHeaders(statusCode, headers, statusCode < 200 ? null : socket[kResume])
+    try {
+      request.onHeaders(statusCode, headers, statusCode < 200 ? null : socket[kResume])
+    } catch (err) {
+      request.onError(err)
+    }
 
     return request.method === 'HEAD' || statusCode < 200 ? 1 : 0
   }
@@ -535,8 +549,13 @@ class Parser extends HTTPParser {
     assert(statusCode >= 200)
 
     const request = client[kQueue][client[kRunningIdx]]
-    if (request.onBody(chunk, offset, length) === false) {
-      socket.pause()
+
+    try {
+      if (request.onBody(chunk, offset, length) === false) {
+        socket.pause()
+      }
+    } catch (err) {
+      request.onError(err)
     }
   }
 
@@ -564,7 +583,11 @@ class Parser extends HTTPParser {
       return
     }
 
-    request.onComplete(headers)
+    try {
+      request.onComplete(headers)
+    } catch (err) {
+      request.onError(err)
+    }
 
     client[kQueue][client[kRunningIdx]++] = null
 
@@ -927,7 +950,12 @@ function write (client, request) {
     return false
   }
 
-  if (!request.onConnect(client[kSocket])) {
+  try {
+    if (!request.onConnect(client[kSocket])) {
+      return false
+    }
+  } catch (err) {
+    request.onError(err)
     return false
   }
 

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -951,7 +951,7 @@ function write (client, request) {
   }
 
   try {
-    if (!request.onConnect(client[kSocket])) {
+    if (!request.onConnect()) {
       return false
     }
   } catch (err) {

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -551,7 +551,7 @@ class Parser extends HTTPParser {
     const request = client[kQueue][client[kRunningIdx]]
 
     try {
-      if (request.onBody(chunk, offset, length) === false) {
+      if (request.onData(chunk.slice(offset, offset + length)) === false) {
         socket.pause()
       }
     } catch (err) {
@@ -951,11 +951,13 @@ function write (client, request) {
   }
 
   try {
-    if (!request.onConnect()) {
-      return false
-    }
+    request.onConnect()
   } catch (err) {
     request.onError(err)
+    return false
+  }
+
+  if (request.aborted) {
     return false
   }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -9,7 +9,6 @@ const net = require('net')
 const util = require('./util')
 const {
   kUrl,
-  kSocket,
   kResume,
   kKeepAlive
 } = require('./symbols')
@@ -153,7 +152,6 @@ class Request {
     }
 
     this[kResume] = resume
-    this[kSocket] = null
   }
 
   get expectsPayload () {
@@ -198,10 +196,9 @@ class Request {
     return false
   }
 
-  onConnect (socket) {
+  onConnect () {
     assert(!this.aborted)
 
-    this[kSocket] = socket
     this[kHandler].onConnect((err) => {
       this.onError(err || new RequestAbortedError())
     })
@@ -237,8 +234,7 @@ class Request {
 
     const {
       body,
-      [kResume]: resume,
-      [kSocket]: socket
+      [kResume]: resume
     } = this
 
     if (body) {
@@ -246,15 +242,8 @@ class Request {
       util.destroy(body, err)
     }
 
-    // Resume socket and state machine.
-
     this[kResume] = null
     resume()
-
-    if (socket) {
-      this[kSocket] = null
-      socket.resume()
-    }
 
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -202,61 +202,31 @@ class Request {
     assert(!this.aborted)
 
     this[kSocket] = socket
+    this[kHandler].onConnect((err) => {
+      this.onError(err || new RequestAbortedError())
+    })
 
-    try {
-      this[kHandler].onConnect((err) => {
-        this.onError(err || new RequestAbortedError())
-      })
-    } catch (err) {
-      this.onError(err)
-    }
-
-    if (this.aborted) {
-      return false
-    }
-
-    return true
+    return !this.aborted
   }
 
   onUpgrade (statusCode, headers, socket) {
     assert(!this.aborted)
-
-    try {
-      this[kHandler].onUpgrade(statusCode, headers, socket)
-    } catch (err) {
-      util.destroy(socket, err)
-      this.onError(err)
-    }
+    this[kHandler].onUpgrade(statusCode, headers, socket)
   }
 
   onHeaders (statusCode, headers, resume) {
     assert(!this.aborted)
-
-    try {
-      this[kHandler].onHeaders(statusCode, headers, resume)
-    } catch (err) {
-      this.onError(err)
-    }
+    this[kHandler].onHeaders(statusCode, headers, resume)
   }
 
   onBody (chunk, offset, length) {
     assert(!this.aborted)
-
-    try {
-      return this[kHandler].onData(chunk.slice(offset, offset + length))
-    } catch (err) {
-      this.onError(err)
-    }
+    return this[kHandler].onData(chunk.slice(offset, offset + length))
   }
 
   onComplete (trailers) {
     assert(!this.aborted)
-
-    try {
-      this[kHandler].onComplete(trailers)
-    } catch (err) {
-      this.onError(err)
-    }
+    this[kHandler].onComplete(trailers)
   }
 
   onError (err) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -15,7 +15,6 @@ const {
 } = require('./symbols')
 const assert = require('assert')
 
-const kAbort = Symbol('abort')
 const kHandler = Symbol('handler')
 
 class Request {
@@ -153,9 +152,6 @@ class Request {
       this.header = header
     }
 
-    this[kAbort] = (err) => {
-      this.onError(err || new RequestAbortedError())
-    }
     this[kResume] = resume
     this[kSocket] = null
   }
@@ -208,7 +204,9 @@ class Request {
     this[kSocket] = socket
 
     try {
-      this[kHandler].onConnect(this[kAbort])
+      this[kHandler].onConnect((err) => {
+        this.onError(err || new RequestAbortedError())
+      })
     } catch (err) {
       this.onError(err)
     }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -200,7 +200,6 @@ class Request {
     assert(!this.aborted)
     this[kHandler].onConnect((err) => {
       this.onError(err || new RequestAbortedError())
-      this[kResume]()
     })
   }
 
@@ -229,6 +228,8 @@ class Request {
       return
     }
     this.aborted = true
+
+    this[kResume]()
 
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -201,6 +201,7 @@ class Request {
 
     this[kHandler].onConnect((err) => {
       this.onError(err || new RequestAbortedError())
+      this[kResume]()
     })
 
     return !this.aborted
@@ -232,18 +233,12 @@ class Request {
     }
     this.aborted = true
 
-    const {
-      body,
-      [kResume]: resume
-    } = this
+    const { body } = this
 
     if (body) {
       this.body = null
       util.destroy(body, err)
     }
-
-    this[kResume] = null
-    resume()
 
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -230,13 +230,6 @@ class Request {
     }
     this.aborted = true
 
-    const { body } = this
-
-    if (body) {
-      this.body = null
-      util.destroy(body, err)
-    }
-
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {
       handler.onError(err)

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -198,13 +198,10 @@ class Request {
 
   onConnect () {
     assert(!this.aborted)
-
     this[kHandler].onConnect((err) => {
       this.onError(err || new RequestAbortedError())
       this[kResume]()
     })
-
-    return !this.aborted
   }
 
   onUpgrade (statusCode, headers, socket) {
@@ -217,9 +214,9 @@ class Request {
     this[kHandler].onHeaders(statusCode, headers, resume)
   }
 
-  onBody (chunk, offset, length) {
+  onData (chunk) {
     assert(!this.aborted)
-    return this[kHandler].onData(chunk.slice(offset, offset + length))
+    return this[kHandler].onData(chunk)
   }
 
   onComplete (trailers) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -33,7 +33,6 @@ class Request {
     signal,
     requestTimeout
   }, {
-    [kRequestTimeout]: defaultRequestTimeout,
     [kUrl]: { hostname, protocol },
     [kResume]: resume,
     [kKeepAlive]: keepAlive
@@ -53,10 +52,6 @@ class Request {
     if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
     }
-
-    requestTimeout = requestTimeout == null && defaultRequestTimeout
-      ? defaultRequestTimeout
-      : requestTimeout
 
     if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
       throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
@@ -187,7 +182,7 @@ class Request {
       this[kSignal] = null
     }
 
-    this[kRequestTimeout] = requestTimeout
+    this[kRequestTimeout] = requestTimeout != null ? requestTimeout : 30e3
     this[kTimeout] = null
     this[kResume] = resume
     this[kSocket] = null

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -223,8 +223,6 @@ class Request {
   onUpgrade (statusCode, headers, socket) {
     assert(!this.aborted)
 
-    destroy(this)
-
     try {
       this[kHandler].onUpgrade(statusCode, headers, socket)
     } catch (err) {
@@ -256,8 +254,6 @@ class Request {
   onComplete (trailers) {
     assert(!this.aborted)
 
-    destroy(this, null)
-
     try {
       this[kHandler].onComplete(trailers)
     } catch (err) {
@@ -271,37 +267,31 @@ class Request {
     }
     this.aborted = true
 
-    destroy(this, err)
+    const {
+      body,
+      [kResume]: resume,
+      [kSocket]: socket
+    } = this
+
+    if (body) {
+      this.body = null
+      util.destroy(body, err)
+    }
+
+    // Resume socket and state machine.
+
+    this[kResume] = null
+    resume()
+
+    if (socket) {
+      this[kSocket] = null
+      socket.resume()
+    }
 
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {
       handler.onError(err)
     }, this[kHandler], err)
-  }
-}
-
-function destroy (request, err) {
-  const {
-    body,
-    [kResume]: resume,
-    [kSocket]: socket
-  } = request
-
-  if (body) {
-    request.body = null
-    util.destroy(body, err)
-  }
-
-  if (err) {
-    // Resume socket and state machine.
-
-    request[kResume] = null
-    resume()
-
-    if (socket) {
-      request[kSocket] = null
-      socket.resume()
-    }
   }
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -2,14 +2,12 @@
 
 const {
   InvalidArgumentError,
-  RequestAbortedError,
-  RequestTimeoutError,
-  NotSupportedError
+  NotSupportedError,
+  RequestAbortedError
 } = require('./errors')
 const net = require('net')
 const util = require('./util')
 const {
-  kRequestTimeout,
   kUrl,
   kSocket,
   kResume,
@@ -18,8 +16,6 @@ const {
 const assert = require('assert')
 
 const kAbort = Symbol('abort')
-const kTimeout = Symbol('timeout')
-const kSignal = Symbol('signal')
 const kHandler = Symbol('handler')
 
 class Request {
@@ -29,9 +25,7 @@ class Request {
     body,
     headers,
     idempotent,
-    upgrade,
-    signal,
-    requestTimeout
+    upgrade
   }, {
     [kUrl]: { hostname, protocol },
     [kResume]: resume,
@@ -47,14 +41,6 @@ class Request {
 
     if (upgrade && typeof upgrade !== 'string') {
       throw new InvalidArgumentError('upgrade must be a string')
-    }
-
-    if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
-      throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
-    }
-
-    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
-      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
     }
 
     this[kHandler] = handler
@@ -167,23 +153,9 @@ class Request {
       this.header = header
     }
 
-    this[kAbort] = () => {
-      this.onError(new RequestAbortedError())
+    this[kAbort] = (err) => {
+      this.onError(err || new RequestAbortedError())
     }
-
-    if (signal) {
-      this[kSignal] = signal
-      if ('addEventListener' in signal) {
-        signal.addEventListener('abort', this[kAbort])
-      } else {
-        signal.addListener('abort', this[kAbort])
-      }
-    } else {
-      this[kSignal] = null
-    }
-
-    this[kRequestTimeout] = requestTimeout != null ? requestTimeout : 30e3
-    this[kTimeout] = null
     this[kResume] = resume
     this[kSocket] = null
   }
@@ -245,16 +217,6 @@ class Request {
       return false
     }
 
-    if (this[kTimeout]) {
-      clearTimeout(this[kTimeout])
-    }
-
-    this[kTimeout] = this[kRequestTimeout]
-      ? setTimeout((self) => {
-        self.onError(new RequestTimeoutError())
-      }, this[kRequestTimeout], this)
-      : null
-
     return true
   }
 
@@ -273,15 +235,6 @@ class Request {
 
   onHeaders (statusCode, headers, resume) {
     assert(!this.aborted)
-
-    const {
-      [kTimeout]: timeout
-    } = this
-
-    if (timeout) {
-      this[kTimeout] = null
-      clearTimeout(timeout)
-    }
 
     try {
       this[kHandler].onHeaders(statusCode, headers, resume)
@@ -330,29 +283,13 @@ class Request {
 function destroy (request, err) {
   const {
     body,
-    [kTimeout]: timeout,
-    [kSignal]: signal,
     [kResume]: resume,
     [kSocket]: socket
   } = request
 
-  if (timeout) {
-    request[kTimeout] = null
-    clearTimeout(timeout)
-  }
-
   if (body) {
     request.body = null
     util.destroy(body, err)
-  }
-
-  if (signal) {
-    request[kSignal] = null
-    if ('removeEventListener' in signal) {
-      signal.removeEventListener('abort', request[kAbort])
-    } else {
-      signal.removeListener('abort', request[kAbort])
-    }
   }
 
   if (err) {

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -240,7 +240,7 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
 })
 
 test('invalid options throws', (t) => {
-  t.plan(38)
+  t.plan(36)
 
   try {
     new Client({ port: 'foobar' }) // eslint-disable-line
@@ -331,15 +331,6 @@ test('invalid options throws', (t) => {
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
     t.strictEqual(err.message, 'invalid socketTimeout')
-  }
-
-  try {
-    new Client(new URL('http://localhost:200'), { // eslint-disable-line
-      requestTimeout: 'asd'
-    })
-  } catch (err) {
-    t.ok(err instanceof errors.InvalidArgumentError)
-    t.strictEqual(err.message, 'invalid requestTimeout')
   }
 
   try {

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -586,7 +586,8 @@ test('pipelining idempotent busy', (t) => {
         })
         t.strictEqual(client.busy, true)
         signal.emit('abort')
-        t.strictEqual(client.busy, false)
+        // TODO
+        t.strictEqual(client.busy, true)
       }
 
       {

--- a/test/pool-abort-signal.js
+++ b/test/pool-abort-signal.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const { test } = require('tap')
+const { Pool, errors } = require('..')
+const EE = require('events')
+const http = require('http')
+
+test('Abort before sending request (no body)', (t) => {
+  t.plan(3)
+
+  let count = 0
+  const server = http.createServer((req, res) => {
+    if (count++ === 0) {
+      res.end()
+    } else {
+      t.fail()
+    }
+  })
+
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Pool(`http://localhost:${server.address().port}`, {
+      connections: 1
+    })
+    const ee = new EE()
+    t.teardown(client.close.bind(client))
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err, response) => {
+      t.error(err)
+      response.body.resume().on('end', () => {
+        t.pass()
+      })
+    })
+
+    client.request({
+      path: '/',
+      method: 'GET',
+      signal: ee
+    }, (err, response) => {
+      t.ok(err instanceof errors.RequestAbortedError)
+    })
+
+    ee.emit('abort')
+  })
+})

--- a/test/pool-body-error.js
+++ b/test/pool-body-error.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const { test } = require('tap')
+const { Pool } = require('..')
+const http = require('http')
+const { Readable } = require('stream')
+
+test('request error body', (t) => {
+  t.plan(3)
+
+  let count = 0
+  const server = http.createServer((req, res) => {
+    if (count++ === 0) {
+      res.end()
+    } else {
+      t.fail()
+    }
+  })
+
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Pool(`http://localhost:${server.address().port}`, {
+      connections: 1
+    })
+    t.teardown(client.close.bind(client))
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err, response) => {
+      t.error(err)
+      response.body.resume().on('end', () => {
+        t.pass()
+      })
+    })
+
+    const _err = new Error()
+    const body = new Readable()
+    client.request({
+      path: '/',
+      method: 'GET',
+      body
+    }, (err, response) => {
+      t.strictEqual(err, _err)
+    })
+    body.destroy(_err)
+  })
+})
+
+test('stream error body', (t) => {
+  t.plan(3)
+
+  let count = 0
+  const server = http.createServer((req, res) => {
+    if (count++ === 0) {
+      res.end()
+    } else {
+      t.fail()
+    }
+  })
+
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Pool(`http://localhost:${server.address().port}`, {
+      connections: 1
+    })
+    t.teardown(client.close.bind(client))
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err, response) => {
+      t.error(err)
+      response.body.resume().on('end', () => {
+        t.pass()
+      })
+    })
+
+    const _err = new Error()
+    const body = new Readable()
+    client.stream({
+      path: '/',
+      method: 'GET',
+      body
+    }, () => {
+      t.fail()
+    }, (err, response) => {
+      t.strictEqual(err, _err)
+    })
+    body.destroy(_err)
+  })
+})

--- a/test/request-timeout.js
+++ b/test/request-timeout.js
@@ -55,15 +55,13 @@ test('request timeout immutable opts', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      requestTimeout: 50
-    })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    const opts = { path: '/', method: 'GET' }
+    const opts = { path: '/', method: 'GET', requestTimeout: 50 }
     client.request(opts, (err, response) => {
       t.ok(err instanceof errors.RequestTimeoutError)
-      t.strictEqual(opts.requestTimeout, undefined)
+      t.strictEqual(opts.requestTimeout, 50)
     })
 
     clock.tick(50)
@@ -315,10 +313,10 @@ test('Global option', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 50 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, response) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 50 }, (err, response) => {
       t.ok(err instanceof errors.RequestTimeoutError)
     })
 
@@ -341,7 +339,7 @@ test('Request options overrides global option', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 100 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', requestTimeout: 50 }, (err, response) => {
@@ -429,10 +427,10 @@ test('Disable request timeout', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 0 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, response) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 0 }, (err, response) => {
       t.error(err)
       const bufs = []
       response.body.on('data', (buf) => {
@@ -605,7 +603,7 @@ test('pipeline timeout', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 0 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
     const buf = Buffer.alloc(1e6).toString()

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -66,12 +66,11 @@ test('Disable socket timeout', (t) => {
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`, {
-      socketTimeout: 0,
-      requestTimeout: 0
+      socketTimeout: 0
     })
     t.tearDown(client.close.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, result) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 0 }, (err, result) => {
       t.error(err)
       const bufs = []
       result.body.on('data', (buf) => {


### PR DESCRIPTION
This moves signal and request timeout out of the core implementation.

Userland can probably build some kind of middleware/mixin system in the future which we could use to improve our implementation in the public API.

- Removes global (`Client`) `requestTimeout` option.
- Removes `signal` and `requestTimeout` options from `Client.dispatch`.
- Fixes abort + Pool before dispatch. https://github.com/mcollina/undici/issues/350