### PR TITLE
test: improve coverage on agent and pool

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -96,32 +96,36 @@ class Agent extends Dispatcher {
 
   get connected () {
     let ret = 0
-    for (const { connected } of this[kClients].values()) {
-      ret += connected
+    for (const ref of this[kClients].values()) {
+      const client = ref.deref()
+      ret += client.connected
     }
     return ret
   }
 
   get size () {
     let ret = 0
-    for (const { size } of this[kClients].values()) {
-      ret += size
+    for (const ref of this[kClients].values()) {
+      const client = ref.deref()
+      ret += client.size
     }
     return ret
   }
 
   get pending () {
     let ret = 0
-    for (const { pending } of this[kClients].values()) {
-      ret += pending
+    for (const ref of this[kClients].values()) {
+      const client = ref.deref()
+      ret += client.pending
     }
     return ret
   }
 
   get running () {
     let ret = 0
-    for (const { running } of this[kClients].values()) {
-      ret += running
+    for (const ref of this[kClients].values()) {
+      const client = ref.deref()
+      ret += client.running
     }
     return ret
   }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -98,7 +98,9 @@ class Agent extends Dispatcher {
     let ret = 0
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      ret += client.connected
+      if (client) {
+        ret += client.connected
+      }
     }
     return ret
   }
@@ -107,7 +109,9 @@ class Agent extends Dispatcher {
     let ret = 0
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      ret += client.size
+      if (client) {
+        ret += client.size
+      }
     }
     return ret
   }
@@ -116,7 +120,9 @@ class Agent extends Dispatcher {
     let ret = 0
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      ret += client.pending
+      if (client) {
+        ret += client.pending
+      }
     }
     return ret
   }
@@ -125,7 +131,9 @@ class Agent extends Dispatcher {
     let ret = 0
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      ret += client.running
+      if (client) {
+        ret += client.running
+      }
     }
     return ret
   }

--- a/test/agent.js
+++ b/test/agent.js
@@ -235,7 +235,7 @@ test('fails with unsupported opts.path', t => {
 
 test('fails with unsupported opts.agent', t => {
   t.plan(1)
-  t.throw(() => request('https://example.com', { agent: new Agent() }), InvalidArgumentError, 'throws on opts.path argument')
+  t.throws(() => request('https://example.com', { agent: new Agent() }), InvalidArgumentError, 'throws on opts.path argument')
 })
 
 test('with globalAgent', t => {
@@ -441,9 +441,9 @@ test('dispatch validations', t => {
   }
 
   t.plan(5)
-  t.throw(() => dispatcher.dispatch('ASD'), InvalidArgumentError, 'throws on missing handler')
-  t.throw(() => dispatcher.dispatch('ASD', noopHandler), InvalidArgumentError, 'throws on invalid opts argument type')
-  t.throw(() => dispatcher.dispatch({}, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
-  t.throw(() => dispatcher.dispatch({ origin: '' }, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
-  t.throw(() => dispatcher.dispatch({}, {}), InvalidArgumentError, 'throws on invalid handler.onError')
+  t.throws(() => dispatcher.dispatch('ASD'), InvalidArgumentError, 'throws on missing handler')
+  t.throws(() => dispatcher.dispatch('ASD', noopHandler), InvalidArgumentError, 'throws on invalid opts argument type')
+  t.throws(() => dispatcher.dispatch({}, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
+  t.throws(() => dispatcher.dispatch({ origin: '' }, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
+  t.throws(() => dispatcher.dispatch({}, {}), InvalidArgumentError, 'throws on invalid handler.onError')
 })

--- a/test/agent.js
+++ b/test/agent.js
@@ -295,9 +295,9 @@ test('with a local agent', t => {
 
   dispatcher.on('connect', (origin, [dispatcher]) => {
     t.ok(dispatcher)
-    t.strictEqual(dispatcher.running, 0)
+    t.equal(dispatcher.running, 0)
     process.nextTick(() => {
-      t.strictEqual(dispatcher.running, 1)
+      t.equal(dispatcher.running, 1)
     })
   })
 

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -11,12 +11,12 @@ test('dispatcher implementation', (t) => {
   t.plan(6)
 
   const dispatcher = new Dispatcher()
-  t.throw(() => dispatcher.dispatch(), Error, 'throws on unimplemented dispatch')
-  t.throw(() => dispatcher.close(), Error, 'throws on unimplemented close')
-  t.throw(() => dispatcher.destroy(), Error, 'throws on unimplemented destroy')
+  t.throws(() => dispatcher.dispatch(), Error, 'throws on unimplemented dispatch')
+  t.throws(() => dispatcher.close(), Error, 'throws on unimplemented close')
+  t.throws(() => dispatcher.destroy(), Error, 'throws on unimplemented destroy')
 
   const poorImplementation = new PoorImplementation()
-  t.throw(() => poorImplementation.dispatch(), Error, 'throws on unimplemented dispatch')
-  t.throw(() => poorImplementation.close(), Error, 'throws on unimplemented close')
-  t.throw(() => poorImplementation.destroy(), Error, 'throws on unimplemented destroy')
+  t.throws(() => poorImplementation.dispatch(), Error, 'throws on unimplemented dispatch')
+  t.throws(() => poorImplementation.close(), Error, 'throws on unimplemented close')
+  t.throws(() => poorImplementation.destroy(), Error, 'throws on unimplemented destroy')
 })

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const t = require('tap')
+const { test } = t
+
+const Dispatcher = require('../lib/dispatcher')
+
+class PoorImplementation extends Dispatcher {}
+
+test('dispatcher implementation', (t) => {
+  t.plan(6)
+
+  const dispatcher = new Dispatcher()
+  t.throw(() => dispatcher.dispatch(), Error, 'throws on unimplemented dispatch')
+  t.throw(() => dispatcher.close(), Error, 'throws on unimplemented close')
+  t.throw(() => dispatcher.destroy(), Error, 'throws on unimplemented destroy')
+
+  const poorImplementation = new PoorImplementation()
+  t.throw(() => poorImplementation.dispatch(), Error, 'throws on unimplemented dispatch')
+  t.throw(() => poorImplementation.close(), Error, 'throws on unimplemented close')
+  t.throw(() => poorImplementation.destroy(), Error, 'throws on unimplemented destroy')
+})

--- a/test/pool.js
+++ b/test/pool.js
@@ -389,7 +389,7 @@ test('busy', (t) => {
 })
 
 test('invalid options throws', (t) => {
-  t.plan(4)
+  t.plan(6)
 
   try {
     new Pool(null, { connections: -1 }) // eslint-disable-line
@@ -404,6 +404,20 @@ test('invalid options throws', (t) => {
     t.ok(err instanceof errors.InvalidArgumentError)
     t.equal(err.message, 'invalid connections')
   }
+
+  try {
+    new Pool(null, { factory: '' }) // eslint-disable-line
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.strictEqual(err.message, 'factory must be a function.')
+  }
+})
+
+test('invalid pool dispatch options', (t) => {
+  t.plan(2)
+  const pool = new Pool('http://notahost')
+  t.throws(() => pool.dispatch({}), errors.InvalidArgumentError, 'throws on invalid handler')
+  t.throws(() => pool.dispatch({}, {}), errors.InvalidArgumentError, 'throws on invalid handler')
 })
 
 test('pool upgrade promise', (t) => {

--- a/test/pool.js
+++ b/test/pool.js
@@ -409,7 +409,7 @@ test('invalid options throws', (t) => {
     new Pool(null, { factory: '' }) // eslint-disable-line
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
-    t.strictEqual(err.message, 'factory must be a function.')
+    t.equal(err.message, 'factory must be a function.')
   }
 })
 


### PR DESCRIPTION
Related to https://github.com/nodejs/undici/issues/438
Started adding some tests to improve coverage. When writing the test for `dispatcher.running`

I realized the iteration in agent `connected`, `size`, `pending`, and `running` was not taking the WeakRef into account.

Wanted to get this change in if it looks good and get back to more tests in another PR.