### PR TITLE
test: support earliest versions in range in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.16.0, 10.x, 12.3.0, 12.x, 14.0.0, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
I'm attempting to use `undici` in a library that supports entire semver major ranges of Node.js. I found that on Windows with Node 12.0.0 there was an abort when used with my library's test suite.

This is an attempt to establish an explicit baseline version range to support.

**EDIT:** I tested locally and the minimum versions included now are the minimum ones that would pass on my machine.