### PR TITLE
fix: detached buffer error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -423,7 +423,6 @@ let currentParser = null
 let currentBufferRef = null
 let currentBufferSize = 16384
 let currentBufferPtr = llhttp.exports.malloc(currentBufferSize)
-let currentBufferView = new Uint8Array(llhttp.exports.memory.buffer, currentBufferPtr, currentBufferSize)
 
 const TIMEOUT_HEADERS = 1
 const TIMEOUT_BODY = 2
@@ -506,11 +505,10 @@ class Parser {
       llhttp.exports.free(currentBufferPtr)
       currentBufferSize = Math.ceil(data.length / 4096) * 4096
       currentBufferPtr = llhttp.exports.malloc(currentBufferSize)
-      currentBufferView = new Uint8Array(llhttp.exports.memory.buffer, currentBufferPtr, currentBufferSize)
     }
 
     // TODO (perf): Can we avoid this copy somehow?
-    currentBufferView.set(data)
+    new Uint8Array(llhttp.exports.memory.buffer, currentBufferPtr, currentBufferSize).set(data)
 
     // Call `execute` on the wasm parser.
     // We pass the `llhttp_parser` pointer address, the pointer address of buffer view data,


### PR DESCRIPTION
Somehow the error `Cannot perform %TypedArray%.prototype.set on a detached ArrayBuffer` occurs when using a saved buffer view.

```js
[1620202083995] FATAL (query): error caused exit
    err: {
      "type": "TypeError",
      "message": "Cannot perform %TypedArray%.prototype.set on a detached ArrayBuffer",
      "stack":
          TypeError: Cannot perform %TypedArray%.prototype.set on a detached ArrayBuffer
              at Uint8Array.set (<anonymous>)
              at Parser.execute (/usr/src/app/node_modules/undici/lib/client.js:513:23)
              at Socket.onSocketData (/usr/src/app/node_modules/undici/lib/client.js:892:10)
              at Socket.emit (node:events:369:20)
              at addChunk (node:internal/streams/readable:313:12)
              at readableAddChunk (node:internal/streams/readable:288:9)
              at Socket.Readable.push (node:internal/streams/readable:227:10)
              at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
    }
```