### PR TITLE
bench: w pipelining & unix sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ undici - stream x 40,543 ops/sec ±1.30% (80 runs sampled)
 undici - dispatch x 50,434 ops/sec ±2.08% (77 runs sampled)
 ```
 
-The benchmark is a simple `hello world` [example](benchmarks/index.js) with
+The benchmark is a simple `hello world` [example](benchmarks/index.js) using a
 single connection, pipelining and unix sockets.
 
 ## API

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ npm i undici
 ## Benchmarks
 
 Machine: 2.8GHz AMD EPYC 7402P<br/>
-Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 Node 14
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm i undici
 Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
+Node 14
 ```
 http - keepalive x 677 ops/sec ±7.70% (75 runs sampled)
 undici - pipeline x 1,627 ops/sec ±5.88% (79 runs sampled)
@@ -30,7 +31,17 @@ undici - stream x 2,144 ops/sec ±0.84% (86 runs sampled)
 undici - dispatch x 2,295 ops/sec ±1.00% (83 runs sampled)
 ```
 
-The benchmark is a simple `hello world` [example](benchmarks/index.js) with pipelining and unix sockets.
+Node 15
+```
+http - keepalive x 1,337 ops/sec ±6.17% (71 runs sampled)
+undici - pipeline x 3,387 ops/sec ±1.37% (80 runs sampled)
+undici - request x 4,117 ops/sec ±3.25% (77 runs sampled)
+undici - stream x 4,543 ops/sec ±1.30% (80 runs sampled)
+undici - dispatch x 5,434 ops/sec ±2.08% (77 runs sampled)
+```
+
+The benchmark is a simple `hello world` [example](benchmarks/index.js) with
+single connection, pipelining and unix sockets.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1
 
 Node 14
 ```
-http - keepalive x 677 ops/sec ±7.70% (75 runs sampled)
-undici - pipeline x 1,627 ops/sec ±5.88% (79 runs sampled)
-undici - request x 1,902 ops/sec ±1.28% (85 runs sampled)
-undici - stream x 2,144 ops/sec ±0.84% (86 runs sampled)
-undici - dispatch x 2,295 ops/sec ±1.00% (83 runs sampled)
+http - keepalive x 6,770 ops/sec ±7.70% (75 runs sampled)
+undici - pipeline x 10,627 ops/sec ±5.88% (79 runs sampled)
+undici - request x 10,902 ops/sec ±1.28% (85 runs sampled)
+undici - stream x 20,144 ops/sec ±0.84% (86 runs sampled)
+undici - dispatch x 20,295 ops/sec ±1.00% (83 runs sampled)
 ```
 
 Node 15
 ```
-http - keepalive x 1,337 ops/sec ±6.17% (71 runs sampled)
-undici - pipeline x 3,387 ops/sec ±1.37% (80 runs sampled)
-undici - request x 4,117 ops/sec ±3.25% (77 runs sampled)
-undici - stream x 4,543 ops/sec ±1.30% (80 runs sampled)
-undici - dispatch x 5,434 ops/sec ±2.08% (77 runs sampled)
+http - keepalive x 10,337 ops/sec ±6.17% (71 runs sampled)
+undici - pipeline x 30,387 ops/sec ±1.37% (80 runs sampled)
+undici - request x 40,117 ops/sec ±3.25% (77 runs sampled)
+undici - stream x 40,543 ops/sec ±1.30% (80 runs sampled)
+undici - dispatch x 50,434 ops/sec ±2.08% (77 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js) with

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 ```
-http - keepalive x 5,857 ops/sec ±1.98% (276 runs sampled)
-undici - pipeline x 8,688 ops/sec ±1.87% (276 runs sampled)
-undici - request x 12,651 ops/sec ±1.07% (280 runs sampled)
-undici - stream x 14,315 ops/sec ±0.57% (280 runs sampled)
-undici - dispatch x 15,148 ops/sec ±0.50% (278 runs sampled)
+http - keepalive x 677 ops/sec ±7.70% (75 runs sampled)
+undici - pipeline x 1,627 ops/sec ±5.88% (79 runs sampled)
+undici - request x 1,902 ops/sec ±1.28% (85 runs sampled)
+undici - stream x 2,144 ops/sec ±0.84% (86 runs sampled)
+undici - dispatch x 2,295 ops/sec ±1.00% (83 runs sampled)
 ```
 
-The benchmark is a simple `hello world` [example](benchmarks/index.js) without pipelining.
+The benchmark is a simple `hello world` [example](benchmarks/index.js) with pipelining and unix sockets.
 
 ## API
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -12,7 +12,7 @@ const { Client } = require('..')
 
 const httpOptions = {
   protocol: 'http:',
-  hostname: 'localhost',
+  hostname: process.argv[2] || 'localhost',
   method: 'GET',
   path: '/',
   port: 3009,

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -12,10 +12,10 @@ const { Client } = require('..')
 
 const httpOptions = {
   protocol: 'http:',
-  hostname: process.argv[2] || 'localhost',
+  hostname: 'localhost',
+  socketPath: '/var/tmp/undici.sock',
   method: 'GET',
   path: '/',
-  port: 3009,
   agent: new http.Agent({
     keepAlive: true,
     maxSockets: 1
@@ -28,8 +28,9 @@ const undiciOptions = {
   requestTimeout: 0
 }
 
-const client = new Client(`http://${httpOptions.hostname}:${httpOptions.port}`, {
-  pipelining: 10
+const client = new Client(`http://${httpOptions.hostname}`, {
+  pipelining: 10,
+  socketPath: '/var/tmp/undici.sock'
 })
 
 client.on('disconnect', (err) => {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -38,7 +38,7 @@ client.on('disconnect', (err) => {
 
 const suite = new Benchmark.Suite()
 
-Benchmark.options.minSamples = 200
+// Benchmark.options.minSamples = 200
 
 suite
   .add('http - keepalive', {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -39,7 +39,7 @@ client.on('disconnect', (err) => {
 
 const suite = new Benchmark.Suite()
 
-// Benchmark.options.minSamples = 200
+Benchmark.options.minSamples = 200
 
 suite
   .add('http - keepalive', {
@@ -127,6 +127,8 @@ suite
     }
   })
   .on('cycle', event => {
+    // TODO: Multiple results by 10x to get opts/sec since we do 10 requests
+    // per run.
     console.log(String(event.target))
   })
   .run()

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -131,6 +131,9 @@ suite
     // per run.
     console.log(String(event.target))
   })
+  .on('complete', () => {
+    client.destroy()
+  })
   .run()
 
 class NoopRequest {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -126,10 +126,11 @@ suite
       }))).then(() => deferred.resolve())
     }
   })
-  .on('cycle', event => {
-    // TODO: Multiple results by 10x to get opts/sec since we do 10 requests
+  .on('cycle', ({ target }) => {
+    // Multiply results by 10x to get opts/sec since we do 10 requests
     // per run.
-    console.log(String(event.target))
+    target.hz *= 10
+    console.log(String(target))
   })
   .on('complete', () => {
     client.destroy()

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -80,19 +80,17 @@ suite
     defer: true,
     fn: deferred => {
       Promise.all(Array.from(Array(10)).map(() => new Promise((resolve) => {
-        client.request(undiciOptions, (err, { body }) => {
-          if (err) {
-            throw err
-          }
-
-          body
-            .pipe(new Writable({
-              write (chunk, encoding, callback) {
-                callback()
-              }
-            }))
-            .on('close', resolve)
-        })
+        client
+          .request(undiciOptions)
+          .then(({ body }) => {
+            body
+              .pipe(new Writable({
+                write (chunk, encoding, callback) {
+                  callback()
+                }
+              }))
+              .on('close', resolve)
+          })
       }))).then(() => deferred.resolve())
     }
   })

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -29,7 +29,7 @@ const undiciOptions = {
 }
 
 const client = new Client(`http://${httpOptions.hostname}:${httpOptions.port}`, {
-  pipelining: 5
+  pipelining: 10
 })
 
 client.on('disconnect', (err) => {

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -4,4 +4,4 @@ const { createServer } = require('http')
 
 createServer((req, res) => {
   res.end('hello world')
-}).listen(3009)
+}).listen('/var/tmp/undici.sock')


### PR DESCRIPTION
EDIT: Weird results resolved. Linux network stack tuning.

Trying to add some pipelining to benchmarks. However, I'm getting weird results when running on a server vs local computer.

OSX MacBook/Node 14
```
http - keepalive x 386 ops/sec ±3.51% (265 runs sampled)
undici - pipeline x 573 ops/sec ±5.17% (260 runs sampled)
undici - request x 877 ops/sec ±5.51% (272 runs sampled)
undici - stream x 1,197 ops/sec ±1.66% (262 runs sampled)
undici - dispatch x 1,351 ops/sec ±2.66% (257 runs sampled)
undici - noop x 2,754 ops/sec ±3.66% (273 runs sampled)
```

Linux Supermicro/Docker/Node 14
```
http - keepalive x 685 ops/sec ±3.13% (271 runs sampled)
undici - pipeline x 374 ops/sec ±5.39% (228 runs sampled)
undici - request x 415 ops/sec ±3.54% (228 runs sampled)
undici - stream x 471 ops/sec ±3.60% (227 runs sampled)
undici - dispatch x 469 ops/sec ±3.71% (225 runs sampled)
undici - noop x 646 ops/sec ±3.77% (219 runs sampled)
```