### PR TITLE
refactor: simplify request

### DIFF
--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -38,7 +38,9 @@ class ConnectHandler extends AsyncResource {
 
     if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, { opaque })
+      process.nextTick((self, callback, err, opaque) => {
+        self.runInAsyncScope(callback, null, err, { opaque })
+      }, this, callback, err, opaque)
     }
   }
 }

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -86,7 +86,9 @@ class RequestHandler extends AsyncResource {
 
     if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, { opaque })
+      process.nextTick((self, callback, err, opaque) => {
+        self.runInAsyncScope(callback, null, err, { opaque })
+      }, this, callback, err, opaque)
     }
 
     if (res) {

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -69,12 +69,12 @@ class StreamHandler extends AsyncResource {
         util.destroy(res, err)
       }
 
+      this.callback = null
+      this.runInAsyncScope(callback, null, err || null, { opaque, trailers })
+
       if (err) {
         abort()
       }
-
-      this.callback = null
-      this.runInAsyncScope(callback, null, err || null, { opaque, trailers })
     })
 
     this.res = res
@@ -101,7 +101,9 @@ class StreamHandler extends AsyncResource {
       util.destroy(res, err)
     } else if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, { opaque })
+      process.nextTick((self, callback, err, opaque) => {
+        self.runInAsyncScope(callback, null, err, { opaque })
+      }, this, callback, err, opaque)
     }
   }
 }

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -37,7 +37,9 @@ class UpgradeHandler extends AsyncResource {
 
     if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, { opaque })
+      process.nextTick((self, callback, err, opaque) => {
+        self.runInAsyncScope(callback, null, err, { opaque })
+      }, this, callback, err, opaque)
     }
   }
 }

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -447,7 +447,13 @@ class Parser extends HTTPParser {
 
       socket.unshift(this.getCurrentBuffer().slice(ret))
 
-      request.onUpgrade(statusCode, headers, socket)
+      try {
+        request.onUpgrade(statusCode, headers, socket)
+      } catch (err) {
+        util.destroy(socket, err)
+        request.onError(err)
+      }
+
       if (!socket.destroyed && !request.aborted) {
         detachSocket(socket)
 
@@ -528,7 +534,12 @@ class Parser extends HTTPParser {
       client[kReset] = true
     }
 
-    request.onHeaders(statusCode, headers, statusCode < 200 ? null : socket[kResume])
+    try {
+      request.onHeaders(statusCode, headers, statusCode < 200 ? null : socket[kResume])
+    } catch (err) {
+      util.destroy(socket, err)
+      return 1
+    }
 
     return request.method === 'HEAD' || statusCode < 200 ? 1 : 0
   }
@@ -543,8 +554,13 @@ class Parser extends HTTPParser {
     assert(statusCode >= 200)
 
     const request = client[kQueue][client[kRunningIdx]]
-    if (request.onBody(chunk, offset, length) === false) {
-      socket.pause()
+
+    try {
+      if (request.onBody(chunk, offset, length) === false) {
+        socket.pause()
+      }
+    } catch (err) {
+      util.destroy(socket, err)
     }
   }
 
@@ -572,7 +588,12 @@ class Parser extends HTTPParser {
       return
     }
 
-    request.onComplete(headers)
+    try {
+      request.onComplete(headers)
+    } catch (err) {
+      util.destroy(socket, err)
+      return
+    }
 
     client[kQueue][client[kRunningIdx]++] = null
 
@@ -935,15 +956,22 @@ function write (client, request) {
     return false
   }
 
-  if (!request.onConnect(client[kSocket])) {
+  try {
+    request.onConnect()
+  } catch (err) {
+    request.onError(err)
     return false
   }
 
-  // TODO: Expect: 100-continue
+  if (request.aborted) {
+    return false
+  }
 
   if (request.reset) {
     client[kReset] = true
   }
+
+  // TODO: Expect: 100-continue
 
   // TODO: An HTTP/1.1 user agent MUST NOT preface
   // or follow a request with an extra CRLF.

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -11,7 +11,6 @@ const util = require('./util')
 const {
   kRequestTimeout,
   kUrl,
-  kSocket,
   kResume,
   kKeepAlive
 } = require('./symbols')
@@ -172,12 +171,11 @@ class Request {
       this.header = header
     }
 
-    this[kAbort] = () => {
-      this.onError(new RequestAbortedError())
-    }
-
     if (signal) {
       this[kSignal] = signal
+      this[kAbort] = () => {
+        this.onError(new RequestAbortedError())
+      }
       if ('addEventListener' in signal) {
         signal.addEventListener('abort', this[kAbort])
       } else {
@@ -185,12 +183,12 @@ class Request {
       }
     } else {
       this[kSignal] = null
+      this[kAbort] = null
     }
 
     this[kRequestTimeout] = requestTimeout
     this[kTimeout] = null
     this[kResume] = resume
-    this[kSocket] = null
   }
 
   get expectsPayload () {
@@ -235,20 +233,8 @@ class Request {
     return false
   }
 
-  onConnect (socket) {
+  onConnect () {
     assert(!this.aborted)
-
-    this[kSocket] = socket
-
-    try {
-      this[kHandler].onConnect(this[kAbort])
-    } catch (err) {
-      this.onError(err)
-    }
-
-    if (this.aborted) {
-      return false
-    }
 
     if (this[kTimeout]) {
       clearTimeout(this[kTimeout])
@@ -260,20 +246,9 @@ class Request {
       }, this[kRequestTimeout], this)
       : null
 
-    return true
-  }
-
-  onUpgrade (statusCode, headers, socket) {
-    assert(!this.aborted)
-
-    destroy(this)
-
-    try {
-      this[kHandler].onUpgrade(statusCode, headers, socket)
-    } catch (err) {
-      util.destroy(socket, err)
-      this.onError(err)
-    }
+    this[kHandler].onConnect((err) => {
+      this.onError(err || new RequestAbortedError())
+    })
   }
 
   onHeaders (statusCode, headers, resume) {
@@ -288,21 +263,21 @@ class Request {
       clearTimeout(timeout)
     }
 
-    try {
-      this[kHandler].onHeaders(statusCode, headers, resume)
-    } catch (err) {
-      this.onError(err)
-    }
+    this[kHandler].onHeaders(statusCode, headers, resume)
   }
 
   onBody (chunk, offset, length) {
     assert(!this.aborted)
 
-    try {
-      return this[kHandler].onData(chunk.slice(offset, offset + length))
-    } catch (err) {
-      this.onError(err)
-    }
+    return this[kHandler].onData(chunk.slice(offset, offset + length))
+  }
+
+  onUpgrade (statusCode, headers, socket) {
+    assert(!this.aborted)
+
+    destroy(this, null)
+
+    this[kHandler].onUpgrade(statusCode, headers, socket)
   }
 
   onComplete (trailers) {
@@ -310,11 +285,7 @@ class Request {
 
     destroy(this, null)
 
-    try {
-      this[kHandler].onComplete(trailers)
-    } catch (err) {
-      this.onError(err)
-    }
+    this[kHandler].onComplete(trailers)
   }
 
   onError (err) {
@@ -325,30 +296,22 @@ class Request {
 
     destroy(this, err)
 
-    // TODO: Try to avoid nextTick here.
-    process.nextTick((handler, err) => {
-      handler.onError(err)
-    }, this[kHandler], err)
+    util.destroy(this.body, err)
+
+    this[kHandler].onError(err)
+    this[kResume]()
   }
 }
 
 function destroy (request, err) {
   const {
-    body,
     [kTimeout]: timeout,
-    [kSignal]: signal,
-    [kResume]: resume,
-    [kSocket]: socket
+    [kSignal]: signal
   } = request
 
   if (timeout) {
     request[kTimeout] = null
     clearTimeout(timeout)
-  }
-
-  if (body) {
-    request.body = null
-    util.destroy(body, err)
   }
 
   if (signal) {
@@ -357,18 +320,6 @@ function destroy (request, err) {
       signal.removeEventListener('abort', request[kAbort])
     } else {
       signal.removeListener('abort', request[kAbort])
-    }
-  }
-
-  if (err) {
-    // Resume socket and state machine.
-
-    request[kResume] = null
-    resume()
-
-    if (socket) {
-      request[kSocket] = null
-      socket.resume()
     }
   }
 }


### PR DESCRIPTION
This is a first part of a refactoring aimed at resolving #350 & #356. The idea is to try and simplify `Request` as much as possible and move logic over to handlers.