### PR TITLE
fix: end message on connection close

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -794,9 +794,9 @@ class Parser {
   }
 
   onMessageComplete () {
-    const { client, socket, statusCode, upgrade, trailers, headers: rawTrailers } = this
+    const { client, socket, statusCode, upgrade, trailers, headers: rawTrailers, shouldKeepAlive } = this
 
-    if (socket.destroyed) {
+    if (socket.destroyed && (!statusCode || shouldKeepAlive)) {
       return -1
     }
 
@@ -863,6 +863,10 @@ class Parser {
       resume(client)
     }
   }
+
+  finish () {
+    llhttp.exports.llhttp_finish(this.ptr)
+  }
 }
 
 function onParserTimeout (parser) {
@@ -901,6 +905,16 @@ function onSocketConnect () {
 }
 
 function onSocketError (err) {
+  const { [kParser]: parser } = this
+  if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
+    // Response does not contain content-length nor chunked encoding.
+    // We treat all incoming data so for as a valid response.
+    currentParser = parser
+    parser.finish()
+    currentParser = null
+    return
+  }
+
   const { [kClient]: client } = this
 
   this[kError] = err
@@ -936,8 +950,9 @@ function onSocketEnd () {
 
   if (parser.statusCode && !parser.shouldKeepAlive) {
     // Response does not contain content-length nor chunked encoding.
-    parser.onMessageComplete()
-    util.destroy()
+    currentParser = parser
+    parser.finish()
+    currentParser = null
     return
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -932,6 +932,13 @@ function onSocketError (err) {
 }
 
 function onSocketEnd () {
+  const { [kParser]: parser } = this
+
+  if (this.statusCode && !this.shouldKeepAlive) {
+    // Response does not contain content-length nor chunked encoding.
+    parser.onMessageComplete()
+  }
+
   util.destroy(this, new SocketError('other side closed'))
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -906,6 +906,9 @@ function onSocketConnect () {
 
 function onSocketError (err) {
   const { [kParser]: parser } = this
+
+  // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
+  // to the user.
   if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
     // Response does not contain content-length nor chunked encoding.
     // We treat all incoming data so for as a valid response.

--- a/lib/client.js
+++ b/lib/client.js
@@ -541,6 +541,12 @@ class Parser {
     }
   }
 
+  finish () {
+    currentParser = this
+    llhttp.exports.llhttp_finish(this.ptr)
+    currentParser = null
+  }
+
   destroy () {
     assert(this.ptr != null)
     assert(currentParser == null)
@@ -863,10 +869,6 @@ class Parser {
       resume(client)
     }
   }
-
-  finish () {
-    llhttp.exports.llhttp_finish(this.ptr)
-  }
 }
 
 function onParserTimeout (parser) {
@@ -910,11 +912,8 @@ function onSocketError (err) {
   // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
   // to the user.
   if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-    // Response does not contain content-length nor chunked encoding.
     // We treat all incoming data so for as a valid response.
-    currentParser = parser
     parser.finish()
-    currentParser = null
     return
   }
 
@@ -952,10 +951,8 @@ function onSocketEnd () {
   const { [kParser]: parser } = this
 
   if (parser.statusCode && !parser.shouldKeepAlive) {
-    // Response does not contain content-length nor chunked encoding.
-    currentParser = parser
+    // We treat all incoming data so for as a valid response.
     parser.finish()
-    currentParser = null
     return
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -934,9 +934,11 @@ function onSocketError (err) {
 function onSocketEnd () {
   const { [kParser]: parser } = this
 
-  if (this.statusCode && !this.shouldKeepAlive) {
+  if (parser.statusCode && !parser.shouldKeepAlive) {
     // Response does not contain content-length nor chunked encoding.
     parser.onMessageComplete()
+    util.destroy()
+    return
   }
 
   util.destroy(this, new SocketError('other side closed'))

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -115,9 +115,7 @@ test('destroy socket abruptly', async (t) => {
 
     // Unfortunately calling destroy synchronously might get us flaky results,
     // therefore we delay it to the next event loop run.
-    setImmediate(() => {
-      socket.destroy()
-    })
+    socket.destroy()
   })
   t.teardown(server.close.bind(server))
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -115,7 +115,7 @@ test('destroy socket abruptly', async (t) => {
 
     // Unfortunately calling destroy synchronously might get us flaky results,
     // therefore we delay it to the next event loop run.
-    socket.destroy()
+    setImmediate(socket.destroy.bind(socket))
   })
   t.teardown(server.close.bind(server))
 
@@ -156,7 +156,7 @@ test('destroy socket abruptly with keep-alive', async (t) => {
 
     // Unfortunately calling destroy synchronously might get us flaky results,
     // therefore we delay it to the next event loop run.
-    socket.destroy()
+    setImmediate(socket.destroy.bind(socket))
   })
   t.teardown(server.close.bind(server))
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -149,6 +149,7 @@ test('destroy socket abruptly with keep-alive', async (t) => {
       'HTTP/1.1 200 OK',
       'Date: Sat, 09 Oct 2010 14:28:02 GMT',
       'Connection: keep-alive',
+      'Content-Length: 42',
       '',
       'the body'
     ]
@@ -173,11 +174,14 @@ test('destroy socket abruptly with keep-alive', async (t) => {
 
   body.setEncoding('utf8')
 
-  let actual = ''
-
-  for await (const chunk of body) {
-    actual += chunk
+  try {
+    /* eslint-disable */
+    for await (const _ of body) {
+      // empty on purpose
+    }
+    /* eslint-enable */
+    t.fail('no error')
+  } catch (err) {
+    t.pass('error happened')
   }
-
-  t.equal(actual, 'the body')
 })

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -112,7 +112,12 @@ test('destroy socket abruptly', async (t) => {
       'the body'
     ]
     socket.end(lines.join('\r\n'))
-    socket.destroy()
+
+    // Unfortunately calling destroy synchronously might get us flaky results,
+    // therefore we delay it to the next event loop run.
+    setImmediate(() => {
+      socket.destroy()
+    })
   })
   t.teardown(server.close.bind(server))
 

--- a/test/client.js
+++ b/test/client.js
@@ -1004,6 +1004,8 @@ test('connected', (t) => {
   t.plan(7)
 
   const server = createServer((req, res) => {
+    // needed so that disconnect is emitted
+    res.setHeader('connection', 'close')
     req.pipe(res)
   })
   t.teardown(server.close.bind(server))

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -231,7 +231,9 @@ test('request streaming no body data when content-length=0', (t) => {
   })
 })
 
-test('response invalid content length with close', (t) => {
+// This test is skipped because we are not currently tracking how
+// many bytes we have received.
+test('response invalid content length with close', { skip: true }, (t) => {
   t.plan(3)
 
   const server = createServer((req, res) => {

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -231,9 +231,7 @@ test('request streaming no body data when content-length=0', (t) => {
   })
 })
 
-// This test is skipped because we are not currently tracking how
-// many bytes we have received.
-test('response invalid content length with close', { skip: true }, (t) => {
+test('response invalid content length with close', (t) => {
   t.plan(3)
 
   const server = createServer((req, res) => {


### PR DESCRIPTION
If response is not keep alive and socket ends then consider it as end of message.

I'm not sure whether this is spec compliant but I believe it would resolve the issue @Ethan-Arrowood encountered.

Refs: https://github.com/nodejs/undici/discussions/782