### PR TITLE
feat(pool): forward connect and disconnect events

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,14 @@ Calls [`client.close(callback)`](#close) on all the clients.
 
 Calls [`client.destroy(err, callback)`](#destroy) on all the clients.
 
+#### Events
+
+* `'connect'`, emitted when a client has connected, the `Client`
+    instance is passed as argument.
+
+* `'disconnect'`, emitted when a client has disconnected, the `Client`
+    instance is passed as argument.
+
 <a name='errors'></a>
 ### `undici.errors`
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const EventEmitter = require('events')
 const Client = require('./core/client')
 const {
   ClientClosedError,
@@ -14,11 +15,13 @@ const kDestroyed = Symbol('destroyed')
 const kClosedPromise = Symbol('closed promise')
 const kClosedResolve = Symbol('closed resolve')
 
-class Pool {
+class Pool extends EventEmitter {
   constructor (url, {
     connections,
     ...options
   } = {}) {
+    super()
+
     if (connections != null && (!Number.isFinite(connections) || connections <= 0)) {
       throw new InvalidArgumentError('invalid connections')
     }
@@ -50,8 +53,18 @@ class Pool {
       }
     }
 
+    function onConnect () {
+      pool.emit('connect', this)
+    }
+
+    function onDisconnect () {
+      pool.emit('disconnect', this)
+    }
+
     for (const client of this[kClients]) {
       client.on('drain', onDrain)
+      client.on('connect', onConnect)
+      client.on('disconnect', onDisconnect)
     }
   }
 


### PR DESCRIPTION
Make the `Pool` forward the `connect` and `disconnect` events emitted by its
clients. The `Client` instance that emitted the event is passed as
the argument.

Fixes #509 