### PR TITLE
Remove process.binding()

### DIFF
--- a/lib/node/http-parser.js
+++ b/lib/node/http-parser.js
@@ -1,6 +1,6 @@
 'use strict'
 
 // TODO: This is not really allowed by Node but it works for now.
-const { HTTPParser } = process.binding('http_parser') // eslint-disable-line
+const { HTTPParser } = require('_http_common')
 
 module.exports = HTTPParser

--- a/lib/node/http-parser.js
+++ b/lib/node/http-parser.js
@@ -1,6 +1,11 @@
 'use strict'
 
 // TODO: This is not really allowed by Node but it works for now.
-const { HTTPParser } = require('_http_common')
+const common = require('_http_common')
 
-module.exports = HTTPParser
+if (common.HTTPParser) {
+  module.exports = common.HTTPParser
+} else {
+  // Node 10
+  module.exports = process.binding('http_parser').HTTPParser // eslint-disable-line
+}


### PR DESCRIPTION
As Node.js prepares to deprecate `process.binding()`, we can still use `_http_common` to get the `HTTPParser`.

Ref: https://github.com/nodejs/node/pull/37485.