### PR TITLE
feat(Client/Pool): Same origin redirect

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -126,6 +126,8 @@ class Agent extends Dispatcher {
         return dispatcher.dispatch(opts, handler)
       }
 
+      opts = { ...opts, maxRedirections: 0 }
+
       if (util.isStream(opts.body) && util.bodyLength(opts.body) !== 0) {
         // TODO (fix): Provide some way for the user to cache the file to e.g. /tmp
         // so that it can be dispatched again?
@@ -141,7 +143,7 @@ class Agent extends Dispatcher {
           })
       }
 
-      return dispatcher.dispatch(opts, new RedirectHandler(this, opts, handler))
+      return dispatcher.dispatch(opts, new RedirectHandler(this, maxRedirections, opts, handler))
     } catch (err) {
       if (typeof handler.onError !== 'function') {
         throw new InvalidArgumentError('invalid onError method')

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@ const net = require('net')
 const util = require('./core/util')
 const Request = require('./core/request')
 const Dispatcher = require('./dispatcher')
+const RedirectHandler = require('./handler/redirect')
 const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
@@ -61,7 +62,8 @@ const {
   kHeadersTimeout,
   kBodyTimeout,
   kStrictContentLength,
-  kConnector
+  kConnector,
+  kMaxRedirections
 } = require('./core/symbols')
 
 class Client extends Dispatcher {
@@ -83,7 +85,8 @@ class Client extends Dispatcher {
     tls,
     strictContentLength,
     maxCachedSessions,
-    [kConnect]: connect
+    [kConnect]: connect,
+    maxRedirections
   } = {}) {
     super()
 
@@ -145,6 +148,11 @@ class Client extends Dispatcher {
 
     this[kUrl] = util.parseOrigin(url)
     this[kConnector] = connect || makeConnect({ tls, socketPath, maxCachedSessions })
+    
+    if (maxRedirections != null && (!Number.isInteger(maxRedirections) || maxRedirections < 0)) {
+      throw new InvalidArgumentError('maxRedirections must be a positive number')
+    }
+
     this[kSocket] = null
     this[kPipelining] = pipelining != null ? pipelining : 1
     this[kMaxHeadersSize] = maxHeaderSize || 16384
@@ -163,6 +171,7 @@ class Client extends Dispatcher {
     this[kBodyTimeout] = bodyTimeout != null ? bodyTimeout : 30e3
     this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 30e3
     this[kStrictContentLength] = strictContentLength == null ? true : strictContentLength
+    this[kMaxRedirections] = maxRedirections == null ? 0 : maxRedirections
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -234,7 +243,10 @@ class Client extends Dispatcher {
     }
 
     try {
-      const request = new Request(opts, handler)
+      console.log('Executing request')
+      const request = this[kMaxRedirections] > 0
+        ? new Request(opts, new RedirectHandler(this, { ...opts, origin: this[kUrl] }, handler))
+        : new Request(opts, handler)
 
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()

--- a/lib/client.js
+++ b/lib/client.js
@@ -170,7 +170,7 @@ class Client extends Dispatcher {
     this[kBodyTimeout] = bodyTimeout != null ? bodyTimeout : 30e3
     this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 30e3
     this[kStrictContentLength] = strictContentLength == null ? true : strictContentLength
-    this[kMaxRedirections] = maxRedirections == null ? 0 : maxRedirections
+    this[kMaxRedirections] = maxRedirections
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -242,8 +242,14 @@ class Client extends Dispatcher {
     }
 
     try {
-      const request = this[kMaxRedirections] > 0
-        ? new Request(opts, new RedirectHandler(this, { ...opts, origin: this[kUrl] }, handler))
+      const { maxRedirections = this[kMaxRedirections] } = opts
+
+      if (maxRedirections != null && (!Number.isInteger(maxRedirections) || maxRedirections < 0)) {
+        throw new InvalidArgumentError('maxRedirections must be a positive number')
+      }
+
+      const request = maxRedirections
+        ? new Request(opts, new RedirectHandler(this, maxRedirections, opts, handler))
         : new Request(opts, handler)
 
       if (this[kDestroyed]) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -248,6 +248,10 @@ class Client extends Dispatcher {
         throw new InvalidArgumentError('maxRedirections must be a positive number')
       }
 
+      if (maxRedirections) {
+        opts = { ...opts, maxRedirections: 0 }
+      }
+
       const request = maxRedirections
         ? new Request(opts, new RedirectHandler(this, maxRedirections, opts, handler))
         : new Request(opts, handler)

--- a/lib/client.js
+++ b/lib/client.js
@@ -85,8 +85,8 @@ class Client extends Dispatcher {
     tls,
     strictContentLength,
     maxCachedSessions,
-    [kConnect]: connect,
-    maxRedirections
+    maxRedirections,
+    [kConnect]: connect
   } = {}) {
     super()
 
@@ -146,13 +146,12 @@ class Client extends Dispatcher {
       throw new InvalidArgumentError('connect must be a function')
     }
 
-    this[kUrl] = util.parseOrigin(url)
-    this[kConnector] = connect || makeConnect({ tls, socketPath, maxCachedSessions })
-    
     if (maxRedirections != null && (!Number.isInteger(maxRedirections) || maxRedirections < 0)) {
       throw new InvalidArgumentError('maxRedirections must be a positive number')
     }
 
+    this[kUrl] = util.parseOrigin(url)
+    this[kConnector] = connect || makeConnect({ tls, socketPath, maxCachedSessions })
     this[kSocket] = null
     this[kPipelining] = pipelining != null ? pipelining : 1
     this[kMaxHeadersSize] = maxHeaderSize || 16384
@@ -243,7 +242,6 @@ class Client extends Dispatcher {
     }
 
     try {
-      console.log('Executing request')
       const request = this[kMaxRedirections] > 0
         ? new Request(opts, new RedirectHandler(this, { ...opts, origin: this[kUrl] }, handler))
         : new Request(opts, handler)

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -37,5 +37,6 @@ module.exports = {
   kSocket: Symbol('socket'),
   kHostHeader: Symbol('host header'),
   kConnector: Symbol('connector'),
-  kStrictContentLength: Symbol('strict content length')
+  kStrictContentLength: Symbol('strict content length'),
+  kMaxRedirections: Symbol('maxRedirections')
 }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -6,7 +6,7 @@ const util = require('../core/util')
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
 class RedirectHandler {
-  constructor (dispatcher, { maxRedirections, ...opts }, handler) {
+  constructor (dispatcher, maxRedirections, opts, handler) {
     this.dispatcher = dispatcher
     this.location = null
     this.abort = null

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -125,21 +125,13 @@ test('basic dispatch get', (t) => {
 })
 
 test('basic dispatch (redirection) get', { only: true }, (t) => {
-  t.plan(23)
+  t.plan(16)
 
   const maxRedirections = 2
   const messages = ['hello', ' world', '!']
   let currentRedirects = 0
   const server = http.createServer((req, res) => {
     let message = 'x2'
-    t.equal('/', req.url)
-    t.equal('GET', req.method)
-    t.equal(`localhost:${server.address().port}`, req.headers.host)
-    t.equal(undefined, req.headers.foo)
-    t.equal('bar', req.headers.bar)
-    t.equal('null', req.headers.baz)
-    t.equal(undefined, req.headers['content-length'])
-
     if (currentRedirects < maxRedirections) {
       res.statusCode = 301
       res.setHeader('Connection', 'close')
@@ -160,9 +152,9 @@ test('basic dispatch (redirection) get', { only: true }, (t) => {
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`, { maxRedirections })
-    const bufs = []
-
     t.teardown(client.close.bind(client))
+
+    const bufs = []
 
     client.dispatch({
       path: '/',
@@ -178,10 +170,9 @@ test('basic dispatch (redirection) get', { only: true }, (t) => {
       onComplete (trailers) {
         t.strict(trailers, [])
         t.equal('hello world!', Buffer.concat(bufs).toString('utf8'))
-        t.teardown(client.close.bind(client))
       },
       onError (err) {
-        t.err(err)
+        t.error(err)
       }
     })
   })

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -124,60 +124,6 @@ test('basic dispatch get', (t) => {
   })
 })
 
-test('basic dispatch (redirection) get', { only: true }, (t) => {
-  t.plan(16)
-
-  const maxRedirections = 2
-  const messages = ['hello', ' world', '!']
-  let currentRedirects = 0
-  const server = http.createServer((req, res) => {
-    let message = 'x2'
-    if (currentRedirects < maxRedirections) {
-      res.statusCode = 301
-      res.setHeader('Connection', 'close')
-      res.setHeader('Location', `http://localhost:${server.address().port}/`)
-      message = messages[currentRedirects]
-      currentRedirects++
-    }
-
-    res.end(message)
-  })
-  t.teardown(server.close.bind(server))
-
-  const reqHeaders = {
-    foo: undefined,
-    bar: 'bar',
-    baz: null
-  }
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { maxRedirections })
-    t.teardown(client.close.bind(client))
-
-    const bufs = []
-
-    client.dispatch({
-      path: '/',
-      method: 'GET',
-      headers: reqHeaders
-    }, {
-      onConnect () {
-      },
-      onHeaders () {},
-      onData (buf) {
-        bufs.push(buf)
-      },
-      onComplete (trailers) {
-        t.strict(trailers, [])
-        t.equal('hello world!', Buffer.concat(bufs).toString('utf8'))
-      },
-      onError (err) {
-        t.error(err)
-      }
-    })
-  })
-})
-
 test('trailers dispatch get', (t) => {
   t.plan(12)
 

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const { request } = require('..')
+const { request, Client, Pool } = require('..')
 const {
   startRedirectingServer,
   startRedirectingWithBodyServer,
@@ -371,4 +371,64 @@ t.test('should handle errors (promise)', async t => {
   } catch (error) {
     t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
   }
+})
+
+t.test('should follow redirection after a HTTP 300 (Pool)', async t => {
+  t.plan(4)
+
+  let body = ''
+  const server = await startRedirectingServer(t)
+
+  const client = new Pool(`http://${server}`)
+  t.teardown(client.close.bind(client))
+
+  const { statusCode, headers, body: bodyStream, context: { history } } = await request(`http://${server}/300?key=value`, {
+    maxRedirections: 10,
+    dispatcher: client
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.equal(statusCode, 200)
+  t.notOk(headers.location)
+  t.same(history.map(x => x.toString()), [
+    `http://${server}/300?key=value`,
+    `http://${server}/300/1?key=value`,
+    `http://${server}/300/2?key=value`,
+    `http://${server}/300/3?key=value`,
+    `http://${server}/300/4?key=value`
+  ])
+  t.equal(body, `GET key=value :: connection@keep-alive host@${server}`)
+})
+
+t.test('should follow redirection after a HTTP 300 (Client)', async t => {
+  t.plan(4)
+
+  let body = ''
+  const server = await startRedirectingServer(t)
+
+  const client = new Client(`http://${server}`)
+  t.teardown(client.close.bind(client))
+
+  const { statusCode, headers, body: bodyStream, context: { history } } = await request(`http://${server}/300?key=value`, {
+    maxRedirections: 10,
+    dispatcher: client
+  })
+
+  for await (const b of bodyStream) {
+    body += b
+  }
+
+  t.equal(statusCode, 200)
+  t.notOk(headers.location)
+  t.same(history.map(x => x.toString()), [
+    `http://${server}/300?key=value`,
+    `http://${server}/300/1?key=value`,
+    `http://${server}/300/2?key=value`,
+    `http://${server}/300/3?key=value`,
+    `http://${server}/300/4?key=value`
+  ])
+  t.equal(body, `GET key=value :: connection@keep-alive host@${server}`)
 })

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -2,9 +2,6 @@
 
 const t = require('tap')
 const { request } = require('..')
-const RedirectHandler = require('../lib/handler/redirect')
-const { InvalidArgumentError } = require('../lib/core/errors')
-const { nop } = require('../lib/core/util')
 const {
   startRedirectingServer,
   startRedirectingWithBodyServer,
@@ -374,18 +371,4 @@ t.test('should handle errors (promise)', async t => {
   } catch (error) {
     t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
   }
-})
-
-t.test('should complain for invalid headers', async t => {
-  t.plan(1)
-
-  const handler = new RedirectHandler('AGENT', { headers: 'ASD', origin: 'http://localhost' }, { context: {} })
-
-  t.throws(
-    () => {
-      handler.onHeaders(301, ['location', 'http://localhost'], nop)
-    },
-    InvalidArgumentError,
-    'throws on invalid headers'
-  )
 })


### PR DESCRIPTION
**WIP**

Closes #686 
This PR introduces support for redirect by using `RedirectHandler` on `Client` for support redirection.
