### PR TITLE
fix: omit 'path' in undici.request opts (ts)

### DIFF
--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -18,7 +18,7 @@ expectAssignable<Agent>(new Agent({}))
 
 {
   expectAssignable<PromiseLike<Client.ResponseData>>(request(''))
-  expectAssignable<PromiseLike<Client.StreamData>>(stream('', { path: '', method: '' }, data => {
+  expectAssignable<PromiseLike<Client.StreamData>>(stream('', { method: '' }, data => {
     expectAssignable<Client.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -26,7 +26,7 @@ expectAssignable<Agent>(new Agent({}))
 }
 
 {
-  expectAssignable<Duplex>(pipeline('', { path: '', method: '' }, data => {
+  expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
     expectAssignable<Client.PipelineHandlerData>(data)
     return new Readable()
   }))

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -21,17 +21,17 @@ declare function setGlobalAgent<AgentImplementation extends Agent>(agent: AgentI
 
 declare function request(
   url: string | URL | UrlObject,
-  opts?: { agent?: Agent } & Client.RequestOptions,
+  opts?: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
 ): PromiseLike<Client.ResponseData>;
 
 declare function stream(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Client.RequestOptions,
+  opts: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
   factory: Client.StreamFactory
 ): PromiseLike<Client.StreamData>;
 
 declare function pipeline(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Client.PipelineOptions,
+  opts: { agent?: Agent } & Omit<Client.PipelineOptions, 'path'>,
   handler: Client.PipelineHandler
 ): Duplex;


### PR DESCRIPTION
In `undici.request|stream|pipeline` helper functions, the opts param may not contain path.

see https://github.com/nodejs/undici#undicirequesturl-opts-promise

Without this fix you get the following Typescript error:

![image](https://user-images.githubusercontent.com/41679/108612106-f0d70980-73ed-11eb-941f-43a3ec666f47.png)

But if you pass the path parameter you get a runtime error: https://github.com/nodejs/undici/blob/master/lib/agent.js#L86-L88