### PR TITLE
Fix capitalization of 'errors' in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import Pool from './types/pool'
 import Client from './types/client'
-import Errors from './types/errors'
+import errors from './types/errors'
 
-export { Pool, Client, Errors }
+export { Pool, Client, errors }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool


### PR DESCRIPTION
Trivial change I didn't catch until now. Just need to rename the import/export here so that the type resolution comes across the same as the JS api