### PR TITLE
Test WeakRef support

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -3,3 +3,5 @@ ts: false
 jsx: false
 flow: false
 coverage: true
+expose-gc: true
+timeout: 60

--- a/test/gc.js
+++ b/test/gc.js
@@ -1,0 +1,100 @@
+'use strict'
+/* global WeakRef, FinalizationRegistry */
+
+const { test } = require('tap')
+const { createServer } = require('net')
+const { Client, Pool } = require('..')
+
+const SKIP = typeof WeakRef === 'undefined' || typeof FinalizationRegistry === 'undefined'
+
+test('gc should collect the client if, and only if, there are no active sockets', { skip: SKIP }, t => {
+  t.plan(4)
+
+  const server = createServer((socket) => {
+    socket.write('HTTP/1.1 200 OK\r\n')
+    socket.write('Content-Length: 0\r\n')
+    socket.write('Keep-Alive: timeout=1s\r\n')
+    socket.write('Connection: keep-alive\r\n')
+    socket.write('\r\n\r\n')
+  })
+  t.teardown(server.close.bind(server))
+
+  let weakRef
+  let disconnected = false
+
+  const registry = new FinalizationRegistry((data) => {
+    t.strictEqual(data, 'test')
+    t.strictEqual(disconnected, true)
+    t.strictEqual(weakRef.deref(), undefined)
+  })
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`, {
+      keepAliveTimeoutThreshold: 100
+    })
+    client.once('disconnect', () => {
+      disconnected = true
+      setImmediate(() => {
+        global.gc()
+      })
+    })
+
+    weakRef = new WeakRef(client)
+    registry.register(client, 'test')
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err, { body }) => {
+      t.error(err)
+      body.resume()
+    })
+  })
+})
+
+test('gc should collect the pool if, and only if, there are no active sockets', { skip: SKIP }, t => {
+  t.plan(4)
+
+  const server = createServer((socket) => {
+    socket.write('HTTP/1.1 200 OK\r\n')
+    socket.write('Content-Length: 0\r\n')
+    socket.write('Keep-Alive: timeout=1s\r\n')
+    socket.write('Connection: keep-alive\r\n')
+    socket.write('\r\n\r\n')
+  })
+  t.teardown(server.close.bind(server))
+
+  let weakRef
+  let disconnected = false
+
+  const registry = new FinalizationRegistry((data) => {
+    t.strictEqual(data, 'test')
+    t.strictEqual(disconnected, true)
+    t.strictEqual(weakRef.deref(), undefined)
+  })
+
+  server.listen(0, () => {
+    const pool = new Pool(`http://localhost:${server.address().port}`, {
+      connections: 1,
+      keepAliveTimeoutThreshold: 500
+    })
+
+    pool.once('disconnect', () => {
+      disconnected = true
+      setImmediate(() => {
+        global.gc()
+      })
+    })
+
+    weakRef = new WeakRef(pool)
+    registry.register(pool, 'test')
+
+    pool.request({
+      path: '/',
+      method: 'GET'
+    }, (err, { body }) => {
+      t.error(err)
+      body.resume()
+    })
+  })
+})


### PR DESCRIPTION
Add a test to check [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) support. 

I wasn't able to trigger the gc cycle any faster, I had to increase the default timeout of `tap`.

Fixes #501 