### PR TITLE
Pool docs

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -8,6 +8,7 @@ Imports: `http`, `stream`, `events`
 
 - [Class: Client](#class-client)
   - [`new Client(url, [options])`](#new-clienturl-options)
+    - [Paramter: `ClientOptions`](#parameter-clientoptions)
     - [Example - Basic Client instantiation](#example---basic-client-instantiation)
   - [Instance Methods](#instance-methods)
     - [`Client.close([ callback ])`](#clientclose-callback-)
@@ -50,6 +51,7 @@ Imports: `http`, `stream`, `events`
     - [`Client.pipelining`](#clientpipelining)
     - [`Client.running`](#clientrunning)
     - [`Client.size`](#clientsize)
+    - [`Client.url`](#clienturl)
   - [Instance Events](#instance-events)
     - [Event: `'connect'`](#event-connect)
       - [Example - Client connect event](#example---client-connect-event)
@@ -66,18 +68,21 @@ Imports: `http`, `stream`, `events`
 Arguments:
 
 * **url** `URL | string` - It should only include the **protocol, hostname, and port**.
-* **options** `object` (optional)
-  * **bodyTimeout** `number | null` (optional) - Default: `30e3` - the timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Defaults to 30 seconds.
-  * **headersTimeout** `number | null` (optional) - Default: `30e3` - The amount of time the parser will wait to receive the complete HTTP headers. Defaults to 30 seconds.
-  * **keepAliveMaxTimeout** `number | null` (optional) - Default: `600e3` - The maximum allowed `keepAliveTimeout` when overriden by *keep-alive* hints from the server. Defaults to 10 minutes.
-  * **keepAliveTimeout** `number | null` (optional) - Default: `4e3` - The timeout after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overriden by *keep-alive* hints from the server. See [MDN: HTTP - Headers - Keep-Alive directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive#directives) for more details. Defaults to 4 seconds.
-  * **keepAliveTimeoutThreshold** `number | null` (optional) - Default: `1e3` - A number subtracted from server *keep-alive* hints when overriding `keepAliveTimeout` to account for timing inaccuries caused by e.g. transport latency. Defaults to 1 second.
-  * **maxHeaderSize** `number | null` (optional) - Default: `16384` - The maximum length of request headers in bytes. Defaults to 16KiB.
-  * **pipelining** `number | null` (optional) - Default: `1` - The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Carefully consider your workload and environment before enabling concurrent requests as pipelining may reduce performance if used incorrectly. Pipelining is sensitive to network stack settings as well as head of line blocking caused by e.g. long running requests. Set to `0` to disable keep-alive connections.
-  * **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
-  * **tls** `TlsOptions | null` (optional) - Default: `null` - An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
+* **options** `ClientOptions` (optional)
 
 Returns: `Client`
+
+### Parameter: `ClientOptions`
+
+* **bodyTimeout** `number | null` (optional) - Default: `30e3` - the timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Defaults to 30 seconds.
+* **headersTimeout** `number | null` (optional) - Default: `30e3` - The amount of time the parser will wait to receive the complete HTTP headers. Defaults to 30 seconds.
+* **keepAliveMaxTimeout** `number | null` (optional) - Default: `600e3` - The maximum allowed `keepAliveTimeout` when overriden by *keep-alive* hints from the server. Defaults to 10 minutes.
+* **keepAliveTimeout** `number | null` (optional) - Default: `4e3` - The timeout after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overriden by *keep-alive* hints from the server. See [MDN: HTTP - Headers - Keep-Alive directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive#directives) for more details. Defaults to 4 seconds.
+* **keepAliveTimeoutThreshold** `number | null` (optional) - Default: `1e3` - A number subtracted from server *keep-alive* hints when overriding `keepAliveTimeout` to account for timing inaccuries caused by e.g. transport latency. Defaults to 1 second.
+* **maxHeaderSize** `number | null` (optional) - Default: `16384` - The maximum length of request headers in bytes. Defaults to 16KiB.
+* **pipelining** `number | null` (optional) - Default: `1` - The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Carefully consider your workload and environment before enabling concurrent requests as pipelining may reduce performance if used incorrectly. Pipelining is sensitive to network stack settings as well as head of line blocking caused by e.g. long running requests. Set to `0` to disable keep-alive connections.
+* **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
+* **tls** `TlsOptions | null` (optional) - Default: `null` - An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
 
 ### Example - Basic Client instantiation
 
@@ -856,6 +861,12 @@ Number of inflight requests.
 * `number`
 
 Number of pending and running requests.
+
+### `Client.url`
+
+* `URL` - _readonly_
+
+The URL of the Client instance.
 
 ## Instance Events
 

--- a/docs/Pool.md
+++ b/docs/Pool.md
@@ -17,7 +17,7 @@ Arguments:
 
 Extends: [`ClientOptions`](./Client.md#parameter-clientoptions)
 
-* **connections** `number | null` (optional) - Default: `null` - The number of `Client` instances to create.
+* **connections** `number | null` (optional) - Default: `null` - The number of `Client` instances to create. When set to `null`, the `Pool` instance will create an unlimited amount of `Client` instances.
 
 ## Instance Properties
 
@@ -41,6 +41,11 @@ Implements [Client.destroyed](./Client.md#clientdestroyed)
 
 Implements [Client.pending](./Client.md#clientpending)
 
+<!-- TODO: https://github.com/nodejs/undici/issues/561 
+### `Pool.pipelining`
+
+Implements [Client.pipelining](./Client.md#clientpipelining) -->
+
 ### `Pool.running`
 
 Implements [Client.running](./Client.md#clientrunning)
@@ -57,24 +62,46 @@ Implements [Client.url](./Client.md#clienturl)
 
 ### `Pool.close(callback)`
 
-### `Pool.connect(options, handler)`
+Implements [`Client.close([ callback ])`](./Client.md#clientclose-callback-)
 
-### `Pool.destroy(error, callback)`
+### `Pool.connect(options [, callback])`
 
-### `Pool.dispatch(options, handler)`
+Implements [`Client.connect(options [, callback])`](./Client.md#clientconnectoptions--callback)
+
+### `Pool.destroy(error)`
+
+Implements [`Client.destroy(error)`](./Client.md#clientdestroyerror)
+
+### `Pool.dispatch(options, handlers)`
+
+Implements [`Client.dispatch(options, handlers)`](./Client.md#clientdispatchoptions-handlers)
 
 ### `Pool.pipeline(options, handler)`
 
-### `Pool.request(options, handler)`
+Implements [`Client.pipeline(options, handler)`](./Client.md#clientpipelineoptions-handler)
 
-### `Pool.stream(options, handler)`
+### `Pool.request(options [, callback])`
 
-### `Pool.upgrade(options, handler)`
+Implements [`Client.request(options [, callback])`](./Client.md#clientrequestoptions--callback)
+
+### `Pool.stream(options, factory, [, callback])`
+
+Implements [`Client.stream(options, factory [, callback])`](./Client.md#clientstreamoptions-factory--callback)
+
+### `Pool.upgrade(options [, callback])`
+
+Implements [`Client.upgrade(options[, callback])`](./Client.md#clientupgradeoptions-callback)
 
 ## Instance Events
 
 ### Event: `'connect'`
 
+Implements [Client Event: `'connect'`](./Client.md#event-connect)
+
 ### Event: `'disconnect'`
 
+Implements [Client Event: `'disconnect'`](./Client.md#event-connect)
+
 ### Event: `'drain'`
+
+Implements [Client Event: `'drain'`](./Client.md#event-connect)

--- a/docs/Pool.md
+++ b/docs/Pool.md
@@ -1,0 +1,53 @@
+# Class: Pool
+
+Extends: `events.EventEmitter`
+
+A pool of [Client](./Client.md) instances connected to the same upstream target. Implements the same api as [Client](./Client.md).
+
+Requests are not guaranteed to be dispatched in order of invocation.
+
+## `new Pool(options)`
+
+## Instance Properties
+
+### `Pool.busy`
+
+### `Pool.closed`
+
+### `Pool.connected`
+
+### `Pool.destroyed`
+
+### `Pool.pending`
+
+### `Pool.running`
+
+### `Pool.size`
+
+### `Pool.url`
+
+## Instance Methods
+
+### `Pool.close(callback)`
+
+### `Pool.connect(options, handler)`
+
+### `Pool.destroy(error, callback)`
+
+### `Pool.dispatch(options, handler)`
+
+### `Pool.pipeline(options, handler)`
+
+### `Pool.request(options, handler)`
+
+### `Pool.stream(options, handler)`
+
+### `Pool.upgrade(options, handler)`
+
+## Instance Events
+
+### Event: `'connect'`
+
+### Event: `'disconnect'`
+
+### Event: `'drain'`

--- a/docs/Pool.md
+++ b/docs/Pool.md
@@ -6,25 +6,52 @@ A pool of [Client](./Client.md) instances connected to the same upstream target.
 
 Requests are not guaranteed to be dispatched in order of invocation.
 
-## `new Pool(options)`
+## `new Pool(url, [options])`
+
+Arguments:
+
+* **url** `URL | string` - It should only include the **protocol, hostname, and port**.
+* **options** `PoolOptions` (optional)
+
+### Parameter: `PoolOptions`
+
+Extends: [`ClientOptions`](./Client.md#parameter-clientoptions)
+
+* **connections** `number | null` (optional) - Default: `null` - The number of `Client` instances to create.
 
 ## Instance Properties
 
 ### `Pool.busy`
 
+Implements [Client.busy](./Client.md#clientbusy)
+
 ### `Pool.closed`
+
+Implements [Client.closed](./Client.md#clientclosed)
 
 ### `Pool.connected`
 
+Implements [Client.connected](./Client.md#clientconnected)
+
 ### `Pool.destroyed`
+
+Implements [Client.destroyed](./Client.md#clientdestroyed)
 
 ### `Pool.pending`
 
+Implements [Client.pending](./Client.md#clientpending)
+
 ### `Pool.running`
+
+Implements [Client.running](./Client.md#clientrunning)
 
 ### `Pool.size`
 
+Implements [Client.size](./Client.md#clientsize)
+
 ### `Pool.url`
+
+Implements [Client.url](./Client.md#clienturl)
 
 ## Instance Methods
 

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -231,9 +231,14 @@ class Client extends EventEmitter {
     this.once('connect', cb)
   }
 
+  // The key to understanding how Undici works is within the `dispatch` method.
+
   dispatch (opts, handler) {
     try {
+      // each call to `dispatch` starts with a new `Request` instance
       const request = new Request(opts, handler)
+
+      // `dispatch` verifies the client is not in a `destroyed` or `closed` state
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
       }
@@ -242,14 +247,21 @@ class Client extends EventEmitter {
         throw new ClientClosedError()
       }
 
+      // and then adds `request` to the queue for processing
       this[kQueue].push(request)
+
+      // do nothing if the Client is in a `resuming` state
       if (this[kResuming]) {
         // Do nothing.
+      // otherwise `dispatch` will transition to the `resuming` state
       } else if (util.isStream(request.body)) {
+        // if the body is a stream then the `resuming` state is set in the current tick
+        // `resume` is called with the Client instance, but the `sync` argument is undefined
         // Wait a tick in case stream is ended in the same tick.
         this[kResuming] = 1
         process.nextTick(resume, this)
       } else {
+        // otherwise, call resume with Client instance and sync set to true.
         resume(this, true)
       }
     } catch (err) {
@@ -906,16 +918,21 @@ function socketResume (socket) {
   }
 }
 
+// emitDrain sets NeedDrain back to 0 and emits the 'drain' event
 function emitDrain (client) {
   client[kNeedDrain] = 0
   client.emit('drain')
 }
 
+// The core to undici is this method - it is called by `dispatch`
 function resume (client, sync) {
+  // if the `resuming` state is set to 2 just return
+  // TODO: what sets kResuming to 2?
   if (client[kResuming] === 2) {
     return
   }
 
+  // set kResuming to 2 before calling `_resume`
   client[kResuming] = 2
   _resume(client, sync)
   client[kResuming] = 0
@@ -929,20 +946,30 @@ function resume (client, sync) {
 
 function _resume (client, sync) {
   while (true) {
+    // first check if the `client` is in the `destroyed` state
     if (client[kDestroyed]) {
+      // and assert there are no `pending` requests
       assert(!client.pending)
+      // return back to the `resume` function
       return
     }
 
+    // if `client` is in the `closed` state and the `size` is falsy, destroy with a nop
     if (client[kClosed] && !client.size) {
       client.destroy(util.nop)
+      // continue the while loop execution
       continue
     }
 
+    // if the `socket` is truthy
     if (client[kSocket]) {
+      // get the socket
       const socket = client[kSocket]
+      // get the timeout. if client is in a `running` state, return 0, otherwise use the `keepAliveTimeoutValue` which defaults to 4 seconds
+      // the running state is determined by the difference of the PendingIdx and the RunningIdx
       const timeout = client.running ? 0 : client[kKeepAliveTimeoutValue]
 
+      // TODO: not sure how this block gets executed
       if (socket[kIdleTimeoutValue] !== timeout) {
         clearTimeout(socket[kIdleTimeout])
         if (timeout) {
@@ -954,7 +981,9 @@ function _resume (client, sync) {
       }
     }
 
+    // if the client is in the `running` state
     if (client.running) {
+      // check the AbortSignal and see if we need to destroy the request
       const { aborted } = client[kQueue][client[kRunningIdx]]
       if (aborted) {
         util.destroy(client[kSocket])
@@ -962,29 +991,41 @@ function _resume (client, sync) {
       }
     }
 
+    // if the client is in the `busy` state
+    // the `busy` state is determiend by a complex conditional found in the `get busy()` getter method.
     if (client.busy) {
+      // if busy, set enter the `needDrain` state
       client[kNeedDrain] = 2
+    // if not busy, check if the client is in the `needDrain` state
     } else if (client[kNeedDrain] === 2) {
+      // if the sync argument is truthy, set NeedDrain to 1 and call emitDrain in the next tick
+      // the emitDrain method will set NeedDrain to 0
       if (sync) {
         client[kNeedDrain] = 1
         process.nextTick(emitDrain, client)
       } else {
         emitDrain(client)
       }
+      // continue the while loop
       continue
     }
 
+    // if the client is not in the pending state return to `resume`
+    // the pending state is determined by checking if the PendingIdx is equivalent to the Queue length
     if (!client.pending) {
       return
     }
 
+    // if the value of the `running` state is greater than or equal to the `pipelining` state value or 1 then return to `resume
     if (client.running >= (client[kPipelining] || 1)) {
       return
     }
 
+    // get the socket and the currently pending request
     const socket = client[kSocket]
     const request = client[kQueue][client[kPendingIdx]]
 
+    // special case for https requests
     if (client[kUrl].protocol === 'https:' && client[kHost] !== request.host) {
       if (client.running) {
         return
@@ -1005,19 +1046,25 @@ function _resume (client, sync) {
       }
     }
 
+    // if socket is missing
     if (!socket) {
+      // connect the client
       connect(client)
+      // return to the `resume` method
       return
     }
 
+    // if the client is not connected (determined by the `connected` getter method), return to the `resume` method
     if (!client.connected) {
       return
     }
 
+    // if the socket is in a `writing` or `reset` state retunr
     if (socket[kWriting] || socket[kReset]) {
       return
     }
 
+    // if the client is in a `running` state and the request is not idempotent
     if (client.running && !request.idempotent) {
       // Non-idempotent request cannot be retried.
       // Ensure that no other requests are inflight and
@@ -1025,6 +1072,7 @@ function _resume (client, sync) {
       return
     }
 
+    // if the client is in a `running` state and the request is in an `upgrade` state?
     if (client.running && request.upgrade) {
       // Don't dispatch an upgrade until all preceeding requests have completed.
       // A misbehaving server might upgrade the connection before all pipelined
@@ -1032,7 +1080,9 @@ function _resume (client, sync) {
       return
     }
 
+    // if the request body is a stream and the body length is 0
     if (util.isStream(request.body) && util.bodyLength(request.body) === 0) {
+      // set some event listeners to trigger onError events and destroy the `this` which I believe is the `request`
       request.body
         .on('data', /* istanbul ignore next */ function () {
           /* istanbul ignore next */
@@ -1048,6 +1098,7 @@ function _resume (client, sync) {
       request.body = null
     }
 
+    // if the client is in a `running` state and the body is a stream
     if (client.running && util.isStream(request.body)) {
       // Request with stream body can error while other requests
       // are inflight and indirectly error those as well.
@@ -1060,14 +1111,19 @@ function _resume (client, sync) {
       return
     }
 
+    // if the request is not in an aborted state, and the write method returns truthy
     if (!request.aborted && write(client, request)) {
+      // get the parser
       const parser = client[kSocket][kParser]
+      // handle the timeout
       if (!parser.timeout && client[kHeadersTimeout]) {
         parser.timeout = setTimeout(onHeadersTimeout, client[kHeadersTimeout], parser)
       }
 
+      // increment the pending index, i beleive instructing undici to start on the next request
       client[kPendingIdx]++
     } else {
+      // if the request was aborted or write failed then splice the currently pending request from the queue
       client[kQueue].splice(client[kPendingIdx], 1)
     }
   }

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -231,14 +231,9 @@ class Client extends EventEmitter {
     this.once('connect', cb)
   }
 
-  // The key to understanding how Undici works is within the `dispatch` method.
-
   dispatch (opts, handler) {
     try {
-      // each call to `dispatch` starts with a new `Request` instance
       const request = new Request(opts, handler)
-
-      // `dispatch` verifies the client is not in a `destroyed` or `closed` state
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
       }
@@ -247,21 +242,14 @@ class Client extends EventEmitter {
         throw new ClientClosedError()
       }
 
-      // and then adds `request` to the queue for processing
       this[kQueue].push(request)
-
-      // do nothing if the Client is in a `resuming` state
       if (this[kResuming]) {
         // Do nothing.
-      // otherwise `dispatch` will transition to the `resuming` state
       } else if (util.isStream(request.body)) {
-        // if the body is a stream then the `resuming` state is set in the current tick
-        // `resume` is called with the Client instance, but the `sync` argument is undefined
         // Wait a tick in case stream is ended in the same tick.
         this[kResuming] = 1
         process.nextTick(resume, this)
       } else {
-        // otherwise, call resume with Client instance and sync set to true.
         resume(this, true)
       }
     } catch (err) {
@@ -918,21 +906,16 @@ function socketResume (socket) {
   }
 }
 
-// emitDrain sets NeedDrain back to 0 and emits the 'drain' event
 function emitDrain (client) {
   client[kNeedDrain] = 0
   client.emit('drain')
 }
 
-// The core to undici is this method - it is called by `dispatch`
 function resume (client, sync) {
-  // if the `resuming` state is set to 2 just return
-  // TODO: what sets kResuming to 2?
   if (client[kResuming] === 2) {
     return
   }
 
-  // set kResuming to 2 before calling `_resume`
   client[kResuming] = 2
   _resume(client, sync)
   client[kResuming] = 0
@@ -946,30 +929,20 @@ function resume (client, sync) {
 
 function _resume (client, sync) {
   while (true) {
-    // first check if the `client` is in the `destroyed` state
     if (client[kDestroyed]) {
-      // and assert there are no `pending` requests
       assert(!client.pending)
-      // return back to the `resume` function
       return
     }
 
-    // if `client` is in the `closed` state and the `size` is falsy, destroy with a nop
     if (client[kClosed] && !client.size) {
       client.destroy(util.nop)
-      // continue the while loop execution
       continue
     }
 
-    // if the `socket` is truthy
     if (client[kSocket]) {
-      // get the socket
       const socket = client[kSocket]
-      // get the timeout. if client is in a `running` state, return 0, otherwise use the `keepAliveTimeoutValue` which defaults to 4 seconds
-      // the running state is determined by the difference of the PendingIdx and the RunningIdx
       const timeout = client.running ? 0 : client[kKeepAliveTimeoutValue]
 
-      // TODO: not sure how this block gets executed
       if (socket[kIdleTimeoutValue] !== timeout) {
         clearTimeout(socket[kIdleTimeout])
         if (timeout) {
@@ -981,9 +954,7 @@ function _resume (client, sync) {
       }
     }
 
-    // if the client is in the `running` state
     if (client.running) {
-      // check the AbortSignal and see if we need to destroy the request
       const { aborted } = client[kQueue][client[kRunningIdx]]
       if (aborted) {
         util.destroy(client[kSocket])
@@ -991,41 +962,29 @@ function _resume (client, sync) {
       }
     }
 
-    // if the client is in the `busy` state
-    // the `busy` state is determiend by a complex conditional found in the `get busy()` getter method.
     if (client.busy) {
-      // if busy, set enter the `needDrain` state
       client[kNeedDrain] = 2
-    // if not busy, check if the client is in the `needDrain` state
     } else if (client[kNeedDrain] === 2) {
-      // if the sync argument is truthy, set NeedDrain to 1 and call emitDrain in the next tick
-      // the emitDrain method will set NeedDrain to 0
       if (sync) {
         client[kNeedDrain] = 1
         process.nextTick(emitDrain, client)
       } else {
         emitDrain(client)
       }
-      // continue the while loop
       continue
     }
 
-    // if the client is not in the pending state return to `resume`
-    // the pending state is determined by checking if the PendingIdx is equivalent to the Queue length
     if (!client.pending) {
       return
     }
 
-    // if the value of the `running` state is greater than or equal to the `pipelining` state value or 1 then return to `resume
     if (client.running >= (client[kPipelining] || 1)) {
       return
     }
 
-    // get the socket and the currently pending request
     const socket = client[kSocket]
     const request = client[kQueue][client[kPendingIdx]]
 
-    // special case for https requests
     if (client[kUrl].protocol === 'https:' && client[kHost] !== request.host) {
       if (client.running) {
         return
@@ -1046,25 +1005,19 @@ function _resume (client, sync) {
       }
     }
 
-    // if socket is missing
     if (!socket) {
-      // connect the client
       connect(client)
-      // return to the `resume` method
       return
     }
 
-    // if the client is not connected (determined by the `connected` getter method), return to the `resume` method
     if (!client.connected) {
       return
     }
 
-    // if the socket is in a `writing` or `reset` state retunr
     if (socket[kWriting] || socket[kReset]) {
       return
     }
 
-    // if the client is in a `running` state and the request is not idempotent
     if (client.running && !request.idempotent) {
       // Non-idempotent request cannot be retried.
       // Ensure that no other requests are inflight and
@@ -1072,7 +1025,6 @@ function _resume (client, sync) {
       return
     }
 
-    // if the client is in a `running` state and the request is in an `upgrade` state?
     if (client.running && request.upgrade) {
       // Don't dispatch an upgrade until all preceeding requests have completed.
       // A misbehaving server might upgrade the connection before all pipelined
@@ -1080,9 +1032,7 @@ function _resume (client, sync) {
       return
     }
 
-    // if the request body is a stream and the body length is 0
     if (util.isStream(request.body) && util.bodyLength(request.body) === 0) {
-      // set some event listeners to trigger onError events and destroy the `this` which I believe is the `request`
       request.body
         .on('data', /* istanbul ignore next */ function () {
           /* istanbul ignore next */
@@ -1098,7 +1048,6 @@ function _resume (client, sync) {
       request.body = null
     }
 
-    // if the client is in a `running` state and the body is a stream
     if (client.running && util.isStream(request.body)) {
       // Request with stream body can error while other requests
       // are inflight and indirectly error those as well.
@@ -1111,19 +1060,14 @@ function _resume (client, sync) {
       return
     }
 
-    // if the request is not in an aborted state, and the write method returns truthy
     if (!request.aborted && write(client, request)) {
-      // get the parser
       const parser = client[kSocket][kParser]
-      // handle the timeout
       if (!parser.timeout && client[kHeadersTimeout]) {
         parser.timeout = setTimeout(onHeadersTimeout, client[kHeadersTimeout], parser)
       }
 
-      // increment the pending index, i beleive instructing undici to start on the next request
       client[kPendingIdx]++
     } else {
-      // if the request was aborted or write failed then splice the currently pending request from the queue
       client[kQueue].splice(client[kPendingIdx], 1)
     }
   }


### PR DESCRIPTION
I know this page might seem redundant, but I think it is the best way to document `Pool`. This clearly shows the user what methods, properties, and events are available to them, and provides easy links to the relevant part of the `Client` documentation. 

Reviewers:

If there is anything specific we should highlight for any of the properties or methods in regards to descriptions we should include that. For example, we may want to include descriptions for properties like `pending`, `busy`, etc. specifying how they are evaluated for the pool of clients.