### PR TITLE
fix(docs): use bold text for new collaborator name

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ the prior pipeline and instead error the corresponding callback/promise/stream.
 
 ## Collaborators
 
-* [  Ethan Arrowood  ](https://github.com/ethan-arrowood), <https://www.npmjs.com/~ethan_arrowood>
+* [__Ethan Arrowood__](https://github.com/ethan-arrowood), <https://www.npmjs.com/~ethan_arrowood>
 * [__Daniele Belardi__](https://github.com/dnlup), <https://www.npmjs.com/~dnlup>
 * [__Matteo Collina__](https://github.com/mcollina), <https://www.npmjs.com/~matteo.collina>
 * [__Robert Nagy__](https://github.com/ronag), <https://www.npmjs.com/~ronag>


### PR DESCRIPTION
cc @Ethan-Arrowood 