### PR TITLE
agent: add support on Node 12 and lower

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,15 +650,11 @@ Calls [`client.destroy(err, callback)`](#destroy) on all the clients.
 
 Returns: `Agent`
 
-Requires: Node.js v14+
-
 Returns a new Agent instance for use with pool based requests or the following top-level methods `request`, `pipeline`, and `stream`.
 
 #### `agent.get(origin): Pool`
 
 * origin `string` - A pool origin to be retrieved from the Agent.
-
-Requires: Node.js v14+
 
 This method retrieves Pool instances from the Agent. If the pool does not exist it is automatically added. You do not need to manually close these pools as they are automatically removed using a WeakCache based on WeakRef and FinalizationRegistry.
 
@@ -672,8 +668,6 @@ Sets the global agent used by `request`, `pipeline`, and `stream` methods.
 
 The default global agent creates `undici.Pool`s with no max number of
 connections.
-
-Requires: Node.js v14+
 
 The agent must only **implement** the `Agent` API; not necessary extend from it.
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,24 +1,13 @@
 'use strict'
-/* global WeakRef, FinalizationRegistry */
-
 const { InvalidArgumentError, InvalidReturnValueError } = require('./core/errors')
 const Pool = require('./pool')
 const util = require('./core/util')
-const { kAgentOpts, kAgentCache, kAgentCleanup } = require('./core/symbols')
+const { kAgentOpts, kAgentCache } = require('./core/symbols')
 
 class Agent {
   constructor (opts) {
     this[kAgentOpts] = opts
     this[kAgentCache] = new Map()
-    this[kAgentCleanup] = new FinalizationRegistry(key => {
-      // get the WeakRef from the cache
-      const ref = this[kAgentCache].get(key)
-      // if the WeakRef exists and the object has been reclaimed
-      if (ref !== undefined && ref.deref() === undefined) {
-        // remove the WeakRef from the cache
-        this[kAgentCache].delete(key)
-      }
-    })
   }
 
   get (origin) {
@@ -26,58 +15,43 @@ class Agent {
       throw new InvalidArgumentError('Origin must be a non-empty string.')
     }
 
-    // check the cache for an existing WeakRef
-    const ref = this[kAgentCache].get(origin)
+    const self = this
+    let pool = self[kAgentCache].get(origin)
 
-    // if one exists in the cache try to return the WeakRef
-    if (ref !== undefined) {
-      const cached = ref.deref()
-      if (cached !== undefined) {
-        return cached
+    function onDisconnect () {
+      if (this.connected === 0) {
+        this.removeListener('disconnect', onDisconnect)
+        self[kAgentCache].delete(origin)
       }
     }
 
-    // otherwise, if it isn't in the cache or the reference has been cleaned up, create a new one!
-    const value = new Pool(origin, this[kAgentOpts])
-    // add a WeakRef of the value to the cache
-    this[kAgentCache].set(origin, new WeakRef(value))
-    // add the value to the finalization registry
-    this[kAgentCleanup].register(value, origin)
+    if (!pool) {
+      pool = new Pool(origin, self[kAgentOpts])
+      pool.on('disconnect', onDisconnect)
+      self[kAgentCache].set(origin, pool)
+    }
 
-    return value
+    return pool
   }
 
   close () {
     const closePromises = []
-    for (const ref of this[kAgentCache].values()) {
-      const pool = ref.deref()
-
-      if (pool) {
-        closePromises.push(pool.close())
-      }
+    for (const pool of this[kAgentCache].values()) {
+      closePromises.push(pool.close())
     }
     return Promise.all(closePromises)
   }
 
   destroy () {
     const destroyPromises = []
-    for (const ref of this[kAgentCache].values()) {
-      const pool = ref.deref()
-
-      if (pool) {
-        destroyPromises.push(pool.destroy())
-      }
+    for (const pool of this[kAgentCache].values()) {
+      destroyPromises.push(pool.destroy())
     }
     return Promise.all(destroyPromises)
   }
 }
 
-let globalAgent = null
-try {
-  globalAgent = new Agent({ connections: null })
-} catch (err) {
-  // Silently fail to set globalAgent due to unsupported environment.
-}
+let globalAgent = new Agent({ connections: null })
 
 function setGlobalAgent (agent) {
   if (!agent || typeof agent.get !== 'function') {

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -20,7 +20,7 @@ class Agent {
 
     function onDisconnect () {
       if (this.connected === 0) {
-        this.removeListener('disconnect', onDisconnect)
+        this.off('disconnect', onDisconnect)
         self[kAgentCache].delete(origin)
       }
     }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -19,7 +19,7 @@ class Agent {
     let pool = self[kAgentCache].get(origin)
 
     function onDisconnect () {
-      if (this.connected === 0) {
+      if (this.connected === 0 && this.pending === 0) {
         this.off('disconnect', onDisconnect)
         self[kAgentCache].delete(origin)
       }

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -33,6 +33,5 @@ module.exports = {
   kTLSSession: Symbol('tls session cache'),
   kHostHeader: Symbol('host header'),
   kAgentOpts: Symbol('agent opts'),
-  kAgentCache: Symbol('agent cache'),
-  kAgentCleanup: Symbol('agent cleanup')
+  kAgentCache: Symbol('agent cache')
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -7,9 +7,7 @@ const { PassThrough } = require('stream')
 const { InvalidArgumentError, InvalidReturnValueError } = require('../lib/core/errors')
 const { errors } = require('..')
 
-const SKIP = typeof WeakRef === 'undefined' || typeof FinalizationRegistry === 'undefined'
-
-tap.test('Agent', { skip: SKIP }, t => {
+tap.test('Agent', t => {
   t.plan(6)
 
   t.test('setGlobalAgent', t => {


### PR DESCRIPTION
Use `Pool`'s `connect`/`disconnect` events to add support of the `Agent` on Node 12 and lower.

Fixes #529 

Note:

I think it's better to wait for https://github.com/nodejs/undici/pull/521 to get merged before continuing. I have to touch many of the same blocks of that PR.