### PR TITLE
core/request.js: http proxies support

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -23,8 +23,8 @@ class Request {
     upgrade,
     requestTimeout
   }, handler) {
-    if (typeof path !== 'string' || path[0] !== '/') {
-      throw new InvalidArgumentError('path must be a valid path')
+    if (typeof path !== 'string') {
+      throw new InvalidArgumentError('path must be a string')
     }
 
     if (typeof method !== 'string') {


### PR DESCRIPTION
To support http proxies path must accept url.

e.g.
```
GET http://example.com/ HTTP/1.1
```