### PR TITLE
fix(benchmarks): fix timeout errors

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -53,7 +53,7 @@ suite
                 callback()
               }
             }))
-            .on('close', resolve)
+            .on('finish', resolve)
         })
       }))).then(() => deferred.resolve())
     }
@@ -72,7 +72,7 @@ suite
               callback()
             }
           }))
-          .on('close', resolve)
+          .on('finish', resolve)
       }))).then(() => deferred.resolve())
     }
   })
@@ -89,7 +89,7 @@ suite
                   callback()
                 }
               }))
-              .on('close', resolve)
+              .on('finish', resolve)
           })
       }))).then(() => deferred.resolve())
     }
@@ -167,7 +167,7 @@ class SimpleRequest {
       write (chunk, encoding, callback) {
         callback()
       }
-    }).on('close', resolve)
+    }).on('finish', resolve)
   }
 
   onConnect (abort) {


### PR DESCRIPTION
The use of `close` event was causing timeouts. Switching to the `finish` event fixed it.

Fixes #456 