### PR TITLE
Update abort docs to native AbortController

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16.0, 10.x, 12.3.0, 12.18.0, 12.x, 14.0.0, 14.x]
+        node-version: [10.16.0, 10.x, 12.3.0, 12.18.0, 12.x, 14.0.0, 14.x, 15.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Options:
   Default: `null`.
 * `headers: Object|Array|Null`, an object with header-value pairs or an array with header-value pairs bi-indexed (`['header1', 'value1', 'header2', 'value2']`).
   Default: `null`.
-* `signal: AbortController|EventEmitter|Null`
+* `signal: AbortSignal|EventEmitter|Null`
   Default: `null`.
 - `headersTimeout: Number`, the timeout after which a request will time out, in
   milliseconds. Monitors time between receiving a complete headers. 
@@ -185,10 +185,10 @@ idempotent requests with a stream request body.
 ##### Aborting a request
 
 A request can may be aborted using either an `AbortController` or an `EventEmitter`.
-To use `AbortController`, you will need to `npm i abort-controller`.
+To use `AbortController` in Node.js versions earlier than 15, you will need to
+install a shim - `npm i abort-controller`.
 
 ```js
-const { AbortController } = require('abort-controller')
 const { Client } = require('undici')
 
 const client = new Client('http://localhost:3000')
@@ -377,7 +377,7 @@ Options:
   Default: `GET`
 * `headers: Object|Null`, an object with header-value pairs.
   Default: `null`
-* `signal: AbortController|EventEmitter|Null`.
+* `signal: AbortSignal|EventEmitter|Null`.
   Default: `null`
 * `requestTimeout: Number`, the timeout after which a request will time out, in
   milliseconds. Monitors time between request being enqueued and receiving
@@ -405,7 +405,7 @@ Options:
 * `opaque: Any`
 * `headers: Object|Null`, an object with header-value pairs.
   Default: `null`
-* `signal: AbortController|EventEmitter|Null`.
+* `signal: AbortSignal|EventEmitter|Null`.
   Default: `null`
 * `requestTimeout: Number`, the timeout after which a request will time out, in
   milliseconds. Monitors time between request being enqueued and receiving

--- a/test/abort-controller.js
+++ b/test/abort-controller.js
@@ -1,123 +1,64 @@
 'use strict'
 
 const { test } = require('tap')
-const { AbortController } = require('abort-controller')
+const { AbortController: NPMAbortController } = require('abort-controller')
 const { Client, errors } = require('..')
 const { createServer } = require('http')
 const { createReadStream } = require('fs')
 
-test('Abort before sending request (no body)', (t) => {
-  t.plan(3)
+const controllers = [{
+  AbortControllerImpl: NPMAbortController,
+  controllerName: 'npm-abortcontroller-shim'
+}]
 
-  let count = 0
-  const server = createServer((req, res) => {
-    if (count === 1) {
-      t.fail('The second request should never be executed')
-    }
-    count += 1
-    res.end('hello')
+if (global.AbortController) {
+  controllers.push({
+    AbortControllerImpl: global.AbortController,
+    controllerName: 'native-abortcontroller'
   })
-  t.teardown(server.close.bind(server))
+}
+for (const { AbortControllerImpl, controllerName } of controllers) {
+  test(`Abort ${controllerName} before sending request (no body)`, (t) => {
+    t.plan(3)
 
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    const abortController = new AbortController()
-    t.teardown(client.destroy.bind(client))
+    let count = 0
+    const server = createServer((req, res) => {
+      if (count === 1) {
+        t.fail('The second request should never be executed')
+      }
+      count += 1
+      res.end('hello')
+    })
+    t.teardown(server.close.bind(server))
 
-    client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.error(err)
-      const bufs = []
-      response.body.on('data', (buf) => {
-        bufs.push(buf)
+    server.listen(0, () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      const abortController = new AbortControllerImpl()
+      t.teardown(client.destroy.bind(client))
+
+      client.request({ path: '/', method: 'GET' }, (err, response) => {
+        t.error(err)
+        const bufs = []
+        response.body.on('data', (buf) => {
+          bufs.push(buf)
+        })
+        response.body.on('end', () => {
+          t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+        })
       })
-      response.body.on('end', () => {
-        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
-      })
-    })
 
-    client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.ok(err instanceof errors.RequestAbortedError)
-    })
-
-    abortController.abort()
-  })
-})
-
-test('Abort while waiting response (no body)', (t) => {
-  t.plan(1)
-
-  const abortController = new AbortController()
-  const server = createServer((req, res) => {
-    abortController.abort()
-    res.setHeader('content-type', 'text/plain')
-    res.end('hello world')
-  })
-  t.teardown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.teardown(client.destroy.bind(client))
-
-    client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.ok(err instanceof errors.RequestAbortedError)
-    })
-  })
-})
-
-test('Abort while waiting response (write headers started) (no body)', (t) => {
-  t.plan(1)
-
-  const abortController = new AbortController()
-  const server = createServer((req, res) => {
-    res.writeHead(200, { 'content-type': 'text/plain' })
-    res.flushHeaders()
-    abortController.abort()
-    res.end('hello world')
-  })
-  t.teardown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.teardown(client.destroy.bind(client))
-
-    client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.ok(err instanceof errors.RequestAbortedError)
-    })
-  })
-})
-
-test('Abort while waiting response (write headers and write body started) (no body)', (t) => {
-  t.plan(2)
-
-  const abortController = new AbortController()
-  const server = createServer((req, res) => {
-    res.writeHead(200, { 'content-type': 'text/plain' })
-    res.write('hello')
-    res.end('world')
-  })
-  t.teardown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.teardown(client.destroy.bind(client))
-
-    client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.error(err)
-      response.body.on('data', () => {
-        abortController.abort()
-      })
-      response.body.on('error', err => {
+      client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.ok(err instanceof errors.RequestAbortedError)
       })
+
+      abortController.abort()
     })
   })
-})
 
-function waitingWithBody (body, type) {
-  test(`Abort while waiting response (with body ${type})`, (t) => {
+  test(`Abort ${controllerName} while waiting response (no body)`, (t) => {
     t.plan(1)
 
-    const abortController = new AbortController()
+    const abortController = new AbortControllerImpl()
     const server = createServer((req, res) => {
       abortController.abort()
       res.setHeader('content-type', 'text/plain')
@@ -129,22 +70,16 @@ function waitingWithBody (body, type) {
       const client = new Client(`http://localhost:${server.address().port}`)
       t.teardown(client.destroy.bind(client))
 
-      client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+      client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.ok(err instanceof errors.RequestAbortedError)
       })
     })
   })
-}
 
-waitingWithBody('hello', 'string')
-waitingWithBody(createReadStream(__filename), 'stream')
-waitingWithBody(new Uint8Array([42]), 'Uint8Array')
-
-function writeHeadersStartedWithBody (body, type) {
-  test(`Abort while waiting response (write headers started) (with body ${type})`, (t) => {
+  test(`Abort ${controllerName} while waiting response (write headers started) (no body)`, (t) => {
     t.plan(1)
 
-    const abortController = new AbortController()
+    const abortController = new AbortControllerImpl()
     const server = createServer((req, res) => {
       res.writeHead(200, { 'content-type': 'text/plain' })
       res.flushHeaders()
@@ -157,22 +92,16 @@ function writeHeadersStartedWithBody (body, type) {
       const client = new Client(`http://localhost:${server.address().port}`)
       t.teardown(client.destroy.bind(client))
 
-      client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+      client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.ok(err instanceof errors.RequestAbortedError)
       })
     })
   })
-}
 
-writeHeadersStartedWithBody('hello', 'string')
-writeHeadersStartedWithBody(createReadStream(__filename), 'stream')
-writeHeadersStartedWithBody(new Uint8Array([42]), 'Uint8Array')
-
-function writeBodyStartedWithBody (body, type) {
-  test(`Abort while waiting response (write headers and write body started) (with body ${type})`, (t) => {
+  test(`Abort ${controllerName} while waiting response (write headers and write body started) (no body)`, (t) => {
     t.plan(2)
 
-    const abortController = new AbortController()
+    const abortController = new AbortControllerImpl()
     const server = createServer((req, res) => {
       res.writeHead(200, { 'content-type': 'text/plain' })
       res.write('hello')
@@ -184,7 +113,7 @@ function writeBodyStartedWithBody (body, type) {
       const client = new Client(`http://localhost:${server.address().port}`)
       t.teardown(client.destroy.bind(client))
 
-      client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+      client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.error(err)
         response.body.on('data', () => {
           abortController.abort()
@@ -195,8 +124,92 @@ function writeBodyStartedWithBody (body, type) {
       })
     })
   })
-}
 
-writeBodyStartedWithBody('hello', 'string')
-writeBodyStartedWithBody(createReadStream(__filename), 'stream')
-writeBodyStartedWithBody(new Uint8Array([42]), 'Uint8Array')
+  function waitingWithBody (body, type) { // eslint-disable-line
+    test(`Abort ${controllerName} while waiting response (with body ${type})`, (t) => {
+      t.plan(1)
+
+      const abortController = new AbortControllerImpl()
+      const server = createServer((req, res) => {
+        abortController.abort()
+        res.setHeader('content-type', 'text/plain')
+        res.end('hello world')
+      })
+      t.teardown(server.close.bind(server))
+
+      server.listen(0, () => {
+        const client = new Client(`http://localhost:${server.address().port}`)
+        t.teardown(client.destroy.bind(client))
+
+        client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+          t.ok(err instanceof errors.RequestAbortedError)
+        })
+      })
+    })
+  }
+
+  waitingWithBody('hello', 'string')
+  waitingWithBody(createReadStream(__filename), 'stream')
+  waitingWithBody(new Uint8Array([42]), 'Uint8Array')
+
+  function writeHeadersStartedWithBody (body, type) {  // eslint-disable-line
+    test(`Abort ${controllerName} while waiting response (write headers started) (with body ${type})`, (t) => {
+      t.plan(1)
+
+      const abortController = new AbortControllerImpl()
+      const server = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' })
+        res.flushHeaders()
+        abortController.abort()
+        res.end('hello world')
+      })
+      t.teardown(server.close.bind(server))
+
+      server.listen(0, () => {
+        const client = new Client(`http://localhost:${server.address().port}`)
+        t.teardown(client.destroy.bind(client))
+
+        client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+          t.ok(err instanceof errors.RequestAbortedError)
+        })
+      })
+    })
+  }
+
+  writeHeadersStartedWithBody('hello', 'string')
+  writeHeadersStartedWithBody(createReadStream(__filename), 'stream')
+  writeHeadersStartedWithBody(new Uint8Array([42]), 'Uint8Array')
+
+  function writeBodyStartedWithBody (body, type) { // eslint-disable-line
+    test(`Abort ${controllerName} while waiting response (write headers and write body started) (with body ${type})`, (t) => {
+      t.plan(2)
+
+      const abortController = new AbortControllerImpl()
+      const server = createServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' })
+        res.write('hello')
+        res.end('world')
+      })
+      t.teardown(server.close.bind(server))
+
+      server.listen(0, () => {
+        const client = new Client(`http://localhost:${server.address().port}`)
+        t.teardown(client.destroy.bind(client))
+
+        client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
+          t.error(err)
+          response.body.on('data', () => {
+            abortController.abort()
+          })
+          response.body.on('error', err => {
+            t.ok(err instanceof errors.RequestAbortedError)
+          })
+        })
+      })
+    })
+  }
+
+  writeBodyStartedWithBody('hello', 'string')
+  writeBodyStartedWithBody(createReadStream(__filename), 'stream')
+  writeBodyStartedWithBody(new Uint8Array([42]), 'Uint8Array')
+}


### PR DESCRIPTION
Noticed this very randomly ^^

We have native abortcontroller so it can be used.

Also - a few of the places used `AbortController` for signals incorrectly.

Cheers