### PR TITLE
Fix for node 12.19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16.0, 10.x, 12.3.0, 12.x, 14.0.0, 14.x]
+        node-version: [10.16.0, 10.x, 12.3.0, 12.18.0, 12.x, 14.0.0, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -59,7 +59,9 @@ const {
 
 const kHostHeader = Symbol('host header')
 
-const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
+const nodeVersions = process.version.split('.')
+const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
+const nodeMinorVersion = parseInt(nodeVersions[1])
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
 class Client extends EventEmitter {
@@ -346,11 +348,19 @@ class Client extends EventEmitter {
 class Parser extends HTTPParser {
   constructor (client, socket) {
     /* istanbul ignore next */
-    if (nodeMajorVersion === 12) {
+    if (nodeMajorVersion === 12 && nodeMinorVersion < 19) {
       super()
       this.initialize(
         HTTPParser.RESPONSE,
         {},
+        client[kHeadersTimeout]
+      )
+    } else if (nodeMajorVersion === 12 && nodeMinorVersion >= 19) {
+      super()
+      this.initialize(
+        HTTPParser.RESPONSE,
+        {},
+        client[kMaxHeadersSize],
         client[kHeadersTimeout]
       )
     } else if (nodeMajorVersion > 12) {


### PR DESCRIPTION
Unfortunately the private API of the HTTP parser changed in 12.19.0. It would crash without this fix.