### PR TITLE
feat: Added RedirectPool.

### DIFF
--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -19,7 +19,7 @@ Extends: [`PoolOptions`](docs/api/Pool.md#parameter-pooloptions)
 ```js
 'use strict'
 const { createServer } = require('http')
-const { Agent, request, RedirectPool } = require('.')
+const { Agent, request, RedirectPool } = require('undici')
 
 const server = createServer((request, response) => {
   response.setHeader('Connection', `close`)

--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -2,11 +2,18 @@
 
 ## `new undici.Agent(opts)`
 
-* opts `undici.Pool.options` - options passed through to Pool constructor
+* opts `AgentOptions` - options passed through to Pool constructor
 
 Returns: `Agent`
 
 Returns a new Agent instance for use with pool based requests or the following top-level methods `request`, `pipeline`, and `stream`.
+
+### Parameter: `AgentOptions`
+
+Extends: [`PoolOptions`](docs/api/Pool.md#parameter-pooloptions)
+
+* **clientClass** `Class extends Client` (optional) - The class to instantiate clients.
+* **poolClass** `Class extends Pool` (optional) - The class to use to instantiate pools.
 
 ## `agent.get(origin): Pool`
 

--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -12,8 +12,7 @@ Returns a new Agent instance for use with pool based requests or the following t
 
 Extends: [`PoolOptions`](docs/api/Pool.md#parameter-pooloptions)
 
-* **clientClass** `Class extends Client` (optional) - The class to instantiate clients.
-* **poolClass** `Class extends Pool` (optional) - The class to use to instantiate pools.
+* **factory** `(url: string, options?: Client.Options): Pool` (optional) - A factory which returns the pool to use for the request.
 
 ## `agent.get(origin): Pool`
 

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -112,12 +112,22 @@ Extends: `Pool`
 
 A pool which will automatically follow redirections.
 
-When used, the option `maxRedirections` can be additionally provided to top level `request`, `stream` and `pipeline`. The option must be a boolean or a number:
+When used, the option `maxRedirections` can be additionally provided to top level `request`, `stream` and `pipeline`. The option must a positive number:
 
-* If omitted or set to `true`, up to 10 redirections are followed.
-
-* If set to `false`, redirections are not followed.
+* If omitted, up to 10 redirections are followed.
 
 * If set to a positive number, it specifies the maximum number of redirections to follow.
 
 The data returned by the top-level method (via callback or promise) will contain the additional property `redirections` that lists all the followed redirections, in order.
+
+# Function: redirectPoolFactory
+
+A factory function which returns a `RedirectPool` for a specific URL.
+
+Arguments:
+
+* **url** `URL | string` - It should only include the **protocol, hostname, and port**.
+* **options** `PoolOptions` (optional)
+
+Returns: `RedirectPool` - The pool to be used by the agent.
+

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -105,29 +105,3 @@ Implements [Client Event: `'disconnect'`](docs/api/Client.md#event-connect)
 ### Event: `'drain'`
 
 Implements [Client Event: `'drain'`](docs/api/Client.md#event-connect)
-
-# Class: RedirectPool
-
-Extends: `Pool`
-
-A pool which will automatically follow redirections.
-
-When used, the option `maxRedirections` can be additionally provided to top level `request`, `stream` and `pipeline`. The option must a positive number:
-
-* If omitted, up to 10 redirections are followed.
-
-* If set to a positive number, it specifies the maximum number of redirections to follow.
-
-The data returned by the top-level method (via callback or promise) will contain the additional property `redirections` that lists all the followed redirections, in order.
-
-# Function: redirectPoolFactory
-
-A factory function which returns a `RedirectPool` for a specific URL.
-
-Arguments:
-
-* **url** `URL | string` - It should only include the **protocol, hostname, and port**.
-* **options** `PoolOptions` (optional)
-
-Returns: `RedirectPool` - The pool to be used by the agent.
-

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -105,3 +105,19 @@ Implements [Client Event: `'disconnect'`](docs/api/Client.md#event-connect)
 ### Event: `'drain'`
 
 Implements [Client Event: `'drain'`](docs/api/Client.md#event-connect)
+
+# Class: RedirectPool
+
+Extends: `Pool`
+
+A pool which will automatically follow redirections.
+
+When used, the option `maxRedirections` can be additionally provided to top level `request`, `stream` and `pipeline`. The option must be a boolean or a number:
+
+* If omitted or set to `true`, up to 10 redirections are followed.
+
+* If set to `false`, redirections are not followed.
+
+* If set to a positive number, it specifies the maximum number of redirections to follow.
+
+The data returned by the top-level method (via callback or promise) will contain the additional property `redirections` that lists all the followed redirections, in order.

--- a/docs/api/RedirectPool.md
+++ b/docs/api/RedirectPool.md
@@ -12,6 +12,13 @@ When used, the option `maxRedirections` can be additionally provided to top leve
 
 The data returned by the top-level method (via callback or promise) will contain the additional property `redirections` that lists all the followed redirections, in order.
 
+## Restrictions
+
+For memory and performance reason, undici never copies or duplicates the request body in memory. When dealing with redirections (which means using `RedirectPool`), this leads to the following restrictions:
+
+1. Use `undici.pipeline` with a `RedirectPool`.
+2. Use `undici.request` or `undici.stream` with a `RedirectPool` passing a stream as request body. Note the passing strings or buffers is still allowed.
+
 # Function: redirectPoolFactory
 
 A factory function which returns a `RedirectPool` for a specific URL.

--- a/docs/api/RedirectPool.md
+++ b/docs/api/RedirectPool.md
@@ -1,0 +1,24 @@
+# Class: RedirectPool
+
+Extends: `Pool`
+
+A pool which will automatically follow redirections.
+
+When used, the option `maxRedirections` can be additionally provided to top level `request`, `stream` and `pipeline`. The option must a positive number:
+
+* If omitted, up to 10 redirections are followed.
+
+* If set to a positive number, it specifies the maximum number of redirections to follow.
+
+The data returned by the top-level method (via callback or promise) will contain the additional property `redirections` that lists all the followed redirections, in order.
+
+# Function: redirectPoolFactory
+
+A factory function which returns a `RedirectPool` for a specific URL.
+
+Arguments:
+
+* **url** `URL | string` - It should only include the **protocol, hostname, and port**.
+* **options** `PoolOptions` (optional)
+
+Returns: `RedirectPool` - The pool to be used by the agent.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,17 @@
 import Pool from './types/pool'
+import RedirectPool from './types/redirect-pool'
 import Client from './types/client'
 import errors from './types/errors'
 import { Agent, setGlobalAgent, request, stream, pipeline } from './types/agent'
 
-export { Pool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline }
+export { Pool, RedirectPool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool
 
 declare namespace Undici {
   var Pool: typeof import('./types/pool');
+  var RedirectPool: typeof import('./types/redirect-pool');
   var Client: typeof import('./types/client');
   var errors: typeof import('./types/errors');
   var Agent: typeof import('./types/agent').Agent;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 import Pool from './types/pool'
-import RedirectPool from './types/redirect-pool'
+import {RedirectPool, redirectPoolFactory } from './types/redirect-pool'
 import Client from './types/client'
 import errors from './types/errors'
 import { Agent, setGlobalAgent, request, stream, pipeline } from './types/agent'
 
-export { Pool, RedirectPool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline }
+export { Pool, RedirectPool, Client, errors, Agent, redirectPoolFactory, setGlobalAgent, request, stream, pipeline }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool
@@ -15,6 +15,7 @@ declare namespace Undici {
   var Client: typeof import('./types/client');
   var errors: typeof import('./types/errors');
   var Agent: typeof import('./types/agent').Agent;
+  var redirectPoolFactory: typeof import('./types/redirect-pool').redirectPoolFactory;
   var setGlobalAgent: typeof import('./types/agent').setGlobalAgent;
   var request: typeof import('./types/agent').request;
   var stream: typeof import('./types/agent').stream;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Client = require('./lib/core/client')
 const errors = require('./lib/core/errors')
 const Pool = require('./lib/pool')
 const { Agent, request, stream, pipeline, setGlobalAgent } = require('./lib/agent')
-const RedirectPool = require('./lib/redirect-pool')
+const { RedirectPool, redirectPoolFactory } = require('./lib/redirect-pool')
 
 Client.prototype.request = require('./lib/client-request')
 Client.prototype.stream = require('./lib/client-stream')
@@ -28,3 +28,4 @@ module.exports.request = request
 module.exports.stream = stream
 module.exports.pipeline = pipeline
 module.exports.setGlobalAgent = setGlobalAgent
+module.exports.redirectPoolFactory = redirectPoolFactory

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Client = require('./lib/core/client')
 const errors = require('./lib/core/errors')
 const Pool = require('./lib/pool')
 const { Agent, request, stream, pipeline, setGlobalAgent } = require('./lib/agent')
+const RedirectPool = require('./lib/redirect-pool')
 
 Client.prototype.request = require('./lib/client-request')
 Client.prototype.stream = require('./lib/client-stream')
@@ -18,6 +19,7 @@ function undici (url, opts) {
 module.exports = undici
 
 module.exports.Pool = Pool
+module.exports.RedirectPool = RedirectPool
 module.exports.Client = Client
 module.exports.errors = errors
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -6,6 +6,8 @@ const util = require('./core/util')
 const { kAgentOpts, kAgentCache } = require('./core/symbols')
 const EventEmitter = require('events')
 
+const kClientClass = Symbol('clientClass')
+const kPoolClass = Symbol('poolClass')
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
 
@@ -17,6 +19,9 @@ class Agent extends EventEmitter {
     this[kAgentCache] = new Map()
 
     const agent = this
+
+    this[kClientClass] = (opts && opts.clientClass) || Client
+    this[kPoolClass] = (opts && opts.poolClass) || Pool
 
     this[kOnConnect] = function onConnect (client) {
       agent.emit('connect', client)
@@ -41,10 +46,11 @@ class Agent extends EventEmitter {
     let pool = self[kAgentCache].get(origin)
 
     if (!pool) {
-      pool = self[kAgentOpts] && self[kAgentOpts].connections === 1
-        ? new Client(origin, self[kAgentOpts])
-        : new Pool(origin, self[kAgentOpts])
+      const Klass = self[kAgentOpts] && self[kAgentOpts].connections === 1
+        ? self[kClientClass]
+        : self[kPoolClass]
 
+      pool = new Klass(origin, self[kAgentOpts])
       pool
         .on('connect', this[kOnConnect])
         .on('disconnect', this[kOnDisconnect])
@@ -97,7 +103,7 @@ function dispatchFromAgent (requestType) {
       throw new InvalidReturnValueError(`Client returned from Agent.get() does not implement method ${requestType}`)
     }
 
-    return client[requestType]({ ...opts, method, path }, ...additionalArgs)
+    return client[requestType]({ ...opts, agent, method, path }, ...additionalArgs)
   }
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -109,7 +109,7 @@ function dispatchFromAgent (requestType) {
       throw new InvalidReturnValueError(`Client returned from Agent.get() does not implement method ${requestType}`)
     }
 
-    return client[requestType]({ ...opts, agent, requestType, method, path }, ...additionalArgs)
+    return client[requestType]({ ...opts, agent, method, path }, ...additionalArgs)
   }
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -6,8 +6,7 @@ const util = require('./core/util')
 const { kAgentOpts, kAgentCache } = require('./core/symbols')
 const EventEmitter = require('events')
 
-const kClientClass = Symbol('clientClass')
-const kPoolClass = Symbol('poolClass')
+const kFactory = Symbol('factory')
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
 
@@ -20,8 +19,11 @@ class Agent extends EventEmitter {
 
     const agent = this
 
-    this[kClientClass] = (opts && opts.clientClass) || Client
-    this[kPoolClass] = (opts && opts.poolClass) || Pool
+    const factoryType = typeof opts.factory
+    if (factoryType !== 'undefined' && factoryType !== 'function') {
+      throw new InvalidArgumentError('factory must be a function.')
+    }
+    this[kFactory] = (opts && opts.factory) || defaultFactory
 
     this[kOnConnect] = function onConnect (client) {
       agent.emit('connect', client)
@@ -46,11 +48,7 @@ class Agent extends EventEmitter {
     let pool = self[kAgentCache].get(origin)
 
     if (!pool) {
-      const Klass = self[kAgentOpts] && self[kAgentOpts].connections === 1
-        ? self[kClientClass]
-        : self[kPoolClass]
-
-      pool = new Klass(origin, self[kAgentOpts])
+      pool = this[kFactory](origin, self[kAgentOpts])
       pool
         .on('connect', this[kOnConnect])
         .on('disconnect', this[kOnDisconnect])
@@ -80,6 +78,10 @@ class Agent extends EventEmitter {
 
 let globalAgent = new Agent({ connections: null })
 
+function defaultFactory(origin, opts) {
+  return opts && opts.connections === 1 ? new Client(origin, opts) : new Pool(origin, opts)
+}
+
 function setGlobalAgent (agent) {
   if (!agent || typeof agent.get !== 'function') {
     throw new InvalidArgumentError('Argument agent must implement Agent')
@@ -103,7 +105,7 @@ function dispatchFromAgent (requestType) {
       throw new InvalidReturnValueError(`Client returned from Agent.get() does not implement method ${requestType}`)
     }
 
-    return client[requestType]({ ...opts, agent, method, path }, ...additionalArgs)
+    return client[requestType]({ ...opts, agent, requestType, method, path }, ...additionalArgs)
   }
 }
 

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -19,11 +19,17 @@ class Agent extends EventEmitter {
 
     const agent = this
 
-    const factoryType = typeof opts.factory
-    if (factoryType !== 'undefined' && factoryType !== 'function') {
-      throw new InvalidArgumentError('factory must be a function.')
+    if (opts && opts.factory) {
+      const factoryType = typeof opts.factory
+
+      if (factoryType !== 'undefined' && factoryType !== 'function') {
+        throw new InvalidArgumentError('factory must be a function.')
+      }
+
+      this[kFactory] = opts.factory
+    } else {
+      this[kFactory] = defaultFactory
     }
-    this[kFactory] = (opts && opts.factory) || defaultFactory
 
     this[kOnConnect] = function onConnect (client) {
       agent.emit('connect', client)
@@ -49,9 +55,7 @@ class Agent extends EventEmitter {
 
     if (!pool) {
       pool = this[kFactory](origin, self[kAgentOpts])
-      pool
-        .on('connect', this[kOnConnect])
-        .on('disconnect', this[kOnDisconnect])
+      pool.on('connect', this[kOnConnect]).on('disconnect', this[kOnDisconnect])
 
       self[kAgentCache].set(origin, pool)
     }
@@ -78,7 +82,7 @@ class Agent extends EventEmitter {
 
 let globalAgent = new Agent({ connections: null })
 
-function defaultFactory(origin, opts) {
+function defaultFactory (origin, opts) {
   return opts && opts.connections === 1 ? new Client(origin, opts) : new Pool(origin, opts)
 }
 

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -83,7 +83,7 @@ class RequestHandler extends AsyncResource {
     this.abort = abort
   }
 
-  onHeaders (statusCode, headers, resume) {
+  onHeaders (statusCode, headers, resume, additionalCallbackData) {
     const { callback, opaque, abort } = this
 
     if (statusCode < 200) {
@@ -100,7 +100,8 @@ class RequestHandler extends AsyncResource {
       headers: util.parseHeaders(headers),
       trailers: this.trailers,
       opaque,
-      body
+      body,
+      ...additionalCallbackData
     })
   }
 

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -68,7 +68,7 @@ class StreamHandler extends AsyncResource {
     this.abort = abort
   }
 
-  onHeaders (statusCode, headers, resume) {
+  onHeaders (statusCode, headers, resume, additionalCallbackData) {
     const { factory, opaque } = this
 
     if (statusCode < 200) {
@@ -79,7 +79,8 @@ class StreamHandler extends AsyncResource {
     const res = this.runInAsyncScope(factory, null, {
       statusCode,
       headers: util.parseHeaders(headers),
-      opaque
+      opaque,
+      ...additionalCallbackData
     })
 
     if (

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -92,7 +92,7 @@ class RedirectPool extends Pool {
         Remove headers referring to the original URL.
         By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
       */
-      if ('headers' in opts) {
+      if (opts.headers) {
         cleanRequestHeaders(opts.headers, statusCode === 303)
       }
 
@@ -122,7 +122,7 @@ class RedirectPool extends Pool {
           stream(location, opts, handler.factory, handler.callback)
           break
         case 'pipeline':
-          pipeline(location, handler.handler)
+          pipeline(location, opts, handler.handler)
           break
       }
 

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -1,14 +1,66 @@
+'use strict'
+
 const { Readable } = require('stream')
 const { pipeline, request, stream } = require('./agent')
+const { InvalidArgumentError } = require('./core/errors')
 const util = require('./core/util')
 const Pool = require('./pool')
 
-const kOrigin = Symbol('Origin')
-const kDispatchMethod = Symbol('RedirectPoolDispatchMethod')
-const kRedirectsLeft = Symbol('RedirectPoolRedirectsLeft')
+const kOrigin = Symbol('origin')
+const kLeftRedirections = Symbol('left redirections')
 
 const redirectCodes = [300, 301, 302, 303, 307, 308]
 const defaultMaxRedirections = 10
+
+function parseMaxRedirections({ maxRedirections = defaultMaxRedirections }) {
+  if (maxRedirections != null && (maxRedirections <= 0 || !Number.isInteger(maxRedirections))) {
+    throw new InvalidArgumentError('maxRedirections must be a positive number')
+  }
+
+  return maxRedirections
+}
+
+function redirectLocation(statusCode, headers, opts) {
+  if (opts[kLeftRedirections] < 0 || redirectCodes.indexOf(statusCode) === -1) {
+    return null
+  }
+
+  for (let i = 0; i < headers.length; i += 2) {
+    // Find the matching headers, then return its value
+    if (headers[i].length && headers[i].toLowerCase() === 'location') {
+      return headers[i + 1]
+    }
+  }
+
+  return null
+}
+
+// https://tools.ietf.org/html/rfc7231#section-6.4.4
+function shouldRemoveHeader(header, removeContent) {
+  const lcHeader = header.toLowerCase()
+
+  return lcHeader === 'host' || (removeContent && lcHeader.indexOf('content-') === 0)
+}
+
+// https://tools.ietf.org/html/rfc7231#section-6.4
+function cleanRequestHeaders(headers, removeContent) {
+  if (Array.isArray(headers)) {
+    for (let i = headers.length - 2; i >= 0; i -= 2) {
+      const headerName = headers[i].toLowerCase()
+
+      if (shouldRemoveHeader(headers[i], removeContent)) {
+        headers.splice(i, 2)
+      }
+    }
+  } else {
+    // IncomingHttpHeaders
+    for (const header of Object.keys(headers)) {
+      if (shouldRemoveHeader(header, removeContent)) {
+        headers[header] = undefined
+      }
+    }
+  }
+}
 
 class RedirectDiscardedResponse extends Readable {
   constructor(resume) {
@@ -23,48 +75,38 @@ class RedirectPool extends Pool {
     this[kOrigin] = origin
   }
 
-  request(opts, callback) {
-    opts[kDispatchMethod] = 'request'
-
-    return super.request(opts, callback)
-  }
-
-  stream(opts, factory, callback) {
-    opts[kDispatchMethod] = 'stream'
-
-    return super.stream(opts, factory, callback)
-  }
-
-  pipeline(opts, handler) {
-    opts[kDispatchMethod] = 'pipeline'
-
-    return super.pipeline(opts, handler)
-  }
-
   dispatch(opts, handler) {
     const pool = this
 
     // Compute the number of left redirects, if needed
-    if (!(kRedirectsLeft in opts)) {
-      this.parseMaxRedirects(opts)
+    if (!(kLeftRedirections in opts)) {
+      opts[kLeftRedirections] = parseMaxRedirections(opts)
     }
 
     const originalOnHeaders = handler.onHeaders
 
     handler.onHeaders = function onHeadersWithRedirect(statusCode, headers, resume) {
       // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
-      const location = pool.redirectLocation(statusCode, headers, opts)
+      const location = redirectLocation(statusCode, headers, opts)
 
+      // Nothing to follow, use the original implementation
       if (!location) {
         return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: opts.redirections })
       }
 
+      /*
+        https://tools.ietf.org/html/rfc7231#section-6.4
+
+        Remove headers referring to the original URL.
+        By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
+      */
+      if ('headers' in opts) {
+        cleanRequestHeaders(opts.headers, statusCode === 303)
+      }
+
+      // https://tools.ietf.org/html/rfc7231#section-6.4.4
       // In case of HTTP 303, always replace method to be either HEAD or GET
       if (statusCode === 303 && opts.method !== 'HEAD') {
-        if ('headers' in opts) {
-          pool.removeHostSpecificHeaders(opts.headers)
-        }
-
         opts.method = 'GET'
       }
 
@@ -77,10 +119,10 @@ class RedirectPool extends Pool {
 
       // Update options
       opts.path = null
-      opts[kRedirectsLeft]--
+      opts[kLeftRedirections]--
 
       // Follow the redirect
-      switch (opts[kDispatchMethod]) {
+      switch (opts.requestType) {
         case 'request':
           request(location, opts, handler.callback)
           break
@@ -103,51 +145,13 @@ class RedirectPool extends Pool {
     // Call the original implementation to proceed
     super.dispatch(opts, handler)
   }
-
-  parseMaxRedirects(opts) {
-    if (opts.maxRedirections === false) {
-      opts[kRedirectsLeft] = -1
-    } else if (
-      opts.maxRedirections === true ||
-      typeof opts.maxRedirections !== 'number' ||
-      isNaN(opts.maxRedirections)
-    ) {
-      opts[kRedirectsLeft] = defaultMaxRedirections
-    } else {
-      opts[kRedirectsLeft] = opts.maxRedirections
-    }
-  }
-
-  redirectLocation(statusCode, headers, opts) {
-    if (opts[kRedirectsLeft] < 0 || redirectCodes.indexOf(statusCode) === -1) {
-      return null
-    }
-
-    // Find the Location header and then the value
-    const headerIndex = headers.findIndex(h => h.toLowerCase() === 'location')
-    return headerIndex >= 0 ? headers[headerIndex + 1] : null
-  }
-
-  removeHostSpecificHeaders(headers) {
-    if (Array.isArray(headers)) {
-      for (let i = headers.length - 2; i >= 0; i -= 2) {
-        const headerName = headers[i].toLowerCase()
-
-        if (headerName === 'host' || headerName.indexOf('content-') === 0) {
-          headers.splice(i, 2)
-        }
-      }
-    } else {
-      // IncomingHttpHeaders
-      for (const rawHeaderName of Object.keys(headers)) {
-        const headerName = rawHeaderName.toLowerCase()
-
-        if (headerName === 'host' || headerName.indexOf('content-') === 0) {
-          headers[rawHeaderName] = undefined
-        }
-      }
-    }
-  }
 }
 
-module.exports = RedirectPool
+function redirectPoolFactory(origin, opts) {
+  return new RedirectPool(origin, opts)
+}
+
+module.exports = {
+  redirectPoolFactory,
+  RedirectPool
+}

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -45,18 +45,26 @@ function shouldRemoveHeader (header, removeContent) {
 // https://tools.ietf.org/html/rfc7231#section-6.4
 function cleanRequestHeaders (headers, removeContent) {
   if (Array.isArray(headers)) {
-    for (let i = headers.length - 2; i >= 0; i -= 2) {
-      if (shouldRemoveHeader(headers[i], removeContent)) {
-        headers.splice(i, 2)
+    const filteredHeaders = []
+
+    for (let i = 0; i < headers.length; i += 2) {
+      if (!shouldRemoveHeader(headers[i], removeContent)) {
+        filteredHeaders.push(headers[i], headers[i + 1])
       }
     }
+
+    return filteredHeaders
   } else {
+    const filteredHeaders = {}
+
     // IncomingHttpHeaders
-    for (const header of Object.keys(headers)) {
-      if (shouldRemoveHeader(header, removeContent)) {
-        headers[header] = undefined
+    for (const [header, value] of Object.entries(headers)) {
+      if (!shouldRemoveHeader(header, removeContent)) {
+        filteredHeaders[header] = value
       }
     }
+
+    return filteredHeaders
   }
 }
 
@@ -119,7 +127,7 @@ class RedirectPool extends Pool {
           By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
         */
         if (requestHeaders) {
-          cleanRequestHeaders(requestHeaders, statusCode === 303)
+          requestHeaders = cleanRequestHeaders(requestHeaders, statusCode === 303)
         }
 
         // https://tools.ietf.org/html/rfc7231#section-6.4.4

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -1,0 +1,153 @@
+const { Readable } = require('stream')
+const { pipeline, request, stream } = require('./agent')
+const util = require('./core/util')
+const Pool = require('./pool')
+
+const kOrigin = Symbol('Origin')
+const kDispatchMethod = Symbol('RedirectPoolDispatchMethod')
+const kRedirectsLeft = Symbol('RedirectPoolRedirectsLeft')
+
+const redirectCodes = [300, 301, 302, 303, 307, 308]
+const defaultMaxRedirections = 10
+
+class RedirectDiscardedResponse extends Readable {
+  constructor(resume) {
+    super({ autoDestroy: true, read: resume })
+  }
+}
+
+class RedirectPool extends Pool {
+  constructor(origin, options) {
+    super(origin, options)
+
+    this[kOrigin] = origin
+  }
+
+  request(opts, callback) {
+    opts[kDispatchMethod] = 'request'
+
+    return super.request(opts, callback)
+  }
+
+  stream(opts, factory, callback) {
+    opts[kDispatchMethod] = 'stream'
+
+    return super.stream(opts, factory, callback)
+  }
+
+  pipeline(opts, handler) {
+    opts[kDispatchMethod] = 'pipeline'
+
+    return super.pipeline(opts, handler)
+  }
+
+  dispatch(opts, handler) {
+    const pool = this
+
+    // Compute the number of left redirects, if needed
+    if (!(kRedirectsLeft in opts)) {
+      this.parseMaxRedirects(opts)
+    }
+
+    const originalOnHeaders = handler.onHeaders
+
+    handler.onHeaders = function onHeadersWithRedirect(statusCode, headers, resume) {
+      // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
+      const location = pool.redirectLocation(statusCode, headers, opts)
+
+      if (!location) {
+        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: opts.redirections })
+      }
+
+      // In case of HTTP 303, always replace method to be either HEAD or GET
+      if (statusCode === 303 && opts.method !== 'HEAD') {
+        if ('headers' in opts) {
+          pool.removeHostSpecificHeaders(opts.headers)
+        }
+
+        opts.method = 'GET'
+      }
+
+      // Add the current URL to the list of redirects
+      if (!opts.redirections) {
+        opts.redirections = []
+      }
+
+      opts.redirections.push(`${pool[kOrigin]}${opts.path}`)
+
+      // Update options
+      opts.path = null
+      opts[kRedirectsLeft]--
+
+      // Follow the redirect
+      switch (opts[kDispatchMethod]) {
+        case 'request':
+          request(location, opts, handler.callback)
+          break
+        case 'stream':
+          stream(location, opts, handler.factory, handler.callback)
+          break
+        case 'pipeline':
+          pipeline(location, handler.handler)
+          break
+      }
+
+      // Ignore the body
+      handler.onData = util.nop
+      handler.onComplete = util.nop
+
+      // Pause the current socket not to buffer the body (if any) at all
+      return true
+    }
+
+    // Call the original implementation to proceed
+    super.dispatch(opts, handler)
+  }
+
+  parseMaxRedirects(opts) {
+    if (opts.maxRedirections === false) {
+      opts[kRedirectsLeft] = -1
+    } else if (
+      opts.maxRedirections === true ||
+      typeof opts.maxRedirections !== 'number' ||
+      isNaN(opts.maxRedirections)
+    ) {
+      opts[kRedirectsLeft] = defaultMaxRedirections
+    } else {
+      opts[kRedirectsLeft] = opts.maxRedirections
+    }
+  }
+
+  redirectLocation(statusCode, headers, opts) {
+    if (opts[kRedirectsLeft] < 0 || redirectCodes.indexOf(statusCode) === -1) {
+      return null
+    }
+
+    // Find the Location header and then the value
+    const headerIndex = headers.findIndex(h => h.toLowerCase() === 'location')
+    return headerIndex >= 0 ? headers[headerIndex + 1] : null
+  }
+
+  removeHostSpecificHeaders(headers) {
+    if (Array.isArray(headers)) {
+      for (let i = headers.length - 2; i >= 0; i -= 2) {
+        const headerName = headers[i].toLowerCase()
+
+        if (headerName === 'host' || headerName.indexOf('content-') === 0) {
+          headers.splice(i, 2)
+        }
+      }
+    } else {
+      // IncomingHttpHeaders
+      for (const rawHeaderName of Object.keys(headers)) {
+        const headerName = rawHeaderName.toLowerCase()
+
+        if (headerName === 'host' || headerName.indexOf('content-') === 0) {
+          headers[rawHeaderName] = undefined
+        }
+      }
+    }
+  }
+}
+
+module.exports = RedirectPool

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pipeline, request, stream } = require('./agent')
+const { request, stream } = require('./agent')
 const { InvalidArgumentError } = require('./core/errors')
 const util = require('./core/util')
 const Pool = require('./pool')
@@ -20,8 +20,8 @@ function parseMaxRedirections ({ maxRedirections = defaultMaxRedirections }) {
   return maxRedirections
 }
 
-function redirectLocation (statusCode, headers, opts) {
-  if (opts[kLeftRedirections] < 0 || redirectCodes.indexOf(statusCode) === -1) {
+function redirectLocation (statusCode, headers, leftRedirections) {
+  if (leftRedirections < 0 || redirectCodes.indexOf(statusCode) === -1) {
     return null
   }
 
@@ -69,22 +69,40 @@ class RedirectPool extends Pool {
 
   dispatch (opts, handler) {
     const pool = this
-
-    // Compute the number of left redirects, if needed
-    if (!(kLeftRedirections in opts)) {
-      opts[kLeftRedirections] = parseMaxRedirections(opts)
-    }
-
     const originalOnHeaders = handler.onHeaders
 
+    // Cannot use RedirectPool on pipelines
+    if (handler.handler) {
+      throw new InvalidArgumentError('RedirectPool cannot be used with pipeline')
+    }
+
+    if (util.isStream(opts.body)) {
+      throw new InvalidArgumentError('body cannot be a stream when using RedirectPool')
+    }
+
+    const maxRedirections = parseMaxRedirections(opts)
+
     handler.onHeaders = function onHeadersWithRedirect (statusCode, headers, resume) {
+      let { [kLeftRedirections]: leftRedirections, [kFollowedRedirections]: followedRedirections } = opts
+
+      if (typeof leftRedirections !== 'number') {
+        leftRedirections = maxRedirections
+      }
+
       // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
-      const location = redirectLocation(statusCode, headers, opts)
+      const location = redirectLocation(statusCode, headers, leftRedirections)
 
       // Nothing to follow, use the original implementation
       if (!location) {
-        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: opts[kFollowedRedirections] })
+        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: followedRedirections })
       }
+
+      // Gather other request options that will be modified
+      let {
+        method,
+        headers: requestHeaders,
+        body
+      } = opts
 
       /*
         https://tools.ietf.org/html/rfc7231#section-6.4
@@ -92,38 +110,40 @@ class RedirectPool extends Pool {
         Remove headers referring to the original URL.
         By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
       */
-      if (opts.headers) {
-        cleanRequestHeaders(opts.headers, statusCode === 303)
+      if (requestHeaders) {
+        cleanRequestHeaders(requestHeaders, statusCode === 303)
       }
 
       // https://tools.ietf.org/html/rfc7231#section-6.4.4
       // In case of HTTP 303, always replace method to be either HEAD or GET
-      if (statusCode === 303 && opts.method !== 'HEAD') {
-        opts.method = 'GET'
+      if (statusCode === 303 && method !== 'HEAD') {
+        method = 'GET'
+        body = null
       }
 
       // Add the current URL to the list of redirects
-      if (!opts[kFollowedRedirections]) {
-        opts[kFollowedRedirections] = []
+      if (!Array.isArray(followedRedirections)) {
+        followedRedirections = []
       }
 
-      opts[kFollowedRedirections].push(`${pool[kOrigin]}${opts.path}`)
+      followedRedirections.push(`${pool[kOrigin]}${opts.path}`)
 
-      // Update options
-      opts.path = null
-      opts[kLeftRedirections]--
+      // Prepare options for the next request
+      const redirectedOpts = {
+        ...opts,
+        method,
+        path: null,
+        headers: requestHeaders,
+        body,
+        [kLeftRedirections]: leftRedirections - 1,
+        [kFollowedRedirections]: followedRedirections
+      }
 
-      // Follow the redirect
-      switch (opts.requestType) {
-        case 'request':
-          request(location, opts, handler.callback)
-          break
-        case 'stream':
-          stream(location, opts, handler.factory, handler.callback)
-          break
-        case 'pipeline':
-          pipeline(location, opts, handler.handler)
-          break
+      // Follow the redirect using same options - Note the top-level method must be used to support cross origin
+      if (handler.factory) { // This is a StreamHandler
+        stream(location, redirectedOpts, handler.factory, handler.callback)
+      } else {
+        request(location, redirectedOpts, handler.callback)
       }
 
       // Ignore the body

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -69,7 +69,6 @@ class RedirectPool extends Pool {
 
   dispatch (opts, handler) {
     const pool = this
-    const originalOnHeaders = handler.onHeaders
 
     // Cannot use RedirectPool on pipelines
     if (handler.handler) {
@@ -82,80 +81,99 @@ class RedirectPool extends Pool {
 
     const maxRedirections = parseMaxRedirections(opts)
 
-    handler.onHeaders = function onHeadersWithRedirect (statusCode, headers, resume) {
-      let { [kLeftRedirections]: leftRedirections, [kFollowedRedirections]: followedRedirections } = opts
+    const redirectingHandler = {
+      onConnect (abort) {
+        handler.onConnect(abort)
+      },
 
-      if (typeof leftRedirections !== 'number') {
-        leftRedirections = maxRedirections
+      onUpgrade (statusCode, headers, socket) {
+        handler.onUpgrade(statusCode, headers, socket)
+      },
+
+      onError (error) {
+        handler.onError(error)
+      },
+
+      onHeaders (statusCode, headers, resume) {
+        let { [kLeftRedirections]: leftRedirections, [kFollowedRedirections]: followedRedirections } = opts
+
+        if (typeof leftRedirections !== 'number') {
+          leftRedirections = maxRedirections
+        }
+
+        // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
+        const location = redirectLocation(statusCode, headers, leftRedirections)
+
+        // Nothing to follow, use the original implementation
+        if (!location) {
+          return handler.onHeaders(statusCode, headers, resume, { redirections: followedRedirections })
+        }
+
+        // Gather other request options that will be modified
+        let { method, headers: requestHeaders, body } = opts
+
+        /*
+          https://tools.ietf.org/html/rfc7231#section-6.4
+
+          Remove headers referring to the original URL.
+          By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
+        */
+        if (requestHeaders) {
+          cleanRequestHeaders(requestHeaders, statusCode === 303)
+        }
+
+        // https://tools.ietf.org/html/rfc7231#section-6.4.4
+        // In case of HTTP 303, always replace method to be either HEAD or GET
+        if (statusCode === 303 && method !== 'HEAD') {
+          method = 'GET'
+          body = null
+        }
+
+        // Add the current URL to the list of redirects
+        if (!Array.isArray(followedRedirections)) {
+          followedRedirections = []
+        }
+
+        followedRedirections.push(`${pool[kOrigin]}${opts.path}`)
+
+        // Prepare options for the next request
+        const redirectedOpts = {
+          ...opts,
+          method,
+          path: null,
+          headers: requestHeaders,
+          body,
+          [kLeftRedirections]: leftRedirections - 1,
+          [kFollowedRedirections]: followedRedirections
+        }
+
+        // Follow the redirect using same options - Note the top-level method must be used to support cross origin
+        if (handler.factory) {
+          // This is a StreamHandler
+          stream(location, redirectedOpts, handler.factory, handler.callback)
+        } else {
+          request(location, redirectedOpts, handler.callback)
+        }
+
+        // Ignore the body
+        redirectingHandler.onData = util.nop
+        redirectingHandler.onComplete = util.nop
+
+        // Pause the current socket not to buffer the body (if any) at all
+        return true
+      },
+
+      onData (chunk) {
+        return handler.onData(chunk)
+      },
+
+      onComplete (trailers) {
+        handler.onComplete(trailers)
       }
-
-      // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
-      const location = redirectLocation(statusCode, headers, leftRedirections)
-
-      // Nothing to follow, use the original implementation
-      if (!location) {
-        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: followedRedirections })
-      }
-
-      // Gather other request options that will be modified
-      let {
-        method,
-        headers: requestHeaders,
-        body
-      } = opts
-
-      /*
-        https://tools.ietf.org/html/rfc7231#section-6.4
-
-        Remove headers referring to the original URL.
-        By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
-      */
-      if (requestHeaders) {
-        cleanRequestHeaders(requestHeaders, statusCode === 303)
-      }
-
-      // https://tools.ietf.org/html/rfc7231#section-6.4.4
-      // In case of HTTP 303, always replace method to be either HEAD or GET
-      if (statusCode === 303 && method !== 'HEAD') {
-        method = 'GET'
-        body = null
-      }
-
-      // Add the current URL to the list of redirects
-      if (!Array.isArray(followedRedirections)) {
-        followedRedirections = []
-      }
-
-      followedRedirections.push(`${pool[kOrigin]}${opts.path}`)
-
-      // Prepare options for the next request
-      const redirectedOpts = {
-        ...opts,
-        method,
-        path: null,
-        headers: requestHeaders,
-        body,
-        [kLeftRedirections]: leftRedirections - 1,
-        [kFollowedRedirections]: followedRedirections
-      }
-
-      // Follow the redirect using same options - Note the top-level method must be used to support cross origin
-      if (handler.factory) { // This is a StreamHandler
-        stream(location, redirectedOpts, handler.factory, handler.callback)
-      } else {
-        request(location, redirectedOpts, handler.callback)
-      }
-
-      // Ignore the body
-      handler.onData = util.nop
-      handler.onComplete = util.nop
-
-      // Pause the current socket not to buffer the body (if any) at all
-      return true
     }
 
-    // Call the original implementation to proceed
-    super.dispatch(opts, handler)
+    // Call the original implementation with the new handler to proceed
+    super.dispatch(opts, redirectingHandler)
   }
 }
 

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Readable } = require('stream')
 const { pipeline, request, stream } = require('./agent')
 const { InvalidArgumentError } = require('./core/errors')
 const util = require('./core/util')
@@ -12,7 +11,7 @@ const kLeftRedirections = Symbol('left redirections')
 const redirectCodes = [300, 301, 302, 303, 307, 308]
 const defaultMaxRedirections = 10
 
-function parseMaxRedirections({ maxRedirections = defaultMaxRedirections }) {
+function parseMaxRedirections ({ maxRedirections = defaultMaxRedirections }) {
   if (maxRedirections != null && (maxRedirections <= 0 || !Number.isInteger(maxRedirections))) {
     throw new InvalidArgumentError('maxRedirections must be a positive number')
   }
@@ -20,7 +19,7 @@ function parseMaxRedirections({ maxRedirections = defaultMaxRedirections }) {
   return maxRedirections
 }
 
-function redirectLocation(statusCode, headers, opts) {
+function redirectLocation (statusCode, headers, opts) {
   if (opts[kLeftRedirections] < 0 || redirectCodes.indexOf(statusCode) === -1) {
     return null
   }
@@ -36,18 +35,16 @@ function redirectLocation(statusCode, headers, opts) {
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4.4
-function shouldRemoveHeader(header, removeContent) {
+function shouldRemoveHeader (header, removeContent) {
   const lcHeader = header.toLowerCase()
 
   return lcHeader === 'host' || (removeContent && lcHeader.indexOf('content-') === 0)
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4
-function cleanRequestHeaders(headers, removeContent) {
+function cleanRequestHeaders (headers, removeContent) {
   if (Array.isArray(headers)) {
     for (let i = headers.length - 2; i >= 0; i -= 2) {
-      const headerName = headers[i].toLowerCase()
-
       if (shouldRemoveHeader(headers[i], removeContent)) {
         headers.splice(i, 2)
       }
@@ -62,20 +59,14 @@ function cleanRequestHeaders(headers, removeContent) {
   }
 }
 
-class RedirectDiscardedResponse extends Readable {
-  constructor(resume) {
-    super({ autoDestroy: true, read: resume })
-  }
-}
-
 class RedirectPool extends Pool {
-  constructor(origin, options) {
+  constructor (origin, options) {
     super(origin, options)
 
     this[kOrigin] = origin
   }
 
-  dispatch(opts, handler) {
+  dispatch (opts, handler) {
     const pool = this
 
     // Compute the number of left redirects, if needed
@@ -85,7 +76,7 @@ class RedirectPool extends Pool {
 
     const originalOnHeaders = handler.onHeaders
 
-    handler.onHeaders = function onHeadersWithRedirect(statusCode, headers, resume) {
+    handler.onHeaders = function onHeadersWithRedirect (statusCode, headers, resume) {
       // Check if statusCode is 3xx, if there is a location header and if the redirection can be followed
       const location = redirectLocation(statusCode, headers, opts)
 
@@ -147,7 +138,7 @@ class RedirectPool extends Pool {
   }
 }
 
-function redirectPoolFactory(origin, opts) {
+function redirectPoolFactory (origin, opts) {
   return new RedirectPool(origin, opts)
 }
 

--- a/lib/redirect-pool.js
+++ b/lib/redirect-pool.js
@@ -6,6 +6,7 @@ const util = require('./core/util')
 const Pool = require('./pool')
 
 const kOrigin = Symbol('origin')
+const kFollowedRedirections = Symbol('followed redirections')
 const kLeftRedirections = Symbol('left redirections')
 
 const redirectCodes = [300, 301, 302, 303, 307, 308]
@@ -82,7 +83,7 @@ class RedirectPool extends Pool {
 
       // Nothing to follow, use the original implementation
       if (!location) {
-        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: opts.redirections })
+        return originalOnHeaders.call(handler, statusCode, headers, resume, { redirections: opts[kFollowedRedirections] })
       }
 
       /*
@@ -102,11 +103,11 @@ class RedirectPool extends Pool {
       }
 
       // Add the current URL to the list of redirects
-      if (!opts.redirections) {
-        opts.redirections = []
+      if (!opts[kFollowedRedirections]) {
+        opts[kFollowedRedirections] = []
       }
 
-      opts.redirections.push(`${pool[kOrigin]}${opts.path}`)
+      opts[kFollowedRedirections].push(`${pool[kOrigin]}${opts.path}`)
 
       // Update options
       opts.path = null

--- a/test/redirect-pipeline.js
+++ b/test/redirect-pipeline.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const t = require('tap')
+const { pipeline: undiciPipeline, Agent, redirectPoolFactory } = require('..')
+const { Readable, Writable, pipeline: streamPipelineCb } = require('stream')
+const { promisify } = require('util')
+
+const streamPipeline = promisify(streamPipelineCb)
+
+t.test('should not allow use of RedirectPool with pipelines', async t => {
+  t.plan(1)
+
+  const body = []
+
+  try {
+    await streamPipeline(
+      new Readable({
+        read () {
+          this.push(Buffer.from('REQUEST'))
+          this.push(null)
+        }
+      }),
+      undiciPipeline(
+        'http://localhost:0',
+        { agent: new Agent({ factory: redirectPoolFactory }) },
+        ({ statusCode, headers, body }) => {
+          t.fail('Pipelined')
+
+          return body
+        }
+      ),
+      new Writable({
+        write (chunk, _, callback) {
+          body.push(chunk.toString())
+          callback()
+        },
+        final (callback) {
+          callback()
+        }
+      })
+    )
+
+    throw new Error('Did not throw')
+  } catch (error) {
+    t.strictEqual(error.message, 'RedirectPool cannot be used with pipeline')
+  }
+})

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const t = require('tap')
-const { request, Agent, RedirectPool, redirectPoolFactory } = require('..')
+const { request, Agent, redirectPoolFactory } = require('..')
 const { createServer } = require('http')
 
-function defaultHandler(req, res) {
+function defaultHandler (req, res) {
   // Parse the path and normalize arguments
   let [code, redirections] = req.url
     .slice(1)
@@ -42,7 +42,7 @@ function defaultHandler(req, res) {
   res.end('')
 }
 
-function startServer(t, handler = defaultHandler) {
+function startServer (t, handler = defaultHandler) {
   return new Promise(resolve => {
     const server = createServer(handler)
 
@@ -291,7 +291,7 @@ t.only('should ignore HTTP 3xx response bodies', async t => {
   t.is(statusCode, 200)
   t.notOk(headers.location)
   t.deepEqual(redirections, [`http://${serverRoot}/`])
-  t.is(body, `FINAL`)
+  t.is(body, 'FINAL')
 })
 
 t.test('should follow a redirect chain up to the allowed number of times', async t => {

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -426,7 +426,7 @@ t.test('should handle errors (callback)', t => {
       agent: new Agent({ factory: redirectPoolFactory })
     },
     error => {
-      t.is(error.code, 'EADDRNOTAVAIL')
+      t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
     }
   )
 })
@@ -437,7 +437,7 @@ t.test('should handle errors (promise)', async t => {
   try {
     await request('http://localhost:0', { agent: new Agent({ factory: redirectPoolFactory }) })
     throw new Error('Did not throw')
-  } catch (e) {
-    t.is(e.code, 'EADDRNOTAVAIL')
+  } catch (error) {
+    t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
   }
 })

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -1,0 +1,464 @@
+'use strict'
+
+const t = require('tap')
+const { request, Agent, RedirectPool } = require('..')
+const { createServer } = require('http')
+
+function defaultHandler(req, res) {
+  // Parse the path and normalize arguments
+  let [code, redirections] = req.url
+    .slice(1)
+    .split('/')
+    .map(r => parseInt(r, 10))
+
+  if (isNaN(code) || code < 0) {
+    code = 302
+  }
+
+  if (isNaN(redirections) || redirections < 0) {
+    redirections = 0
+  }
+
+  // On 303, the method must be GET or HEAD after the first redirect
+  if (code === 303 && redirections > 0 && req.method !== 'GET' && req.method !== 'HEAD') {
+    res.statusCode = 400
+    res.end('Did not switch to GET')
+    return
+  }
+
+  // End the chain at some point
+  if (redirections === 5) {
+    res.end(
+      `${req.method} :: ${Object.entries(req.headers)
+        .map(([k, v]) => `${k}@${v}`)
+        .join(' ')}`
+    )
+    return
+  }
+
+  // Redirect by default
+  res.statusCode = code
+  res.setHeader('Location', `http://localhost:${this.address().port}/${code}/${++redirections}`)
+  res.end('')
+}
+
+function startServer(t, handler = defaultHandler) {
+  return new Promise(resolve => {
+    const server = createServer(handler)
+
+    server.listen(0, () => {
+      resolve(`localhost:${server.address().port}`)
+    })
+
+    t.teardown(server.close.bind(server))
+  })
+}
+
+t.test('should not follow redirection by default if not using RedirectPool', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t, (req, res) => {
+    res.statusCode = 301
+    res.setHeader('Location', serverRoot)
+    res.end('')
+  })
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}`)
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 301)
+  t.is(headers.location, serverRoot)
+  t.equal(body.length, 0)
+})
+
+t.test('should follow redirection after a HTTP 300', async t => {
+  t.plan(4)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream, redirections } = await request(`http://${serverRoot}/300`, {
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.deepEqual(redirections, [
+    `http://${serverRoot}/300`,
+    `http://${serverRoot}/300/1`,
+    `http://${serverRoot}/300/2`,
+    `http://${serverRoot}/300/3`,
+    `http://${serverRoot}/300/4`
+  ])
+  t.is(body, `GET :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should follow redirection after a HTTP 301', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/301`, {
+    method: 'POST',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `POST :: connection@keep-alive host@${serverRoot} content-length@0`)
+})
+
+t.test('should follow redirection after a HTTP 302', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/302`, {
+    method: 'PUT',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `PUT :: connection@keep-alive host@${serverRoot} content-length@0`)
+})
+
+t.test('should follow redirection after a HTTP 303 changing method to GET', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/303`, {
+    method: 'PATCH',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `GET :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should remove Host and request body related headers when following HTTP 303 (array)', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/303`, {
+    method: 'PATCH',
+    headers: [
+      'Content-Encoding',
+      'gzip',
+      'X-Foo1',
+      '1',
+      'X-Foo2',
+      '2',
+      'Content-Type',
+      'application/json',
+      'X-Foo3',
+      '3',
+      'Host',
+      'localhost',
+      'X-Bar',
+      '4'
+    ],
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `GET :: connection@keep-alive host@${serverRoot} x-foo1@1 x-foo2@2 x-foo3@3 x-bar@4`)
+})
+
+t.test('should remove Host and request body related headers when following HTTP 303 (object)', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/303`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Encoding': 'gzip',
+      'X-Foo1': '1',
+      'X-Foo2': '2',
+      'Content-Type': 'application/json',
+      'X-Foo3': '3',
+      Host: 'localhost',
+      'X-Bar': '4'
+    },
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `GET :: connection@keep-alive host@${serverRoot} x-foo1@1 x-foo2@2 x-foo3@3 x-bar@4`)
+})
+
+t.test('should follow redirection after a HTTP 307', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/307`, {
+    method: 'DELETE',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `DELETE :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should follow redirection after a HTTP 308', async t => {
+  t.plan(3)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/308`, {
+    method: 'OPTIONS',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.is(body, `OPTIONS :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.only('should ignore HTTP 3xx response bodies', async t => {
+  t.plan(4)
+
+  let body = ''
+  const serverRoot = await startServer(t, (req, res) => {
+    if (req.url === '/') {
+      res.statusCode = 301
+      res.setHeader('Location', `http://${serverRoot}/end`)
+      res.end('REDIRECT')
+      return
+    }
+
+    res.end('FINAL')
+  })
+
+  const { statusCode, headers, body: bodyStream, redirections } = await request(`http://${serverRoot}/`, {
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.deepEqual(redirections, [`http://${serverRoot}/`])
+  t.is(body, `FINAL`)
+})
+
+t.test('should follow a redirect chain up to the allowed number of times', async t => {
+  t.plan(4)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream, redirections } = await request(`http://${serverRoot}/300`, {
+    agent: new Agent({ poolClass: RedirectPool }),
+    maxRedirections: 2
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 300)
+  t.is(headers.location, `http://${serverRoot}/300/4`)
+  t.deepEqual(redirections, [`http://${serverRoot}/300`, `http://${serverRoot}/300/1`, `http://${serverRoot}/300/2`])
+  t.equal(body.length, 0)
+})
+
+t.test('should not follow redirections when disabled', async t => {
+  t.plan(4)
+
+  let body = ''
+  const serverRoot = await startServer(t)
+
+  const { statusCode, headers, body: bodyStream, redirections } = await request(`http://${serverRoot}/300`, {
+    agent: new Agent({ poolClass: RedirectPool }),
+    maxRedirections: false
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 300)
+  t.is(headers.location, `http://${serverRoot}/300/1`)
+  t.notOk(redirections)
+  t.equal(body.length, 0)
+})
+
+t.test('should follow redirections when going cross origin', async t => {
+  const server1 = await startServer(t, (req, res) => {
+    if (req.url === '/') {
+      res.statusCode = 301
+      res.setHeader('Location', `http://${server2}/`)
+      res.end('')
+      return
+    }
+
+    res.end(req.method)
+  })
+
+  const server2 = await startServer(t, (req, res) => {
+    res.statusCode = 301
+
+    if (req.url === '/') {
+      res.setHeader('Location', `http://${server3}/`)
+    } else {
+      res.setHeader('Location', `http://${server3}/end`)
+    }
+
+    res.end('')
+  })
+
+  const server3 = await startServer(t, (req, res) => {
+    res.statusCode = 301
+
+    if (req.url === '/') {
+      res.setHeader('Location', `http://${server2}/end`)
+    } else {
+      res.setHeader('Location', `http://${server1}/end`)
+    }
+
+    res.end('')
+  })
+
+  t.plan(4)
+
+  let body = ''
+
+  const { statusCode, headers, body: bodyStream, redirections } = await request(`http://${server1}`, {
+    method: 'POST',
+    agent: new Agent({ poolClass: RedirectPool })
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.is(statusCode, 200)
+  t.notOk(headers.location)
+  t.deepEqual(redirections, [
+    `http://${server1}/`,
+    `http://${server2}/`,
+    `http://${server3}/`,
+    `http://${server2}/end`,
+    `http://${server3}/end`
+  ])
+  t.is(body, 'POST')
+})
+
+t.test('when a Location response header is NOT present', async t => {
+  const redirectCodes = [300, 301, 302, 303, 307, 308]
+
+  const serverRoot = await startServer(t, (req, res) => {
+    // Parse the path and normalize arguments
+    let [code] = req.url
+      .slice(1)
+      .split('/')
+      .map(r => parseInt(r, 10))
+
+    if (isNaN(code) || code < 0) {
+      code = 302
+    }
+
+    res.statusCode = code
+    res.end('')
+  })
+
+  t.plan(redirectCodes.length)
+
+  for (const code of redirectCodes) {
+    t.test(`should return the original response after a HTTP ${code}`, async t => {
+      t.plan(3)
+
+      let body = ''
+
+      const { statusCode, headers, body: bodyStream } = await request(`http://${serverRoot}/${code}`, {
+        agent: new Agent({ poolClass: RedirectPool })
+      })
+
+      for await (const b of bodyStream) {
+        body += b
+      }
+
+      t.is(statusCode, code)
+      t.notOk(headers.location)
+      t.equal(body.length, 0)
+    })
+  }
+})
+
+t.test('should handle errors (callback)', t => {
+  t.plan(1)
+
+  request(
+    'http://localhost:0',
+    {
+      agent: new Agent({ poolClass: RedirectPool })
+    },
+    error => {
+      t.is(error.code, 'EADDRNOTAVAIL')
+    }
+  )
+})
+
+t.test('should handle errors (promise)', async t => {
+  t.plan(1)
+
+  try {
+    await request('http://localhost:0', { agent: new Agent({ poolClass: RedirectPool }) })
+    throw new Error('Did not throw')
+  } catch (e) {
+    t.is(e.code, 'EADDRNOTAVAIL')
+  }
+})

--- a/test/redirect-stream.js
+++ b/test/redirect-stream.js
@@ -1,0 +1,496 @@
+'use strict'
+
+const t = require('tap')
+const { stream, Agent, redirectPoolFactory } = require('..')
+const { createServer } = require('http')
+const { Writable } = require('stream')
+
+function defaultHandler (req, res) {
+  // Parse the path and normalize arguments
+  let [code, redirections] = req.url
+    .slice(1)
+    .split('/')
+    .map(r => parseInt(r, 10))
+
+  if (isNaN(code) || code < 0) {
+    code = 302
+  }
+
+  if (isNaN(redirections) || redirections < 0) {
+    redirections = 0
+  }
+
+  // On 303, the method must be GET or HEAD after the first redirect
+  if (code === 303 && redirections > 0 && req.method !== 'GET' && req.method !== 'HEAD') {
+    res.statusCode = 400
+    res.setHeader('Connection', 'close')
+    res.end('Did not switch to GET')
+    return
+  }
+
+  // End the chain at some point
+  if (redirections === 5) {
+    res.setHeader('Connection', 'close')
+    res.end(
+      `${req.method} :: ${Object.entries(req.headers)
+        .map(([k, v]) => `${k}@${v}`)
+        .join(' ')}`
+    )
+    return
+  }
+
+  // Redirect by default
+  res.statusCode = code
+  res.setHeader('Connection', 'close')
+  res.setHeader('Location', `http://localhost:${this.address().port}/${code}/${++redirections}`)
+  res.end('')
+}
+
+function startServer (t, handler = defaultHandler) {
+  return new Promise(resolve => {
+    const server = createServer(handler)
+
+    server.listen(0, () => {
+      resolve(`localhost:${server.address().port}`)
+    })
+
+    t.teardown(server.close.bind(server))
+  })
+}
+
+function createWritable (target) {
+  return new Writable({
+    write (chunk, _, callback) {
+      target.push(chunk.toString())
+      callback()
+    },
+    final (callback) {
+      callback()
+    }
+  })
+}
+
+t.test('should not follow redirection by default if not using RedirectPool', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t, (req, res) => {
+    res.statusCode = 301
+    res.setHeader('Connection', 'close')
+    res.setHeader('Location', serverRoot)
+    res.end('')
+  })
+
+  await stream(`http://${serverRoot}`, { opaque: body }, ({ statusCode, headers, opaque }) => {
+    t.strictEqual(statusCode, 301)
+    t.strictEqual(headers.location, serverRoot)
+
+    return createWritable(opaque)
+  })
+
+  t.strictEqual(body.length, 0)
+})
+
+t.test('should follow redirection after a HTTP 300', async t => {
+  t.plan(4)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/300`,
+    { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+      t.deepEqual(redirections, [
+        `http://${serverRoot}/300`,
+        `http://${serverRoot}/300/1`,
+        `http://${serverRoot}/300/2`,
+        `http://${serverRoot}/300/3`,
+        `http://${serverRoot}/300/4`
+      ])
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `GET :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should follow redirection after a HTTP 301', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/301`,
+    { method: 'POST', opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `POST :: connection@keep-alive host@${serverRoot} content-length@0`)
+})
+
+t.test('should follow redirection after a HTTP 302', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/302`,
+    { method: 'PUT', opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `PUT :: connection@keep-alive host@${serverRoot} content-length@0`)
+})
+
+t.test('should follow redirection after a HTTP 303 changing method to GET', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/303`,
+    { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `GET :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should remove Host and request body related headers when following HTTP 303 (array)', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/303`,
+    {
+      method: 'PATCH',
+      headers: [
+        'Content-Encoding',
+        'gzip',
+        'X-Foo1',
+        '1',
+        'X-Foo2',
+        '2',
+        'Content-Type',
+        'application/json',
+        'X-Foo3',
+        '3',
+        'Host',
+        'localhost',
+        'X-Bar',
+        '4'
+      ],
+      opaque: body,
+      agent: new Agent({ factory: redirectPoolFactory })
+    },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `GET :: connection@keep-alive host@${serverRoot} x-foo1@1 x-foo2@2 x-foo3@3 x-bar@4`)
+})
+
+t.test('should remove Host and request body related headers when following HTTP 303 (object)', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/303`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Encoding': 'gzip',
+        'X-Foo1': '1',
+        'X-Foo2': '2',
+        'Content-Type': 'application/json',
+        'X-Foo3': '3',
+        Host: 'localhost',
+        'X-Bar': '4'
+      },
+      opaque: body,
+      agent: new Agent({ factory: redirectPoolFactory })
+    },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `GET :: connection@keep-alive host@${serverRoot} x-foo1@1 x-foo2@2 x-foo3@3 x-bar@4`)
+})
+
+t.test('should follow redirection after a HTTP 307', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/307`,
+    { method: 'DELETE', opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `DELETE :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should follow redirection after a HTTP 308', async t => {
+  t.plan(3)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/308`,
+    { method: 'OPTIONS', opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), `OPTIONS :: connection@keep-alive host@${serverRoot}`)
+})
+
+t.test('should ignore HTTP 3xx response bodies', async t => {
+  t.plan(4)
+
+  const body = []
+  const serverRoot = await startServer(t, (req, res) => {
+    if (req.url === '/') {
+      res.statusCode = 301
+      res.setHeader('Connection', 'close')
+      res.setHeader('Location', `http://${serverRoot}/end`)
+      res.end('REDIRECT')
+      return
+    }
+
+    res.setHeader('Connection', 'close')
+    res.end('FINAL')
+  })
+
+  await stream(
+    `http://${serverRoot}/`,
+    { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+      t.deepEqual(redirections, [`http://${serverRoot}/`])
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), 'FINAL')
+})
+
+t.test('should follow a redirect chain up to the allowed number of times', async t => {
+  t.plan(4)
+
+  const body = []
+  const serverRoot = await startServer(t)
+
+  await stream(
+    `http://${serverRoot}/300`,
+    { opaque: body, agent: new Agent({ factory: redirectPoolFactory }), maxRedirections: 2 },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 300)
+      t.strictEqual(headers.location, `http://${serverRoot}/300/4`)
+      t.deepEqual(redirections, [
+        `http://${serverRoot}/300`,
+        `http://${serverRoot}/300/1`,
+        `http://${serverRoot}/300/2`
+      ])
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.length, 0)
+})
+
+t.test('should follow redirections when going cross origin', async t => {
+  const server1 = await startServer(t, (req, res) => {
+    if (req.url === '/') {
+      res.statusCode = 301
+      res.setHeader('Connection', 'close')
+      res.setHeader('Location', `http://${server2}/`)
+      res.end('')
+      return
+    }
+
+    res.setHeader('Connection', 'close')
+    res.end(req.method)
+  })
+
+  const server2 = await startServer(t, (req, res) => {
+    res.statusCode = 301
+    res.setHeader('Connection', 'close')
+
+    if (req.url === '/') {
+      res.setHeader('Location', `http://${server3}/`)
+    } else {
+      res.setHeader('Location', `http://${server3}/end`)
+    }
+
+    res.end('')
+  })
+
+  const server3 = await startServer(t, (req, res) => {
+    res.statusCode = 301
+    res.setHeader('Connection', 'close')
+
+    if (req.url === '/') {
+      res.setHeader('Location', `http://${server2}/end`)
+    } else {
+      res.setHeader('Location', `http://${server1}/end`)
+    }
+
+    res.end('')
+  })
+
+  t.plan(4)
+
+  const body = []
+
+  await stream(
+    `http://${server1}`,
+    { method: 'POST', opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      t.strictEqual(statusCode, 200)
+      t.notOk(headers.location)
+      t.deepEqual(redirections, [
+        `http://${server1}/`,
+        `http://${server2}/`,
+        `http://${server3}/`,
+        `http://${server2}/end`,
+        `http://${server3}/end`
+      ])
+
+      return createWritable(opaque)
+    }
+  )
+
+  t.strictEqual(body.join(''), 'POST')
+})
+
+t.test('when a Location response header is NOT present', async t => {
+  const redirectCodes = [300, 301, 302, 303, 307, 308]
+
+  const serverRoot = await startServer(t, (req, res) => {
+    // Parse the path and normalize arguments
+    let [code] = req.url
+      .slice(1)
+      .split('/')
+      .map(r => parseInt(r, 10))
+
+    if (isNaN(code) || code < 0) {
+      code = 302
+    }
+
+    res.statusCode = code
+    res.setHeader('Connection', 'close')
+    res.end('')
+  })
+
+  t.plan(redirectCodes.length)
+
+  for (const code of redirectCodes) {
+    t.test(`should return the original response after a HTTP ${code}`, async t => {
+      t.plan(3)
+
+      const body = []
+
+      await stream(
+        `http://${serverRoot}/${code}`,
+        { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+        ({ statusCode, headers, opaque }) => {
+          t.strictEqual(statusCode, code)
+          t.notOk(headers.location)
+
+          return createWritable(opaque)
+        }
+      )
+
+      t.strictEqual(body.length, 0)
+    })
+  }
+})
+
+t.test('should handle errors (callback)', t => {
+  t.plan(2)
+
+  const body = []
+
+  stream(
+    'http://localhost:0',
+    { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+    ({ statusCode, headers, redirections, opaque }) => {
+      return createWritable(opaque)
+    },
+    error => {
+      t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
+      t.strictEqual(body.length, 0)
+    }
+  )
+})
+
+t.test('should handle errors (promise)', async t => {
+  t.plan(2)
+
+  const body = []
+
+  try {
+    await stream(
+      'http://localhost:0',
+      { opaque: body, agent: new Agent({ factory: redirectPoolFactory }) },
+      ({ statusCode, headers, redirections, opaque }) => {
+        return createWritable(opaque)
+      }
+    )
+
+    throw new Error('Did not throw')
+  } catch (error) {
+    t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
+    t.strictEqual(body.length, 0)
+  }
+})

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { Pool, Agent, setGlobalAgent, request, stream, pipeline, Client } from '../..'
+import { Pool, Agent, setGlobalAgent, request, stream, pipeline, Client, RedirectPool } from '../..'
 import { Writable, Readable, Duplex } from 'stream'
 
 expectAssignable<Agent>(new Agent())
@@ -13,12 +13,13 @@ expectAssignable<Agent>(new Agent({}))
 
 {
   expectAssignable<void>(setGlobalAgent(new Agent()))
+  expectAssignable<void>(setGlobalAgent(new Agent({ poolClass: RedirectPool })))
   expectAssignable<void>(setGlobalAgent({ get: origin => new Pool(origin) }))
 }
 
 {
-  expectAssignable<PromiseLike<Client.ResponseData>>(request(''))
-  expectAssignable<PromiseLike<Client.StreamData>>(stream('', { method: '' }, data => {
+  expectAssignable<PromiseLike<Client.ResponseData>>(request('', { maxRedirections: 1 }))
+  expectAssignable<PromiseLike<Client.StreamData>>(stream('', { method: '', maxRedirections: 1 }, data => {
     expectAssignable<Client.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -26,7 +27,7 @@ expectAssignable<Agent>(new Agent({}))
 }
 
 {
-  expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
+  expectAssignable<Duplex>(pipeline('', { method: '', maxRedirections: 1 }, data => {
     expectAssignable<Client.PipelineHandlerData>(data)
     return new Readable()
   }))

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { Pool, Agent, setGlobalAgent, request, stream, pipeline, Client, RedirectPool } from '../..'
+import { Pool, Agent, setGlobalAgent, request, stream, pipeline, Client, redirectPoolFactory } from '../..'
 import { Writable, Readable, Duplex } from 'stream'
 
 expectAssignable<Agent>(new Agent())
@@ -13,8 +13,7 @@ expectAssignable<Agent>(new Agent({}))
 
 {
   expectAssignable<void>(setGlobalAgent(new Agent()))
-  expectAssignable<void>(setGlobalAgent(new Agent({ poolClass: RedirectPool })))
-  expectAssignable<void>(setGlobalAgent({ get: origin => new Pool(origin) }))
+  expectAssignable<void>(setGlobalAgent(new Agent({ factory: redirectPoolFactory })))
 }
 
 {

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -1,8 +1,7 @@
-import { UrlObject } from 'url'
-import Pool from './pool'
-import Client from './client'
 import { Duplex } from 'stream'
-import { URL } from 'url'
+import { URL, UrlObject } from 'url'
+import Client from './client'
+import Pool from './pool'
 
 export {
   Agent,
@@ -12,8 +11,17 @@ export {
   pipeline,
 }
 
+
+interface ClientConstructor {
+  new(url: string | URL, options?: Client.Options): Client;
+}
+
+interface PoolConstructor {
+  new(url: string | URL, options?: Pool.Options): Pool;
+}
+
 declare class Agent {
-  constructor(opts?: Pool.Options)
+  constructor(opts?: Pool.Options & { clientClass?: ClientConstructor, poolClass?: PoolConstructor })
   get(origin: string): Pool;
 }
 
@@ -21,17 +29,17 @@ declare function setGlobalAgent<AgentImplementation extends Agent>(agent: AgentI
 
 declare function request(
   url: string | URL | UrlObject,
-  opts?: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
+  opts?: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.RequestOptions>, 'path'>,
 ): PromiseLike<Client.ResponseData>;
 
 declare function stream(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
+  opts: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.RequestOptions>, 'path'>,
   factory: Client.StreamFactory
 ): PromiseLike<Client.StreamData>;
 
 declare function pipeline(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Omit<Client.PipelineOptions, 'path'>,
+  opts: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.PipelineOptions>, 'path'>,
   handler: Client.PipelineHandler
 ): Duplex;

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -20,17 +20,17 @@ declare function setGlobalAgent<AgentImplementation extends Agent>(agent: AgentI
 
 declare function request(
   url: string | URL | UrlObject,
-  opts?: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.RequestOptions>, 'path'>,
+  opts?: { agent?: Agent, maxRedirections?: number } & Omit<Partial<Client.RequestOptions>, 'path'>,
 ): PromiseLike<Client.ResponseData>;
 
 declare function stream(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.RequestOptions>, 'path'>,
+  opts: { agent?: Agent, maxRedirections?: number } & Omit<Partial<Client.RequestOptions>, 'path'>,
   factory: Client.StreamFactory
 ): PromiseLike<Client.StreamData>;
 
 declare function pipeline(
   url: string | URL | UrlObject,
-  opts: { agent?: Agent, maxRedirections?: boolean | number } & Omit<Partial<Client.PipelineOptions>, 'path'>,
+  opts: { agent?: Agent, maxRedirections?: number } & Omit<Partial<Client.PipelineOptions>, 'path'>,
   handler: Client.PipelineHandler
 ): Duplex;

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -11,17 +11,8 @@ export {
   pipeline,
 }
 
-
-interface ClientConstructor {
-  new(url: string | URL, options?: Client.Options): Client;
-}
-
-interface PoolConstructor {
-  new(url: string | URL, options?: Pool.Options): Pool;
-}
-
 declare class Agent {
-  constructor(opts?: Pool.Options & { clientClass?: ClientConstructor, poolClass?: PoolConstructor })
+  constructor(opts?: Pool.Options & { factory?: (url: string, opts: Pool.Options) => Pool })
   get(origin: string): Pool;
 }
 

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -1,5 +1,5 @@
-import Client from './client'
 import { URL } from 'url'
+import Client from './client'
 
 export = Pool
 

--- a/types/redirect-pool.d.ts
+++ b/types/redirect-pool.d.ts
@@ -1,0 +1,7 @@
+import Client from './client'
+import Pool from './pool'
+
+declare class RedirectPool extends Pool {}
+declare function redirectPoolFactory(url: string | URL, options?: Client.Options): RedirectPool
+
+export { RedirectPool, redirectPoolFactory }

--- a/types/redirect-pool.d.ts
+++ b/types/redirect-pool.d.ts
@@ -2,6 +2,6 @@ import Client from './client'
 import Pool from './pool'
 
 declare class RedirectPool extends Pool {}
-declare function redirectPoolFactory(url: string | URL, options?: Client.Options): RedirectPool
+declare function redirectPoolFactory(url: string, options?: Client.Options): RedirectPool
 
 export { RedirectPool, redirectPoolFactory }

--- a/types/redirect-pool.ts
+++ b/types/redirect-pool.ts
@@ -1,5 +1,0 @@
-import Pool from './pool'
-
-export = RedirectPool
-
-declare class RedirectPool extends Pool {}

--- a/types/redirect-pool.ts
+++ b/types/redirect-pool.ts
@@ -1,0 +1,5 @@
+import Pool from './pool'
+
+export = RedirectPool
+
+declare class RedirectPool extends Pool {}


### PR DESCRIPTION
This PR adds the RedirectPool as suggested by @mcollina and @ronag  in #597 to add a pool subclass which is able to follow redirected.

This PR supersedes #597 by avoiding monkey patching of the agent and clients.

At the moment has only be tested on the top-level request method, but I'd like to have your opinion before extending it to stream and pipeline.

@ronag Can you check the way I ignored the redirected request body? I realize that since HTTP 1.1 is on a single connection, I have to process the body anyway even tho I ignore it in order not to block pipelining. Thus, I just emptied the handler events.

I have two questions:

1. In https://github.com/nodejs/undici/blob/2366fa34e30ac5a8c33a3d02259f2ae0f7678c85/lib/agent.js#L43 we instantiate a Client if connections are explicitily set to `1`. Why is that? Do we still need it?
2. If the previous question answer is `yes`, does it mean I also need to create the `RedirectClient` as well?