### PR TITLE
fix: add more strict check for streams in `util.isStream()'

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -36,7 +36,7 @@ class Request {
 
     if (body == null) {
       this.body = null
-    } else if (util.isStream(body)) {
+    } else if (util.isReadable(body)) {
       this.body = body
     } else if (util.isBuffer(body)) {
       this.body = body.length ? body : null

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -10,7 +10,8 @@ const { InvalidArgumentError } = require('./errors')
 function nop () {}
 
 function isStream (body) {
-  return !!(body && typeof body.on === 'function')
+  return !!(body && typeof body.on === 'function' &&
+    (typeof body.pipe === 'function' || typeof body.write === 'function'))
 }
 
 function parseURL (url) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -9,9 +9,18 @@ const { InvalidArgumentError } = require('./errors')
 
 function nop () {}
 
-function isStream (body) {
-  return !!(body && typeof body.on === 'function' &&
-    (typeof body.pipe === 'function' || typeof body.write === 'function'))
+function isReadable (obj) {
+  return !!(obj && typeof obj.pipe === 'function' &&
+    typeof obj.on === 'function')
+}
+
+function isWritable (obj) {
+  return !!(obj && typeof obj.write === 'function' &&
+    typeof obj.on === 'function')
+}
+
+function isStream (obj) {
+  return isReadable(obj) || isWritable(obj)
 }
 
 function parseURL (url) {
@@ -162,6 +171,7 @@ module.exports = {
   getServerName,
   errnoException,
   isStream,
+  isReadable,
   isDestroyed,
   parseHeaders,
   parseKeepAliveTimeout,

--- a/test/stream-compat.js
+++ b/test/stream-compat.js
@@ -19,7 +19,7 @@ test('stream body without destroy', (t) => {
 
     const signal = new EE()
     const body = new Readable({ read () {} })
-    delete body.destroy
+    body.destroy = undefined
     body.on('error', (err) => {
       t.ok(err)
     })

--- a/test/stream-compat.js
+++ b/test/stream-compat.js
@@ -3,6 +3,7 @@
 const { test } = require('tap')
 const { Client } = require('..')
 const { createServer } = require('http')
+const { Readable } = require('stream')
 const EE = require('events')
 
 test('stream body without destroy', (t) => {
@@ -17,7 +18,8 @@ test('stream body without destroy', (t) => {
     t.teardown(client.destroy.bind(client))
 
     const signal = new EE()
-    const body = new EE()
+    const body = new Readable({ read () {} })
+    delete body.destroy
     body.on('error', (err) => {
       t.ok(err)
     })

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const t = require('tap')
+const { test } = t
+const { Stream } = require('stream')
+const { EventEmitter } = require('events')
+
+const util = require('../lib/core/util')
+
+test('isStream', (t) => {
+  t.plan(3)
+
+  const stream = new Stream()
+  t.ok(util.isStream(stream))
+
+  const buffer = Buffer.alloc(0)
+  t.notOk(util.isStream(buffer))
+
+  const ee = new EventEmitter()
+  t.notOk(util.isStream(ee))
+})


### PR DESCRIPTION
Fixes #625 - Added a similar check that the Node.js project uses.

The check used in `undici` was the reverse of the problem in the Node.js project. The commit mentioned in #625 shows they were missing the check for `.on()` where `undici` was missing the checks for `pipe()` or `write()'.

In its current state the `util.isStream()` allows `Stream`, correctly returns false on `Buffer`, but does allow `EventEmitter` since it also has `.on()`.

I changed the `util.isStream()` method to match what the Node.js project uses.

In https://github.com/nodejs/undici/blob/main/lib/core/request.js#L39 I switched to using the newly exposed `util.isReadable()` since the error message there indicates that it should be a Readable stream. There are likely other places that should use the more specific `util.isReadable()`.

I had to change the test `stream body without destroy` in `test/stream-compat.js` that was passing an `EventEmitter` as the request `body` since that case now fails differently than the test was looking for. I believe I kept the spirit of the test intact.

Hopefully, this is the direction intended for the issue.