### PR TITLE
fix: simplify timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Options:
   transport latency.
   Default: `1e3` milliseconds (1s).
 
+- `headersTimeout: Number`, the timeout after which a request will time out, in
+  milliseconds. Monitors time between receiving a complete headers.
+  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
+
+- `bodyTimeout: Number`, the timeout after which a request will time out, in
+  milliseconds. Monitors time between receiving a body data.
+  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
+
 - `pipelining: Number`, the amount of concurrent requests to be sent over the
   single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2).
   Carefully consider your workload and environment before enabling concurrent requests
@@ -94,12 +102,6 @@ Options:
   Default: `null`.
 * `signal: AbortSignal|EventEmitter|Null`
   Default: `null`.
-- `headersTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a complete headers.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
-- `bodyTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a body data.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
 * `idempotent: Boolean`, whether the requests can be safely retried or not.
   If `false` the request won't be sent until all preceding
   requests in the pipeline has completed.
@@ -385,9 +387,6 @@ Options:
   Default: `null`
 * `signal: AbortSignal|EventEmitter|Null`.
   Default: `null`
-- `headersTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a complete headers.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
 * `protocol: String`, a string of comma separated protocols, in descending preference order.
   Default: `Websocket`.
 
@@ -412,9 +411,6 @@ Options:
   Default: `null`
 * `signal: AbortSignal|EventEmitter|Null`.
   Default: `null`
-- `headersTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a complete headers.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
 
 The `data` parameter in `callback` is defined as follow:
 
@@ -442,12 +438,6 @@ Options:
   Default: `null`.
 * `headers: Object|Null`, an object with header-value pairs.
   Default: `null`.
-- `headersTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a complete headers.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
-- `bodyTimeout: Number`, the timeout after which a request will time out, in
-  milliseconds. Monitors time between receiving a body data.
-  Use `0` to disable it entirely. Default: `30e3` milliseconds (30s).
 * `idempotent: Boolean`, whether the requests can be safely retried or not.
   If `false` the request won't be sent until all preceding
   requests in the pipeline has completed.

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -13,6 +13,7 @@ const {
   TrailerMismatchError,
   InvalidArgumentError,
   RequestAbortedError,
+  HeadersTimeoutError,
   ClientDestroyedError,
   ClientClosedError,
   SocketError,
@@ -50,7 +51,9 @@ const {
   kKeepAliveTimeoutThreshold,
   kTLSSession,
   kIdleTimeout,
-  kIdleTimeoutValue
+  kIdleTimeoutValue,
+  kHeadersTimeout,
+  kBodyTimeout
 } = require('./symbols')
 
 const nodeVersions = process.version.split('.')
@@ -72,6 +75,7 @@ class Client extends EventEmitter {
     maxHeaderSize,
     headersTimeout,
     socketTimeout,
+    bodyTimeout,
     idleTimeout,
     keepAliveTimeout,
     maxKeepAliveTimeout,
@@ -85,10 +89,6 @@ class Client extends EventEmitter {
 
     if (socketTimeout !== undefined) {
       throw new InvalidArgumentError('unsupported socketTimeout')
-    }
-
-    if (headersTimeout !== undefined) {
-      throw new InvalidArgumentError('unsupported headersTimeout')
     }
 
     if (idleTimeout !== undefined) {
@@ -143,6 +143,14 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid keepAliveTimeoutThreshold')
     }
 
+    if (headersTimeout != null && (!Number.isInteger(headersTimeout) || headersTimeout < 0)) {
+      throw new InvalidArgumentError('headersTimeout must be a positive integer or zero')
+    }
+
+    if (bodyTimeout != null && (!Number.isInteger(bodyTimeout) || bodyTimeout < 0)) {
+      throw new InvalidArgumentError('bodyTimeout must be a positive integer or zero')
+    }
+
     this[kSocket] = null
     this[kReset] = false
     this[kPipelining] = pipelining != null ? pipelining : 1
@@ -169,6 +177,8 @@ class Client extends EventEmitter {
     }
     this[kTLSSession] = null
     this[kHostHeader] = `host: ${this[kUrl].hostname}${this[kUrl].port ? `:${this[kUrl].port}` : ''}\r\n`
+    this[kBodyTimeout] = bodyTimeout != null ? bodyTimeout : 30e3
+    this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 30e3
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -523,6 +533,11 @@ class Parser extends HTTPParser {
       return
     }
 
+    clearTimeout(this.timeout)
+    this.timeout = client[kBodyTimeout]
+      ? setTimeout(onBodyTimeout, client[kBodyTimeout], this)
+      : null
+
     // TODO: Check for content-length mismatch from server?
 
     assert(!this.upgrade)
@@ -596,10 +611,6 @@ class Parser extends HTTPParser {
       client[kReset] = true
     }
 
-    if (statusCode >= 200 && request.bodyTimeout) {
-      this.timeout = setTimeout(onBodyTimeout, request.bodyTimeout, this)
-    }
-
     try {
       if (request.onHeaders(statusCode, headers, this._resume) === false) {
         this._pause()
@@ -646,7 +657,7 @@ class Parser extends HTTPParser {
       return
     }
 
-    const { client, socket, statusCode, headers, upgrade, request, trailers, timeout } = this
+    const { client, socket, statusCode, headers, upgrade, request, trailers } = this
 
     if (socket.destroyed) {
       return
@@ -666,13 +677,13 @@ class Parser extends HTTPParser {
     this.request = null
     this.trailers = null
 
+    clearTimeout(this.timeout)
+    this.timeout = client[kHeadersTimeout]
+      ? setTimeout(onHeadersTimeout, client[kHeadersTimeout], this)
+      : null
+
     if (statusCode < 200) {
       return
-    }
-
-    if (timeout) {
-      clearTimeout(timeout)
-      this.timeout = null
     }
 
     try {
@@ -722,6 +733,7 @@ class Parser extends HTTPParser {
 
   destroy () {
     clearTimeout(this.timeout)
+    this.timeout = null
     this.unconsume()
     setImmediate((self) => self.close(), this)
   }
@@ -731,6 +743,10 @@ function onBodyTimeout (self) {
   if (!self.paused) {
     util.destroy(self.socket, new BodyTimeoutError())
   }
+}
+
+function onHeadersTimeout (self) {
+  util.destroy(self.socket, new HeadersTimeoutError())
 }
 
 function onSocketConnect () {
@@ -1057,6 +1073,11 @@ function _resume (client, sync) {
     }
 
     if (write(client, request)) {
+      const parser = client[kSocket][kParser]
+      if (!parser.timeout && client[kHeadersTimeout]) {
+        parser.timeout = setTimeout(onHeadersTimeout, client[kHeadersTimeout], parser)
+      }
+
       client[kPendingIdx]++
     } else {
       client[kQueue].splice(client[kPendingIdx], 1)

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -3,14 +3,11 @@
 const {
   InvalidArgumentError,
   RequestAbortedError,
-  HeadersTimeoutError,
   NotSupportedError
 } = require('./errors')
 const util = require('./util')
 const assert = require('assert')
 
-const kHeadersTimeout = Symbol('headers timeout')
-const kTimeout = Symbol('timeout')
 const kHandler = Symbol('handler')
 
 // Borrowed from https://gist.github.com/dperini/729294
@@ -40,14 +37,6 @@ class Request {
 
     if (upgrade && typeof upgrade !== 'string') {
       throw new InvalidArgumentError('upgrade must be a string')
-    }
-
-    if (headersTimeout != null && (!Number.isInteger(headersTimeout) || headersTimeout < 0)) {
-      throw new InvalidArgumentError('headersTimeout must be a positive integer or zero')
-    }
-
-    if (bodyTimeout != null && (!Number.isInteger(bodyTimeout) || bodyTimeout < 0)) {
-      throw new InvalidArgumentError('bodyTimeout must be a positive integer or zero')
     }
 
     this.method = method
@@ -115,67 +104,46 @@ class Request {
       throw new InvalidArgumentError('invalid onError method')
     }
 
-    this.bodyTimeout = bodyTimeout != null ? bodyTimeout : 30e3
-
-    this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 30e3
-    this[kTimeout] = null
     this[kHandler] = handler
   }
 
   onConnect (resume) {
     assert(!this.aborted)
 
-    const abort = (err) => {
+    return this[kHandler].onConnect((err) => {
       if (!this.aborted) {
         this.onError(err || new RequestAbortedError())
         resume()
       }
-    }
-
-    if (this[kHeadersTimeout]) {
-      clearTimeout(this[kTimeout])
-      this[kTimeout] = setTimeout((abort) => {
-        abort(new HeadersTimeoutError())
-      }, this[kHeadersTimeout], abort)
-    }
-
-    this[kHandler].onConnect(abort)
+    })
   }
 
   onHeaders (statusCode, headers, resume) {
     assert(!this.aborted)
-
-    if (statusCode >= 200) {
-      clearTimeout(this[kTimeout])
-      this[kTimeout] = null
-    } else if (this[kTimeout] && this[kTimeout].refresh) {
-      this[kTimeout].refresh()
-    }
 
     return this[kHandler].onHeaders(statusCode, headers, resume)
   }
 
   onBody (chunk, offset, length) {
     assert(!this.aborted)
+
     return this[kHandler].onData(chunk.slice(offset, offset + length))
   }
 
   onUpgrade (statusCode, headers, socket) {
     assert(!this.aborted)
 
-    clearTimeout(this[kTimeout])
-    this[kTimeout] = null
-
     if (typeof this[kHandler].onUpgrade !== 'function') {
       throw new InvalidArgumentError('invalid onUpgrade method')
     }
 
-    this[kHandler].onUpgrade(statusCode, headers, socket)
+    return this[kHandler].onUpgrade(statusCode, headers, socket)
   }
 
   onComplete (trailers) {
     assert(!this.aborted)
-    this[kHandler].onComplete(trailers)
+
+    return this[kHandler].onComplete(trailers)
   }
 
   onError (err) {
@@ -184,10 +152,7 @@ class Request {
     }
     this.aborted = true
 
-    clearTimeout(this[kTimeout])
-    this[kTimeout] = null
-
-    this[kHandler].onError(err)
+    return this[kHandler].onError(err)
   }
 }
 

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -12,6 +12,8 @@ module.exports = {
   kKeepAliveTimeoutThreshold: Symbol('keep alive timeout threshold'),
   kKeepAliveTimeoutValue: Symbol('keep alive timeout'),
   kKeepAlive: Symbol('keep alive'),
+  kHeadersTimeout: Symbol('headers timeout'),
+  kBodyTimeout: Symbol('body timeout'),
   kTLSServerName: Symbol('server name'),
   kHost: Symbol('host'),
   kTLSOpts: Symbol('TLS Options'),
@@ -30,6 +32,5 @@ module.exports = {
   kSocketPath: Symbol('socket path'),
   kSocket: Symbol('socket'),
   kTLSSession: Symbol('tls session cache'),
-  kHostHeader: Symbol('host header'),
-  kBodyTimeout: Symbol('body timeout')
+  kHostHeader: Symbol('host header')
 }

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -24,15 +24,16 @@ test('timeout with pipelining 1', (t) => {
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`, {
-      pipelining: 1
+      pipelining: 1,
+      headersTimeout: 500,
+      bodyTimeout: 500
     })
     t.tearDown(client.close.bind(client))
 
     client.request({
       path: '/',
       method: 'GET',
-      opaque: 'asd',
-      headersTimeout: 500
+      opaque: 'asd'
     }, (err, data) => {
       t.ok(err instanceof errors.HeadersTimeoutError) // we are expecting an error
       t.strictEqual(data.opaque, 'asd')
@@ -40,8 +41,7 @@ test('timeout with pipelining 1', (t) => {
 
     client.request({
       path: '/',
-      method: 'GET',
-      bodyTimeout: 500
+      method: 'GET'
     }, (err, { statusCode, headers, body }) => {
       t.error(err)
       t.strictEqual(statusCode, 200)
@@ -74,11 +74,12 @@ test('Disable socket timeout', (t) => {
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`, {
-      bodyTimeout: 0
+      bodyTimeout: 0,
+      headersTimeout: 0
     })
     t.tearDown(client.close.bind(client))
 
-    client.request({ path: '/', method: 'GET', headersTimeout: 0, bodyTimeout: 0 }, (err, result) => {
+    client.request({ path: '/', method: 'GET' }, (err, result) => {
       t.error(err)
       const bufs = []
       result.body.on('data', (buf) => {


### PR DESCRIPTION
body and headers timeouts live in the parser and not on the request. Makes the implementation cleaner and simpler.