### PR TITLE
fix: busy if full

### DIFF
--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -210,7 +210,11 @@ class Client extends EventEmitter {
 
   get busy () {
     const socket = this[kSocket]
-    return (socket && (socket[kReset] || socket[kWriting])) || this.pending > 0
+    return (
+      (socket && (socket[kReset] || socket[kWriting])) ||
+      (this.size >= (this[kPipelining] || 1)) ||
+      this.pending > 0
+    )
   }
 
   get destroyed () {
@@ -958,20 +962,20 @@ function _resume (client, sync) {
       }
     }
 
-    if (!client.pending) {
-      if (client[kNeedDrain] === 2 && !client.busy) {
-        if (sync) {
-          client[kNeedDrain] = 1
-          process.nextTick(emitDrain, client)
-        } else {
-          emitDrain(client)
-        }
-        continue
-      }
-
-      return
-    } else {
+    if (client.busy) {
       client[kNeedDrain] = 2
+    } else if (client[kNeedDrain] === 2) {
+      if (sync) {
+        client[kNeedDrain] = 1
+        process.nextTick(emitDrain, client)
+      } else {
+        emitDrain(client)
+      }
+      continue
+    }
+
+    if (!client.pending) {
+      return
     }
 
     if (client.running >= (client[kPipelining] || 1)) {


### PR DESCRIPTION
busy should be true if pipeline is full. Should not have request unnecessarily queued. 