### PR TITLE
chore: Replace benchmark with cronometro for benchmarking.

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -123,14 +123,14 @@ class SimpleRequest {
   }
 }
 
-function makeParallelsRequests (cb) {
+function makeParallelRequests (cb) {
   return Promise.all(Array.from(Array(parallelRequests)).map(() => new Promise(cb)))
 }
 
 cronometro(
   {
     'http - no agent' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         http.get(httpNoAgent, res => {
           res
             .pipe(
@@ -145,7 +145,7 @@ cronometro(
       })
     },
     'http - keepalive' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         http.get(httpOptions, res => {
           res
             .pipe(
@@ -160,7 +160,7 @@ cronometro(
       })
     },
     'http - keepalive - multiple sockets' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         http.get(httpOptionsMultiSocket, res => {
           res
             .pipe(
@@ -175,7 +175,7 @@ cronometro(
       })
     },
     'undici - pipeline' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         client
           .pipeline(undiciOptions, data => {
             return data.body
@@ -192,7 +192,7 @@ cronometro(
       })
     },
     'undici - request' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         client.request(undiciOptions).then(({ body }) => {
           body
             .pipe(
@@ -207,7 +207,7 @@ cronometro(
       })
     },
     'undici - pool - request - multiple sockets' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         pool.request(undiciOptions).then(({ body }) => {
           body
             .pipe(
@@ -222,7 +222,7 @@ cronometro(
       })
     },
     'undici - stream' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         return client
           .stream(undiciOptions, () => {
             return new Writable({
@@ -235,12 +235,12 @@ cronometro(
       })
     },
     'undici - dispatch' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         client.dispatch(undiciOptions, new SimpleRequest(resolve))
       })
     },
     'undici - noop' () {
-      return makeParallelsRequests(resolve => {
+      return makeParallelRequests(resolve => {
         client.dispatch(undiciOptions, new NoopRequest(resolve))
       })
     }

--- a/benchmarks/multiple-sockets.js
+++ b/benchmarks/multiple-sockets.js
@@ -1,0 +1,247 @@
+'use strict'
+
+const cronometro = require('cronometro')
+const { Writable } = require('stream')
+const http = require('http')
+const os = require('os')
+const path = require('path')
+
+const { Client, Pool } = require('..')
+
+// # Start the Node.js server
+// node benchmarks/server.js
+//
+// # Start the benchmarks
+// node benchmarks/index.js
+
+// Parse and normalize parameters
+const samples = parseInt(process.env.SAMPLES, 10) || 100
+const connections = parseInt(process.env.CONNECTIONS, 10) || 50
+const parallelRequests = parseInt(process.env.PARALLEL, 10) || 10
+const pipelining = parseInt(process.env.PIPELINING, 10) || 10
+const headersTimeout = parseInt(process.env.HEADERS_TIMEOUT, 10) || 0
+const bodyTimeout = parseInt(process.env.BODY_TIMEOUT, 10) || 0
+const dest = {}
+
+if (process.env.PORT) {
+  dest.port = process.env.PORT
+  dest.url = `http://localhost:${process.env.PORT}`
+} else {
+  dest.url = 'http://localhost'
+  dest.socketPath = path.join(os.tmpdir(), 'undici.sock')
+}
+
+const httpBaseOptions = {
+  protocol: 'http:',
+  hostname: 'localhost',
+  method: 'GET',
+  path: '/',
+  ...dest
+}
+
+const httpNoKeepAliveOptions = {
+  ...httpBaseOptions,
+  agent: new http.Agent({
+    keepAlive: false,
+    maxSockets: connections
+  })
+}
+
+const httpKeepAliveOptions = {
+  ...httpBaseOptions,
+  agent: new http.Agent({
+    keepAlive: true,
+    maxSockets: connections
+  })
+}
+
+const undiciOptions = {
+  path: '/',
+  method: 'GET',
+  headersTimeout,
+  bodyTimeout
+}
+
+const client = new Client(httpBaseOptions.url, {
+  pipelining,
+  ...dest
+})
+
+const pool = new Pool(httpBaseOptions.url, {
+  pipelining,
+  connections,
+  ...dest
+})
+
+class NoopRequest {
+  constructor (resolve) {
+    this.resolve = resolve
+  }
+
+  onConnect (abort) {}
+
+  onHeaders (statusCode, headers, resume) {}
+
+  onData (chunk) {
+    return true
+  }
+
+  onComplete (trailers) {
+    this.resolve()
+  }
+
+  onError (err) {
+    throw err
+  }
+}
+
+class SimpleRequest {
+  constructor (resolve) {
+    this.dst = new Writable({
+      write (chunk, encoding, callback) {
+        callback()
+      }
+    }).on('finish', resolve)
+  }
+
+  onConnect (abort) {}
+
+  onHeaders (statusCode, headers, resume) {
+    this.dst.on('drain', resume)
+  }
+
+  onData (chunk) {
+    return this.dst.write(chunk)
+  }
+
+  onComplete () {
+    this.dst.end()
+  }
+
+  onError (err) {
+    throw err
+  }
+}
+
+function makeParallelRequests (cb) {
+  return Promise.all(Array.from(Array(parallelRequests)).map(() => new Promise(cb)))
+}
+
+cronometro(
+  {
+    'http - no keepalive - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        http.get(httpNoKeepAliveOptions, res => {
+          res
+            .pipe(
+              new Writable({
+                write (chunk, encoding, callback) {
+                  callback()
+                }
+              })
+            )
+            .on('finish', resolve)
+        })
+      })
+    },
+    'http - keepalive - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        http.get(httpKeepAliveOptions, res => {
+          res
+            .pipe(
+              new Writable({
+                write (chunk, encoding, callback) {
+                  callback()
+                }
+              })
+            )
+            .on('finish', resolve)
+        })
+      })
+    },
+    'undici - pipeline - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        client
+          .pipeline(undiciOptions, data => {
+            return data.body
+          })
+          .end()
+          .pipe(
+            new Writable({
+              write (chunk, encoding, callback) {
+                callback()
+              }
+            })
+          )
+          .on('finish', resolve)
+      })
+    },
+    'undici - request - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        client.request(undiciOptions).then(({ body }) => {
+          body
+            .pipe(
+              new Writable({
+                write (chunk, encoding, callback) {
+                  callback()
+                }
+              })
+            )
+            .on('finish', resolve)
+        })
+      })
+    },
+    'undici - pool - request - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        pool.request(undiciOptions).then(({ body }) => {
+          body
+            .pipe(
+              new Writable({
+                write (chunk, encoding, callback) {
+                  callback()
+                }
+              })
+            )
+            .on('finish', resolve)
+        })
+      })
+    },
+    'undici - stream - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        return client
+          .stream(undiciOptions, () => {
+            return new Writable({
+              write (chunk, encoding, callback) {
+                callback()
+              }
+            })
+          })
+          .then(resolve)
+      })
+    },
+    'undici - dispatch - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        client.dispatch(undiciOptions, new SimpleRequest(resolve))
+      })
+    },
+    'undici - noop - multiple sockets' () {
+      return makeParallelRequests(resolve => {
+        client.dispatch(undiciOptions, new NoopRequest(resolve))
+      })
+    }
+  },
+  {
+    iterations: samples,
+    print: {
+      colors: false,
+      compare: true
+    }
+  },
+  err => {
+    if (err) {
+      throw err
+    }
+
+    client.destroy()
+  }
+)

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -1,10 +1,19 @@
 'use strict'
 
+const { unlinkSync } = require('fs')
 const { createServer } = require('http')
 const os = require('os')
 const path = require('path')
 
-const port = process.env.PORT || path.join(os.tmpdir(), 'undici.sock')
+const socketPath = path.join(os.tmpdir(), 'undici.sock')
+
+try {
+  unlinkSync(socketPath)
+} catch (_) {
+  // Do not nothing if the socket does not exist
+}
+
+const port = process.env.PORT || socketPath
 const timeout = parseInt(process.env.TIMEOUT, 10) || 1
 
 createServer((req, res) => {

--- a/benchmarks/wait.js
+++ b/benchmarks/wait.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const os = require('os')
+const path = require('path')
+const waitOn = require('wait-on')
+
+const socketPath = path.join(os.tmpdir(), 'undici.sock')
+
+waitOn({
+  resources: [`http-get://unix:${socketPath}:/`],
+  timeout: 5000
+}).catch(() => process.exit(1))

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bench": "concurrently -k -s first npm:bench:server npm:bench:run",
     "bench:server": "node benchmarks/server.js",
     "prebench:run": "node benchmarks/wait.js",
-    "bench:run": "node benchmarks",
+    "bench:run": "node benchmarks/single-socket.js && node benchmarks/multiple-sockets.js",
     "serve:website": "docsify serve .",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "test:typescript": "tsd",
     "coverage": "standard | snazzy && tap test/*.js",
     "coverage:ci": "npm run coverage -- --coverage-report=lcovonly",
-    "prebench": "node -e \"try { require('fs').unlinkSync(require('path').join(require('os').tmpdir(), 'undici.sock')) } catch (_) {}\"",
-    "bench": "npx concurrently -k -s first \"node benchmarks/server.js\" \"node -e 'setTimeout(() => {}, 1000)' && node benchmarks\"",
+    "bench": "concurrently -k -s first npm:bench:server npm:bench:run",
+    "bench:server": "node benchmarks/server.js",
+    "prebench:run": "node benchmarks/wait.js",
+    "bench:run": "node benchmarks",
     "serve:website": "docsify serve .",
     "prepare": "husky install"
   },
@@ -46,8 +48,8 @@
     "@sinonjs/fake-timers": "^7.0.5",
     "@types/node": "^14.14.39",
     "abort-controller": "^3.0.0",
-    "benchmark": "^2.1.4",
     "concurrently": "^6.0.2",
+    "cronometro": "^0.8.0",
     "docsify-cli": "^4.4.2",
     "https-pem": "^2.0.0",
     "husky": "^6.0.0",
@@ -60,7 +62,8 @@
     "snazzy": "^9.0.0",
     "standard": "^16.0.3",
     "tap": "^15.0.0",
-    "tsd": "^0.14.0"
+    "tsd": "^0.14.0",
+    "wait-on": "^5.3.0"
   },
   "engines": {
     "node": ">=12.18"


### PR DESCRIPTION
This PR closes #715 and #736 by replacing `benchmark` with `cronometro`.

I also refactored the benchmark NPM scripts to use `wait-on` instead of a flat timeout for better reliability.