### PR TITLE
feat: improve global API ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Arguments:
 
 Returns a promise with the result of the `Dispatcher.stream` method.
 
-`url` may contain pathname. `options` may not contain path.
-
 Calls `options.dispatcher.stream(options, factory)`.
 
 See [Dispatcher.stream](docs/api/Dispatcher.md#dispatcherstream) for more details.
@@ -104,8 +102,6 @@ Arguments:
 * **handler** `Dispatcher.pipeline.handler`
 
 Returns: `stream.Duplex`
-
-`url` may contain pathname. `options` may not contain path.
 
 Calls `options.dispatch.pipeline(options, handler)`.
 
@@ -124,8 +120,6 @@ Arguments:
 
 Returns a promise with the result of the `Dispatcher.connect` method.
 
-`url` may contain pathname. `options` may not contain path.
-
 Calls `options.dispatch.connect(options)`.
 
 See [Dispatcher.connect](docs/api/Dispatcher.md#dispatcherconnect) for more details.
@@ -142,8 +136,6 @@ Arguments:
 * **callback** `(error: Error | null, data: UpgradeData) => void` (optional)
 
 Returns a promise with the result of the `Dispatcher.upgrade` method.
-
-`url` may contain pathname. `options` may not contain path.
 
 Calls `options.dispatcher.upgrade(options)`.
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ console.log('trailers', trailers)
 
 This section documents our most commonly used API methods. Additional APIs are documented in their own files within the [docs](./docs/) folder and are accessible via the navigation list on the left side of the docs site.
 
-### `undici.request(url[, options]): Promise`
+### `undici.request([url, options]): Promise`
 
 Arguments:
 
 * **url** `string | URL | object`
 * **options** [`RequestOptions`](./docs/api/Dispatcher.md#parameter-requestoptions)
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
-  * **method** `String` - Default: `GET`
+  * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
   * **maxRedirections** `Integer` - Default: `0`
 
 Returns a promise with the result of the `Dispatcher.request` method.
@@ -75,14 +75,14 @@ Calls `options.dispatcher.request(options)`.
 
 See [Dispatcher.request](./docs/api/Dispatcher.md#dispatcherrequestoptions-callback) for more details.
 
-### `undici.stream(url, options, factory): Promise`
+### `undici.stream([url, options, ]factory): Promise`
 
 Arguments:
 
 * **url** `string | URL | object`
 * **options** [`StreamOptions`](./docs/api/Dispatcher.md#parameter-streamoptions)
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
-  * **method** `String` - Default: `GET`
+  * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
 * **factory** `Dispatcher.stream.factory`
 
 Returns a promise with the result of the `Dispatcher.stream` method.
@@ -93,14 +93,14 @@ Calls `options.dispatcher.stream(options, factory)`.
 
 See [Dispatcher.stream](docs/api/Dispatcher.md#dispatcherstream) for more details.
 
-### `undici.pipeline(url, options, handler): Duplex`
+### `undici.pipeline([url, options, ]handler): Duplex`
 
 Arguments:
 
 * **url** `string | URL | object`
 * **options** [`PipelineOptions`](docs/api/Dispatcher.md#parameter-pipelineoptions)
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
-  * **method** `String` - Default: `GET`
+  * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
 * **handler** `Dispatcher.pipeline.handler`
 
 Returns: `stream.Duplex`
@@ -111,7 +111,7 @@ Calls `options.dispatch.pipeline(options, handler)`.
 
 See [Dispatcher.pipeline](docs/api/Dispatcher.md#dispatcherpipeline) for more details.
 
-### `undici.connect(url, options): Promise`
+### `undici.connect([url, options]): Promise`
 
 Starts two-way communications with the requested resource using [HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT).
 
@@ -120,7 +120,6 @@ Arguments:
 * **url** `string | URL | object`
 * **options** [`ConnectOptions`](docs/api/Dispatcher.md#parameter-connectoptions)
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
-  * **method** `String` - Default: `GET`
 * **callback** `(err: Error | null, data: ConnectData | null) => void` (optional)
 
 Returns a promise with the result of the `Dispatcher.connect` method.
@@ -131,7 +130,7 @@ Calls `options.dispatch.connect(options)`.
 
 See [Dispatcher.connect](docs/api/Dispatcher.md#dispatcherconnect) for more details.
 
-### `undici.upgrade(url, options): Promise`
+### `undici.upgrade([url, options]): Promise`
 
 Upgrade to a different protocol. See [MDN - HTTP - Protocol upgrade mechanism](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) for more details.
 
@@ -140,7 +139,6 @@ Arguments:
 * **url** `string | URL | object`
 * **options** [`UpgradeOptions`](docs/api/Dispatcher.md#parameter-upgradeoptions)
   * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
-  * **method** `String` - Default: `GET`
 * **callback** `(error: Error | null, data: UpgradeData) => void` (optional)
 
 Returns a promise with the result of the `Dispatcher.upgrade` method.

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function getGlobalDispatcher () {
 }
 
 function makeDispatcher (fn) {
-  return (url, opts = {}, ...additionalArgs) => {
+  return (url, opts, ...additionalArgs) => {
     if (url && typeof url === 'object' && !(url instanceof URL)) {
       additionalArgs = [opts, ...additionalArgs]
       opts = url
@@ -43,6 +43,7 @@ function makeDispatcher (fn) {
       throw new InvalidArgumentError('cannot combine url.pathname and opts.path')
     }
 
+    opts = opts || {}
     const { agent, dispatcher = getGlobalDispatcher() } = opts
 
     if (agent) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -50,7 +50,7 @@ function parseURL (url) {
     }[url.protocol]
     assert(port != null)
     const path = url.path || `${url.pathname || '/'}${url.search || ''}`
-    url = new URL(path, `${url.protocol}//${url.hostname}:${port}`)
+    url = new URL(path, url.origin || `${url.protocol}//${url.hostname}:${port}`)
   }
 
   return url

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -48,15 +48,11 @@ function parseURL (url) {
   }
 
   if (!(url instanceof URL)) {
-    let origin = url.origin
-    if (!origin) {
-      const port = url.port || {
-        'http:': 80,
-        'https:': 443
-      }[url.protocol]
-      assert(port != null)
-      origin = `${url.protocol}//${url.hostname}:${port}`
-    }
+    const port = url.port || {
+      'http:': 80,
+      'https:': 443
+    }[url.protocol]
+    const origin = url.origin || `${url.protocol}//${url.hostname}${port != null ? `:${port}` : ''}`
     const path = url.path || `${url.pathname || '/'}${url.search || ''}`
     url = new URL(path, origin)
   }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -39,6 +39,10 @@ function parseURL (url) {
     throw new InvalidArgumentError('invalid hostname')
   }
 
+  if (url.origin != null && typeof url.origin !== 'string') {
+    throw new InvalidArgumentError('invalid origin')
+  }
+
   if (!/https?/.test(url.protocol)) {
     throw new InvalidArgumentError('invalid protocol')
   }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -44,13 +44,17 @@ function parseURL (url) {
   }
 
   if (!(url instanceof URL)) {
-    const port = url.port || {
-      'http:': 80,
-      'https:': 443
-    }[url.protocol]
-    assert(port != null)
+    let origin = url.origin
+    if (!origin) {
+      const port = url.port || {
+        'http:': 80,
+        'https:': 443
+      }[url.protocol]
+      assert(port != null)
+      origin = `${url.protocol}//${url.hostname}:${port}`
+    }
     const path = url.path || `${url.pathname || '/'}${url.search || ''}`
-    url = new URL(path, url.origin || `${url.protocol}//${url.hostname}:${port}`)
+    url = new URL(path, origin)
   }
 
   return url


### PR DESCRIPTION
```js
undici.request('http://foo:800', { path: '/bar' })
undici.request({ path: '/bar', origin: 'http://foo:800' })
undici.request('http://foo:800/bar')
```