### PR TITLE
fix: simpler and faster idle timeout

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -44,7 +44,7 @@ const {
   kPipelining,
   kSocket,
   kSocketPath,
-  kKeepAliveTimeout,
+  kKeepAliveTimeoutValue,
   kMaxHeadersSize,
   kKeepAliveMaxTimeout,
   kKeepAliveTimeoutThreshold,
@@ -143,7 +143,7 @@ class Client extends EventEmitter {
     this[kKeepAliveDefaultTimeout] = keepAliveTimeout == null ? 4e3 : keepAliveTimeout
     this[kKeepAliveMaxTimeout] = keepAliveMaxTimeout == null ? 600e3 : keepAliveMaxTimeout
     this[kKeepAliveTimeoutThreshold] = keepAliveTimeoutThreshold == null ? 1e3 : keepAliveTimeoutThreshold
-    this[kKeepAliveTimeout] = this[kKeepAliveDefaultTimeout]
+    this[kKeepAliveTimeoutValue] = this[kKeepAliveDefaultTimeout]
     this[kClosed] = false
     this[kDestroyed] = false
     this[kTLSServerName] = (tls && tls.servername) || null
@@ -517,10 +517,10 @@ class Parser extends HTTPParser {
         if (timeout < 1e3) {
           client[kReset] = true
         } else {
-          client[kKeepAliveTimeout] = timeout
+          client[kKeepAliveTimeoutValue] = timeout
         }
       } else {
-        client[kKeepAliveTimeout] = client[kKeepAliveDefaultTimeout]
+        client[kKeepAliveTimeoutValue] = client[kKeepAliveDefaultTimeout]
       }
     } else {
       // Stop more requests from being dispatched.
@@ -845,7 +845,7 @@ function _resume (client, sync) {
 
     if (client[kSocket]) {
       const socket = client[kSocket]
-      const timeout = client.running ? 0 : client[kKeepAliveTimeout]
+      const timeout = client.running ? 0 : client[kKeepAliveTimeoutValue]
 
       if (socket[kIdleTimeoutValue] !== timeout) {
         clearTimeout(socket[kIdleTimeout])

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -32,7 +32,7 @@ const {
   kQueue,
   kNeedDrain,
   kTLSServerName,
-  kIdleTimeout,
+  kKeepAliveDefaultTimeout,
   kHostHeader,
   kTLSOpts,
   kClosed,
@@ -48,7 +48,9 @@ const {
   kMaxHeadersSize,
   kKeepAliveMaxTimeout,
   kKeepAliveTimeoutThreshold,
-  kTLSSession
+  kTLSSession,
+  kIdleTimeout,
+  kIdleTimeoutValue
 } = require('./symbols')
 
 const nodeVersions = process.version.split('.')
@@ -138,10 +140,10 @@ class Client extends EventEmitter {
     this[kMaxHeadersSize] = maxHeaderSize || 16384
     this[kUrl] = url
     this[kSocketPath] = socketPath
-    this[kIdleTimeout] = keepAliveTimeout == null ? 4e3 : keepAliveTimeout
+    this[kKeepAliveDefaultTimeout] = keepAliveTimeout == null ? 4e3 : keepAliveTimeout
     this[kKeepAliveMaxTimeout] = keepAliveMaxTimeout == null ? 600e3 : keepAliveMaxTimeout
     this[kKeepAliveTimeoutThreshold] = keepAliveTimeoutThreshold == null ? 1e3 : keepAliveTimeoutThreshold
-    this[kKeepAliveTimeout] = this[kIdleTimeout]
+    this[kKeepAliveTimeout] = this[kKeepAliveDefaultTimeout]
     this[kClosed] = false
     this[kDestroyed] = false
     this[kTLSServerName] = (tls && tls.servername) || null
@@ -393,12 +395,6 @@ class Parser extends HTTPParser {
       return
     }
 
-    // When the underlying `net.Socket` instance is consumed - no
-    // `data` events are emitted, and thus `socket.setTimeout` fires the
-    // callback even if the data is constantly flowing into the socket.
-    // See, https://github.com/nodejs/node/commit/ec2822adaad76b126b5cccdeaa1addf2376c9aa6
-    socket._unrefTimer()
-
     // This logic cannot live in kOnHeadersComplete since we
     // have no way of slicing the parsing buffer without knowing
     // the offset which is only provided in kOnExecute.
@@ -524,7 +520,7 @@ class Parser extends HTTPParser {
           client[kKeepAliveTimeout] = timeout
         }
       } else {
-        client[kKeepAliveTimeout] = client[kIdleTimeout]
+        client[kKeepAliveTimeout] = client[kKeepAliveDefaultTimeout]
       }
     } else {
       // Stop more requests from being dispatched.
@@ -649,10 +645,6 @@ function onSocketConnect () {
   resume(client)
 }
 
-function onIdleTimeout () {
-  util.destroy(this, new InformationalError('socket idle timeout'))
-}
-
 function onSocketError (err) {
   const { [kClient]: client } = this
 
@@ -726,6 +718,10 @@ function onSocketSession (session) {
 }
 
 function detachSocket (socket) {
+  clearTimeout(socket[kIdleTimeout])
+  socket[kIdleTimeout] = null
+  socket[kIdleTimeoutValue] = null
+
   socket[kParser].destroy()
   socket[kParser] = null
   socket[kPause] = null
@@ -733,7 +729,6 @@ function detachSocket (socket) {
   socket[kClient] = null
   socket[kError] = null
   socket
-    .removeListener('timeout', onIdleTimeout)
     .removeListener('session', onSocketSession)
     .removeListener('error', onSocketError)
     .removeListener('end', onSocketEnd)
@@ -778,6 +773,8 @@ function connect (client) {
     parser.consume(socket._handle._externalStream)
   }
 
+  socket[kIdleTimeout] = null
+  socket[kIdleTimeoutValue] = null
   socket[kPause] = socketPause.bind(socket)
   socket[kResume] = socketResume.bind(socket)
   socket[kError] = null
@@ -785,9 +782,7 @@ function connect (client) {
   socket[kClient] = client
   socket
     .setNoDelay(true)
-    .setTimeout(client[kIdleTimeout])
     .on(protocol === 'https:' ? 'secureConnect' : 'connect', onSocketConnect)
-    .on('timeout', onIdleTimeout)
     .on('error', onSocketError)
     .on('end', onSocketEnd)
     .on('close', onSocketClose)
@@ -849,10 +844,17 @@ function _resume (client, sync) {
     }
 
     if (client[kSocket]) {
+      const socket = client[kSocket]
       const timeout = client.running ? 0 : client[kKeepAliveTimeout]
 
-      if (client[kSocket].timeout !== timeout) {
-        client[kSocket].setTimeout(timeout)
+      if (socket[kIdleTimeoutValue] !== timeout) {
+        clearTimeout(socket[kIdleTimeout])
+        if (timeout) {
+          socket[kIdleTimeout] = setTimeout((socket) => {
+            util.destroy(socket, new InformationalError('socket idle timeout'))
+          }, timeout, socket)
+        }
+        socket[kIdleTimeoutValue] = timeout
       }
     }
 
@@ -874,6 +876,7 @@ function _resume (client, sync) {
         }
         continue
       }
+
       return
     } else {
       client[kNeedDrain] = 2

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -7,6 +7,8 @@ module.exports = {
   kResume: Symbol('resume'),
   kPause: Symbol('pause'),
   kIdleTimeout: Symbol('idle timeout'),
+  kIdleTimeoutValue: Symbol('idle timeout value'),
+  kKeepAliveDefaultTimeout: Symbol('default keep alive timeout'),
   kKeepAliveMaxTimeout: Symbol('max keep alive timeout'),
   kKeepAliveTimeoutThreshold: Symbol('keep alive timeout threshold'),
   kKeepAliveTimeout: Symbol('keep alive timeout'),

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -11,7 +11,7 @@ module.exports = {
   kKeepAliveDefaultTimeout: Symbol('default keep alive timeout'),
   kKeepAliveMaxTimeout: Symbol('max keep alive timeout'),
   kKeepAliveTimeoutThreshold: Symbol('keep alive timeout threshold'),
-  kKeepAliveTimeout: Symbol('keep alive timeout'),
+  kKeepAliveTimeoutValue: Symbol('keep alive timeout'),
   kKeepAlive: Symbol('keep alive'),
   kTLSServerName: Symbol('server name'),
   kHost: Symbol('host'),


### PR DESCRIPTION
Avoid using socket timeout. We don't need to refresh the timer on every chunk.