### PR TITLE
fix: fallback to url as servername

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -57,6 +57,15 @@ const nodeMajorVersion = parseInt(nodeVersions[0].slice(1))
 const nodeMinorVersion = parseInt(nodeVersions[1])
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
+function getServerName (client, host) {
+  return (
+    util.getServerName(host) ||
+    (client[kTLSOpts] && client[kTLSOpts].servername) ||
+    util.getServerName(client[kUrl].host || client[kUrl].hostname) ||
+    null
+  )
+}
+
 class Client extends EventEmitter {
   constructor (url, {
     maxHeaderSize,
@@ -145,9 +154,9 @@ class Client extends EventEmitter {
     this[kKeepAliveTimeoutValue] = this[kKeepAliveDefaultTimeout]
     this[kClosed] = false
     this[kDestroyed] = false
-    this[kTLSServerName] = (tls && tls.servername) || null
-    this[kHost] = null
     this[kTLSOpts] = tls
+    this[kTLSServerName] = getServerName(this)
+    this[kHost] = null
     this[kOnDestroyed] = []
     this[kWriting] = false
     this[kResuming] = 0 // 0, idle, 1, scheduled, 2 resuming
@@ -954,11 +963,7 @@ function _resume (client, sync) {
 
       client[kHost] = request.host
 
-      const servername = (
-        request.host &&
-        !/^\[/.test(request.host) &&
-        !net.isIP(request.host)
-      ) ? request.host : (client[kTLSOpts] && client[kTLSOpts].servername)
+      const servername = getServerName(client, request.host)
 
       if (client[kTLSServerName] !== servername) {
         client[kTLSServerName] = servername

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -4,11 +4,33 @@ const assert = require('assert')
 const { kDestroyed } = require('./symbols')
 const { IncomingMessage } = require('http')
 const util = require('util')
+const net = require('net')
 
 function nop () {}
 
 function isStream (body) {
   return !!(body && typeof body.on === 'function')
+}
+
+function getServerName (host) {
+  if (!host) {
+    return null
+  }
+
+  let servername = host
+
+  if (servername.startsWith('[')) {
+    const idx = servername.indexOf(']')
+    servername = idx === -1 ? servername : servername.substr(1, idx - 1)
+  } else {
+    servername = servername.split(':', 1)[0]
+  }
+
+  if (net.isIP(servername)) {
+    servername = null
+  }
+
+  return servername
 }
 
 function bodyLength (body) {
@@ -90,6 +112,7 @@ function errnoException (code, syscall) {
 
 module.exports = {
   nop,
+  getServerName,
   errnoException,
   isStream,
   isDestroyed,


### PR DESCRIPTION
Fails on certain endpoints. Not sure why and wasn't able to create a test. The endpoint I was able to reproduce with is unfortunately private.