### PR TITLE
fix(parser): safer get_error_reason

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -515,8 +515,13 @@ class Parser {
       socket.unshift(data.slice(offset))
     } else {
       const ptr = this.inst.llhttp_get_error_reason(this.ptr)
-      const len = new Uint8Array(this.inst.memory.buffer).indexOf(0, ptr) - ptr
-      const message = Buffer.from(this.inst.memory.buffer, ptr, len).toString()
+      let message
+      if (ptr !== 0) {
+        const len = new Uint8Array(this.inst.memory.buffer).indexOf(0, ptr) - ptr
+        message = Buffer.from(this.inst.memory.buffer, ptr, len).toString()
+      } else {
+        message = ''
+      }
       const code = constants.ERROR[ret]
       util.destroy(socket, new HTTPParserError(message, code))
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -516,7 +516,7 @@ class Parser {
     } else {
       const ptr = this.inst.llhttp_get_error_reason(this.ptr)
       let message
-      if (ptr !== 0) {
+      if (ptr) {
         const len = new Uint8Array(this.inst.memory.buffer).indexOf(0, ptr) - ptr
         message = Buffer.from(this.inst.memory.buffer, ptr, len).toString()
       } else {


### PR DESCRIPTION
Check that the returned pointer is valid befire retrieving the error
message.

Fixes #684