### PR TITLE
Coverage badge

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,8 +30,11 @@ jobs:
 
     - name: Unit test
       run: |
-        npm run coverage
+        npm run coverage:ci
 
     - name: Test types
       run: |
         npm run test:typescript
+
+    - name: Coverage report
+      uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # undici
 
-![Node CI](https://github.com/mcollina/undici/workflows/Node%20CI/badge.svg)  [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![npm version](https://badge.fury.io/js/undici.svg)](https://badge.fury.io/js/undici)
+![Node CI](https://github.com/mcollina/undici/workflows/Node%20CI/badge.svg)  [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![npm version](https://badge.fury.io/js/undici.svg)](https://badge.fury.io/js/undici) [![codecov](https://codecov.io/gh/nodejs/undici/branch/master/graph/badge.svg)](https://codecov.io/gh/nodejs/undici)
 
 A HTTP/1.1 client, written from scratch for Node.js.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "tap test/*.{mjs,js} --no-coverage && jest test/jest/test",
     "test:typescript": "tsd",
     "coverage": "standard | snazzy && tap test/*.js",
+    "coverage:ci": "npm run coverage -- --coverage-report=lcovonly",
     "bench": "npx concurrently -k -s first \"node benchmarks/server.js\" \"node -e 'setTimeout(() => {}, 1000)' && node benchmarks\""
   },
   "repository": {


### PR DESCRIPTION
* setup codecov coverage report in CI workflow
* add coverage badge in README

Fixes #397 

There is no custom configuration setup using `codecov.yml` file, I don't see anything we could add ATM. The config reference:

https://docs.codecov.io/docs/codecov-yaml