### PR TITLE
refactor: remove Client requestTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ Options:
   transport latency.
   Default: `1e3` milliseconds (1s).
 
-- `requestTimeout: Number`, the timeout after which a request will time out.
-  Monitors time between request is dispatched on socket and receiving
-  a response. Use `0` to disable it entirely.
-  Default: `30e3` milliseconds (30s).
-
 - `pipelining: Number`, the amount of concurrent requests to be sent over the
   single TCP/TLS connection according to
   [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2).

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -35,7 +35,6 @@ const {
   kServerName,
   kIdleTimeout,
   kSocketTimeout,
-  kRequestTimeout,
   kTLSOpts,
   kClosed,
   kDestroyed,
@@ -71,7 +70,6 @@ class Client extends EventEmitter {
     keepAliveMaxTimeout = maxKeepAliveTimeout,
     keepAliveTimeoutThreshold,
     socketPath,
-    requestTimeout,
     pipelining,
     tls
   } = {}) {
@@ -129,10 +127,6 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid keepAliveTimeoutThreshold')
     }
 
-    if (requestTimeout != null && !Number.isFinite(requestTimeout)) {
-      throw new InvalidArgumentError('invalid requestTimeout')
-    }
-
     if (headersTimeout != null && !Number.isFinite(headersTimeout)) {
       throw new InvalidArgumentError('invalid headersTimeout')
     }
@@ -150,7 +144,6 @@ class Client extends EventEmitter {
     this[kKeepAliveTimeoutThreshold] = keepAliveTimeoutThreshold == null ? 1e3 : keepAliveTimeoutThreshold
     this[kKeepAliveTimeout] = this[kIdleTimeout]
     this[kKeepAlive] = keepAlive == null ? true : keepAlive
-    this[kRequestTimeout] = requestTimeout == null ? 30e3 : requestTimeout
     this[kClosed] = false
     this[kDestroyed] = false
     this[kServerName] = (tls && tls.servername) || null
@@ -234,7 +227,7 @@ class Client extends EventEmitter {
 
   dispatch (opts, handler) {
     try {
-      const request = new Request(opts, this, handler)
+      const request = new Request(opts, handler)
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
       }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -25,8 +25,6 @@ class Request {
     idempotent,
     upgrade,
     requestTimeout
-  }, {
-    [kRequestTimeout]: defaultRequestTimeout
   }, handler) {
     if (typeof path !== 'string' || path[0] !== '/') {
       throw new InvalidArgumentError('path must be a valid path')
@@ -39,10 +37,6 @@ class Request {
     if (upgrade && typeof upgrade !== 'string') {
       throw new InvalidArgumentError('upgrade must be a string')
     }
-
-    requestTimeout = requestTimeout == null && defaultRequestTimeout
-      ? defaultRequestTimeout
-      : requestTimeout
 
     if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
       throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
@@ -133,7 +127,7 @@ class Request {
       }
     }
 
-    this[kRequestTimeout] = requestTimeout
+    this[kRequestTimeout] = requestTimeout != null ? requestTimeout : 30e3
     this[kTimeout] = null
     this[kResume] = null
     this[kHandler] = handler

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -7,14 +7,12 @@ const {
   NotSupportedError
 } = require('./errors')
 const util = require('./util')
-const {
-  kRequestTimeout,
-  kResume
-} = require('./symbols')
 const assert = require('assert')
 
+const kRequestTimeout = Symbol('request timeout')
 const kTimeout = Symbol('timeout')
 const kHandler = Symbol('handler')
+const kResume = Symbol('resume')
 
 class Request {
   constructor ({

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -8,7 +8,6 @@ module.exports = {
   kPause: Symbol('pause'),
   kSocketTimeout: Symbol('socket timeout'),
   kIdleTimeout: Symbol('idle timeout'),
-  kRequestTimeout: Symbol('request timeout'),
   kKeepAliveMaxTimeout: Symbol('max keep alive timeout'),
   kKeepAliveTimeoutThreshold: Symbol('keep alive timeout threshold'),
   kKeepAliveTimeout: Symbol('keep alive timeout'),

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -332,15 +332,6 @@ test('invalid options throws', (t) => {
   }
 
   try {
-    new Client(new URL('http://localhost:200'), { // eslint-disable-line
-      requestTimeout: 'asd'
-    })
-  } catch (err) {
-    t.ok(err instanceof errors.InvalidArgumentError)
-    t.strictEqual(err.message, 'invalid requestTimeout')
-  }
-
-  try {
     new Client({ // eslint-disable-line
       protocol: 'asd'
     })

--- a/test/request-timeout.js
+++ b/test/request-timeout.js
@@ -40,36 +40,6 @@ test('request timeout', (t) => {
   })
 })
 
-test('request timeout immutable opts', (t) => {
-  t.plan(2)
-
-  const clock = FakeTimers.install()
-  t.teardown(clock.uninstall.bind(clock))
-
-  const server = createServer((req, res) => {
-    setTimeout(() => {
-      res.end('hello')
-    }, 100)
-    clock.tick(100)
-  })
-  t.teardown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      requestTimeout: 50
-    })
-    t.teardown(client.destroy.bind(client))
-
-    const opts = { path: '/', method: 'GET' }
-    client.request(opts, (err, response) => {
-      t.ok(err instanceof errors.RequestTimeoutError)
-      t.strictEqual(opts.requestTimeout, undefined)
-    })
-
-    clock.tick(50)
-  })
-})
-
 test('Subsequent request starves', (t) => {
   t.plan(3)
 
@@ -315,10 +285,10 @@ test('Global option', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 50 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, response) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 50 }, (err, response) => {
       t.ok(err instanceof errors.RequestTimeoutError)
     })
 
@@ -341,7 +311,7 @@ test('Request options overrides global option', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 100 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', requestTimeout: 50 }, (err, response) => {
@@ -429,10 +399,10 @@ test('Disable request timeout', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 0 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, response) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 0 }, (err, response) => {
       t.error(err)
       const bufs = []
       response.body.on('data', (buf) => {
@@ -525,7 +495,7 @@ test('stream custom timeout', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 0 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
     client.stream({
@@ -605,7 +575,7 @@ test('pipeline timeout', (t) => {
   t.teardown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { requestTimeout: 0 })
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
     const buf = Buffer.alloc(1e6).toString()

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -66,12 +66,11 @@ test('Disable socket timeout', (t) => {
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`, {
-      socketTimeout: 0,
-      requestTimeout: 0
+      socketTimeout: 0
     })
     t.tearDown(client.close.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, result) => {
+    client.request({ path: '/', method: 'GET', requestTimeout: 0 }, (err, result) => {
       t.error(err)
       const bufs = []
       result.body.on('data', (buf) => {


### PR DESCRIPTION
Fully decouples `Request` from `Client` at the cost of losing the global `requestTimeout` option.

A little bit hard to motivate but still something I would personally like to do. Eventually maybe even move `requestTimeout` out from core and into handlers. 