### PR TITLE
refactor: reduce Request dependency on client

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -954,7 +954,7 @@ function write (client, request) {
   }
 
   try {
-    request.onConnect()
+    request.onConnect(client[kResume])
   } catch (err) {
     request.onError(err)
     return false

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -27,8 +27,7 @@ class Request {
     upgrade,
     requestTimeout
   }, {
-    [kRequestTimeout]: defaultRequestTimeout,
-    [kResume]: resume
+    [kRequestTimeout]: defaultRequestTimeout
   }, handler) {
     if (typeof path !== 'string' || path[0] !== '/') {
       throw new InvalidArgumentError('path must be a valid path')
@@ -142,11 +141,13 @@ class Request {
 
     this[kRequestTimeout] = requestTimeout
     this[kTimeout] = null
-    this[kResume] = resume
+    this[kResume] = null
   }
 
-  onConnect () {
+  onConnect (resume) {
     assert(!this.aborted)
+
+    this[kResume] = resume
 
     if (this[kRequestTimeout]) {
       if (this[kTimeout]) {
@@ -208,7 +209,14 @@ class Request {
 
     destroy(this)
 
-    this[kResume]()
+    const {
+      [kResume]: resume
+    } = this
+
+    if (this[kResume]) {
+      this[kResume] = null
+      resume()
+    }
 
     this[kHandler].onError(err)
   }


### PR DESCRIPTION
With a few more changes `Request` would no longer need to live in core.