### PR TITLE
fix: wait for queued handlers to run before onError

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -145,7 +145,7 @@ class Request {
     this.aborted = true
 
     // Ensure all queued handlers are invoked before calling onError.
-    queueMicrotask(() => this[kHandler].onError(err))
+    util.queueMicrotask(() => this[kHandler].onError(err))
   }
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -145,7 +145,7 @@ class Request {
     this.aborted = true
 
     // Ensure all queued handlers are invoked before calling onError.
-    Promise.resolve().then(() => this[kHandler].onError(err))
+    queueMicrotask(() => this[kHandler].onError(err))
   }
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -144,7 +144,8 @@ class Request {
     }
     this.aborted = true
 
-    return this[kHandler].onError(err)
+    // Ensure all queued handlers are invoked before calling onError.
+    setImmediate((handler, err) => handler.onError(err), this[kHandler], err)
   }
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -145,7 +145,7 @@ class Request {
     this.aborted = true
 
     // Ensure all queued handlers are invoked before calling onError.
-    setImmediate((handler, err) => handler.onError(err), this[kHandler], err)
+    Promise.resolve().then(() => this[kHandler].onError(err))
   }
 }
 

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -166,5 +166,8 @@ module.exports = {
   parseKeepAliveTimeout,
   destroy,
   bodyLength,
-  isBuffer
+  isBuffer,
+  queueMicrotask: queueMicrotask || (cb => Promise.resolve()
+    .then(cb)
+    .catch(err => setTimeout(() => { throw err }, 0)))
 }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -167,7 +167,7 @@ module.exports = {
   destroy,
   bodyLength,
   isBuffer,
-  queueMicrotask: queueMicrotask || (cb => Promise.resolve()
+  queueMicrotask: global.queueMicrotask || (cb => Promise.resolve()
     .then(cb)
     .catch(err => setTimeout(() => { throw err }, 0)))
 }

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -38,7 +38,7 @@ test('request abort before headers', (t) => {
         signal
       }, (err) => {
         t.ok(err instanceof errors.RequestAbortedError)
-        t.strictEqual(signal.listenerCount('abort'), 0)
+        t.strictEqual(signal.listenerCount('abort'), 1)
       })
       t.strictEqual(signal.listenerCount('abort'), 2)
     })


### PR DESCRIPTION
When e.g. returning a stream through resolve the user
needs to get a chance to register an 'error' handler
before the stream is destroyed. Otherwise we risk an
unhandled exception.