### PR TITLE
fix(core/request): handle header set to null

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -155,7 +155,7 @@ class Request {
 }
 
 function processHeader (request, key, val) {
-  if (typeof val === 'object') {
+  if (typeof val === 'object' && val !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   } else if (val === undefined) {
     return

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -21,7 +21,7 @@ test('dispatch invalid opts', (t) => {
 })
 
 test('basic dispatch get', (t) => {
-  t.plan(10)
+  t.plan(11)
 
   const server = http.createServer((req, res) => {
     t.strictEqual('/', req.url)
@@ -29,6 +29,7 @@ test('basic dispatch get', (t) => {
     t.strictEqual('localhost', req.headers.host)
     t.strictEqual(undefined, req.headers.foo)
     t.strictEqual('bar', req.headers.bar)
+    t.strictEqual('null', req.headers.baz)
     t.strictEqual(undefined, req.headers['content-length'])
     res.end('hello')
   })
@@ -36,7 +37,8 @@ test('basic dispatch get', (t) => {
 
   const reqHeaders = {
     foo: undefined,
-    bar: 'bar'
+    bar: 'bar',
+    baz: null
   }
 
   server.listen(0, () => {

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { Client, errors } = require('..')
 
 test('invalid headers', (t) => {
-  t.plan(11)
+  t.plan(10)
 
   const client = new Client('http://localhost:3000')
   t.teardown(client.destroy.bind(client))
@@ -71,16 +71,6 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: {
       foo: {}
-    }
-  }, (err, data) => {
-    t.ok(err instanceof errors.InvalidArgumentError)
-  })
-
-  client.request({
-    path: '/',
-    method: 'GET',
-    headers: {
-      asd: null
     }
   }, (err, data) => {
     t.ok(err instanceof errors.InvalidArgumentError)


### PR DESCRIPTION
If a header is set to null it is casted to the string 'null'.

This is the same behavior we have in Node's HTTP client if I am not mistaken.

Note: I am not sure this is a fix, though. I can amend the commit :wink: 

Fix #416 