### PR TITLE
fix: Changing hardcoded `socketPath` to utilize `os.tmpdir()`

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -3,6 +3,8 @@ const { Writable } = require('stream')
 const http = require('http')
 const Benchmark = require('benchmark')
 const { Client, Pool } = require('..')
+const os = require('os')
+const path = require('path')
 
 // # Start the Node.js server
 // node benchmarks/server.js
@@ -20,7 +22,7 @@ if (process.env.PORT) {
   dest.url = `http://localhost:${process.env.PORT}`
 } else {
   dest.url = 'http://localhost'
-  dest.socketPath = '/var/tmp/undici.sock'
+  dest.socketPath = path.join(os.tmpdir(), 'undici.sock')
 }
 
 const httpNoAgent = {

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const { createServer } = require('http')
+const os = require('os')
+const path = require('path')
 
-const port = process.env.PORT || '/var/tmp/undici.sock'
+const port = process.env.PORT || path.join(os.tmpdir(), 'undici.sock')
 const timeout = parseInt(process.env.TIMEOUT, 10) || 1
 
 createServer((req, res) => {


### PR DESCRIPTION
Very minor change to make it portable for *nix benchmarking.

Noticed the benchmark fails in windows but is unrelated to this PR (pre-existing).