### PR TITLE
refactor: cleanup and restructure

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@
 
 const Client = require('./lib/core/client')
 const errors = require('./lib/core/errors')
-const Pool = require('./lib/pool')
-const { Agent, request, stream, pipeline, setGlobalAgent } = require('./lib/agent')
+const Pool = require('./lib/client-pool')
+const { Agent, getGlobalAgent, setGlobalAgent } = require('./lib/agent')
+const util = require('./lib/core/util')
+const { InvalidArgumentError, InvalidReturnValueError } = require('./lib/core/errors')
+const api = require('./lib/api')
 
-Client.prototype.request = require('./lib/client-request')
-Client.prototype.stream = require('./lib/client-stream')
-Client.prototype.pipeline = require('./lib/client-pipeline')
-Client.prototype.upgrade = require('./lib/client-upgrade')
-Client.prototype.connect = require('./lib/client-connect')
+Object.assign(Client.prototype, api)
+Object.assign(Pool.prototype, api)
 
 function undici (url, opts) {
   return new Pool(url, opts)
@@ -22,7 +22,30 @@ module.exports.Client = Client
 module.exports.errors = errors
 
 module.exports.Agent = Agent
-module.exports.request = request
-module.exports.stream = stream
-module.exports.pipeline = pipeline
 module.exports.setGlobalAgent = setGlobalAgent
+module.exports.getGlobalAgent = getGlobalAgent
+
+function dispatchFromAgent (requestType) {
+  return (url, { agent = getGlobalAgent(), method = 'GET', ...opts } = {}, ...additionalArgs) => {
+    if (opts.path != null) {
+      throw new InvalidArgumentError('unsupported opts.path')
+    }
+
+    const { origin, pathname, search } = util.parseURL(url)
+    const path = `${pathname || '/'}${search || ''}`
+
+    const client = agent.get(origin)
+
+    if (client && typeof client[requestType] !== 'function') {
+      throw new InvalidReturnValueError(`Client returned from Agent.get() does not implement method ${requestType}`)
+    }
+
+    return client[requestType]({ ...opts, method, path }, ...additionalArgs)
+  }
+}
+
+module.exports.request = dispatchFromAgent('request')
+module.exports.stream = dispatchFromAgent('stream')
+module.exports.pipeline = dispatchFromAgent('pipeline')
+module.exports.connect = dispatchFromAgent('connect')
+module.exports.upgrade = dispatchFromAgent('upgrade')

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,20 +1,30 @@
 'use strict'
-const { InvalidArgumentError, InvalidReturnValueError } = require('./core/errors')
-const Pool = require('./pool')
+const { InvalidArgumentError } = require('./core/errors')
+const Pool = require('./client-pool')
 const Client = require('./core/client')
-const util = require('./core/util')
-const { kAgentOpts, kAgentCache } = require('./core/symbols')
 const EventEmitter = require('events')
 
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
+const kCache = Symbol('cache')
+const kFactory = Symbol('factory')
+
+function defaultFactory (origin, opts) {
+  return opts && opts.connections === 1
+    ? new Client(origin, opts)
+    : new Pool(origin, opts)
+}
 
 class Agent extends EventEmitter {
-  constructor (opts) {
+  constructor ({ factory = defaultFactory, ...opts } = {}) {
     super()
 
-    this[kAgentOpts] = opts
-    this[kAgentCache] = new Map()
+    if (typeof factory !== 'function') {
+      throw new InvalidArgumentError('factory must be a function.')
+    }
+
+    this[kFactory] = (origin) => factory(origin, opts)
+    this[kCache] = new Map()
 
     const agent = this
 
@@ -25,7 +35,7 @@ class Agent extends EventEmitter {
     this[kOnDisconnect] = function onDestroy (client, err) {
       if (this.connected === 0 && this.size === 0) {
         this.off('disconnect', agent[kOnDisconnect])
-        agent[kAgentCache].delete(this.origin)
+        agent[kCache].delete(this.origin)
       }
 
       agent.emit('disconnect', client, err)
@@ -37,19 +47,14 @@ class Agent extends EventEmitter {
       throw new InvalidArgumentError('Origin must be a non-empty string.')
     }
 
-    const self = this
-    let pool = self[kAgentCache].get(origin)
+    let pool = this[kCache].get(origin)
 
     if (!pool) {
-      pool = self[kAgentOpts] && self[kAgentOpts].connections === 1
-        ? new Client(origin, self[kAgentOpts])
-        : new Pool(origin, self[kAgentOpts])
-
-      pool
+      pool = this[kFactory](origin)
         .on('connect', this[kOnConnect])
         .on('disconnect', this[kOnDisconnect])
 
-      self[kAgentCache].set(origin, pool)
+      this[kCache].set(origin, pool)
     }
 
     return pool
@@ -57,7 +62,7 @@ class Agent extends EventEmitter {
 
   close () {
     const closePromises = []
-    for (const pool of this[kAgentCache].values()) {
+    for (const pool of this[kCache].values()) {
       closePromises.push(pool.close())
     }
     return Promise.all(closePromises)
@@ -65,7 +70,7 @@ class Agent extends EventEmitter {
 
   destroy () {
     const destroyPromises = []
-    for (const pool of this[kAgentCache].values()) {
+    for (const pool of this[kCache].values()) {
       destroyPromises.push(pool.destroy())
     }
     return Promise.all(destroyPromises)
@@ -81,32 +86,12 @@ function setGlobalAgent (agent) {
   globalAgent = agent
 }
 
-function dispatchFromAgent (requestType) {
-  return (url, { agent = globalAgent, method = 'GET', ...opts } = {}, ...additionalArgs) => {
-    if (opts.path != null) {
-      throw new InvalidArgumentError('unsupported opts.path')
-    }
-
-    const { origin, pathname, search } = util.parseURL(url)
-
-    const path = `${pathname || '/'}${search || ''}`
-
-    const client = agent.get(origin)
-
-    if (client && typeof client[requestType] !== 'function') {
-      throw new InvalidReturnValueError(`Client returned from Agent.get() does not implement method ${requestType}`)
-    }
-
-    return client[requestType]({ ...opts, method, path }, ...additionalArgs)
-  }
+function getGlobalAgent (agent) {
+  return globalAgent
 }
 
 module.exports = {
-  request: dispatchFromAgent('request'),
-  stream: dispatchFromAgent('stream'),
-  pipeline: dispatchFromAgent('pipeline'),
-  connect: dispatchFromAgent('connect'),
-  upgrade: dispatchFromAgent('upgrade'),
   setGlobalAgent,
+  getGlobalAgent,
   Agent
 }

--- a/lib/api/abort-signal.js
+++ b/lib/api/abort-signal.js
@@ -1,4 +1,4 @@
-const { RequestAbortedError } = require('./core/errors')
+const { RequestAbortedError } = require('../core/errors')
 
 const kListener = Symbol('kListener')
 const kSignal = Symbol('kSignal')

--- a/lib/api/api-connect.js
+++ b/lib/api/api-connect.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const { InvalidArgumentError, RequestAbortedError } = require('./core/errors')
+const { InvalidArgumentError, RequestAbortedError } = require('../core/errors')
 const { AsyncResource } = require('async_hooks')
-const util = require('./core/util')
+const util = require('../core/util')
 const { addSignal, removeSignal } = require('./abort-signal')
-const assert = require('assert')
 
-class UpgradeHandler extends AsyncResource {
+class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -18,7 +17,7 @@ class UpgradeHandler extends AsyncResource {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
     }
 
-    super('UNDICI_UPGRADE')
+    super('UNDICI_CONNECT')
 
     this.opaque = opaque || null
     this.callback = callback
@@ -38,12 +37,11 @@ class UpgradeHandler extends AsyncResource {
   onUpgrade (statusCode, headers, socket) {
     const { callback, opaque } = this
 
-    assert.strictEqual(statusCode, 101)
-
     removeSignal(this)
 
     this.callback = null
     this.runInAsyncScope(callback, null, null, {
+      statusCode,
       headers: util.parseHeaders(headers),
       socket,
       opaque
@@ -64,10 +62,10 @@ class UpgradeHandler extends AsyncResource {
   }
 }
 
-function upgrade (opts, callback) {
+function connect (opts, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
-      upgrade.call(this, opts, (err, data) => {
+      connect.call(this, opts, (err, data) => {
         return err ? reject(err) : resolve(data)
       })
     })
@@ -78,24 +76,11 @@ function upgrade (opts, callback) {
   }
 
   try {
-    const upgradeHandler = new UpgradeHandler(opts, callback)
-    const {
-      path,
-      method,
-      headers,
-      signal,
-      protocol
-    } = opts
-    this.dispatch({
-      path,
-      method: method || 'GET',
-      headers,
-      signal,
-      upgrade: protocol || 'Websocket'
-    }, upgradeHandler)
+    const connectHandler = new ConnectHandler(opts, callback)
+    this.dispatch({ ...opts, method: 'CONNECT' }, connectHandler)
   } catch (err) {
     process.nextTick(callback, err, { opaque: opts && opts.opaque })
   }
 }
 
-module.exports = upgrade
+module.exports = connect

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -9,8 +9,8 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = require('./core/errors')
-const util = require('./core/util')
+} = require('../core/errors')
+const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { assert } = require('console')
 const { addSignal, removeSignal } = require('./abort-signal')
@@ -225,21 +225,7 @@ class PipelineHandler extends AsyncResource {
 function pipeline (opts, handler) {
   try {
     const pipelineHandler = new PipelineHandler(opts, handler)
-    const {
-      path,
-      method,
-      headers,
-      idempotent,
-      signal
-    } = opts
-    this.dispatch({
-      path,
-      method,
-      body: pipelineHandler.req,
-      headers,
-      idempotent,
-      signal
-    }, pipelineHandler)
+    this.dispatch({ ...opts, body: pipelineHandler.req }, pipelineHandler)
     return pipelineHandler.ret
   } catch (err) {
     return new PassThrough().destroy(err)

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -4,8 +4,8 @@ const { Readable } = require('stream')
 const {
   InvalidArgumentError,
   RequestAbortedError
-} = require('./core/errors')
-const util = require('./core/util')
+} = require('../core/errors')
+const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
 

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -5,8 +5,8 @@ const {
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError
-} = require('./core/errors')
-const util = require('./core/util')
+} = require('../core/errors')
+const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
 

--- a/lib/api/api-upgrade.js
+++ b/lib/api/api-upgrade.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const { InvalidArgumentError, RequestAbortedError } = require('./core/errors')
+const { InvalidArgumentError, RequestAbortedError } = require('../core/errors')
 const { AsyncResource } = require('async_hooks')
-const util = require('./core/util')
+const util = require('../core/util')
 const { addSignal, removeSignal } = require('./abort-signal')
+const assert = require('assert')
 
-class ConnectHandler extends AsyncResource {
+class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -17,7 +18,7 @@ class ConnectHandler extends AsyncResource {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
     }
 
-    super('UNDICI_CONNECT')
+    super('UNDICI_UPGRADE')
 
     this.opaque = opaque || null
     this.callback = callback
@@ -37,11 +38,12 @@ class ConnectHandler extends AsyncResource {
   onUpgrade (statusCode, headers, socket) {
     const { callback, opaque } = this
 
+    assert.strictEqual(statusCode, 101)
+
     removeSignal(this)
 
     this.callback = null
     this.runInAsyncScope(callback, null, null, {
-      statusCode,
       headers: util.parseHeaders(headers),
       socket,
       opaque
@@ -62,10 +64,10 @@ class ConnectHandler extends AsyncResource {
   }
 }
 
-function connect (opts, callback) {
+function upgrade (opts, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
-      connect.call(this, opts, (err, data) => {
+      upgrade.call(this, opts, (err, data) => {
         return err ? reject(err) : resolve(data)
       })
     })
@@ -76,21 +78,15 @@ function connect (opts, callback) {
   }
 
   try {
-    const connectHandler = new ConnectHandler(opts, callback)
-    const {
-      path,
-      headers,
-      signal
-    } = opts
+    const upgradeHandler = new UpgradeHandler(opts, callback)
     this.dispatch({
-      path,
-      method: 'CONNECT',
-      headers,
-      signal
-    }, connectHandler)
+      ...opts,
+      method: opts.method || 'GET',
+      upgrade: opts.protocol || 'Websocket'
+    }, upgradeHandler)
   } catch (err) {
     process.nextTick(callback, err, { opaque: opts && opts.opaque })
   }
 }
 
-module.exports = connect
+module.exports = upgrade

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports.request = require('./api-request')
 module.exports.stream = require('./api-stream')
 module.exports.pipeline = require('./api-pipeline')

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,5 @@
+module.exports.request = require('./api-request')
+module.exports.stream = require('./api-stream')
+module.exports.pipeline = require('./api-pipeline')
+module.exports.upgrade = require('./api-upgrade')
+module.exports.connect = require('./api-connect')

--- a/lib/client-pool.js
+++ b/lib/client-pool.js
@@ -283,10 +283,4 @@ function addCachedSessionToTLSOptions (pool, options) {
   return tls
 }
 
-Pool.prototype.request = require('./client-request')
-Pool.prototype.stream = require('./client-stream')
-Pool.prototype.pipeline = require('./client-pipeline')
-Pool.prototype.upgrade = require('./client-upgrade')
-Pool.prototype.connect = require('./client-connect')
-
 module.exports = Pool

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -33,7 +33,5 @@ module.exports = {
   kTLSSession: Symbol('tls session cache'),
   kSetTLSSession: Symbol('set tls session'),
   kHostHeader: Symbol('host header'),
-  kAgentOpts: Symbol('agent opts'),
-  kAgentCache: Symbol('agent cache'),
   kStrictContentLength: Symbol('strict content length')
 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -2,7 +2,7 @@
 
 const tap = require('tap')
 const http = require('http')
-const { Agent, request, stream, pipeline, setGlobalAgent } = require('../lib/agent')
+const { Agent, request, stream, pipeline, setGlobalAgent } = require('../index')
 const { PassThrough } = require('stream')
 const { InvalidArgumentError, InvalidReturnValueError } = require('../lib/core/errors')
 const { Client, Pool, errors } = require('../index')

--- a/test/pool.js
+++ b/test/pool.js
@@ -289,7 +289,7 @@ test('backpressure algorithm', (t) => {
     }
   }
 
-  const Pool = proxyquire('../lib/pool', {
+  const Pool = proxyquire('../lib/client-pool', {
     './core/client': FakeClient
   })
 


### PR DESCRIPTION
- Move `client-*` to api folder as `api-*`.
- Rename `pool` to `client-pool`.
- Move `api-` references to index root only.