### PR TITLE
add old agent and errors docs

### DIFF
--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -1,0 +1,69 @@
+# Agent
+
+## `new undici.Agent(opts)`
+
+* opts `undici.Pool.options` - options passed through to Pool constructor
+
+Returns: `Agent`
+
+Returns a new Agent instance for use with pool based requests or the following top-level methods `request`, `pipeline`, and `stream`.
+
+## `agent.get(origin): Pool`
+
+* origin `string` - A pool origin to be retrieved from the Agent.
+
+This method retrieves Pool instances from the Agent. If the pool does not exist it is automatically added. You do not need to manually close these pools as they are automatically removed using a WeakCache based on WeakRef and FinalizationRegistry.
+The following methods `request`, `pipeline`, and `stream` utilize this feature.
+
+## `agent.close(): Promise`
+
+Returns a `Promise.all` operation closing all of the pool instances in the Agent instance. This calls `pool.close` under the hood.
+
+## `agent.destroy(): Promise`
+
+Returns a `Promise.all` operation destroying all of the pool instances in the Agent instance. This calls `pool.destroy` under the hood.
+
+## `undici.setGlobalAgent(agent)`
+
+* agent `Agent`
+
+Sets the global agent used by `request`, `pipeline`, and `stream` methods.
+The default global agent creates `undici.Pool`s with no max number of
+connections.
+
+The agent must only **implement** the `Agent` API; not necessary extend from it.
+
+## `undici.request(url[, opts]): Promise`
+
+* url `string | URL | object`
+* opts `{ agent: Agent } & client.request.opts`
+
+`url` may contain path. `opts` may not contain path. `opts.method` is `GET` by default.
+Calls `pool.request(opts)` on the pool returned from either the globalAgent (see [setGlobalAgent](#undicisetglobalagentagent)) or the agent passed to the `opts` argument.
+
+Returns a promise with the result of the `request` method.
+
+## `undici.stream(url, opts, factory): Promise`
+
+* url `string | URL | object`
+* opts `{ agent: Agent } & client.stream.opts`
+* factory `client.stream.factory`
+
+`url` may contain path. `opts` may not contain path.
+See [client.stream](docs/api/Client.md#clientstreamoptions-factory--callback) for details on the `opts` and `factory` arguments.
+Calls `pool.stream(opts, factory)` on the pool returned from either the globalAgent (see [setGlobalAgent](#undicisetglobalagentagent)) or the agent passed to the `opts` argument.
+Result is returned in the factory function. See [client.stream](docs/api/Client.md#clientstreamoptions-factory--callback) for more details.
+
+## `undici.pipeline(url, opts, handler): Duplex`
+
+* url `string | URL | object`
+* opts `{ agent: Agent } & client.pipeline.opts`
+* handler `client.pipeline.handler`
+
+`url` may contain path. `opts` may not contain path.
+
+See [client.pipeline](docs/api/Client.md#clientpipelining) for details on the `opts` and `handler` arguments.
+
+Calls `pool.pipeline(opts, factory)` on the pool returned from either the globalAgent (see [setGlobalAgent](#undicisetglobalagentagent)) or the agent passed to the `opts` argument.
+
+See [client.pipeline](docs/api/Client.md#clientpipelining) for more details.

--- a/docs/api/Errors.md
+++ b/docs/api/Errors.md
@@ -1,0 +1,21 @@
+# Errors
+
+Undici exposes a variety of error objects that you can use to enhance your error handling.
+You can find all the error objects inside the `errors` key.
+
+```js
+const { errors } = require('undici')
+```
+
+| Error                        | Error Codes                       | Description                                    |
+| -----------------------------|-----------------------------------|------------------------------------------------|
+| `InvalidArgumentError`       |  `UND_ERR_INVALID_ARG`            | passed an invalid argument.                    |
+| `InvalidReturnValueError`    |  `UND_ERR_INVALID_RETURN_VALUE`   | returned an invalid value.                     |
+| `RequestAbortedError`        |  `UND_ERR_ABORTED`                | the request has been aborted by the user       |
+| `ClientDestroyedError`       |  `UND_ERR_DESTROYED`              | trying to use a destroyed client.              |
+| `ClientClosedError`          |  `UND_ERR_CLOSED`                 | trying to use a closed client.                 |
+| `SocketError`                |  `UND_ERR_SOCKET`                 | there is an error with the socket.             |
+| `NotSupportedError`          |  `UND_ERR_NOT_SUPPORTED`          | encountered unsupported functionality.         |
+| `ContentLengthMismatchError` |  `UND_ERR_CONTENT_LENGTH_MISMATCH`| body does not match content-length header      |
+| `InformationalError`         |  `UND_ERR_INFO`                   | expected error with reason                     |
+| `TrailerMismatchError`       |  `UND_ERR_TRAILER_MISMATCH`       | trailers did not match specification           |

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -4,6 +4,8 @@
 * API
   * [Client](/docs/api/Client.md "Undici API - Client")
   * [Pool](/docs/api/Pool.md "Undici API - Pool")
+  * [Agent](/docs/api/Agent.md "Undici API - Agent")
+  * [Errors](/docs/api/Errors.md "Undici API - Errors")
   * [API Lifecycle](/docs/api/api-lifecycle.md "Undici API - Lifecycle")
 * Best Practices
   * [Proxy](docs/best-practices/proxy.md "Connecting through a proxy")


### PR DESCRIPTION
Hey folks, 

So i'm going to be away-from-keyboard this weekend, but I did not want to leave our docs without the Agent or Errors api. I've gone ahead and copy-pasted the old docs we had for these sections and added them to the docs folder. I also touched them up a little bit so links work and it renders nicely. I'm okay for "launching" our docs site with this content if that happens this weekend; otherwise, I'll follow up next week with documentation pages similar to `Client` and `Pool`.

🚀