### PR TITLE
Add support to https thru an http tunnel (proxy)

### DIFF
--- a/test/proxy.js
+++ b/test/proxy.js
@@ -4,6 +4,9 @@ const { test } = require('tap')
 const { Client, Pool } = require('..')
 const { createServer } = require('http')
 const proxy = require('proxy')
+const { readFileSync } = require('fs')
+const { join } = require('path')
+const https = require('https')
 
 test('connect through proxy', async (t) => {
   t.plan(3)
@@ -117,6 +120,49 @@ test('connect through proxy (with pool)', async (t) => {
   pool.close()
 })
 
+test('connect through proxy to an https server', async (t) => {
+  t.plan(3)
+
+  const server = await buildHttpsServer()
+  const proxy = await buildProxy()
+
+  const serverUrl = `https://localhost:${server.address().port}`
+  const proxyUrl = `http://localhost:${proxy.address().port}`
+
+  server.on('request', (req, res) => {
+    t.equal(req.url, '/hello?foo=bar')
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ hello: 'world' }))
+  })
+
+  const ca = readFileSync(join(__dirname, 'fixtures', 'ca.pem'), 'utf8')
+  const client = new Client(proxyUrl, {
+    tls: {
+      ca,
+      rejectUnauthorized: false,
+      maxCachedSessions: 1,
+      servername: 'agent1'
+    }
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: serverUrl + '/hello?foo=bar'
+  })
+
+  response.body.setEncoding('utf8')
+  let data = ''
+  for await (const chunk of response.body) {
+    data += chunk
+  }
+  t.equal(response.statusCode, 200)
+  t.same(JSON.parse(data), { hello: 'world' })
+
+  server.close()
+  proxy.close()
+  client.close()
+})
+
 function buildServer () {
   return new Promise((resolve, reject) => {
     const server = createServer()
@@ -127,6 +173,17 @@ function buildServer () {
 function buildProxy () {
   return new Promise((resolve, reject) => {
     const server = proxy(createServer())
+    server.listen(0, () => resolve(server))
+  })
+}
+
+function buildHttpsServer () {
+  return new Promise((resolve, reject) => {
+    const options = {
+      key: readFileSync(join(__dirname, 'fixtures', 'key.pem'), 'utf8'),
+      cert: readFileSync(join(__dirname, 'fixtures', 'cert.pem'), 'utf8')
+    }
+    const server = https.createServer(options)
     server.listen(0, () => resolve(server))
   })
 }


### PR DESCRIPTION
Hey, 

I didn't know if this was supposed to be working or not, but I added a failing spec to it and I'm willing to put in the effort to make it work. Apparently Undici does not support https requests thru an http tunnel (proxy). According to [this wiki page](https://en.wikipedia.org/wiki/HTTP_tunnel) and [the CONNECT specification](https://tools.ietf.org/html/rfc7231#page-30), a `CONNECT www.domain.com:443 HTTP/1.1\r\n` should be sent after TCP handshake, and the TLS handshake should happen as usual after that.

Again, I'm willing to add support for this feature if you guys agree to. I just need some high level direction on where this logic should be (I'm kinda new in writing HTTP clients).