### PR TITLE
fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This section documents our most commonly used API methods. Additional APIs are d
 Arguments:
 
 * **url** `string | URL | object`
-* **options** [`RequestOptions`]
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
+* **options** [`RequestOptions`](./docs/api/Dispatcher.md#parameter-requestoptions)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
   * **method** `String` - Default: `GET`
 * **maxRedirections** `Integer` - Default: `0`
 
@@ -73,15 +73,15 @@ Returns a promise with the result of the `Dispatcher.request` method.
 
 Calls `options.dispatcher.request(options)`.
 
-See [Dispatcher.request] for more details.
+See [Dispatcher.request](./docs/api/Dispatcher.md#dispatcherrequestoptions-callback) for more details.
 
 ### `undici.stream(url, options, factory): Promise`
 
 Arguments:
 
 * **url** `string | URL | object`
-* **options** [`StreamOptions`]
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
+* **options** [`StreamOptions`](./docs/api/Dispatcher.md#parameter-streamoptions)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
   * **method** `String` - Default: `GET`
 * **factory** `Dispatcher.stream.factory`
 
@@ -98,8 +98,8 @@ See [Dispatcher.stream](docs/api/Dispatcher.md#dispatcherstream) for more detail
 Arguments:
 
 * **url** `string | URL | object`
-* **options** [`PipelineOptions`]
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
+* **options** [`PipelineOptions`](docs/api/Dispatcher.md#parameter-pipelineoptions)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
   * **method** `String` - Default: `GET`
 * **handler** `Dispatcher.pipeline.handler`
 
@@ -117,8 +117,8 @@ Starts two-way communications with the requested resource using [HTTP CONNECT](h
 
 Arguments:
 
-* **options** [`ConnectOptions`]
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
+* **options** [`ConnectOptions`](docs/api/Dispatcher.md#parameter-connectoptions)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
   * **method** `String` - Default: `GET`
 * **callback** `(err: Error | null, data: ConnectData | null) => void` (optional)
 
@@ -136,8 +136,8 @@ Upgrade to a different protocol. See [MDN - HTTP - Protocol upgrade mechanism](h
 
 Arguments:
 
-* **options** [`UpgradeOptions`]
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher]
+* **options** [`UpgradeOptions`](docs/api/Dispatcher.md#parameter-upgradeoptions)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
   * **method** `String` - Default: `GET`
 * **callback** `(error: Error | null, data: UpgradeData) => void` (optional)
 
@@ -147,7 +147,7 @@ Returns a promise with the result of the `Dispatcher.upgrade` method.
 
 Calls `options.dispatcher.upgrade(options)`.
 
-See [Dispatcher.upgrade](docs/api/Dispatcher.md#clientpipelining) for more details.
+See [Dispatcher.upgrade](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback) for more details.
 
 ### `undici.setGlobalDispatcher(dispatcher)`
 

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -231,37 +231,3 @@ server.listen(() => {
   })
 })
 ```
-
-## Parameter: `UndiciHeaders`
-
-* `http.IncomingHttpHeaders | string[] | null`
-
-Header arguments such as `options.headers` in [`Client.dispatch`](./Client.md#client-dispatchoptions-handlers) can be specified in two forms; either as an object specified by the `http.IncomingHttpHeaders` type, or an array of strings. An array representation of a header list must have an even length or an `InvalidArgumentError` will be thrown.
-
-Keys are lowercase and values are not modified. 
-
-Response headers will derive a `host` from the `url` of the [Client](#class-client) instance if no `host` header was previously specified.
-
-### Example 1 - Object
-
-```js
-{
-  'content-length': '123',
-  'content-type': 'text/plain',
-  connection: 'keep-alive',
-  host: 'mysite.com',
-  accept: '*/*'
-}
-```
-
-### Example 2 - Array
-
-```js
-[
-  'content-length', '123',
-  'content-type', 'text/plain',
-  'connection', 'keep-alive',
-  'host', 'mysite.com',
-  'accept', '*/*'
-]
-```

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -17,7 +17,7 @@ Arguments:
 
 Extends: [`ClientOptions`](docs/api/Client.md#parameter-clientoptions)
 
-* **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Client(origin, opts)` 
+* **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Client(origin, opts)`
 * **connections** `number | null` (optional) - Default: `null` - The number of `Client` instances to create. When set to `null`, the `Pool` instance will create an unlimited amount of `Client` instances.
 
 ## Instance Properties

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -2,10 +2,14 @@
 
 * [**Home**](/ "Node.js Undici")
 * API
+  * [Dispatcher](/docs/api/Dispatcher.md "Undici API - Dispatcher")
   * [Client](/docs/api/Client.md "Undici API - Client")
   * [Pool](/docs/api/Pool.md "Undici API - Pool")
   * [Agent](/docs/api/Agent.md "Undici API - Agent")
   * [Errors](/docs/api/Errors.md "Undici API - Errors")
+  * [MockClient](/docs/api/MockClient.md "Undici API - MockClient")
+  * [MockPool](/docs/api/MockPool.md "Undici API - MockPool")
+  * [MockAgent](/docs/api/MockAgent.md "Undici API - MockAgent")
   * [API Lifecycle](/docs/api/api-lifecycle.md "Undici API - Lifecycle")
 * Best Practices
   * [Proxy](docs/best-practices/proxy.md "Connecting through a proxy")


### PR DESCRIPTION
Fixed up some broken links. 

There is a lot and I probably missed some things. We should consider adding this to our actions pipeline: https://github.com/Youssef1313/markdown-links-verifier at some later point

Types all look okay. I scanned through the tests and it all seems to be up to date; honestly, akin to Fastify's types, the best fixes come from the community when they discover edge cases and such; its very hard to make sure we are 1:1 when hand rolling the types. 