### PR TITLE
test: change `http - no agent` benchmark to use the correct options

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -76,7 +76,7 @@ suite
     defer: true,
     fn: deferred => {
       Promise.all(Array.from(Array(parallelRequests)).map(() => new Promise((resolve) => {
-        http.get(httpOptions, (res) => {
+        http.get(httpNoAgent, (res) => {
           res
             .pipe(new Writable({
               write (chunk, encoding, callback) {


### PR DESCRIPTION
Based on the naming and the look of the options there, it appears the `http - no agent` benchmark was using the incorrect options object.