### PR TITLE
fix: exports of `index.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
-    "index.(js|d.ts)",
+    "*.d.ts",
+    "index.js",
     "lib",
     "types",
     "docs"


### PR DESCRIPTION
This pr properly exports `index.d.ts` which was not exported previously.

Closes #757 