### PR TITLE
handle maxCachedSessions option in connect class

### DIFF
--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -27,6 +27,7 @@ Returns: `Client`
 * **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
 * **tls** `TlsOptions | null` (optional) - Default: `null` - An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
 * **strictContentLength** `Boolean` (optional) - Default: `true` - Whether to treat request content length mismatches as errors. If true, an error is thrown when the request content-length header doesn't match the length of the request body.
+* **maxCachedSessions** `number | null` (optional) - Default: `100` - Maximum number of TLS cached sessions. Use 0 to disable TLS session caching. Default: 100.
 
 ### Example - Basic Client instantiation
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,6 +80,7 @@ class Client extends Dispatcher {
     pipelining,
     tls,
     strictContentLength,
+    maxCachedSessions,
     [kConnect]: connect
   } = {}) {
     super()
@@ -136,12 +137,16 @@ class Client extends Dispatcher {
       throw new InvalidArgumentError('bodyTimeout must be a positive integer or zero')
     }
 
+    if (maxCachedSessions != null && (!Number.isInteger(maxCachedSessions) || maxCachedSessions < 0)) {
+      throw new InvalidArgumentError('maxCachedSessions must be a positive integer or zero')
+    }
+
     if (connect != null && typeof connect !== 'function') {
       throw new InvalidArgumentError('connect must be a function')
     }
 
     this[kUrl] = util.parseOrigin(url)
-    this[kConnector] = connect || makeConnect({ tls, socketPath })
+    this[kConnector] = connect || makeConnect({ tls, socketPath, maxCachedSessions })
     this[kSocket] = null
     this[kPipelining] = pipelining != null ? pipelining : 1
     this[kMaxHeadersSize] = maxHeaderSize || 16384

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -13,8 +13,13 @@ const util = require('./util')
 class Connector {
   constructor ({ tls, socketPath }) {
     this.tls = tls || {} // TODO: Make shallow copy to protect against mutations.
+
+    if (this.tls.maxCachedSessions === undefined) {
+      this.tls.maxCachedSessions = 100
+    }
+
     this.socketPath = socketPath
-    this.sessionCache = new Map()
+    this.sessionCache = { map: new Map(), list: [] }
   }
 
   connect ({ hostname, host, protocol, port, servername }, callback) {
@@ -23,7 +28,7 @@ class Connector {
       servername = servername || this.tls.servername || util.getServerName(host)
 
       const session = this.tls.reuseSessions !== false
-        ? this.sessionCache.get(servername)
+        ? this.sessionCache.map.get(servername)
         : null
 
       const opts = { ...this.tls, servername, session }
@@ -38,13 +43,30 @@ class Connector {
         socket
           .on('session', function (session) {
             assert(this.servername)
-            cache.set(this.servername, session)
+
+            // cache is disabled
+            if (opts.maxCachedSessions === 0) {
+              return
+            }
+
+            if (cache.list.length >= opts.maxCachedSessions) {
+              const oldKey = cache.list.shift()
+              cache.map.delete(oldKey)
+            }
+
+            cache.list.push(this.servername)
+            cache.map.set(this.servername, session)
           })
           .on('error', function (err) {
             assert(this.servername)
             if (err.code !== 'UND_ERR_INFO') {
               // TODO (fix): Only delete for session related errors.
-              cache.delete(this.servername)
+              const sessionIndex = cache.list.indexOf(this.servername)
+
+              if (sessionIndex > -1) {
+                cache.list.splice(sessionIndex, 1)
+                cache.map.delete(this.servername)
+              }
             }
           })
       }

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -11,15 +11,15 @@ const util = require('./util')
 // re-use is enabled.
 
 class Connector {
-  constructor ({ tls, socketPath }) {
+  constructor ({ tls, socketPath, maxCachedSessions }) {
     this.tls = tls || {} // TODO: Make shallow copy to protect against mutations.
 
-    if (this.tls.maxCachedSessions === undefined) {
-      this.tls.maxCachedSessions = 100
-    }
-
     this.socketPath = socketPath
-    this.sessionCache = { map: new Map(), list: [] }
+    this.sessionCache = new Map()
+
+    this.maxCachedSessions = maxCachedSessions === undefined
+      ? 100
+      : maxCachedSessions
   }
 
   connect ({ hostname, host, protocol, port, servername }, callback) {
@@ -27,9 +27,7 @@ class Connector {
     if (protocol === 'https:') {
       servername = servername || this.tls.servername || util.getServerName(host)
 
-      const session = this.tls.reuseSessions !== false
-        ? this.sessionCache.map.get(servername)
-        : null
+      const session = this.sessionCache.get(servername) || null
 
       const opts = { ...this.tls, servername, session }
 
@@ -37,39 +35,33 @@ class Connector {
         ? tls.connect(this.socketPath, opts)
         : tls.connect(port || /* istanbul ignore next */ 443, hostname, opts)
 
-      if (this.tls.reuseSessions !== false) {
-        const cache = this.sessionCache
+      const cache = this.sessionCache
+      const maxCachedSessions = this.maxCachedSessions
 
-        socket
-          .on('session', function (session) {
-            assert(this.servername)
+      socket
+        .on('session', function (session) {
+          assert(this.servername)
 
-            // cache is disabled
-            if (opts.maxCachedSessions === 0) {
-              return
-            }
+          // cache is disabled
+          if (maxCachedSessions === 0) {
+            return
+          }
 
-            if (cache.list.length >= opts.maxCachedSessions) {
-              const oldKey = cache.list.shift()
-              cache.map.delete(oldKey)
-            }
+          if (cache.size >= maxCachedSessions) {
+            // remove the oldest session
+            const { value: oldestKey } = cache.keys().next()
+            cache.delete(oldestKey)
+          }
 
-            cache.list.push(this.servername)
-            cache.map.set(this.servername, session)
-          })
-          .on('error', function (err) {
-            assert(this.servername)
-            if (err.code !== 'UND_ERR_INFO') {
-              // TODO (fix): Only delete for session related errors.
-              const sessionIndex = cache.list.indexOf(this.servername)
-
-              if (sessionIndex > -1) {
-                cache.list.splice(sessionIndex, 1)
-                cache.map.delete(this.servername)
-              }
-            }
-          })
-      }
+          cache.set(this.servername, session)
+        })
+        .on('error', function (err) {
+          assert(this.servername)
+          if (err.code !== 'UND_ERR_INFO') {
+            // TODO (fix): Only delete for session related errors.
+            cache.delete(this.servername)
+          }
+        })
     } else {
       socket = this.socketPath
         ? net.connect(this.socketPath)

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -474,6 +474,22 @@ test('invalid options throws', (t) => {
     t.equal(err.message, 'connect must be a function')
   }
 
+  try {
+    new Client(new URL('http://localhost:200'), { maxCachedSessions: -10 }) // eslint-disable-line
+    t.fail()
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.equal(err.message, 'maxCachedSessions must be a positive integer or zero')
+  }
+
+  try {
+    new Client(new URL('http://localhost:200'), { maxCachedSessions: 'foo' }) // eslint-disable-line
+    t.fail()
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.equal(err.message, 'maxCachedSessions must be a positive integer or zero')
+  }
+
   t.end()
 })
 

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -36,12 +36,12 @@ test('A client should reuse its TLS session', {
       const tls = {
         ca,
         rejectUnauthorized: false,
-        maxCachedSessions: 1,
         servername: 'agent1'
       }
       const client = new Client(`https://localhost:${server.address().port}`, {
         pipelining: 0,
-        tls
+        tls,
+        maxCachedSessions: 1
       })
 
       t.teardown(() => {
@@ -154,12 +154,12 @@ test('A client should disable session caching', {
       const tls = {
         ca,
         rejectUnauthorized: false,
-        maxCachedSessions: 0,
         servername: 'agent1'
       }
       const client = new Client(`https://localhost:${server.address().port}`, {
         pipelining: 0,
-        tls
+        tls,
+        maxCachedSessions: 0
       })
 
       t.teardown(() => {
@@ -234,23 +234,21 @@ test('A pool should be able to reuse TLS sessions between clients', {
       const poolWithSessionReuse = new Pool(`https://localhost:${server.address().port}`, {
         pipelining: 0,
         connections: 100,
+        maxCachedSessions: 1,
         tls: {
           ca,
           rejectUnauthorized: false,
-          maxCachedSessions: 1,
-          servername: 'agent1',
-          reuseSessions: true
+          servername: 'agent1'
         }
       })
       const poolWithoutSessionReuse = new Pool(`https://localhost:${server.address().port}`, {
         pipelining: 0,
         connections: 100,
+        maxCachedSessions: 0,
         tls: {
           ca,
           rejectUnauthorized: false,
-          maxCachedSessions: 1,
-          servername: 'agent1',
-          reuseSessions: false
+          servername: 'agent1'
         }
       })
 

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -37,5 +37,7 @@ declare namespace Client {
     headersTimeout?: number | null;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
     strictContentLength?: boolean
+    /** maximum number of TLS cached sessions. Use 0 to disable TLS session caching. Default: 100. */
+    maxCachedSessions?: number | null;
   }
 }


### PR DESCRIPTION
Issue: https://github.com/nodejs/undici/issues/783

As per the issue description I've added the implementation to handle the maxCachedSessions option, inspired by the node http.Agent.

I would like to discuss about how I handled the default and the zero value.

- Is it ok to set the default to 100 as node does in its Agent?
- Is it ok to disable the session reusability if the value of this option is zero, even if you can disable it reuseSessions option?

Thanks.