### PR TITLE
fix: unify Pool and Client APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ Options:
 
 Performs a HTTP request.
 
-Requests are not guaranteeed to be dispatched in order of invocation.
-
 Options:
 
 * `path: String`

--- a/README.md
+++ b/README.md
@@ -570,8 +570,7 @@ called and the client shutdown has completed.
 ### `new undici.Pool(url, opts)`
 
 A pool of [`Client`][] connected to the same upstream target.
-Implements the same api as [`Client`][] with a few minor
-differences.
+Implements the same api as [`Client`][].
 
 Requests are not guaranteeed to be dispatched in order of invocation.
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Number of inflight requests.
 
 Number of pending and running requests.
 
-#### `client.connected: Boolean|Integer`
+#### `client.connected: Number`
 
 Thruthy if the client has an active connection. The client will lazily
 create a connection when it receives a request and will destroy it
@@ -555,11 +555,13 @@ called and the client shutdown has completed.
   saturated.
 
 * `'connect'`, emitted when a socket has been created and
-  connected. The client will connect once `client.size > 0`.
+  connected. The first argument is the  `Client` instance. 
+  The client will connect once `client.size > 0`.
 
 * `'disconnect'`, emitted when socket has disconnected. The
   first argument of the event is the error which caused the
-  socket to disconnect. The client will reconnect if or once
+  socket to disconnect. The second argument is the
+   `Client` instance. The client will reconnect if or once
   `client.size > 0`.
 
 <a name='pool'></a>
@@ -576,14 +578,6 @@ Options:
 * ... same as [`Client`][].
 * `connections`, the number of clients to create.
   Default `10`.
-
-#### Events
-
-* `'connect'`, emitted when a client has connected. The first argument is the
-   `Client` instance
-
-* `'disconnect'`, emitted when a client has disconnected. The first argument is the
-   `Client` instance, the second is the the error that caused the disconnection.
 
 <a name='agent'></a>
 ### `new undici.Agent(opts)`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Options:
 
 Performs a HTTP request.
 
+Requests are not guaranteeed to be dispatched in order of invocation.
+
 Options:
 
 * `path: String`

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,6 +1,7 @@
 'use strict'
 const { InvalidArgumentError, InvalidReturnValueError } = require('./core/errors')
 const Pool = require('./pool')
+const Client = require('./core/client')
 const util = require('./core/util')
 const { kAgentOpts, kAgentCache } = require('./core/symbols')
 
@@ -26,7 +27,9 @@ class Agent {
     }
 
     if (!pool) {
-      pool = new Pool(origin, self[kAgentOpts])
+      pool = self[kAgentOpts] && self[kAgentOpts].connections === 1
+        ? new Client(origin, self[kAgentOpts])
+        : new Pool(origin, self[kAgentOpts])
       pool.on('disconnect', onDisconnect)
       self[kAgentCache].set(origin, pool)
     }

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -193,7 +193,7 @@ class Client extends EventEmitter {
        this[kSocket].authorizationError
       ) &&
       !this[kSocket].destroyed
-    )
+    ) ? 1 : 0
   }
 
   get pending () {
@@ -741,7 +741,7 @@ function onHeadersTimeout (self) {
 function onSocketConnect () {
   const { [kClient]: client } = this
 
-  client.emit('connect')
+  client.emit('connect', client)
   resume(client)
 }
 
@@ -820,7 +820,7 @@ function onSocketClose () {
     // Retry remaining requests.
     client[kPendingIdx] = client[kRunningIdx]
 
-    client.emit('disconnect', err)
+    client.emit('disconnect', client, err)
   }
 
   resume(client)

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -71,14 +71,14 @@ class Pool extends EventEmitter {
       }
     }
 
-    this[kOnConnect] = function onConnect () {
+    this[kOnConnect] = function onConnect (client) {
       pool[kConnected]++
-      pool.emit('connect', this)
+      pool.emit('connect', client)
     }
 
-    this[kOnDisconnect] = function onDisconnect (err) {
+    this[kOnDisconnect] = function onDisconnect (client, err) {
       pool[kConnected]--
-      pool.emit('disconnect', this, err)
+      pool.emit('disconnect', client, err)
     }
   }
 

--- a/test/client.js
+++ b/test/client.js
@@ -961,7 +961,7 @@ test('busy', (t) => {
 })
 
 test('connected', (t) => {
-  t.plan(4)
+  t.plan(5)
 
   const server = createServer((req, res) => {
     req.pipe(res)
@@ -981,6 +981,7 @@ test('connected', (t) => {
       t.strictEqual(client, self)
     })
 
+    t.strictEqual(client.connected, 0)
     client[kConnect](() => {
       client.request({
         path: '/',

--- a/test/client.js
+++ b/test/client.js
@@ -959,3 +959,36 @@ test('busy', (t) => {
     })
   })
 })
+
+test('connected', (t) => {
+  t.plan(4)
+
+  const server = createServer((req, res) => {
+    req.pipe(res)
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`, {
+      pipelining: 1
+    })
+    t.tearDown(client.close.bind(client))
+
+    client.on('connect', self => {
+      t.strictEqual(client, self)
+    })
+    client.on('disconnect', self => {
+      t.strictEqual(client, self)
+    })
+
+    client[kConnect](() => {
+      client.request({
+        path: '/',
+        method: 'GET'
+      }, (err) => {
+        t.error(err)
+      })
+      t.strictEqual(client.connected, 1)
+    })
+  })
+})

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -256,7 +256,7 @@ test('response invalid content length with close', (t) => {
     })
     t.teardown(client.destroy.bind(client))
 
-    client.on('disconnect', (err) => {
+    client.on('disconnect', (client, err) => {
       t.strictEqual(err.code, 'UND_ERR_SOCKET')
     })
 


### PR DESCRIPTION
- 'connect' and 'disconnect' event should have same arguments.
- connected should be an integer