### PR TITLE
test: add socket error and remove reconnect from client

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -626,7 +626,11 @@ function onSocketError (err) {
     while (client.pending && client[kQueue][client[kPendingIdx]].host === client[kHost]) {
       client[kQueue][client[kPendingIdx]++].onError(err)
     }
-  } else if (!client.running) {
+  } else if (
+    !client.running &&
+    err.code !== 'UND_ERR_INFO' &&
+    err.code !== 'UND_ERR_SOCKET'
+  ) {
     assert(client[kPendingIdx] === client[kRunningIdx])
     // Error is not caused by running request and not a recoverable
     // socket error.

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -927,3 +927,15 @@ test('invalid body chunk does not crash', (t) => {
     })
   })
 })
+
+test('socket errors', t => {
+  t.plan(2)
+  const client = new Client('http://localhost:5554')
+  t.tearDown(client.destroy.bind(client))
+
+  client.request({ path: '/', method: 'GET' }, (err, data) => {
+    t.ok(err)
+    t.is('ECONNREFUSED', err.code)
+    t.end()
+  })
+})


### PR DESCRIPTION
Don't error requests in client `onSocketError` on these codes:

* `UND_ERR_INFO`
* `UND_ERR_SOCKET`

Modify `client-reconnect.js` test. Add socket error test.