### PR TITLE
Override timeouts per request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ yarn.lock
 
 # IDE files
 .idea
+.vscode
 
 *0x
 *clinic*

--- a/lib/client.js
+++ b/lib/client.js
@@ -271,6 +271,7 @@ class Client extends Dispatcher {
       }
 
       const request = new Request(opts, handler)
+
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
       }
@@ -609,17 +610,25 @@ class Parser {
       return -1
     }
 
+    const headersTimeout = request.headersTimeout !== undefined
+      ? request.headersTimeout
+      : client[kHeadersTimeout]
+
     assert(
       timeout || // have timeout
-      !client[kHeadersTimeout] || // no timeout
+      !headersTimeout || // no timeout
       socket[kWriting], // still writing
       'invalid headers timeout state'
     )
 
+    const bodyTimeout = request.bodyTimeout !== undefined
+      ? request.bodyTimeout
+      : client[kBodyTimeout]
+
     if (statusCode >= 200) {
       clearTimeout(timeout)
-      this.timeout = client[kBodyTimeout]
-        ? setTimeout(onBodyTimeout, client[kBodyTimeout], this.socket)
+      this.timeout = bodyTimeout
+        ? setTimeout(onBodyTimeout, bodyTimeout, this.socket)
         : null
     } else if (timeout && timeout.refresh) {
       timeout.refresh()
@@ -1064,20 +1073,24 @@ function _resume (client, sync) {
     }
 
     if (client.running > 0) {
-      const { aborted } = client[kQueue][client[kRunningIdx]]
-      if (aborted) {
+      const request = client[kQueue][client[kRunningIdx]]
+      if (request.aborted) {
         assert(socket)
         util.destroy(socket, new InformationalError('abort'))
         return
       }
 
+      const headersTimeout = request.headersTimeout !== undefined
+        ? request.headersTimeout
+        : client[kHeadersTimeout]
+
       if (
-        client[kHeadersTimeout] &&
+        headersTimeout &&
         socket &&
         !socket[kWriting] &&
         !socket[kParser].timeout
       ) {
-        socket[kParser].timeout = setTimeout(onHeadersTimeout, client[kHeadersTimeout], socket)
+        socket[kParser].timeout = setTimeout(onHeadersTimeout, headersTimeout, socket)
       }
     }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -16,7 +16,9 @@ class Request {
     body,
     headers,
     idempotent,
-    upgrade
+    upgrade,
+    headersTimeout,
+    bodyTimeout
   }, handler) {
     if (typeof path !== 'string') {
       throw new InvalidArgumentError('path must be a string')
@@ -31,6 +33,17 @@ class Request {
     if (upgrade && typeof upgrade !== 'string') {
       throw new InvalidArgumentError('upgrade must be a string')
     }
+
+    if (headersTimeout !== undefined && typeof headersTimeout !== 'number') {
+      throw new InvalidArgumentError('headersTimeout must be a number')
+    }
+
+    if (bodyTimeout !== undefined && typeof bodyTimeout !== 'number') {
+      throw new InvalidArgumentError('bodyTimeout must be a number')
+    }
+
+    this.headersTimeout = headersTimeout
+    this.bodyTimeout = bodyTimeout
 
     this.method = method
 


### PR DESCRIPTION
Trying to close https://github.com/nodejs/undici/issues/666

Not sure I'm on the right way,  still missing tests 

I'm curious about the HttpParser, I don't have a context there, so I rely on `client[kRunningIdx]` inside `onHeaders`
as it is done in `onHeadersComplete`