### PR TITLE
feat: Add callback context and redirect history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Arguments:
 * **options** [`RequestOptions`]
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
   * **method** `String` - Default: `GET`
-* **maxRedirections** `Integer` - Default: `0`
+  * **maxRedirections** `Integer` - Default: `0`
 
 Returns a promise with the result of the `Dispatcher.request` method.
 
@@ -83,6 +83,7 @@ Arguments:
 * **options** [`StreamOptions`]
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
   * **method** `String` - Default: `GET`
+  * **maxRedirections** `Integer` - Default: `0`
 * **factory** `Dispatcher.stream.factory`
 
 Returns a promise with the result of the `Dispatcher.stream` method.

--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -19,7 +19,7 @@ Returns: `Agent`
 Extends: [`ClientOptions`](docs/api/Pool.md#parameter-pooloptions)
 
 * **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)` 
-* **maxRedirections** `Integer` - Default: `0`.
+* **maxRedirections** `Integer` - Default: `0`. The number of HTTP redirection to follow. Redirections history will be available in `context.history` in the response callback (or the response resolved value).
 
 ## Instance Properties
 

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -195,6 +195,7 @@ Extends: [`RequestOptions`](#parameter-requestoptions)
 * **headers** `IncomingHttpHeaders`
 * **opaque** `unknown`
 * **body** `stream.Readable`
+* **context** `object`
 
 #### Example 1 - Pipeline Echo
 
@@ -287,6 +288,7 @@ The `RequestOptions.method` property should not be value `'CONNECT'`.
 * **trailers** `Record<string, string>` - This object starts out
   as empty and will be mutated to contain trailers after `body` has emitted `'end'`.
 * **opaque** `unknown`
+* **context** `object`
 
 #### Example 1 - Basic GET Request
 
@@ -435,6 +437,7 @@ Returns: `void | Promise<StreamData>` - Only returns a `Promise` if no `callback
 
 * **opaque** `unknown`
 * **trailers** `Record<string, string>`
+* **context** `object`
 
 #### Example 1 - Basic GET stream request
 

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -86,6 +86,7 @@ class PipelineHandler extends AsyncResource {
     this.opaque = opaque || null
     this.handler = handler
     this.abort = null
+    this.context = {}
 
     this.req = new PipelineRequest().on('error', util.nop)
 
@@ -167,7 +168,8 @@ class PipelineHandler extends AsyncResource {
         statusCode,
         headers: util.parseHeaders(headers),
         opaque,
-        body: this.res
+        body: this.res,
+        context: this.context
       })
     } catch (err) {
       this.res.on('error', util.nop)

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -65,6 +65,7 @@ class RequestHandler extends AsyncResource {
     this.abort = null
     this.body = body
     this.trailers = {}
+    this.context = {}
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -100,7 +101,8 @@ class RequestHandler extends AsyncResource {
       headers: util.parseHeaders(headers),
       trailers: this.trailers,
       opaque,
-      body
+      body,
+      context: this.context
     })
   }
 

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -50,6 +50,7 @@ class StreamHandler extends AsyncResource {
     this.abort = null
     this.trailers = null
     this.body = body
+    this.context = {}
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -79,7 +80,8 @@ class StreamHandler extends AsyncResource {
     const res = this.runInAsyncScope(factory, null, {
       statusCode,
       headers: util.parseHeaders(headers),
-      opaque
+      opaque,
+      context: this.context
     })
 
     if (

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -36,6 +36,13 @@ class RedirectHandler {
       return this.handler.onHeaders(statusCode, headers, resume)
     }
 
+    // Add the URL to the list of URLs visited while following redirections
+    if (!Array.isArray(this.handler.context.history)) {
+      this.handler.context.history = []
+    }
+
+    this.handler.context.history.push(new URL(this.opts.path, this.opts.origin).toString())
+
     const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin))
     const path = search ? `${pathname}${search}` : pathname
 

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -3,6 +3,8 @@
 const { InvalidArgumentError } = require('../core/errors')
 const util = require('../core/util')
 
+const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
+
 class RedirectHandler {
   constructor (agent, opts, handler) {
     this.agent = agent
@@ -26,22 +28,20 @@ class RedirectHandler {
   }
 
   onHeaders (statusCode, headers, resume) {
-    if ([300, 301, 302, 303, 307, 308].indexOf(statusCode) === -1) {
-      return this.handler.onHeaders(statusCode, headers, resume)
-    }
-
-    this.location = parseLocation(headers)
+    this.location = parseLocation(statusCode, headers)
 
     if (!this.location) {
       return this.handler.onHeaders(statusCode, headers, resume)
     }
 
     // Add the URL to the list of URLs visited while following redirections
-    if (!Array.isArray(this.handler.context.history)) {
-      this.handler.context.history = []
-    }
+    if (typeof this.handler.context === 'object') {
+      if (!Array.isArray(this.handler.context.history)) {
+        this.handler.context.history = []
+      }
 
-    this.handler.context.history.push(new URL(this.opts.path, this.opts.origin).toString())
+      this.handler.context.history.push(new URL(this.opts.path, this.opts.origin).toString())
+    }
 
     const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin))
     const path = search ? `${pathname}${search}` : pathname
@@ -106,7 +106,11 @@ class RedirectHandler {
   }
 }
 
-function parseLocation (headers) {
+function parseLocation (statusCode, headers) {
+  if (redirectableStatusCodes.indexOf(statusCode) === -1) {
+    return null
+  }
+
   for (let i = 0; i < headers.length; i += 2) {
     if (headers[i].length === 8 && headers[i].toString().toLowerCase() === 'location') {
       return headers[i + 1]

--- a/test/redirect-stream.js
+++ b/test/redirect-stream.js
@@ -27,7 +27,7 @@ t.test('should not follow redirection by default if not using RedirectAgent', as
 })
 
 t.test('should follow redirection after a HTTP 300', async t => {
-  t.plan(3)
+  t.plan(4)
 
   const body = []
   const server = await startRedirectingServer(t)
@@ -35,20 +35,16 @@ t.test('should follow redirection after a HTTP 300', async t => {
   await stream(
     `http://${server}/300?key=value`,
     { opaque: body, maxRedirections: 10 },
-    ({ statusCode, headers, opaque }) => {
+    ({ statusCode, headers, opaque, context: { history } }) => {
       t.equal(statusCode, 200)
       t.notOk(headers.location)
-      /*
-        TODO: Test for the redirect history once added to the callback data.
-
-        [
-          `http://${server1}/`,
-          `http://${server2}/`,
-          `http://${server3}/`,
-          `http://${server2}/end`,
-          `http://${server3}/end`
-        ]
-      */
+      t.same(history, [
+        `http://${server}/300?key=value`,
+        `http://${server}/300/1?key=value`,
+        `http://${server}/300/2?key=value`,
+        `http://${server}/300/3?key=value`,
+        `http://${server}/300/4?key=value`
+      ])
 
       return createWritable(opaque)
     }
@@ -103,16 +99,12 @@ t.test('should follow redirection after a HTTP 303 changing method to GET', asyn
   const body = []
   const server = await startRedirectingServer(t)
 
-  await stream(
-    `http://${server}/303`,
-    { opaque: body, maxRedirections: 10 },
-    ({ statusCode, headers, opaque }) => {
-      t.equal(statusCode, 200)
-      t.notOk(headers.location)
+  await stream(`http://${server}/303`, { opaque: body, maxRedirections: 10 }, ({ statusCode, headers, opaque }) => {
+    t.equal(statusCode, 200)
+    t.notOk(headers.location)
 
-      return createWritable(opaque)
-    }
-  )
+    return createWritable(opaque)
+  })
 
   t.equal(body.join(''), `GET :: connection@keep-alive host@${server}`)
 })
@@ -231,28 +223,28 @@ t.test('should follow redirection after a HTTP 308', async t => {
 })
 
 t.test('should ignore HTTP 3xx response bodies', async t => {
-  t.plan(3)
+  t.plan(4)
 
   const body = []
   const server = await startRedirectingWithBodyServer(t)
 
-  await stream(`http://${server}/`, { opaque: body, maxRedirections: 10 }, ({ statusCode, headers, opaque }) => {
-    t.equal(statusCode, 200)
-    t.notOk(headers.location)
-    /*
-      TODO: Test for the redirect history once added to the callback data.
+  await stream(
+    `http://${server}/`,
+    { opaque: body, maxRedirections: 10 },
+    ({ statusCode, headers, opaque, context: { history } }) => {
+      t.equal(statusCode, 200)
+      t.notOk(headers.location)
+      t.same(history, [`http://${server}/`])
 
-      [`http://${server}/`]
-    */
-
-    return createWritable(opaque)
-  })
+      return createWritable(opaque)
+    }
+  )
 
   t.equal(body.join(''), 'FINAL')
 })
 
 t.test('should follow a redirect chain up to the allowed number of times', async t => {
-  t.plan(3)
+  t.plan(4)
 
   const body = []
   const server = await startRedirectingServer(t)
@@ -260,14 +252,10 @@ t.test('should follow a redirect chain up to the allowed number of times', async
   await stream(
     `http://${server}/300`,
     { opaque: body, maxRedirections: 2 },
-    ({ statusCode, headers, opaque }) => {
+    ({ statusCode, headers, opaque, context: { history } }) => {
       t.equal(statusCode, 300)
       t.equal(headers.location, `http://${server}/300/3`)
-      /*
-        TODO: Test for the redirect history once added to the callback data.
-
-        [`http://${server}/300`, `http://${server}/300/1`]
-      */
+      t.same(history, [`http://${server}/300`, `http://${server}/300/1`])
 
       return createWritable(opaque)
     }
@@ -277,28 +265,24 @@ t.test('should follow a redirect chain up to the allowed number of times', async
 })
 
 t.test('should follow redirections when going cross origin', async t => {
-  t.plan(3)
+  t.plan(4)
 
-  const [server1] = await startRedirectingChainServers(t)
+  const [server1, server2, server3] = await startRedirectingChainServers(t)
   const body = []
 
   await stream(
     `http://${server1}`,
     { method: 'POST', opaque: body, maxRedirections: 10 },
-    ({ statusCode, headers, opaque }) => {
+    ({ statusCode, headers, opaque, context: { history } }) => {
       t.equal(statusCode, 200)
       t.notOk(headers.location)
-      /*
-        TODO: Test for the redirect history once added to the callback data.
-
-        [
-          `http://${server1}/`,
-          `http://${server2}/`,
-          `http://${server3}/`,
-          `http://${server2}/end`,
-          `http://${server3}/end`
-        ]
-      */
+      t.same(history, [
+        `http://${server1}/`,
+        `http://${server2}/`,
+        `http://${server3}/`,
+        `http://${server2}/end`,
+        `http://${server3}/end`
+      ])
 
       return createWritable(opaque)
     }
@@ -382,13 +366,9 @@ t.test('should handle errors (promise)', async t => {
   const body = []
 
   try {
-    await stream(
-      'http://localhost:0',
-      { opaque: body, maxRedirections: 10 },
-      ({ statusCode, headers, opaque }) => {
-        return createWritable(opaque)
-      }
-    )
+    await stream('http://localhost:0', { opaque: body, maxRedirections: 10 }, ({ statusCode, headers, opaque }) => {
+      return createWritable(opaque)
+    })
 
     throw new Error('Did not throw')
   } catch (error) {

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -92,12 +92,14 @@ declare namespace Dispatcher {
     body: Readable;
     trailers: Record<string, string>;
     opaque: unknown;
+    context: object;
   }
   export interface PipelineHandlerData {
     statusCode: number;
     headers: IncomingHttpHeaders;
     opaque: unknown;
     body: Readable;
+    context: object;
   }
   export interface StreamData {
     opaque: unknown;
@@ -112,6 +114,7 @@ declare namespace Dispatcher {
     statusCode: number;
     headers: IncomingHttpHeaders;
     opaque: unknown;
+    context: object;
   }
   export type StreamFactory = (data: StreamFactoryData) => Writable;
   export interface DispatchHandlers {


### PR DESCRIPTION
This PR concludes #603 by adding support for redirections history in the response.

To guarantee extensibility and encourage other handlers, I chose to introduce in the internal API the concept of `context`. All three major API methods (`request`, `pipeline` and `stream`) now always return a `context` in the response. This context is initially just an empty object, but handlers can fill them. 

This is what the `RedirectHandler` current uses.