### PR TITLE
Feat: Agent connect/disconnect events

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -4,11 +4,32 @@ const Pool = require('./pool')
 const Client = require('./core/client')
 const util = require('./core/util')
 const { kAgentOpts, kAgentCache } = require('./core/symbols')
+const EventEmitter = require('events')
 
-class Agent {
+const kOnConnect = Symbol('onConnect')
+const kOnDisconnect = Symbol('onDisconnect')
+
+class Agent extends EventEmitter {
   constructor (opts) {
+    super()
+
     this[kAgentOpts] = opts
     this[kAgentCache] = new Map()
+
+    const agent = this
+
+    this[kOnConnect] = function onConnect (client) {
+      agent.emit('connect', client)
+    }
+
+    this[kOnDisconnect] = function onDestroy (client, err) {
+      if (this.connected === 0 && this.size === 0) {
+        this.off('disconnect', agent[kOnDisconnect])
+        agent[kAgentCache].delete(this.origin)
+      }
+
+      agent.emit('disconnect', client, err)
+    }
   }
 
   get (origin) {
@@ -19,18 +40,15 @@ class Agent {
     const self = this
     let pool = self[kAgentCache].get(origin)
 
-    function onDisconnect () {
-      if (this.connected === 0 && this.size === 0) {
-        this.off('disconnect', onDisconnect)
-        self[kAgentCache].delete(origin)
-      }
-    }
-
     if (!pool) {
       pool = self[kAgentOpts] && self[kAgentOpts].connections === 1
         ? new Client(origin, self[kAgentOpts])
         : new Pool(origin, self[kAgentOpts])
-      pool.on('disconnect', onDisconnect)
+
+      pool
+        .on('connect', this[kOnConnect])
+        .on('disconnect', this[kOnDisconnect])
+
       self[kAgentCache].set(origin, pool)
     }
 


### PR DESCRIPTION
✅  Closes: #522 

* Add support for connect and disconnect events to Agent.
* Provide the necessary set of tests for this change.
* Increase the test coverage of Agent, by testing the `pool` instance returned from the Agent `get` method.
 
@ronag If any changes are required prior to merging these changes, I'll be more than glad to contribute.