### PR TITLE
Update typings to match new Dispatcher API

### DIFF
--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -95,7 +95,7 @@ See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#clientupg
 
 * `number`
 
-Number of acive client connections. The client will lazily create a connection when it receives a request and will destroy it if there is no activity for the duration of the `timeout` value.
+Number of active client connections. The client will lazily create a connection when it receives a request and will destroy it if there is no activity for the duration of the `timeout` value.
 
 ### `Client.destroyed`
 

--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -309,16 +309,9 @@ setGlobalDispatcher(mockAgent)
 await mockAgent.close()
 ```
 
-### `MockAgent.dispatch(options, handlers: MockAgentDispatchOptions)`
+### `MockAgent.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
-
-#### Parameter: `MockAgentDispatchOptions`
-
-Extends: [`DispatchOptions``](docs/api/Dispatcher.md#parameter-dispatchoptions)
-
-* **origin** `string | URL`
-* **maxRedirections** `Integer`.
+Implements [`Agent.dispatch(options, handlers)`](docs/api/Agent.md#parameter-agentdispatchoptions).
 
 ### `MockAgent.request(options[, callback])`
 

--- a/docs/api/MockClient.md
+++ b/docs/api/MockClient.md
@@ -17,7 +17,7 @@ Returns: `MockClient`
 
 Extends: `ClientOptions`
 
-* **agent** `Agent` (optional) - Default: `new Agent([options])` - a custom agent encapsulated by the MockAgent.
+* **agent** `Agent` - the agent to associate this MockClient with.
 
 ### Example - Basic MockClient instantiation
 

--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -17,7 +17,7 @@ Returns: `MockPool`
 
 Extends: `PoolOptions`
 
-* **agent** `Agent` (optional) - Default: `new Agent([options])` - a custom agent encapsulated by the MockAgent.
+* **agent** `Agent` - the agent to associate this MockPool with.
 
 ### Example - Basic MockPool instantiation
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import Dispatcher from './types/dispatcher'
 import Pool from './types/pool'
 import Client from './types/client'
 import errors from './types/errors'
@@ -6,12 +7,13 @@ import MockClient from './types/mock-client'
 import MockPool from './types/mock-pool'
 import MockAgent from './types/mock-agent'
 
-export { Pool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline, MockClient, MockPool, MockAgent }
+export { Dispatcher, Pool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline, MockClient, MockPool, MockAgent }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool
 
 declare namespace Undici {
+  var Dispatcher: typeof import('./types/dispatcher')
   var Pool: typeof import('./types/pool');
   var Client: typeof import('./types/client');
   var errors: typeof import('./types/errors');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,15 @@
 import Dispatcher from './types/dispatcher'
+import { setGlobalDispatcher, getGlobalDispatcher } from './types/global-dispatcher'
 import Pool from './types/pool'
 import Client from './types/client'
 import errors from './types/errors'
-import { Agent, setGlobalAgent, request, stream, pipeline } from './types/agent'
+import Agent from './types/agent'
 import MockClient from './types/mock-client'
 import MockPool from './types/mock-pool'
 import MockAgent from './types/mock-agent'
+import { request, pipeline, stream, connect, upgrade } from './types/api'
 
-export { Dispatcher, Pool, Client, errors, Agent, setGlobalAgent, request, stream, pipeline, MockClient, MockPool, MockAgent }
+export { Dispatcher, Pool, Client, errors, Agent, request, stream, pipeline, connect, upgrade, setGlobalDispatcher, getGlobalDispatcher, MockClient, MockPool, MockAgent }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool
@@ -17,11 +19,14 @@ declare namespace Undici {
   var Pool: typeof import('./types/pool');
   var Client: typeof import('./types/client');
   var errors: typeof import('./types/errors');
-  var Agent: typeof import('./types/agent').Agent;
-  var setGlobalAgent: typeof import('./types/agent').setGlobalAgent;
-  var request: typeof import('./types/agent').request;
-  var stream: typeof import('./types/agent').stream;
-  var pipeline: typeof import('./types/agent').pipeline;
+  var Agent: typeof import('./types/agent');
+  var setGlobalDispatcher: typeof import('./types/global-dispatcher').setGlobalDispatcher;
+  var getGlobalDispatcher: typeof import('./types/global-dispatcher').getGlobalDispatcher;
+  var request: typeof import('./types/api').request;
+  var stream: typeof import('./types/api').stream;
+  var pipeline: typeof import('./types/api').pipeline;
+  var connect: typeof import('./types/api').connect;
+  var upgrade: typeof import('./types/api').upgrade;
   var MockClient: typeof import('./types/mock-client');
   var MockPool: typeof import('./types/mock-pool');
   var MockAgent: typeof import('./types/mock-agent');

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -17,35 +17,35 @@ test('MockAgent - constructor', t => {
 
   t.test('sets up mock agent', t => {
     t.plan(1)
-    t.notThrow(() => new MockAgent())
+    t.doesNotThrow(() => new MockAgent())
   })
 
   t.test('should implement the Dispatcher API', t => {
     t.plan(1)
 
     const mockAgent = new MockAgent()
-    t.true(mockAgent instanceof Dispatcher)
+    t.ok(mockAgent instanceof Dispatcher)
   })
 
   t.test('sets up mock agent with single connection', t => {
     t.plan(1)
-    t.notThrow(() => new MockAgent({ connections: 1 }))
+    t.doesNotThrow(() => new MockAgent({ connections: 1 }))
   })
 
   t.test('should error passed agent is not valid', t => {
     t.plan(2)
-    t.throw(() => new MockAgent({ agent: {} }), new InvalidArgumentError('Argument opts.agent must implement Agent'))
-    t.throw(() => new MockAgent({ agent: { dispatch: '' } }), new InvalidArgumentError('Argument opts.agent must implement Agent'))
+    t.throws(() => new MockAgent({ agent: {} }), new InvalidArgumentError('Argument opts.agent must implement Agent'))
+    t.throws(() => new MockAgent({ agent: { dispatch: '' } }), new InvalidArgumentError('Argument opts.agent must implement Agent'))
   })
 
   t.test('should be able to specify the agent to mock', t => {
     t.plan(1)
     const agent = new Agent()
-    t.tearDown(agent.close.bind(agent))
+    t.teardown(agent.close.bind(agent))
     const mockAgent = new MockAgent({ agent })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
-    t.strictEqual(mockAgent[kAgent], agent)
+    t.equal(mockAgent[kAgent], agent)
   })
 })
 
@@ -58,10 +58,10 @@ test('MockAgent - get', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get(baseUrl)
-    t.true(mockClient instanceof MockClient)
+    t.ok(mockClient instanceof MockClient)
   })
 
   t.test('should return MockPool', (t) => {
@@ -70,10 +70,10 @@ test('MockAgent - get', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get(baseUrl)
-    t.true(mockPool instanceof MockPool)
+    t.ok(mockPool instanceof MockPool)
   })
 
   t.test('should return the same instance if already created', (t) => {
@@ -82,11 +82,11 @@ test('MockAgent - get', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool1 = mockAgent.get(baseUrl)
     const mockPool2 = mockAgent.get(baseUrl)
-    t.strictEqual(mockPool1, mockPool2)
+    t.equal(mockPool1, mockPool2)
   })
 })
 
@@ -99,7 +99,7 @@ test('MockAgent - dispatch', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get(baseUrl)
 
@@ -108,7 +108,7 @@ test('MockAgent - dispatch', t => {
       method: 'GET'
     }).reply(200, 'hello')
 
-    t.notThrow(() => mockAgent.dispatch({
+    t.doesNotThrow(() => mockAgent.dispatch({
       origin: baseUrl,
       path: '/foo',
       method: 'GET'
@@ -125,7 +125,7 @@ test('MockAgent - dispatch', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get(baseUrl)
 
@@ -134,7 +134,7 @@ test('MockAgent - dispatch', t => {
       method: 'GET'
     }).reply(200, 'hello')
 
-    t.notThrow(() => mockAgent.dispatch({
+    t.doesNotThrow(() => mockAgent.dispatch({
       origin: baseUrl,
       path: '/foo',
       method: 'GET'
@@ -152,17 +152,17 @@ test('MockAgent - .close should clean up registered pools', async (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   // Register a pool
   const mockPool = mockAgent.get(baseUrl)
-  t.true(mockPool instanceof MockPool)
+  t.ok(mockPool instanceof MockPool)
 
-  t.strictEqual(mockPool.connected, 1)
-  t.strictEqual(mockAgent[kClients].size, 1)
+  t.equal(mockPool.connected, 1)
+  t.equal(mockAgent[kClients].size, 1)
   await mockAgent.close()
-  t.strictEqual(mockPool.connected, 0)
-  t.strictEqual(mockAgent[kClients].size, 0)
+  t.equal(mockPool.connected, 0)
+  t.equal(mockAgent[kClients].size, 0)
 })
 
 test('MockAgent - .close should clean up registered clients', async (t) => {
@@ -171,17 +171,17 @@ test('MockAgent - .close should clean up registered clients', async (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   // Register a pool
   const mockClient = mockAgent.get(baseUrl)
-  t.true(mockClient instanceof MockClient)
+  t.ok(mockClient instanceof MockClient)
 
-  t.strictEqual(mockClient.connected, 1)
-  t.strictEqual(mockAgent[kClients].size, 1)
+  t.equal(mockClient.connected, 1)
+  t.equal(mockAgent[kClients].size, 1)
   await mockAgent.close()
-  t.strictEqual(mockClient.connected, 0)
-  t.strictEqual(mockAgent[kClients].size, 0)
+  t.equal(mockClient.connected, 0)
+  t.equal(mockAgent[kClients].size, 0)
 })
 
 test('MockAgent - [kClients] should match encapsulated agent', async (t) => {
@@ -193,17 +193,17 @@ test('MockAgent - [kClients] should match encapsulated agent', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const agent = new Agent()
-  t.tearDown(agent.close.bind(agent))
+  t.teardown(agent.close.bind(agent))
 
   const mockAgent = new MockAgent({ agent })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -212,7 +212,7 @@ test('MockAgent - [kClients] should match encapsulated agent', async (t) => {
   }).reply(200, 'hello')
 
   // The MockAgent should encapsulate the input agent clients
-  t.strictEqual(mockAgent[kClients].size, agent[kClients].size)
+  t.equal(mockAgent[kClients].size, agent[kClients].size)
 })
 
 test('MockAgent - basic intercept with MockAgent.request', async (t) => {
@@ -224,14 +224,14 @@ test('MockAgent - basic intercept with MockAgent.request', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool = mockAgent.get(baseUrl)
 
   mockPool.intercept({
@@ -249,12 +249,12 @@ test('MockAgent - basic intercept with MockAgent.request', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })
@@ -268,7 +268,7 @@ test('MockAgent - basic intercept with request', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -276,7 +276,7 @@ test('MockAgent - basic intercept with request', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool = mockAgent.get(baseUrl)
 
   mockPool.intercept({
@@ -292,12 +292,12 @@ test('MockAgent - basic intercept with request', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })
@@ -311,7 +311,7 @@ test('MockAgent - should support local agents', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -319,7 +319,7 @@ test('MockAgent - should support local agents', async (t) => {
 
   const mockAgent = new MockAgent()
 
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool = mockAgent.get(baseUrl)
 
   mockPool.intercept({
@@ -338,12 +338,12 @@ test('MockAgent - should support local agents', async (t) => {
     body: 'form1=data1&form2=data2',
     dispatcher: mockAgent
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })
@@ -357,18 +357,18 @@ test('MockAgent - should support specifying custom agents to mock', async (t) =>
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const agent = new Agent()
-  t.tearDown(agent.close.bind(agent))
+  t.teardown(agent.close.bind(agent))
 
   const mockAgent = new MockAgent({ agent })
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -386,12 +386,12 @@ test('MockAgent - should support specifying custom agents to mock', async (t) =>
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })
@@ -405,7 +405,7 @@ test('MockAgent - basic Client intercept with request', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -413,7 +413,7 @@ test('MockAgent - basic Client intercept with request', async (t) => {
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
   mockClient.intercept({
@@ -431,12 +431,12 @@ test('MockAgent - basic Client intercept with request', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })
@@ -450,7 +450,7 @@ test('MockAgent - basic intercept with multiple pools', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -458,7 +458,7 @@ test('MockAgent - basic intercept with multiple pools', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool1 = mockAgent.get(baseUrl)
   const mockPool2 = mockAgent.get('http://localhost:9999')
 
@@ -483,12 +483,12 @@ test('MockAgent - basic intercept with multiple pools', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar-1'
   })
 })
@@ -502,7 +502,7 @@ test('MockAgent - should handle multiple responses for an interceptor', async (t
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -510,7 +510,7 @@ test('MockAgent - should handle multiple responses for an interceptor', async (t
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
 
@@ -533,11 +533,11 @@ test('MockAgent - should handle multiple responses for an interceptor', async (t
     const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
       method: 'POST'
     })
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'application/json')
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'application/json')
 
     const jsonResponse = JSON.parse(await getResponse(body))
-    t.deepEqual(jsonResponse, {
+    t.same(jsonResponse, {
       foo: 'bar'
     })
   }
@@ -546,11 +546,11 @@ test('MockAgent - should handle multiple responses for an interceptor', async (t
     const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
       method: 'POST'
     })
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'application/json')
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'application/json')
 
     const jsonResponse = JSON.parse(await getResponse(body))
-    t.deepEqual(jsonResponse, {
+    t.same(jsonResponse, {
       hello: 'there'
     })
   }
@@ -560,12 +560,12 @@ test('MockAgent - should call original Pool dispatch if request not found', asyn
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -573,28 +573,28 @@ test('MockAgent - should call original Pool dispatch if request not found', asyn
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - should call original Client dispatch if request not found', async (t) => {
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -602,16 +602,16 @@ test('MockAgent - should call original Client dispatch if request not found', as
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - should handle string responses', async (t) => {
@@ -623,7 +623,7 @@ test('MockAgent - should handle string responses', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -631,7 +631,7 @@ test('MockAgent - should handle string responses', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -642,10 +642,10 @@ test('MockAgent - should handle string responses', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'POST'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - should handle basic concurrency for requests', { jobs: 5 }, async (t) => {
@@ -653,7 +653,7 @@ test('MockAgent - should handle basic concurrency for requests', { jobs: 5 }, as
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   await Promise.all([...Array(5).keys()].map(idx =>
     t.test(`concurrent job (${idx})`, async (innerTest) => {
@@ -670,10 +670,10 @@ test('MockAgent - should handle basic concurrency for requests', { jobs: 5 }, as
       const { statusCode, body } = await request(`${baseUrl}/foo`, {
         method: 'POST'
       })
-      innerTest.strictEqual(statusCode, 200)
+      innerTest.equal(statusCode, 200)
 
       const jsonResponse = JSON.parse(await getResponse(body))
-      innerTest.deepEqual(jsonResponse, {
+      innerTest.same(jsonResponse, {
         foo: `bar ${idx}`
       })
     })
@@ -689,7 +689,7 @@ test('MockAgent - handle delays to simulate work', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -697,7 +697,7 @@ test('MockAgent - handle delays to simulate work', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -710,12 +710,12 @@ test('MockAgent - handle delays to simulate work', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'POST'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
   const elapsedInMs = process.hrtime(start)[1] / 1e6
-  t.true(elapsedInMs >= 50, `Elapsed time is not greater than 50ms: ${elapsedInMs}`)
+  t.ok(elapsedInMs >= 50, `Elapsed time is not greater than 50ms: ${elapsedInMs}`)
 })
 
 test('MockAgent - should persist requests', async (t) => {
@@ -727,7 +727,7 @@ test('MockAgent - should persist requests', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -735,7 +735,7 @@ test('MockAgent - should persist requests', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -754,12 +754,12 @@ test('MockAgent - should persist requests', async (t) => {
       method: 'POST',
       body: 'form1=data1&form2=data2'
     })
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'application/json')
-    t.deepEqual(trailers, { 'content-md5': 'test' })
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'application/json')
+    t.same(trailers, { 'content-md5': 'test' })
 
     const jsonResponse = JSON.parse(await getResponse(body))
-    t.deepEqual(jsonResponse, {
+    t.same(jsonResponse, {
       foo: 'bar'
     })
   }
@@ -769,12 +769,12 @@ test('MockAgent - should persist requests', async (t) => {
       method: 'POST',
       body: 'form1=data1&form2=data2'
     })
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'application/json')
-    t.deepEqual(trailers, { 'content-md5': 'test' })
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'application/json')
+    t.same(trailers, { 'content-md5': 'test' })
 
     const jsonResponse = JSON.parse(await getResponse(body))
-    t.deepEqual(jsonResponse, {
+    t.same(jsonResponse, {
       foo: 'bar'
     })
   }
@@ -789,7 +789,7 @@ test('MockAgent - handle persists with delayed requests', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -797,7 +797,7 @@ test('MockAgent - handle persists with delayed requests', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -809,20 +809,20 @@ test('MockAgent - handle persists with delayed requests', async (t) => {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'POST'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'hello')
+    t.equal(response, 'hello')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'POST'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'hello')
+    t.equal(response, 'hello')
   }
 })
 
@@ -835,7 +835,7 @@ test('MockAgent - calling close on a mock pool should not affect other mock pool
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -843,7 +843,7 @@ test('MockAgent - calling close on a mock pool should not affect other mock pool
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPoolToClose = mockAgent.get('http://localhost:9999')
   mockPoolToClose.intercept({
@@ -867,20 +867,20 @@ test('MockAgent - calling close on a mock pool should not affect other mock pool
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/bar`, {
       method: 'POST'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'bar')
+    t.equal(response, 'bar')
   }
 })
 
@@ -893,7 +893,7 @@ test('MockAgent - close removes all registered mock clients', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -901,7 +901,7 @@ test('MockAgent - close removes all registered mock clients', async (t) => {
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
   mockClient.intercept({
@@ -910,12 +910,12 @@ test('MockAgent - close removes all registered mock clients', async (t) => {
   }).reply(200, 'foo')
 
   await mockAgent.close()
-  t.strictEqual(mockAgent[kClients].size, 0)
+  t.equal(mockAgent[kClients].size, 0)
 
   try {
     await request(`${baseUrl}/foo`, { method: 'GET' })
   } catch (err) {
-    t.true(err instanceof ClientClosedError)
+    t.ok(err instanceof ClientClosedError)
   }
 })
 
@@ -928,7 +928,7 @@ test('MockAgent - close removes all registered mock pools', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -936,7 +936,7 @@ test('MockAgent - close removes all registered mock pools', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -945,12 +945,12 @@ test('MockAgent - close removes all registered mock pools', async (t) => {
   }).reply(200, 'foo')
 
   await mockAgent.close()
-  t.strictEqual(mockAgent[kClients].size, 0)
+  t.equal(mockAgent[kClients].size, 0)
 
   try {
     await request(`${baseUrl}/foo`, { method: 'GET' })
   } catch (err) {
-    t.true(err instanceof ClientClosedError)
+    t.ok(err instanceof ClientClosedError)
   }
 })
 
@@ -963,7 +963,7 @@ test('MockAgent - should handle replyWithError', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -971,7 +971,7 @@ test('MockAgent - should handle replyWithError', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -986,12 +986,12 @@ test('MockAgent - should support setting a reply to respond a set amount of time
   t.plan(9)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -999,7 +999,7 @@ test('MockAgent - should support setting a reply to respond a set amount of time
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1009,27 +1009,27 @@ test('MockAgent - should support setting a reply to respond a set amount of time
 
   {
     const { statusCode, body } = await request(`${baseUrl}/foo`)
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/foo`)
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, headers, body } = await request(`${baseUrl}/foo`)
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'text/plain')
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'text/plain')
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'hello')
+    t.equal(response, 'hello')
   }
 })
 
@@ -1042,7 +1042,7 @@ test('MockAgent - persist overrides times', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1050,7 +1050,7 @@ test('MockAgent - persist overrides times', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1062,30 +1062,30 @@ test('MockAgent - persist overrides times', async (t) => {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 })
 
@@ -1093,11 +1093,11 @@ test('MockAgent - matcher should not find mock dispatch if path is of unsupporte
   t.plan(4)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1105,7 +1105,7 @@ test('MockAgent - matcher should not find mock dispatch if path is of unsupporte
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1116,10 +1116,10 @@ test('MockAgent - matcher should not find mock dispatch if path is of unsupporte
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - should match path with regex', async (t) => {
@@ -1131,7 +1131,7 @@ test('MockAgent - should match path with regex', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1139,7 +1139,7 @@ test('MockAgent - should match path with regex', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1151,20 +1151,20 @@ test('MockAgent - should match path with regex', async (t) => {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   {
     const { statusCode, body } = await request(`${baseUrl}/hello/foobar`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 })
 
@@ -1177,7 +1177,7 @@ test('MockAgent - should match path with function', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1185,7 +1185,7 @@ test('MockAgent - should match path with function', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1196,10 +1196,10 @@ test('MockAgent - should match path with function', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match method with regex', async (t) => {
@@ -1211,7 +1211,7 @@ test('MockAgent - should match method with regex', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1219,7 +1219,7 @@ test('MockAgent - should match method with regex', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1230,10 +1230,10 @@ test('MockAgent - should match method with regex', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match method with function', async (t) => {
@@ -1245,7 +1245,7 @@ test('MockAgent - should match method with function', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1253,7 +1253,7 @@ test('MockAgent - should match method with function', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1264,10 +1264,10 @@ test('MockAgent - should match method with function', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match body with regex', async (t) => {
@@ -1279,7 +1279,7 @@ test('MockAgent - should match body with regex', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1287,7 +1287,7 @@ test('MockAgent - should match body with regex', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1300,10 +1300,10 @@ test('MockAgent - should match body with regex', async (t) => {
     method: 'GET',
     body: 'hello=there'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match body with function', async (t) => {
@@ -1315,7 +1315,7 @@ test('MockAgent - should match body with function', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1323,7 +1323,7 @@ test('MockAgent - should match body with function', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1336,10 +1336,10 @@ test('MockAgent - should match body with function', async (t) => {
     method: 'GET',
     body: 'hello=there'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match url with regex', async (t) => {
@@ -1351,7 +1351,7 @@ test('MockAgent - should match url with regex', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1359,7 +1359,7 @@ test('MockAgent - should match url with regex', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(new RegExp(baseUrl))
   mockPool.intercept({
@@ -1370,10 +1370,10 @@ test('MockAgent - should match url with regex', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - should match url with function', async (t) => {
@@ -1385,7 +1385,7 @@ test('MockAgent - should match url with function', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1393,7 +1393,7 @@ test('MockAgent - should match url with function', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get((value) => baseUrl === value)
   mockPool.intercept({
@@ -1404,10 +1404,10 @@ test('MockAgent - should match url with function', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - handle default reply headers', async (t) => {
@@ -1419,7 +1419,7 @@ test('MockAgent - handle default reply headers', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1427,7 +1427,7 @@ test('MockAgent - handle default reply headers', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1438,14 +1438,14 @@ test('MockAgent - handle default reply headers', async (t) => {
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.deepEqual(headers, {
+  t.equal(statusCode, 200)
+  t.same(headers, {
     foo: 'bar',
     hello: 'there'
   })
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - handle default reply trailers', async (t) => {
@@ -1457,7 +1457,7 @@ test('MockAgent - handle default reply trailers', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1465,7 +1465,7 @@ test('MockAgent - handle default reply trailers', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1476,14 +1476,14 @@ test('MockAgent - handle default reply trailers', async (t) => {
   const { statusCode, trailers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.deepEqual(trailers, {
+  t.equal(statusCode, 200)
+  t.same(trailers, {
     foo: 'bar',
     hello: 'there'
   })
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - return calculated content-length if specified', async (t) => {
@@ -1495,7 +1495,7 @@ test('MockAgent - return calculated content-length if specified', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1503,7 +1503,7 @@ test('MockAgent - return calculated content-length if specified', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1514,14 +1514,14 @@ test('MockAgent - return calculated content-length if specified', async (t) => {
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.deepEqual(headers, {
+  t.equal(statusCode, 200)
+  t.same(headers, {
     hello: 'there',
     'content-length': 3
   })
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'foo')
+  t.equal(response, 'foo')
 })
 
 test('MockAgent - return calculated content-length for object response if specified', async (t) => {
@@ -1533,7 +1533,7 @@ test('MockAgent - return calculated content-length for object response if specif
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1541,7 +1541,7 @@ test('MockAgent - return calculated content-length for object response if specif
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1552,26 +1552,26 @@ test('MockAgent - return calculated content-length for object response if specif
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.deepEqual(headers, {
+  t.equal(statusCode, 200)
+  t.same(headers, {
     hello: 'there',
     'content-length': 13
   })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, { foo: 'bar' })
+  t.same(jsonResponse, { foo: 'bar' })
 })
 
 test('MockAgent - should activate and deactivate mock clients', async (t) => {
   t.plan(9)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1579,7 +1579,7 @@ test('MockAgent - should activate and deactivate mock clients', async (t) => {
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1591,10 +1591,10 @@ test('MockAgent - should activate and deactivate mock clients', async (t) => {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 
   mockAgent.deactivate()
@@ -1603,11 +1603,11 @@ test('MockAgent - should activate and deactivate mock clients', async (t) => {
     const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
-    t.strictEqual(headers['content-type'], 'text/plain')
+    t.equal(statusCode, 200)
+    t.equal(headers['content-type'], 'text/plain')
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'hello')
+    t.equal(response, 'hello')
   }
 
   mockAgent.activate()
@@ -1616,10 +1616,10 @@ test('MockAgent - should activate and deactivate mock clients', async (t) => {
     const { statusCode, body } = await request(`${baseUrl}/foo`, {
       method: 'GET'
     })
-    t.strictEqual(statusCode, 200)
+    t.equal(statusCode, 200)
 
     const response = await getResponse(body)
-    t.strictEqual(response, 'foo')
+    t.equal(response, 'foo')
   }
 })
 
@@ -1627,12 +1627,12 @@ test('MockAgent - enableNetConnect should allow all original dispatches to be ca
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1640,7 +1640,7 @@ test('MockAgent - enableNetConnect should allow all original dispatches to be ca
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1653,23 +1653,23 @@ test('MockAgent - enableNetConnect should allow all original dispatches to be ca
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - enableNetConnect with a host string should allow all original dispatches to be called if mockDispatch not found', async (t) => {
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1677,7 +1677,7 @@ test('MockAgent - enableNetConnect with a host string should allow all original 
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1690,23 +1690,23 @@ test('MockAgent - enableNetConnect with a host string should allow all original 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - enableNetConnect when called with host string multiple times should allow all original dispatches to be called if mockDispatch not found', async (t) => {
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1714,7 +1714,7 @@ test('MockAgent - enableNetConnect when called with host string multiple times s
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1728,23 +1728,23 @@ test('MockAgent - enableNetConnect when called with host string multiple times s
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - enableNetConnect with a host regex should allow all original dispatches to be called if mockDispatch not found', async (t) => {
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1752,7 +1752,7 @@ test('MockAgent - enableNetConnect with a host regex should allow all original d
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1765,23 +1765,23 @@ test('MockAgent - enableNetConnect with a host regex should allow all original d
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - enableNetConnect with a function should allow all original dispatches to be called if mockDispatch not found', async (t) => {
   t.plan(5)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1789,7 +1789,7 @@ test('MockAgent - enableNetConnect with a function should allow all original dis
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({
@@ -1802,11 +1802,11 @@ test('MockAgent - enableNetConnect with a function should allow all original dis
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'text/plain')
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'text/plain')
 
   const response = await getResponse(body)
-  t.strictEqual(response, 'hello')
+  t.equal(response, 'hello')
 })
 
 test('MockAgent - enableNetConnect with an unknown input should throw', async (t) => {
@@ -1814,7 +1814,7 @@ test('MockAgent - enableNetConnect with an unknown input should throw', async (t
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get('http://localhost:9999')
   mockPool.intercept({
@@ -1829,12 +1829,12 @@ test('MockAgent - disableNetConnect should throw if dispatch not found by net co
   t.plan(1)
 
   const server = createServer((req, res) => {
-    t.strictEqual(req.url, '/foo')
-    t.strictEqual(req.method, 'GET')
+    t.equal(req.url, '/foo')
+    t.equal(req.method, 'GET')
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
@@ -1842,7 +1842,7 @@ test('MockAgent - disableNetConnect should throw if dispatch not found by net co
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
   mockPool.intercept({

--- a/test/mock-client.js
+++ b/test/mock-client.js
@@ -16,19 +16,19 @@ test('MockClient - constructor', t => {
 
   t.test('fails if opts.agent does not implement `get` method', t => {
     t.plan(1)
-    t.throw(() => new MockClient('http://localhost:9999', { agent: { get: 'not a function' } }), InvalidArgumentError)
+    t.throws(() => new MockClient('http://localhost:9999', { agent: { get: 'not a function' } }), InvalidArgumentError)
   })
 
   t.test('sets agent', t => {
     t.plan(1)
-    t.notThrow(() => new MockClient('http://localhost:9999', { agent: new MockAgent({ connections: 1 }) }))
+    t.doesNotThrow(() => new MockClient('http://localhost:9999', { agent: new MockAgent({ connections: 1 }) }))
   })
 
   t.test('should implement the Dispatcher API', t => {
     t.plan(1)
 
     const mockClient = new MockClient('http://localhost:9999', { agent: new MockAgent({ connections: 1 }) })
-    t.true(mockClient instanceof Dispatcher)
+    t.ok(mockClient instanceof Dispatcher)
   })
 })
 
@@ -41,7 +41,7 @@ test('MockClient - dispatch', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get(baseUrl)
 
@@ -60,7 +60,7 @@ test('MockClient - dispatch', t => {
       }
     ]
 
-    t.notThrow(() => mockClient.dispatch({
+    t.doesNotThrow(() => mockClient.dispatch({
       path: '/foo',
       method: 'GET'
     }, {
@@ -77,7 +77,7 @@ test('MockClient - intercept should return a MockInterceptor', (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
 
@@ -86,7 +86,7 @@ test('MockClient - intercept should return a MockInterceptor', (t) => {
     method: 'GET'
   })
 
-  t.true(interceptor instanceof MockInterceptor)
+  t.ok(interceptor instanceof MockInterceptor)
 })
 
 test('MockClient - intercept validation', (t) => {
@@ -95,31 +95,31 @@ test('MockClient - intercept validation', (t) => {
   t.test('it should error if no options specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockClient.intercept(), new InvalidArgumentError('opts must be an object'))
+    t.throws(() => mockClient.intercept(), new InvalidArgumentError('opts must be an object'))
   })
 
   t.test('it should error if no path specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockClient.intercept({}), new InvalidArgumentError('opts.path must be defined'))
+    t.throws(() => mockClient.intercept({}), new InvalidArgumentError('opts.path must be defined'))
   })
 
   t.test('it should error if no method specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent({ connections: 1 })
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockClient.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
+    t.throws(() => mockClient.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
   })
 })
 
@@ -129,7 +129,7 @@ test('MockClient - close should run without error', async (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
   mockClient[kDispatches] = [
@@ -158,17 +158,17 @@ test('MockClient - should be able to set as globalDispatcher', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.true(mockClient instanceof MockClient)
+  t.ok(mockClient instanceof MockClient)
   setGlobalDispatcher(mockClient)
 
   mockClient.intercept({
@@ -179,10 +179,10 @@ test('MockClient - should be able to set as globalDispatcher', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.deepEqual(response, 'hello')
+  t.same(response, 'hello')
 })
 
 test('MockClient - should be able to use as a local dispatcher', async (t) => {
@@ -194,17 +194,17 @@ test('MockClient - should be able to use as a local dispatcher', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.true(mockClient instanceof MockClient)
+  t.ok(mockClient instanceof MockClient)
 
   mockClient.intercept({
     path: '/foo',
@@ -215,10 +215,10 @@ test('MockClient - should be able to use as a local dispatcher', async (t) => {
     method: 'GET',
     dispatcher: mockClient
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.deepEqual(response, 'hello')
+  t.same(response, 'hello')
 })
 
 test('MockClient - basic intercept with MockClient.request', async (t) => {
@@ -230,16 +230,16 @@ test('MockClient - basic intercept with MockClient.request', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockClient = mockAgent.get(baseUrl)
-  t.true(mockClient instanceof MockClient)
+  t.ok(mockClient instanceof MockClient)
 
   mockClient.intercept({
     path: '/foo?hello=there&see=ya',
@@ -256,12 +256,12 @@ test('MockClient - basic intercept with MockClient.request', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -14,7 +14,7 @@ test('MockInterceptor - reply', t => {
       method: ''
     }, [])
     const result = mockInterceptor.reply(200, 'hello')
-    t.true(result instanceof MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -24,9 +24,9 @@ test('MockInterceptor - reply', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockInterceptor.reply(), new InvalidArgumentError('statusCode must be defined'))
-    t.throw(() => mockInterceptor.reply(200), new InvalidArgumentError('data must be defined'))
-    t.throw(() => mockInterceptor.reply(200, '', 'hello'), new InvalidArgumentError('responseOptions must be an object'))
+    t.throws(() => mockInterceptor.reply(), new InvalidArgumentError('statusCode must be defined'))
+    t.throws(() => mockInterceptor.reply(200), new InvalidArgumentError('data must be defined'))
+    t.throws(() => mockInterceptor.reply(200, '', 'hello'), new InvalidArgumentError('responseOptions must be an object'))
   })
 })
 
@@ -40,7 +40,7 @@ test('MockInterceptor - replyWithError', t => {
       method: ''
     }, [])
     const result = mockInterceptor.replyWithError(new Error('kaboom'))
-    t.true(result instanceof MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -50,7 +50,7 @@ test('MockInterceptor - replyWithError', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockInterceptor.replyWithError(), new InvalidArgumentError('error must be defined'))
+    t.throws(() => mockInterceptor.replyWithError(), new InvalidArgumentError('error must be defined'))
   })
 })
 
@@ -64,7 +64,7 @@ test('MockInterceptor - defaultReplyHeaders', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyHeaders({})
-    t.true(result instanceof MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -74,7 +74,7 @@ test('MockInterceptor - defaultReplyHeaders', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockInterceptor.defaultReplyHeaders(), new InvalidArgumentError('headers must be defined'))
+    t.throws(() => mockInterceptor.defaultReplyHeaders(), new InvalidArgumentError('headers must be defined'))
   })
 })
 
@@ -88,7 +88,7 @@ test('MockInterceptor - defaultReplyTrailers', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyTrailers({})
-    t.true(result instanceof MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -98,7 +98,7 @@ test('MockInterceptor - defaultReplyTrailers', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockInterceptor.defaultReplyTrailers(), new InvalidArgumentError('trailers must be defined'))
+    t.throws(() => mockInterceptor.defaultReplyTrailers(), new InvalidArgumentError('trailers must be defined'))
   })
 })
 
@@ -112,6 +112,6 @@ test('MockInterceptor - replyContentLength', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyTrailers({})
-    t.true(result instanceof MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 })

--- a/test/mock-pool.js
+++ b/test/mock-pool.js
@@ -16,19 +16,19 @@ test('MockPool - constructor', t => {
 
   t.test('fails if opts.agent does not implement `get` method', t => {
     t.plan(1)
-    t.throw(() => new MockPool('http://localhost:9999', { agent: { get: 'not a function' } }), InvalidArgumentError)
+    t.throws(() => new MockPool('http://localhost:9999', { agent: { get: 'not a function' } }), InvalidArgumentError)
   })
 
   t.test('sets agent', t => {
     t.plan(1)
-    t.notThrow(() => new MockPool('http://localhost:9999', { agent: new MockAgent() }))
+    t.doesNotThrow(() => new MockPool('http://localhost:9999', { agent: new MockAgent() }))
   })
 
   t.test('should implement the Dispatcher API', t => {
     t.plan(1)
 
     const mockPool = new MockPool('http://localhost:9999', { agent: new MockAgent() })
-    t.true(mockPool instanceof Dispatcher)
+    t.ok(mockPool instanceof Dispatcher)
   })
 })
 
@@ -41,7 +41,7 @@ test('MockPool - dispatch', t => {
     const baseUrl = 'http://localhost:9999'
 
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get(baseUrl)
 
@@ -60,7 +60,7 @@ test('MockPool - dispatch', t => {
       }
     ]
 
-    t.notThrow(() => mockPool.dispatch({
+    t.doesNotThrow(() => mockPool.dispatch({
       path: '/foo',
       method: 'GET'
     }, {
@@ -77,7 +77,7 @@ test('MockPool - intercept should return a MockInterceptor', (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
 
@@ -86,7 +86,7 @@ test('MockPool - intercept should return a MockInterceptor', (t) => {
     method: 'GET'
   })
 
-  t.true(interceptor instanceof MockInterceptor)
+  t.ok(interceptor instanceof MockInterceptor)
 })
 
 test('MockPool - intercept validation', (t) => {
@@ -95,31 +95,31 @@ test('MockPool - intercept validation', (t) => {
   t.test('it should error if no options specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockPool.intercept(), new InvalidArgumentError('opts must be an object'))
+    t.throws(() => mockPool.intercept(), new InvalidArgumentError('opts must be an object'))
   })
 
   t.test('it should error if no path specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockPool.intercept({}), new InvalidArgumentError('opts.path must be defined'))
+    t.throws(() => mockPool.intercept({}), new InvalidArgumentError('opts.path must be defined'))
   })
 
   t.test('it should error if no method specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent()
-    t.tearDown(mockAgent.close.bind(mockAgent))
+    t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get('http://localhost:9999')
 
-    t.throw(() => mockPool.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
+    t.throws(() => mockPool.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
   })
 })
 
@@ -129,7 +129,7 @@ test('MockPool - close should run without error', async (t) => {
   const baseUrl = 'http://localhost:9999'
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
 
@@ -159,17 +159,17 @@ test('MockPool - should be able to set as globalDispatcher', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
-  t.true(mockPool instanceof MockPool)
+  t.ok(mockPool instanceof MockPool)
   setGlobalDispatcher(mockPool)
 
   mockPool.intercept({
@@ -180,10 +180,10 @@ test('MockPool - should be able to set as globalDispatcher', async (t) => {
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.deepEqual(response, 'hello')
+  t.same(response, 'hello')
 })
 
 test('MockPool - should be able to use as a local dispatcher', async (t) => {
@@ -195,17 +195,17 @@ test('MockPool - should be able to use as a local dispatcher', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
-  t.true(mockPool instanceof MockPool)
+  t.ok(mockPool instanceof MockPool)
 
   mockPool.intercept({
     path: '/foo',
@@ -216,10 +216,10 @@ test('MockPool - should be able to use as a local dispatcher', async (t) => {
     method: 'GET',
     dispatcher: mockPool
   })
-  t.strictEqual(statusCode, 200)
+  t.equal(statusCode, 200)
 
   const response = await getResponse(body)
-  t.deepEqual(response, 'hello')
+  t.same(response, 'hello')
 })
 
 test('MockPool - basic intercept with MockPool.request', async (t) => {
@@ -231,16 +231,16 @@ test('MockPool - basic intercept with MockPool.request', async (t) => {
     t.fail('should not be called')
     t.end()
   })
-  t.tearDown(server.close.bind(server))
+  t.teardown(server.close.bind(server))
 
   await promisify(server.listen.bind(server))(0)
 
   const baseUrl = `http://localhost:${server.address().port}`
 
   const mockAgent = new MockAgent()
-  t.tearDown(mockAgent.close.bind(mockAgent))
+  t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool = mockAgent.get(baseUrl)
-  t.true(mockPool instanceof MockPool)
+  t.ok(mockPool instanceof MockPool)
 
   mockPool.intercept({
     path: '/foo?hello=there&see=ya',
@@ -257,12 +257,12 @@ test('MockPool - basic intercept with MockPool.request', async (t) => {
     method: 'POST',
     body: 'form1=data1&form2=data2'
   })
-  t.strictEqual(statusCode, 200)
-  t.strictEqual(headers['content-type'], 'application/json')
-  t.deepEqual(trailers, { 'content-md5': 'test' })
+  t.equal(statusCode, 200)
+  t.equal(headers['content-type'], 'application/json')
+  t.same(trailers, { 'content-md5': 'test' })
 
   const jsonResponse = JSON.parse(await getResponse(body))
-  t.deepEqual(jsonResponse, {
+  t.same(jsonResponse, {
     foo: 'bar'
   })
 })

--- a/test/mock-scope.js
+++ b/test/mock-scope.js
@@ -14,7 +14,7 @@ test('MockScope - delay', t => {
       method: ''
     }, [])
     const result = mockScope.delay(200)
-    t.true(result instanceof MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -24,10 +24,10 @@ test('MockScope - delay', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockScope.delay(), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
-    t.throw(() => mockScope.delay(200.1), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
-    t.throw(() => mockScope.delay(0), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
-    t.throw(() => mockScope.delay(-1), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
+    t.throws(() => mockScope.delay(), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
+    t.throws(() => mockScope.delay(200.1), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
+    t.throws(() => mockScope.delay(0), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
+    t.throws(() => mockScope.delay(-1), new InvalidArgumentError('waitInMs must be a valid integer > 0'))
   })
 })
 
@@ -41,7 +41,7 @@ test('MockScope - persist', t => {
       method: ''
     }, [])
     const result = mockScope.persist()
-    t.true(result instanceof MockScope)
+    t.ok(result instanceof MockScope)
   })
 })
 
@@ -55,7 +55,7 @@ test('MockScope - times', t => {
       method: ''
     }, [])
     const result = mockScope.times(200)
-    t.true(result instanceof MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -65,9 +65,9 @@ test('MockScope - times', t => {
       path: '',
       method: ''
     }, [])
-    t.throw(() => mockScope.times(), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
-    t.throw(() => mockScope.times(200.1), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
-    t.throw(() => mockScope.times(0), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
-    t.throw(() => mockScope.times(-1), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
+    t.throws(() => mockScope.times(), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
+    t.throws(() => mockScope.times(200.1), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
+    t.throws(() => mockScope.times(0), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
+    t.throws(() => mockScope.times(-1), new InvalidArgumentError('repeatTimes must be a valid integer > 0'))
   })
 })

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -13,7 +13,7 @@ test('deleteMockDispatch - should do nothing if not able to find mock dispatch',
     body: 'body'
   }
 
-  t.notThrow(() => deleteMockDispatch([], key))
+  t.doesNotThrow(() => deleteMockDispatch([], key))
 })
 
 test('getMockDispatch', (t) => {
@@ -33,7 +33,7 @@ test('getMockDispatch', (t) => {
       path: 'path',
       method: 'method'
     })
-    t.deepEqual(result, {
+    t.same(result, {
       path: 'path',
       method: 'method',
       consumed: false
@@ -59,7 +59,7 @@ test('getMockDispatch', (t) => {
       path: 'path',
       method: 'method'
     })
-    t.deepEqual(result, {
+    t.same(result, {
       path: 'path',
       method: 'method',
       consumed: false
@@ -80,6 +80,6 @@ test('getMockDispatch', (t) => {
       path: 'wrong',
       method: 'wrong'
     })
-    t.strictEqual(result, undefined)
+    t.equal(result, undefined)
   })
 })

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -1,33 +1,102 @@
+import { Duplex, Readable, Writable } from 'stream'
 import { expectAssignable } from 'tsd'
-import { Pool, Agent, setGlobalAgent, request, stream, pipeline, Client } from '../..'
-import { Writable, Readable, Duplex } from 'stream'
+import { Agent, Dispatcher } from '../..'
+import { URL } from 'url'
 
 expectAssignable<Agent>(new Agent())
 expectAssignable<Agent>(new Agent({}))
+expectAssignable<Agent>(new Agent({ maxRedirections: 1 }))
+expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 
 {
   const agent = new Agent()
 
-  expectAssignable<Pool>(agent.get(''))
-}
+  expectAssignable<number>(agent.pending)
+  expectAssignable<number>(agent.running)
+  expectAssignable<number>(agent.size)
+  expectAssignable<number>(agent.connected)
 
-{
-  expectAssignable<void>(setGlobalAgent(new Agent()))
-  expectAssignable<void>(setGlobalAgent({ get: origin => new Pool(origin) }))
-}
+  // request
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<void>(agent.request({ origin: '', path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
+  expectAssignable<void>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
 
-{
-  expectAssignable<PromiseLike<Client.ResponseData>>(request(''))
-  expectAssignable<PromiseLike<Client.StreamData>>(stream('', { method: '' }, data => {
-    expectAssignable<Client.StreamFactoryData>(data)
+  // stream
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<PromiseLike<Client.ResponseData>>(request(''))
-}
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
+  expectAssignable<void>(agent.stream(
+    { origin: '', path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
+  expectAssignable<void>(agent.stream(
+    { origin: new URL('http://localhost'), path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
 
-{
-  expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
-    expectAssignable<Client.PipelineHandlerData>(data)
+  // pipeline
+  expectAssignable<Duplex>(agent.pipeline({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
+  expectAssignable<Duplex>(agent.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+
+  // upgrade
+  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(agent.upgrade({ path: '' }))
+  expectAssignable<void>(agent.upgrade({ path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.UpgradeData>(data)
+  }))
+
+  // connect
+  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(agent.connect({ path: '' }))
+  expectAssignable<void>(agent.connect({ path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ConnectData>(data)
+  }))
+
+  // dispatch
+  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: '', maxRedirections: 1 }, {}))
+
+  // close
+  expectAssignable<PromiseLike<void>>(agent.close())
+  expectAssignable<void>(agent.close(() => {}))
+
+  // destroy
+  expectAssignable<PromiseLike<void>>(agent.destroy())
+  expectAssignable<PromiseLike<void>>(agent.destroy(new Error()))
+  expectAssignable<PromiseLike<void>>(agent.destroy(null))
+  expectAssignable<void>(agent.destroy(() => {}))
+  expectAssignable<void>(agent.destroy(new Error(), () => {}))
+  expectAssignable<void>(agent.destroy(null, () => {}))
 }

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -11,6 +11,7 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 {
   const agent = new Agent()
 
+  // properties
   expectAssignable<number>(agent.pending)
   expectAssignable<number>(agent.running)
   expectAssignable<number>(agent.size)

--- a/test/types/api.test-d.ts
+++ b/test/types/api.test-d.ts
@@ -1,0 +1,27 @@
+import { Duplex, Readable, Writable } from 'stream'
+import { expectAssignable } from 'tsd'
+import { Dispatcher, request, stream, pipeline, connect, upgrade } from '../..'
+
+// request
+expectAssignable<PromiseLike<Dispatcher.ResponseData>>(request(''))
+expectAssignable<PromiseLike<Dispatcher.ResponseData>>(request('', { method: '' }))
+
+// stream
+expectAssignable<PromiseLike<Dispatcher.StreamData>>(stream('', { method: '' }, data => {
+  expectAssignable<Dispatcher.StreamFactoryData>(data)
+  return new Writable()
+}))
+
+// pipeline
+expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
+  expectAssignable<Dispatcher.PipelineHandlerData>(data)
+  return new Readable()
+}))
+
+// connect
+expectAssignable<PromiseLike<Dispatcher.ConnectData>>(connect(''))
+expectAssignable<PromiseLike<Dispatcher.ConnectData>>(connect('', {}))
+
+// upgrade
+expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(upgrade(''))
+expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(upgrade('', {}))

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -1,6 +1,6 @@
 import { Duplex, Readable, Writable } from 'stream'
 import { expectAssignable } from 'tsd'
-import { Client } from '../..'
+import { Client, Dispatcher } from '../..'
 import { URL } from 'url'
 
 expectAssignable<Client>(new Client(''))
@@ -10,62 +10,88 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 {
   const client = new Client('')
 
-  // methods
+  // properties
   expectAssignable<number>(client.pipelining)
   expectAssignable<number>(client.pending)
   expectAssignable<number>(client.running)
   expectAssignable<number>(client.size)
-  expectAssignable<boolean>(client.connected)
+  expectAssignable<number>(client.connected)
   expectAssignable<boolean>(client.busy)
   expectAssignable<boolean>(client.closed)
   expectAssignable<boolean>(client.destroyed)
+  expectAssignable<URL>(client.url)
 
   // request
-  expectAssignable<PromiseLike<Client.ResponseData>>(client.request({ path: '', method: '' }))
-  expectAssignable<void>(client.request({ path: '', method: '' }, (err, data) => {
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }))
+  expectAssignable<void>(client.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.ResponseData>(data)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
+  expectAssignable<void>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // stream
-  expectAssignable<PromiseLike<Client.StreamData>>(client.stream({ path: '', method: '' }, data => {
-    expectAssignable<Client.StreamFactoryData>(data)
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(client.stream({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(client.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(client.stream(
-    { path: '', method: '' },
+    { origin: '', path: '', method: '' },
     data => {
-      expectAssignable<Client.StreamFactoryData>(data)
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
     },
     (err, data) => {
       expectAssignable<Error | null>(err)
-      expectAssignable<Client.StreamData>(data)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
+  expectAssignable<void>(client.stream(
+    { origin: new URL('http://localhost'), path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
     }
   ))
 
   // pipeline
-  expectAssignable<Duplex>(client.pipeline({ path: '', method: '' }, data => {
-    expectAssignable<Client.PipelineHandlerData>(data)
+  expectAssignable<Duplex>(client.pipeline({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+  expectAssignable<Duplex>(client.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
 
   // upgrade
-  expectAssignable<PromiseLike<Client.UpgradeData>>(client.upgrade({ path: '' }))
+  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(client.upgrade({ path: '' }))
   expectAssignable<void>(client.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.UpgradeData>(data)
+    expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // connect
-  expectAssignable<PromiseLike<Client.ConnectData>>(client.connect({ path: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(client.connect({ path: '' }))
   expectAssignable<void>(client.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.ConnectData>(data)
+    expectAssignable<Dispatcher.ConnectData>(data)
   }))
 
   // dispatch
-  expectAssignable<void>(client.dispatch({ path: '', method: '' }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(client.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // close
   expectAssignable<PromiseLike<void>>(client.close())
@@ -74,6 +100,8 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   // destroy
   expectAssignable<PromiseLike<void>>(client.destroy())
   expectAssignable<PromiseLike<void>>(client.destroy(new Error()))
+  expectAssignable<PromiseLike<void>>(client.destroy(null))
   expectAssignable<void>(client.destroy(() => {}))
   expectAssignable<void>(client.destroy(new Error(), () => {}))
+  expectAssignable<void>(client.destroy(null, () => {}))
 }

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -1,0 +1,94 @@
+import { Duplex, Readable, Writable } from 'stream'
+import { expectAssignable } from 'tsd'
+import { Dispatcher } from '../..'
+import { URL } from 'url'
+
+expectAssignable<Dispatcher>(new Dispatcher())
+
+{
+  const dispatcher = new Dispatcher()
+
+  // dispatch
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
+
+  // connect
+  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(dispatcher.connect({ path: '' }))
+  expectAssignable<void>(dispatcher.connect({ path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ConnectData>(data)
+  }))
+
+  // request
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
+  expectAssignable<void>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
+
+  // pipeline
+  expectAssignable<Duplex>(dispatcher.pipeline({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+  expectAssignable<Duplex>(dispatcher.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+
+  // stream
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(dispatcher.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
+  expectAssignable<void>(dispatcher.stream(
+    { origin: '', path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
+  expectAssignable<void>(dispatcher.stream(
+    { origin: new URL('http://localhost'), path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
+
+  // upgrade
+  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '' }))
+  expectAssignable<void>(dispatcher.upgrade({ path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.UpgradeData>(data)
+  }))
+
+  // close
+  expectAssignable<PromiseLike<void>>(dispatcher.close())
+  expectAssignable<void>(dispatcher.close(() => {}))
+
+  // destroy
+  expectAssignable<PromiseLike<void>>(dispatcher.destroy())
+  expectAssignable<PromiseLike<void>>(dispatcher.destroy(new Error()))
+  expectAssignable<PromiseLike<void>>(dispatcher.destroy(null))
+  expectAssignable<void>(dispatcher.destroy(() => {}))
+  expectAssignable<void>(dispatcher.destroy(new Error(), () => {}))
+  expectAssignable<void>(dispatcher.destroy(null, () => {}))
+}

--- a/test/types/global-dispatcher.test-d.ts
+++ b/test/types/global-dispatcher.test-d.ts
@@ -1,0 +1,12 @@
+import { expectAssignable } from 'tsd'
+import { setGlobalDispatcher, Dispatcher, getGlobalDispatcher } from '../..'
+
+{
+  expectAssignable<void>(setGlobalDispatcher(new Dispatcher()))
+  class CustomDispatcher extends Dispatcher {}
+  expectAssignable<void>(setGlobalDispatcher(new CustomDispatcher()))
+}
+
+{
+  expectAssignable<Dispatcher>(getGlobalDispatcher())
+}

--- a/test/types/mock-agent.test-d.ts
+++ b/test/types/mock-agent.test-d.ts
@@ -1,17 +1,23 @@
 import { expectAssignable } from 'tsd'
-import { MockAgent, MockPool, MockClient, Agent, setGlobalAgent } from '../..'
+import { MockAgent, MockPool, MockClient, Agent, setGlobalDispatcher } from '../..'
 
 expectAssignable<MockAgent>(new MockAgent())
 expectAssignable<MockAgent>(new MockAgent({}))
 
 {
   const mockAgent = new MockAgent()
-  expectAssignable<void>(setGlobalAgent(mockAgent))
+  expectAssignable<void>(setGlobalDispatcher(mockAgent))
+
+  // properties
+  expectAssignable<number>(mockAgent.connected)
 
   // get
   expectAssignable<MockPool>(mockAgent.get(''))
   expectAssignable<MockPool>(mockAgent.get(new RegExp('')))
-  expectAssignable<MockPool>(mockAgent.get((origin: string) => origin === ''))
+  expectAssignable<MockPool>(mockAgent.get((origin) => {
+    expectAssignable<string>(origin)
+    return true
+  }))
 
   // close
   expectAssignable<Promise<void>>(mockAgent.close())
@@ -26,20 +32,27 @@ expectAssignable<MockAgent>(new MockAgent({}))
   expectAssignable<void>(mockAgent.enableNetConnect())
   expectAssignable<void>(mockAgent.enableNetConnect(''))
   expectAssignable<void>(mockAgent.enableNetConnect(new RegExp('')))
-  expectAssignable<void>(mockAgent.enableNetConnect((host: string) => host === ''))
+  expectAssignable<void>(mockAgent.enableNetConnect((host) => {
+    expectAssignable<string>(host)
+    return true
+  }))
 
   // disableNetConnect
   expectAssignable<void>(mockAgent.disableNetConnect())
+
+  // dispatch
+  expectAssignable<void>(mockAgent.dispatch({ origin: '', path: '', method: '' }, {}))
 }
 
 {
   const mockAgent = new MockAgent({ connections: 1 })
-  expectAssignable<void>(setGlobalAgent(mockAgent))
+  expectAssignable<void>(setGlobalDispatcher(mockAgent))
   expectAssignable<MockClient>(mockAgent.get(''))
 }
 
 {
   const agent = new Agent()
   const mockAgent = new MockAgent({ agent })
-  expectAssignable<void>(setGlobalAgent(mockAgent))
+  expectAssignable<void>(setGlobalDispatcher(mockAgent))
+  expectAssignable<MockPool>(mockAgent.get(''))
 }

--- a/test/types/mock-client.test-d.ts
+++ b/test/types/mock-client.test-d.ts
@@ -5,15 +5,30 @@ import { MockInterceptor } from '../../types/mock-interceptor'
 {
   const mockClient: MockClient = new MockAgent({ connections: 1 }).get('')
 
+  // properties
+  expectAssignable<number>(mockClient.connected)
+
   // intercept
   expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '' }))
   expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '', body: '' }))
   expectAssignable<MockInterceptor>(mockClient.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp('') }))
-  expectAssignable<MockInterceptor>(mockClient.intercept({ path: (path: string) => true, method: (method: string) => true, body: (body: string) => true }))
-
+  expectAssignable<MockInterceptor>(mockClient.intercept({
+    path: (path) => {
+      expectAssignable<string>(path)
+      return true
+    },
+    method: (method) => {
+      expectAssignable<string>(method)
+      return true
+    },
+    body: (body) => {
+      expectAssignable<string>(body)
+      return true
+    }
+  }))
 
   // dispatch
-  expectAssignable<void>(mockClient.dispatch({ path: '', method: '' }, {}))
+  expectAssignable<void>(mockClient.dispatch({ origin: '', path: '', method: '' }, {}))
 
   // close
   expectAssignable<Promise<void>>(mockClient.close())

--- a/test/types/mock-pool.test-d.ts
+++ b/test/types/mock-pool.test-d.ts
@@ -5,14 +5,30 @@ import { MockInterceptor } from '../../types/mock-interceptor'
 {
   const mockPool: MockPool = new MockAgent({ connections: 1 }).get('')
 
+  // properties
+  expectAssignable<number>(mockPool.connected)
+
   // intercept
   expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '' }))
   expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '', body: '' }))
   expectAssignable<MockInterceptor>(mockPool.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp('') }))
-  expectAssignable<MockInterceptor>(mockPool.intercept({ path: (path: string) => true, method: (method: string) => true, body: (body: string) => true }))
+  expectAssignable<MockInterceptor>(mockPool.intercept({
+    path: (path) => {
+      expectAssignable<string>(path)
+      return true
+    },
+    method: (method) => {
+      expectAssignable<string>(method)
+      return true
+    },
+    body: (body) => {
+      expectAssignable<string>(body)
+      return true
+    }
+  }))
 
   // dispatch
-  expectAssignable<void>(mockPool.dispatch({ path: '', method: '' }, {}))
+  expectAssignable<void>(mockPool.dispatch({ origin: '', path: '', method: '' }, {}))
 
   // close
   expectAssignable<Promise<void>>(mockPool.close())

--- a/test/types/pool.test-d.ts
+++ b/test/types/pool.test-d.ts
@@ -1,71 +1,99 @@
 import { Duplex, Readable, Writable } from 'stream'
 import { expectAssignable } from 'tsd'
-import { Client, Pool } from '../..'
+import { Dispatcher, Pool, Client } from '../..'
 import { URL } from 'url'
 
 expectAssignable<Pool>(new Pool(''))
 expectAssignable<Pool>(new Pool('', {}))
 expectAssignable<Pool>(new Pool(new URL('http://localhost'), {}))
+expectAssignable<Pool>(new Pool('', { factory: () => new Dispatcher() }))
+expectAssignable<Pool>(new Pool('', { factory: (origin, opts) => new Client(origin, opts) }))
+expectAssignable<Pool>(new Pool('', { connections: 1 }))
 
 {
   const pool = new Pool('', {})
 
-  // methods
-  expectAssignable<number>(pool.pipelining)
+  // properties
   expectAssignable<number>(pool.pending)
   expectAssignable<number>(pool.running)
   expectAssignable<number>(pool.size)
-  expectAssignable<boolean>(pool.connected)
+  expectAssignable<number>(pool.connected)
   expectAssignable<boolean>(pool.busy)
   expectAssignable<boolean>(pool.closed)
   expectAssignable<boolean>(pool.destroyed)
+  expectAssignable<URL>(pool.url)
 
   // request
-  expectAssignable<PromiseLike<Client.ResponseData>>(pool.request({ path: '', method: '' }))
-  expectAssignable<void>(pool.request({ path: '', method: '' }, (err, data) => {
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<void>(pool.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.ResponseData>(data)
+    expectAssignable<Dispatcher.ResponseData>(data)
+  }))
+  expectAssignable<void>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // stream
-  expectAssignable<PromiseLike<Client.StreamData>>(pool.stream({ path: '', method: '' }, data => {
-    expectAssignable<Client.StreamFactoryData>(data)
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(pool.stream({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
+  expectAssignable<PromiseLike<Dispatcher.StreamData>>(pool.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(pool.stream(
-    { path: '', method: '' },
+    { origin: '', path: '', method: '' },
     data => {
-      expectAssignable<Client.StreamFactoryData>(data)
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
     },
     (err, data) => {
       expectAssignable<Error | null>(err)
-      expectAssignable<Client.StreamData>(data)
+      expectAssignable<Dispatcher.StreamData>(data)
+    }
+  ))
+  expectAssignable<void>(pool.stream(
+    { origin: new URL('http://localhost'), path: '', method: '' },
+    data => {
+      expectAssignable<Dispatcher.StreamFactoryData>(data)
+      return new Writable()
+    },
+    (err, data) => {
+      expectAssignable<Error | null>(err)
+      expectAssignable<Dispatcher.StreamData>(data)
     }
   ))
 
   // pipeline
-  expectAssignable<Duplex>(pool.pipeline({ path: '', method: '' }, data => {
-    expectAssignable<Client.PipelineHandlerData>(data)
+  expectAssignable<Duplex>(pool.pipeline({ origin: '', path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+  expectAssignable<Duplex>(pool.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
 
   // upgrade
-  expectAssignable<PromiseLike<Client.UpgradeData>>(pool.upgrade({ path: '' }))
+  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(pool.upgrade({ path: '' }))
   expectAssignable<void>(pool.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.UpgradeData>(data)
+    expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // connect
-  expectAssignable<PromiseLike<Client.ConnectData>>(pool.connect({ path: '' }))
+  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(pool.connect({ path: '' }))
   expectAssignable<void>(pool.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
-    expectAssignable<Client.ConnectData>(data)
+    expectAssignable<Dispatcher.ConnectData>(data)
   }))
 
   // dispatch
-  expectAssignable<void>(pool.dispatch({ path: '', method: '' }, {}))
+  expectAssignable<void>(pool.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(pool.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // close
   expectAssignable<PromiseLike<void>>(pool.close())
@@ -74,6 +102,8 @@ expectAssignable<Pool>(new Pool(new URL('http://localhost'), {}))
   // destroy
   expectAssignable<PromiseLike<void>>(pool.destroy())
   expectAssignable<PromiseLike<void>>(pool.destroy(new Error()))
+  expectAssignable<PromiseLike<void>>(pool.destroy(null))
   expectAssignable<void>(pool.destroy(() => {}))
   expectAssignable<void>(pool.destroy(new Error(), () => {}))
+  expectAssignable<void>(pool.destroy(null, () => {}))
 }

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -1,37 +1,33 @@
-import { UrlObject } from 'url'
-import Pool from './pool'
-import Client from './client'
-import { Duplex } from 'stream'
 import { URL } from 'url'
+import Dispatcher from './dispatcher'
+import Pool from './pool'
 
-export {
-  Agent,
-  setGlobalAgent,
-  request,
-  stream,
-  pipeline,
+export = Agent
+
+declare class Agent extends Dispatcher{
+  constructor(opts?: Agent.Options)
+  /** Number of queued requests. */
+  pending: number;
+  /** Number of inflight requests. */
+  running: number;
+  /** Number of pending and running requests. */
+  size: number;
+  /** Number of active client connections. */
+  connected: number;
+  /** Dispatches a request. */
+  dispatch(options: Agent.DispatchOptions, handler: Dispatcher.DispatchHandlers): void;
 }
 
-declare class Agent {
-  constructor(opts?: Pool.Options)
-  get(origin: string): Pool;
+declare namespace Agent {
+  export interface Options extends Pool.Options {
+    /** Default: `(origin, opts) => new Pool(origin, opts)`. */
+    factory?(origin: URL, opts: Object): Dispatcher;
+    /** Integer. Default: `0` */
+    maxRedirections?: number;
+  }
+
+  export interface DispatchOptions extends Dispatcher.DispatchOptions {
+    /** Integer. */
+    maxRedirections?: number;
+  }
 }
-
-declare function setGlobalAgent<AgentImplementation extends Agent>(agent: AgentImplementation): void;
-
-declare function request(
-  url: string | URL | UrlObject,
-  opts?: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
-): PromiseLike<Client.ResponseData>;
-
-declare function stream(
-  url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Omit<Client.RequestOptions, 'path'>,
-  factory: Client.StreamFactory
-): PromiseLike<Client.StreamData>;
-
-declare function pipeline(
-  url: string | URL | UrlObject,
-  opts: { agent?: Agent } & Omit<Client.PipelineOptions, 'path'>,
-  handler: Client.PipelineHandler
-): Duplex;

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -1,0 +1,43 @@
+import { URL, UrlObject } from 'url'
+import { Duplex } from 'stream'
+import Dispatcher from './dispatcher'
+
+export {
+  request,
+  stream,
+  pipeline,
+  connect,
+  upgrade,
+}
+
+/** Performs an HTTP request. */
+declare function request(
+  url: string | URL | UrlObject,
+  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path'>,
+): PromiseLike<Dispatcher.ResponseData>;
+
+/** A faster version of `request`. */
+declare function stream(
+  url: string | URL | UrlObject,
+  options: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path'>,
+  factory: Dispatcher.StreamFactory
+): PromiseLike<Dispatcher.StreamData>;
+
+/** For easy use with `stream.pipeline`. */
+declare function pipeline(
+  url: string | URL | UrlObject,
+  options: { dispatcher?: Dispatcher } & Omit<Dispatcher.PipelineOptions, 'origin' | 'path'>,
+  handler: Dispatcher.PipelineHandler
+): Duplex;
+
+/** Starts two-way communications with the requested resource. */
+declare function connect(
+  url: string | URL | UrlObject,
+  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.ConnectOptions, 'origin' | 'path'>
+): PromiseLike<Dispatcher.ConnectData>;
+
+/** Upgrade to a different protocol. */
+declare function upgrade(
+  url: string | URL | UrlObject,
+  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.UpgradeOptions, 'origin' | 'path'>
+): PromiseLike<Dispatcher.UpgradeData>;

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,17 +1,12 @@
 import { URL } from 'url'
 import { TlsOptions } from 'tls'
-import { Duplex, Readable, Writable } from 'stream'
-import { EventEmitter } from 'events'
-import { IncomingHttpHeaders } from 'http'
-
-type AbortSignal = unknown;
+import Dispatcher from './dispatcher'
 
 export = Client
 
 /** A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection. Pipelining is disabled by default. */
-declare class Client extends EventEmitter {
+declare class Client extends Dispatcher {
   constructor(url: string | URL, options?: Client.Options);
-
   /** Property to get and set the pipelining factor. */
   pipelining: number;
   /** Number of queued requests. */
@@ -20,172 +15,39 @@ declare class Client extends EventEmitter {
   running: number;
   /** Number of pending and running requests. */
   size: number;
-  /** True if the client has an active connection. The client will lazily create a connection when it receives a request and will destroy it if there is no activity for the duration of the `timeout` value. */
-  connected: boolean;
-  /** True if pipeline is saturated or blocked. Indicates whether dispatching further requests is meaningful. */
+  /** Number of active client connections. The client will lazily create a connection when it receives a request and will destroy it if there is no activity for the duration of the `timeout` value. */
+  connected: number;
+  /** `true` if pipeline is saturated or blocked. Indicates whether dispatching further requests is meaningful. */
   busy: boolean;
-  /** True after `client.close()` has been called. */
+  /** `true` after `client.close()` has been called. */
   closed: boolean;
-  /** True after `client.destroyed()` has been called or `client.close()` has been called and the client shutdown has completed. */
+  /** `true` after `client.destroyed()` has been called or `client.close()` has been called and the client shutdown has completed. */
   destroyed: boolean;
-
-  /** Performs a HTTP request */
-  request(options: Client.RequestOptions): PromiseLike<Client.ResponseData>;
-  request(options: Client.RequestOptions, callback: (err: Error | null, data: Client.ResponseData) => void): void;
-
-  /** A faster version of `Client.request` */
-  stream(options: Client.RequestOptions, factory: Client.StreamFactory): PromiseLike<Client.StreamData>;
-  stream(options: Client.RequestOptions, factory: Client.StreamFactory, callback: (err: Error | null, data: Client.StreamData) => void): void;
-
-  /** For easy use with `stream.pipeline` */
-  pipeline(options: Client.PipelineOptions, handler: Client.PipelineHandler): Duplex;
-
-  /** Upgrade to a different protocol */
-  upgrade(options: Client.UpgradeOptions): PromiseLike<Client.UpgradeData>;
-  upgrade(options: Client.UpgradeOptions, callback: (err: Error | null, data: Client.UpgradeData) => void): void;
-
-  /** Starts two-way communications with the requested resource */
-  connect(options: Client.ConnectOptions): PromiseLike<Client.ConnectData>;
-  connect(options: Client.ConnectOptions, callback: (err: Error | null, data: Client.ConnectData) => void): void;
-
-  /** This is the low level API which all the preceding APIs are implemented on top of. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
-  dispatch(options: Client.DispatchOptions, handlers: Client.DispatchHandlers): void;
-
-  /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returnning a promise if no callback is provided). */
-  close(): PromiseLike<void>;
-  close(callback: () => void): void;
-
-  /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returnning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
-  destroy(): PromiseLike<void>;
-  destroy(err: Error | null): PromiseLike<void>;
-  destroy(callback: () => void): void;
-  destroy(err: Error | null, callback: () => void): void;
+  /** The URL of the Client instance. */
+  readonly url: URL;
 }
 
 declare namespace Client {
   export interface Options {
     /** an IPC endpoint, either Unix domain socket or Windows named pipe. Default: `null`. */
     socketPath?: string | null;
-    /** the timeout after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overriden by *keep-alive* hints from the server. Default: `4e3` milliseconds (4s). */
-    keepAliveTimeout?: number;
-    /** the maximum allowed `idleTimeout` when overriden by *keep-alive* hints from the server. Default: `600e3` milliseconds (10min). */
-    keepAliveMaxTimeout?: number;
-    /** A number subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuries caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
-    keepAliveTimeoutThreshold?: number;
+    /** the timeout after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overridden by *keep-alive* hints from the server. Default: `4e3` milliseconds (4s). */
+    keepAliveTimeout?: number | null;
+    /** the maximum allowed `idleTimeout` when overridden by *keep-alive* hints from the server. Default: `600e3` milliseconds (10min). */
+    keepAliveMaxTimeout?: number | null;
+    /** A number subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuracies caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
+    keepAliveTimeoutThreshold?: number | null;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
-    pipelining?: number;
+    pipelining?: number | null;
     /** An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback). Default: `null`. */
     tls?: TlsOptions | null;
     /** The maximum length of request headers in bytes. Default: `16384` (16KiB). */
-    maxHeaderSize?: number;
+    maxHeaderSize?: number | null;
+    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `30e3` milliseconds (30s). */
+    bodyTimeout?: number | null;
     /** The amount of time the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `30e3` milliseconds (30s). */
-    headersTimeout?: number;
-    /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true` */
+    headersTimeout?: number | null;
+    /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
     strictContentLength?: boolean
-  }
-
-  export interface DispatchOptions {
-    path: string;
-    method: string;
-    /** Default: `null` */
-    body?: string | Buffer | Uint8Array | Readable | null;
-    /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
-    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    headersTimeout?: number;
-    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a body data. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    bodyTimeout?: number;
-    /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceeding requests in the pipeline has completed. Default: `true` if `method` is `HEAD` or `GET`. */
-    idempotent?: boolean;
-  }
-
-  export interface RequestOptions extends DispatchOptions {
-    opaque?: unknown;
-    /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
-  }
-
-  export interface PipelineOptions extends RequestOptions {
-    /** `true` if the `handler` will return an object stream. Default: `false` */
-    objectMode?: boolean;
-  }
-
-  export interface UpgradeOptions {
-    path: string;
-    method?: string;
-    /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
-    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    headersTimeout?: number;
-    /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
-    protocol?: string;
-    /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
-  }
-
-  export interface ConnectOptions {
-    path: string;
-    /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
-    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    headersTimeout?: number;
-    /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
-  }
-
-  export interface ResponseData {
-    statusCode: number;
-    headers: IncomingHttpHeaders;
-    body: Readable;
-    opaque?: unknown;
-  }
-
-  export interface StreamData {
-    opaque: unknown;
-    trailers: Record<string, unknown>;
-  }
-
-  export interface UpgradeData {
-    headers: IncomingHttpHeaders;
-    socket: Duplex;
-    opaque: unknown;
-  }
-
-  export interface ConnectData {
-    statusCode: number;
-    headers: IncomingHttpHeaders;
-    socket: Duplex;
-    opaque: unknown;
-  }
-
-  export interface StreamFactoryData {
-    statusCode: number;
-    headers: IncomingHttpHeaders;
-    opaque: unknown;
-  }
-  export type StreamFactory = (data: StreamFactoryData) => Writable
-
-  export interface PipelineHandlerData {
-    statusCode: number;
-    headers: IncomingHttpHeaders;
-    opaque: unknown;
-    body: Readable;
-  }
-
-  export type PipelineHandler = (data: PipelineHandlerData) => Readable
-
-  export interface DispatchHandlers {
-    /** Invoked before request is dispatched on socket. May be invoked multiple times when a request is retried when the request at the head of the pipeline fails. */
-    onConnect?(abort: () => void): void;
-    /** Invoked when request is upgraded either due to a `Upgrade` header or `CONNECT` method */
-    onUpgrade?(statusCode: number, headers: string[] | null, socket: Duplex): void;
-    /** Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. */
-    onHeaders?(statusCode: number, headers: string[] | null, resume: () => void): boolean;
-    /** Invoked when response payload data is received */
-    onData?(chunk: Buffer): boolean;
-    /** Invoked when response payload and trailers have been received and the request has completed. */
-    onComplete?(trailers: string[] | null): void;
-    /** Invoked when an error has occurred. */
-    onError?(err: Error): void;
   }
 }

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -1,0 +1,165 @@
+import { URL } from 'url'
+import { TlsOptions } from 'tls'
+import { Duplex, Readable, Writable } from 'stream'
+import { EventEmitter } from 'events'
+import { IncomingHttpHeaders } from 'http'
+
+type AbortSignal = unknown;
+
+export = Dispatcher;
+
+/** Dispatcher is the core API used to dispatch requests. */
+declare class Dispatcher extends EventEmitter {
+  /** This is the low level API which all the preceding APIs are implemented on top of. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
+  dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandler): void;
+
+  /** Starts two-way communications with the requested resource. */
+  connect(options: Dispatcher.ConnectOptions): PromiseLike<Dispatcher.ConnectData>;
+  connect(options: Dispatcher.ConnectOptions, callback: (err: Error | null, data: Dispatcher.ConnectData) => void): void;
+
+  /** Performs an HTTP request. */
+  request(options: Dispatcher.RequestOptions): PromiseLike<Dispatcher.ResponseData>;
+  request(options: Dispatcher.RequestOptions, callback: (err: Error | null, data: Dispatcher.ResponseData) => void): void;
+
+  /** For easy use with `stream.pipeline`. */
+  pipeline(options: Dispatcher.PipelineOptions, handler: Dispatcher.PipelineHandler): Duplex;
+
+  /** A faster version of `Dispatcher.request`. */
+  stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory): PromiseLike<Dispatcher.StreamData>;
+  stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory, callback: (err: Error | null, data: Dispatcher.StreamData) => void): void;
+
+  /** Upgrade to a different protocol. */
+  upgrade(options: Dispatcher.UpgradeOptions): PromiseLike<Dispatcher.UpgradeData>;
+  upgrade(options: Dispatcher.UpgradeOptions, callback: (err: Error | null, data: Dispatcher.UpgradeData) => void): void;
+
+  /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returnning a promise if no callback is provided). */
+  close(): PromiseLike<void>;
+  close(callback: () => void): void;
+
+  /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returnning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
+  destroy(): PromiseLike<void>;
+  destroy(err: Error | null): PromiseLike<void>;
+  destroy(callback: () => void): void;
+  destroy(err: Error | null, callback: () => void): void;
+}
+
+declare namespace Dispatcher {
+  export interface DispatchOptions {
+    origin: string | URL;
+    path: string;
+    method: string;
+    /** Default: `null` */
+    body?: string | Buffer | Uint8Array | Readable | null;
+    /** Default: `null` */
+    headers?: IncomingHttpHeaders | null;
+    /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceeding requests in the pipeline has completed. Default: `true` if `method` is `HEAD` or `GET`. */
+    idempotent?: boolean;
+    /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
+    upgrade?: boolean | string | null
+    // TODO: check this
+    // TODO: check this
+    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
+    // headersTimeout?: number;
+    // TODO: check this
+    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a body data. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
+    // bodyTimeout?: number;
+  }
+
+  export interface ConnectOptions {
+    path: string;
+    /** Default: `null` */
+    headers?: IncomingHttpHeaders | null;
+    // TODO: check this
+    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
+    // headersTimeout?: number;
+    /** Default: `null` */
+    signal?: AbortSignal | EventEmitter | null;
+    /** This argument parameter is passed through to `ConnectData` */
+    opaque?: unknown;
+  }
+
+  export interface RequestOptions extends DispatchOptions {
+    /** Default: `null` */
+    opaque?: unknown;
+    /** Default: `null` */
+    signal?: AbortSignal | EventEmitter | null;
+  }
+
+  export interface PipelineOptions extends RequestOptions {
+    /** `true` if the `handler` will return an object stream. Default: `false` */
+    objectMode?: boolean;
+  }
+
+  export interface UpgradeOptions {
+    path: string;
+    /** Default: `'GET'` */
+    method?: string;
+    /** Default: `null` */
+    headers?: IncomingHttpHeaders | null;
+    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
+    // TODO: check this
+    // headersTimeout?: number;
+    // /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
+    /** Default: `'Websocket'` */
+    protocol?: string;
+    /** Default: `null` */
+    signal?: AbortSignal | EventEmitter | null;
+  }
+
+  export interface ConnectData {
+    statusCode: number;
+    headers: IncomingHttpHeaders;
+    socket: Duplex;
+    opaque: unknown;
+  }
+
+  export interface ResponseData {
+    statusCode: number;
+    headers: IncomingHttpHeaders;
+    body: Readable;
+    trailers: Record<string, string>;
+    opaque: unknown;
+  }
+
+  export interface PipelineHandlerData {
+    statusCode: number;
+    headers: IncomingHttpHeaders;
+    opaque: unknown;
+    body: Readable;
+  }
+
+  export interface StreamData {
+    opaque: unknown;
+    trailers: Record<string, string>;
+  }
+
+  export interface UpgradeData {
+    headers: IncomingHttpHeaders;
+    socket: Duplex;
+    opaque: unknown;
+  }
+
+  export interface StreamFactoryData {
+    statusCode: number;
+    headers: IncomingHttpHeaders;
+    opaque: unknown;
+  }
+  export type StreamFactory = (data: StreamFactoryData) => Writable;
+
+  export interface DispatchHandler {
+    /** Invoked before request is dispatched on socket. May be invoked multiple times when a request is retried when the request at the head of the pipeline fails. */
+    onConnect?(abort: () => void): void;
+    /** Invoked when an error has occurred. */
+    onError?(err: Error): void;
+    /** Invoked when request is upgraded either due to a `Upgrade` header or `CONNECT` method. */
+    onUpgrade?(statusCode: number, headers: string[] | null, socket: Duplex): void;
+    /** Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. */
+    onHeaders?(statusCode: number, headers: string[] | null, resume: () => void): boolean;
+    /** Invoked when response payload data is received. */
+    onData?(chunk: Buffer): boolean;
+    /** Invoked when response payload and trailers have been received and the request has completed. */
+    onComplete?(trailers: string[] | null): void;
+  }
+
+  export type PipelineHandler = (data: PipelineHandlerData) => Readable;
+}

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -10,32 +10,25 @@ export = Dispatcher;
 
 /** Dispatcher is the core API used to dispatch requests. */
 declare class Dispatcher extends EventEmitter {
-  /** This is the low level API which all the preceding APIs are implemented on top of. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
-  dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandler): void;
-
+  /** Dispatches a request. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
+  dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandlers): void;
   /** Starts two-way communications with the requested resource. */
   connect(options: Dispatcher.ConnectOptions): PromiseLike<Dispatcher.ConnectData>;
   connect(options: Dispatcher.ConnectOptions, callback: (err: Error | null, data: Dispatcher.ConnectData) => void): void;
-
   /** Performs an HTTP request. */
   request(options: Dispatcher.RequestOptions): PromiseLike<Dispatcher.ResponseData>;
   request(options: Dispatcher.RequestOptions, callback: (err: Error | null, data: Dispatcher.ResponseData) => void): void;
-
   /** For easy use with `stream.pipeline`. */
   pipeline(options: Dispatcher.PipelineOptions, handler: Dispatcher.PipelineHandler): Duplex;
-
   /** A faster version of `Dispatcher.request`. */
   stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory): PromiseLike<Dispatcher.StreamData>;
   stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory, callback: (err: Error | null, data: Dispatcher.StreamData) => void): void;
-
   /** Upgrade to a different protocol. */
   upgrade(options: Dispatcher.UpgradeOptions): PromiseLike<Dispatcher.UpgradeData>;
   upgrade(options: Dispatcher.UpgradeOptions, callback: (err: Error | null, data: Dispatcher.UpgradeData) => void): void;
-
   /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returnning a promise if no callback is provided). */
   close(): PromiseLike<void>;
   close(callback: () => void): void;
-
   /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returnning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
   destroy(): PromiseLike<void>;
   destroy(err: Error | null): PromiseLike<void>;
@@ -56,63 +49,43 @@ declare namespace Dispatcher {
     idempotent?: boolean;
     /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
     upgrade?: boolean | string | null
-    // TODO: check this
-    // TODO: check this
-    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    // headersTimeout?: number;
-    // TODO: check this
-    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a body data. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    // bodyTimeout?: number;
   }
-
   export interface ConnectOptions {
     path: string;
     /** Default: `null` */
     headers?: IncomingHttpHeaders | null;
-    // TODO: check this
-    // /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    // headersTimeout?: number;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
     /** This argument parameter is passed through to `ConnectData` */
     opaque?: unknown;
   }
-
   export interface RequestOptions extends DispatchOptions {
     /** Default: `null` */
     opaque?: unknown;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
   }
-
   export interface PipelineOptions extends RequestOptions {
     /** `true` if the `handler` will return an object stream. Default: `false` */
     objectMode?: boolean;
   }
-
   export interface UpgradeOptions {
     path: string;
     /** Default: `'GET'` */
     method?: string;
     /** Default: `null` */
     headers?: IncomingHttpHeaders | null;
-    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving a complete headers. Use 0 to disable it entirely. Default: `30e3` milliseconds (30s). */
-    // TODO: check this
-    // headersTimeout?: number;
-    // /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
-    /** Default: `'Websocket'` */
+    /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
     protocol?: string;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
   }
-
   export interface ConnectData {
     statusCode: number;
     headers: IncomingHttpHeaders;
     socket: Duplex;
     opaque: unknown;
   }
-
   export interface ResponseData {
     statusCode: number;
     headers: IncomingHttpHeaders;
@@ -120,33 +93,28 @@ declare namespace Dispatcher {
     trailers: Record<string, string>;
     opaque: unknown;
   }
-
   export interface PipelineHandlerData {
     statusCode: number;
     headers: IncomingHttpHeaders;
     opaque: unknown;
     body: Readable;
   }
-
   export interface StreamData {
     opaque: unknown;
     trailers: Record<string, string>;
   }
-
   export interface UpgradeData {
     headers: IncomingHttpHeaders;
     socket: Duplex;
     opaque: unknown;
   }
-
   export interface StreamFactoryData {
     statusCode: number;
     headers: IncomingHttpHeaders;
     opaque: unknown;
   }
   export type StreamFactory = (data: StreamFactoryData) => Writable;
-
-  export interface DispatchHandler {
+  export interface DispatchHandlers {
     /** Invoked before request is dispatched on socket. May be invoked multiple times when a request is retried when the request at the head of the pipeline fails. */
     onConnect?(abort: () => void): void;
     /** Invoked when an error has occurred. */
@@ -160,6 +128,5 @@ declare namespace Dispatcher {
     /** Invoked when response payload and trailers have been received and the request has completed. */
     onComplete?(trailers: string[] | null): void;
   }
-
   export type PipelineHandler = (data: PipelineHandlerData) => Readable;
 }

--- a/types/global-dispatcher.d.ts
+++ b/types/global-dispatcher.d.ts
@@ -1,0 +1,9 @@
+import Dispatcher from "./dispatcher";
+
+export {
+  getGlobalDispatcher,
+  setGlobalDispatcher
+}
+
+declare function setGlobalDispatcher<DispatcherImplementation extends Dispatcher>(dispatcher: DispatcherImplementation): void;
+declare function getGlobalDispatcher(): Dispatcher;

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -1,24 +1,28 @@
-import { Agent } from './agent'
-import Pool from './pool'
+import Agent from './agent'
 import MockPool from './mock-pool'
 import MockClient from './mock-client'
+import Dispatcher from './dispatcher'
 
 export = MockAgent
 
 /** A mocked Agent class that implements the Agent API. It allows one to intercept HTTP requests made through undici and return mocked responses instead. */
-declare class MockAgent {
+declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.Options> extends Dispatcher {
   constructor(options?: MockAgent.Options)
-  /** Creates and retrieves MockPool or MockClient instances which can then be used to intercept HTTP requests. If the number of connections on the mock agent is set to 1, a MockClient instance is returned. Otherwise a MockPool instance is returned. */
-  get(origin: string): MockPool | MockClient;
-  get(origin: RegExp): MockPool | MockClient;
-  get(origin: ((origin: string) => boolean)): MockPool | MockClient;
+  /** Number of active mock client connections. */
+  connected: number;
+  /** Creates and retrieves mock Dispatcher instances which can then be used to intercept HTTP requests. If the number of connections on the mock agent is set to 1, a MockClient instance is returned. Otherwise a MockPool instance is returned. */
+  get<TDispatcher extends Dispatcher>(origin: string): TDispatcher;
+  get<TDispatcher extends Dispatcher>(origin: RegExp): TDispatcher;
+  get<TDispatcher extends Dispatcher>(origin: ((origin: string) => boolean)): TDispatcher;
+  /** Dispatches a mocked request. */
+  dispatch(options: Agent.DispatchOptions, handler: Dispatcher.DispatchHandlers): void;
   /** Closes the mock agent and waits for registered mock pools and clients to also close before resolving. */
   close(): Promise<void>;
   /** Disables mocking in MockAgent. */
   deactivate(): void;
   /** Enables mocking in a MockAgent instance. When instantiated, a MockAgent is automatically activated. Therefore, this method is only effective after `MockAgent.deactivate` has been called. */
   activate(): void;
-  /** Define host matchers so only matching requests that aren't intercepted will be attempted. */
+  /** Define host matchers so only matching requests that aren't intercepted by the mock dispatchers will be attempted. */
   enableNetConnect(): void;
   enableNetConnect(host: string): void;
   enableNetConnect(host: RegExp): void;
@@ -29,7 +33,7 @@ declare class MockAgent {
 
 declare namespace MockAgent {
   /** MockAgent options. */
-  export interface Options extends Pool.Options {
+  export interface Options extends Agent.Options {
     /** A custom agent to be encapsulated by the MockAgent. */
     agent?: Agent;
   }

--- a/types/mock-client.d.ts
+++ b/types/mock-client.d.ts
@@ -1,4 +1,5 @@
 import Client from './client'
+import Dispatcher from './dispatcher'
 import MockAgent from './mock-agent'
 import { MockInterceptor } from './mock-interceptor'
 
@@ -7,10 +8,12 @@ export = MockClient
 /** MockClient extends the Client API and allows one to mock requests. */
 declare class MockClient extends Client {
   constructor(origin: string, options: MockClient.Options);
+  /** Number of connected mock clients */
+  connected: number
   /** Intercepts any matching requests that use the same origin as this mock client. */
   intercept(options: MockInterceptor.Options): MockInterceptor;
-  /** This is a mock of the low level dispatch API. */
-  dispatch(options: Client.DispatchOptions, handlers: Client.DispatchHandlers): void;
+  /** Dispatches a mocked request. */
+  dispatch(options: Dispatcher.DispatchOptions, handlers: Dispatcher.DispatchHandlers): void;
   /** Closes the mock client and gracefully waits for enqueued requests to complete. */
   close(): Promise<void>;
 }
@@ -18,7 +21,7 @@ declare class MockClient extends Client {
 declare namespace MockClient {
   /** MockClient options. */
   export interface Options extends Client.Options {
-    /** The MockAgent to be associated with this mock client. */
+    /** The agent to associate this MockClient with. */
     agent: MockAgent;
   }
 }

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -26,8 +26,8 @@ declare class MockInterceptor {
   /** Set default reply headers on the interceptor for subsequent mocked replies. */
   defaultReplyHeaders(headers: IncomingHttpHeaders): MockInterceptor;
   /** Set default reply trailers on the interceptor for subsequent mocked replies. */
-  defaultReplyTrailers(trailers: IncomingHttpHeaders): MockInterceptor;
-  /** Set automcatically calculated content-length header on subsequent mocked replies. */
+  defaultReplyTrailers(trailers: Record<string, string>): MockInterceptor;
+  /** Set automatically calculated content-length header on subsequent mocked replies. */
   replyContentLength(): MockInterceptor;
 }
 
@@ -48,9 +48,9 @@ declare namespace MockInterceptor {
     data: MockDispatchData<TData, TError>;
   }
   export interface MockDispatchData<TData extends object = object, TError extends Error = Error> extends MockResponseOptions {
-    statusCode: number;
-    data: TData | string;
     error: TError | null;
+    statusCode?: number;
+    data?: TData | string;
   }
   export interface MockResponseOptions {
     headers?: IncomingHttpHeaders;

--- a/types/mock-pool.d.ts
+++ b/types/mock-pool.d.ts
@@ -1,17 +1,19 @@
 import Pool from './pool'
-import Client from './client'
 import MockAgent from './mock-agent'
 import { MockInterceptor } from './mock-interceptor'
+import Dispatcher from './dispatcher'
 
 export = MockPool
 
 /** MockPool extends the Pool API and allows one to mock requests. */
 declare class MockPool extends Pool {
   constructor(origin: string, options: MockPool.Options);
+  /** Number of connected mock clients */
+  connected: number
   /** Intercepts any matching requests that use the same origin as this mock pool. */
   intercept(options: MockInterceptor.Options): MockInterceptor;
-  /** This is a mock of the low level dispatch API. */
-  dispatch(options: Client.DispatchOptions, handlers: Client.DispatchHandlers): void;
+  /** Dispatches a mocked request. */
+  dispatch(options: Dispatcher.DispatchOptions, handlers: Dispatcher.DispatchHandlers): void;
   /** Closes the mock pool and gracefully waits for enqueued requests to complete. */
   close(): Promise<void>;
 }
@@ -19,7 +21,7 @@ declare class MockPool extends Pool {
 declare namespace MockPool {
   /** MockPool options. */
   export interface Options extends Pool.Options {
-    /** The MockAgent to be associated with this mock pool. */
+    /** The agent to associate this MockPool with. */
     agent: MockAgent;
   }
 }

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -1,15 +1,34 @@
 import Client from './client'
+import Dispatcher from './dispatcher'
 import { URL } from 'url'
 
 export = Pool
 
-declare class Pool extends Client {
+declare class Pool extends Dispatcher {
   constructor(url: string | URL, options?: Pool.Options)
+  /** Number of queued requests. */
+  pending: number;
+  /** Number of inflight requests. */
+  running: number;
+  /** Number of pending and running requests. */
+  size: number;
+  /** Number of active client connections. The clients will lazily create a connection when it receives a request and will destroy it if there is no activity for the duration of the `timeout` value. */
+  connected: number;
+  /** `true` if pipeline is saturated or blocked. Indicates whether dispatching further requests is meaningful. */
+  busy: boolean;
+  /** `true` after `pool.close()` has been called. */
+  closed: boolean;
+  /** `true` after `pool.destroyed()` has been called or `pool.close()` has been called and the pool shutdown has completed. */
+  destroyed: boolean;
+  /** The URL of the Pool instance. */
+  readonly url: URL;
 }
 
 declare namespace Pool {
   export interface Options extends Client.Options {
+    /** Default: `(origin, opts) => new Client(origin, opts)`. */
+    factory?(origin: URL, opts: object): Dispatcher;
     /** The max number of clients to create. `null` if no limit. Default `null`. */
-    connections?: number
+    connections?: number | null;
   }
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/nodejs/undici/pull/587 as discussed here: https://github.com/nodejs/undici/pull/587#issuecomment-812039005

It adds the following:
 - Refactor typings to fit new Dispatcher API
 - Adds additional tests for these new typings
 - Resolves `tap` deprecation warnings in mock tests
 - Corrects small typos in docs