### PR TITLE
feat: treat request content length mismatch as warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Options:
 - `maxHeaderSize: Number`, the maximum length of request headers in bytes.
   Default: `16384` (16KiB).
 
+- `strictContentLength: Boolean`, whether to treat request content length mismatches as errors. If true, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`.
+
 <a name='request'></a>
 #### `client.request(opts[, callback(err, data)]): Promise|Void`
 

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -83,6 +83,7 @@ Returns: `Client`
 * **pipelining** `number | null` (optional) - Default: `1` - The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Carefully consider your workload and environment before enabling concurrent requests as pipelining may reduce performance if used incorrectly. Pipelining is sensitive to network stack settings as well as head of line blocking caused by e.g. long running requests. Set to `0` to disable keep-alive connections.
 * **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
 * **tls** `TlsOptions | null` (optional) - Default: `null` - An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
+* **strictContentLength** `Boolean` (optional) - Default: `true` - Whether to treat request content length mismatches as errors. If true, an error is thrown when the request content-length header doesn't match the length of the request body.
 
 ### Example - Basic Client instantiation
 

--- a/lib/core/client.js
+++ b/lib/core/client.js
@@ -51,7 +51,8 @@ const {
   kIdleTimeout,
   kIdleTimeoutValue,
   kHeadersTimeout,
-  kBodyTimeout
+  kBodyTimeout,
+  kStrictContentLength
 } = require('./symbols')
 
 const nodeVersions = process.version.split('.')
@@ -83,7 +84,8 @@ class Client extends EventEmitter {
     keepAliveTimeoutThreshold,
     socketPath,
     pipelining,
-    tls
+    tls,
+    strictContentLength
   } = {}) {
     super()
 
@@ -156,6 +158,7 @@ class Client extends EventEmitter {
     this[kHostHeader] = `host: ${this[kUrl].hostname}${this[kUrl].port ? `:${this[kUrl].port}` : ''}\r\n`
     this[kBodyTimeout] = bodyTimeout != null ? bodyTimeout : 30e3
     this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 30e3
+    this[kStrictContentLength] = strictContentLength == null ? true : strictContentLength
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -1126,8 +1129,12 @@ function write (client, request) {
   }
 
   if (request.contentLength !== null && request.contentLength !== contentLength) {
-    request.onError(new ContentLengthMismatchError())
-    return false
+    if (client[kStrictContentLength]) {
+      request.onError(new ContentLengthMismatchError())
+      return false
+    }
+
+    process.emitWarning(new ContentLengthMismatchError())
   }
 
   if (request.aborted) {
@@ -1236,8 +1243,12 @@ function write (client, request) {
         // TODO: What if not ended and bytesWritten === contentLength?
         // We should defer writing chunks.
         if (contentLength !== null && bytesWritten + len > contentLength) {
-          util.destroy(socket, new ContentLengthMismatchError())
-          return
+          if (client[kStrictContentLength]) {
+            util.destroy(socket, new ContentLengthMismatchError())
+            return
+          }
+
+          process.emitWarning(new ContentLengthMismatchError())
         }
 
         if (bytesWritten === 0) {
@@ -1286,7 +1297,11 @@ function write (client, request) {
       socket[kWriting] = false
 
       if (!err && contentLength !== null && bytesWritten !== contentLength) {
-        err = new ContentLengthMismatchError()
+        if (client[kStrictContentLength]) {
+          err = new ContentLengthMismatchError()
+        } else {
+          process.emitWarning(new ContentLengthMismatchError())
+        }
       }
 
       socket

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -33,5 +33,6 @@ module.exports = {
   kTLSSession: Symbol('tls session cache'),
   kHostHeader: Symbol('host header'),
   kAgentOpts: Symbol('agent opts'),
-  kAgentCache: Symbol('agent cache')
+  kAgentCache: Symbol('agent cache'),
+  kStrictContentLength: Symbol('strict content length')
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pre-commit": "^1.2.2",
     "proxy": "^1.0.2",
     "proxyquire": "^2.0.1",
+    "sinon": "^9.2.4",
     "snazzy": "^8.0.0",
     "standard": "^14.3.4",
     "tap": "^14.10.8",

--- a/test/no-strict-content-length.js
+++ b/test/no-strict-content-length.js
@@ -1,0 +1,247 @@
+'use strict'
+
+const tap = require('tap')
+const { Client } = require('..')
+const { createServer } = require('http')
+const { Readable } = require('stream')
+const sinon = require('sinon')
+
+tap.test('strictContentLength: false', (t) => {
+  t.plan(4)
+
+  const emitWarningStub = sinon.stub(process, 'emitWarning')
+
+  function assertEmitWarningCalledAndReset () {
+    sinon.assert.called(emitWarningStub)
+    emitWarningStub.resetHistory()
+  }
+
+  t.teardown(() => {
+    emitWarningStub.restore()
+  })
+
+  t.test('request invalid content-length', (t) => {
+    t.plan(8)
+
+    const server = createServer((req, res) => {
+      res.end()
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, () => {
+      const client = new Client(`http://localhost:${server.address().port}`, {
+        strictContentLength: false
+      })
+      t.teardown(client.close.bind(client))
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 10
+        },
+        body: 'asd'
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 10
+        },
+        body: 'asdasdasdasdasdasda'
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 10
+        },
+        body: Buffer.alloc(9)
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 10
+        },
+        body: Buffer.alloc(11)
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'HEAD',
+        headers: {
+          'content-length': 10
+        }
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'GET',
+        headers: {
+          'content-length': 0
+        }
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'GET',
+        headers: {
+          'content-length': 4
+        },
+        body: new Readable({
+          read () {
+            this.push('asd')
+            this.push(null)
+          }
+        })
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+
+      client.request({
+        path: '/',
+        method: 'GET',
+        headers: {
+          'content-length': 4
+        },
+        body: new Readable({
+          read () {
+            this.push('asasdasdasdd')
+            this.push(null)
+          }
+        })
+      }, (err, data) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+    })
+  })
+
+  t.test('request streaming content-length less than body size', (t) => {
+    t.plan(1)
+
+    const server = createServer((req, res) => {
+      res.end()
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, () => {
+      const client = new Client(`http://localhost:${server.address().port}`, {
+        strictContentLength: false
+      })
+      t.teardown(client.close.bind(client))
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 2
+        },
+        body: new Readable({
+          read () {
+            setImmediate(() => {
+              this.push('abcd')
+              this.push(null)
+            })
+          }
+        })
+      }, (err) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+    })
+  })
+
+  t.test('request streaming content-length greater than body size', (t) => {
+    t.plan(1)
+
+    const server = createServer((req, res) => {
+      res.end()
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, () => {
+      const client = new Client(`http://localhost:${server.address().port}`, {
+        strictContentLength: false
+      })
+      t.teardown(client.close.bind(client))
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 10
+        },
+        body: new Readable({
+          read () {
+            setImmediate(() => {
+              this.push('abcd')
+              this.push(null)
+            })
+          }
+        })
+      }, (err) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+    })
+  })
+
+  t.test('request streaming data when content-length=0', (t) => {
+    t.plan(1)
+
+    const server = createServer((req, res) => {
+      res.end()
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, () => {
+      const client = new Client(`http://localhost:${server.address().port}`, {
+        strictContentLength: false
+      })
+      t.teardown(client.close.bind(client))
+
+      client.request({
+        path: '/',
+        method: 'PUT',
+        headers: {
+          'content-length': 0
+        },
+        body: new Readable({
+          read () {
+            setImmediate(() => {
+              this.push('asdasdasdkajsdnasdkjasnd')
+              this.push(null)
+            })
+          }
+        })
+      }, (err) => {
+        assertEmitWarningCalledAndReset()
+        t.error(err)
+      })
+    })
+  })
+})

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -80,6 +80,8 @@ declare namespace Client {
     maxHeaderSize?: number;
     /** The amount of time the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `30e3` milliseconds (30s). */
     headersTimeout?: number;
+    /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true` */
+    strictContentLength?: boolean
   }
 
   export interface DispatchOptions {


### PR DESCRIPTION
Closes #581

Adds ability to tread request content length mismatch as a warning instead of an error, via `strictContentLength` option.

### Checklist

- [x] tests
- [x] docs
- [x] types