### PR TITLE
fix: clear timeouts

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -480,22 +480,8 @@ class Parser extends HTTPParser {
       }
 
       if (!socket.destroyed && !request.aborted) {
-        clearTimeout(socket[kIdleTimeout])
-        socket[kIdleTimeout] = null
-        socket[kIdleTimeoutValue] = null
+        detachSocket(socket)
 
-        setImmediate((self) => self.close(), socket[kParser])
-        socket[kParser] = null
-
-        socket[kClient] = null
-        socket[kError] = null
-        socket
-          .removeListener('session', onSocketSession)
-          .removeListener('error', onSocketError)
-          .removeListener('end', onSocketEnd)
-          .removeListener('close', onSocketClose)
-
-        client[kSocket] = null
         client[kQueue][client[kRunningIdx]++] = null
         client.emit('disconnect', new InformationalError('upgrade'))
 
@@ -746,15 +732,34 @@ function onSocketEnd () {
   util.destroy(this, new SocketError('other side closed'))
 }
 
-function onSocketClose () {
-  const { [kClient]: client, [kParser]: parser } = this
-
-  const err = this[kError] || new SocketError('closed')
+function detachSocket (socket) {
+  const { [kClient]: client } = socket
 
   client[kSocket] = null
 
-  parser.unconsume()
-  setImmediate((self) => self.close(), parser)
+  clearTimeout(socket[kIdleTimeout])
+  socket[kIdleTimeout] = null
+  socket[kIdleTimeoutValue] = null
+
+  setImmediate((parser) => parser.close(), socket[kParser])
+  socket[kParser].unconsume()
+  socket[kParser] = null
+
+  socket[kClient] = null
+  socket[kError] = null
+  socket
+    .removeListener('session', onSocketSession)
+    .removeListener('error', onSocketError)
+    .removeListener('end', onSocketEnd)
+    .removeListener('close', onSocketClose)
+}
+
+function onSocketClose () {
+  const { [kClient]: client } = this
+
+  const err = this[kError] || new SocketError('closed')
+
+  detachSocket(this)l
 
   if (err.code !== 'UND_ERR_INFO') {
     // Evict session on errors.

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -481,6 +481,7 @@ class Parser extends HTTPParser {
 
       if (!socket.destroyed && !request.aborted) {
         detachSocket(socket)
+        client[kSocket] = null
 
         client[kQueue][client[kRunningIdx]++] = null
         client.emit('disconnect', new InformationalError('upgrade'))
@@ -733,10 +734,6 @@ function onSocketEnd () {
 }
 
 function detachSocket (socket) {
-  const { [kClient]: client } = socket
-
-  client[kSocket] = null
-
   clearTimeout(socket[kIdleTimeout])
   socket[kIdleTimeout] = null
   socket[kIdleTimeoutValue] = null
@@ -760,6 +757,7 @@ function onSocketClose () {
   const err = this[kError] || new SocketError('closed')
 
   detachSocket(this)
+  client[kSocket] = null
 
   if (err.code !== 'UND_ERR_INFO') {
     // Evict session on errors.

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -759,7 +759,7 @@ function onSocketClose () {
 
   const err = this[kError] || new SocketError('closed')
 
-  detachSocket(this)l
+  detachSocket(this)
 
   if (err.code !== 'UND_ERR_INFO') {
     // Evict session on errors.

--- a/test/client-keep-alive.js
+++ b/test/client-keep-alive.js
@@ -5,6 +5,7 @@ const { Client } = require('..')
 const { kConnect } = require('../lib/core/symbols')
 const { createServer } = require('net')
 const http = require('http')
+const FakeTimers = require('@sinonjs/fake-timers')
 
 test('keep-alive header', (t) => {
   t.plan(2)
@@ -43,6 +44,9 @@ test('keep-alive header', (t) => {
 test('keep-alive header 0', (t) => {
   t.plan(2)
 
+  const clock = FakeTimers.install()
+  t.teardown(clock.uninstall.bind(clock))
+
   const server = createServer((socket) => {
     socket.write('HTTP/1.1 200 OK\r\n')
     socket.write('Content-Length: 0\r\n')
@@ -64,13 +68,10 @@ test('keep-alive header 0', (t) => {
     }, (err, { body }) => {
       t.error(err)
       body.on('end', () => {
-        const timeout = setTimeout(() => {
-          t.fail()
-        }, 600)
         client.on('disconnect', () => {
           t.pass()
-          clearTimeout(timeout)
         })
+        clock.tick(600)
       }).resume()
     })
   })

--- a/test/client.js
+++ b/test/client.js
@@ -8,10 +8,6 @@ const { Readable } = require('stream')
 const { kSocket } = require('../lib/core/symbols')
 const EE = require('events')
 
-setTimeout(() => {
-  throw new Error('timeout')
-}, 2e3).unref()
-
 test('basic get', (t) => {
   t.plan(23)
 
@@ -33,7 +29,9 @@ test('basic get', (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://localhost:${server.address().port}`, {
+      keepAliveTimeout: 300e3
+    })
     t.tearDown(client.close.bind(client))
 
     const signal = new EE()

--- a/test/client.js
+++ b/test/client.js
@@ -8,6 +8,10 @@ const { Readable } = require('stream')
 const { kSocket } = require('../lib/core/symbols')
 const EE = require('events')
 
+setTimeout(() => {
+  throw new Error('timeout')
+}, 2e3).unref()
+
 test('basic get', (t) => {
   t.plan(23)
 


### PR DESCRIPTION
idleTimeout was not cleared when socket is destroyed. Causing process to keep executing for 4s.