### PR TITLE
Improve mock errors

### DIFF
--- a/docs/api/MockErrors.md
+++ b/docs/api/MockErrors.md
@@ -1,0 +1,7 @@
+# MockErrors
+
+Undici uses a variety of mock error objects.
+
+| Mock Error            | Mock Error Codes                | Description                                                |
+| --------------------- | ------------------------------- | ---------------------------------------------------------- |
+| `MockNotMatchedError` | `UND_MOCK_ERR_MOCK_NOT_MATCHED` | The request does not match any registered mock dispatches. |

--- a/docs/api/MockErrors.md
+++ b/docs/api/MockErrors.md
@@ -1,6 +1,11 @@
 # MockErrors
 
-Undici uses a variety of mock error objects.
+Undici exposes a variety of mock error objects that you can use to enhance your mock error handling.
+You can find all the mock error objects inside the `mockErrors` key.
+
+```js
+const { mockErrors } = require('undici')
+```
 
 | Mock Error            | Mock Error Codes                | Description                                                |
 | --------------------- | ------------------------------- | ---------------------------------------------------------- |

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -10,6 +10,7 @@
   * [MockClient](/docs/api/MockClient.md "Undici API - MockClient")
   * [MockPool](/docs/api/MockPool.md "Undici API - MockPool")
   * [MockAgent](/docs/api/MockAgent.md "Undici API - MockAgent")
+  * [MockErrors](/docs/api/MockErrors.md "Undici API - MockErrors")
   * [API Lifecycle](/docs/api/api-lifecycle.md "Undici API - Lifecycle")
 * Best Practices
   * [Proxy](docs/best-practices/proxy.md "Connecting through a proxy")

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,10 @@ import Agent from './types/agent'
 import MockClient from './types/mock-client'
 import MockPool from './types/mock-pool'
 import MockAgent from './types/mock-agent'
+import mockErrors from './types/mock-errors'
 import { request, pipeline, stream, connect, upgrade } from './types/api'
 
-export { Dispatcher, Pool, Client, errors, Agent, request, stream, pipeline, connect, upgrade, setGlobalDispatcher, getGlobalDispatcher, MockClient, MockPool, MockAgent }
+export { Dispatcher, Pool, Client, errors, Agent, request, stream, pipeline, connect, upgrade, setGlobalDispatcher, getGlobalDispatcher, MockClient, MockPool, MockAgent, mockErrors }
 export default Undici
 
 declare function Undici(url: string, opts: Pool.Options): Pool
@@ -30,4 +31,5 @@ declare namespace Undici {
   var MockClient: typeof import('./types/mock-client');
   var MockPool: typeof import('./types/mock-pool');
   var MockAgent: typeof import('./types/mock-agent');
+  var mockErrors: typeof import('./types/mock-errors');
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const api = require('./lib/api')
 const MockClient = require('./lib/mock/mock-client')
 const MockAgent = require('./lib/mock/mock-agent')
 const MockPool = require('./lib/mock/mock-pool')
+const mockErrors = require('./lib/mock/mock-errors')
 
 Object.assign(Dispatcher.prototype, api)
 
@@ -90,3 +91,4 @@ module.exports.upgrade = makeDispatcher(api.upgrade)
 module.exports.MockClient = MockClient
 module.exports.MockPool = MockPool
 module.exports.MockAgent = MockAgent
+module.exports.mockErrors = mockErrors

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -7,7 +7,7 @@ class MockNotMatchedError extends UndiciError {
     super(message)
     Error.captureStackTrace(this, MockNotMatchedError)
     this.name = 'MockNotMatchedError'
-    this.message = message
+    this.message = message || 'The request does not match any registered mock dispatches'
     this.code = 'UND_MOCK_ERR_MOCK_NOT_MATCHED'
   }
 }

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { UndiciError } = require('../core/errors')
+
+class MockNotMatchedError extends UndiciError {
+  constructor (message) {
+    super(message)
+    Error.captureStackTrace(this, MockNotMatchedError)
+    this.name = 'MockNotMatchedError'
+    this.message = message
+    this.code = 'UND_MOCK_ERR_MOCK_NOT_MATCHED'
+  }
+}
+
+module.exports = {
+  MockNotMatchedError
+}

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { MockNotMatchedError } = require('./mock-errors')
 const {
   kDispatches,
   kMockAgent,
@@ -158,7 +159,10 @@ function buildMockDispatch () {
         if (checkNetConnect(netConnect, origin)) {
           originalDispatch.call(this, opts, handler)
         } else {
-          throw new Error(`Unable to find mock dispatch and real dispatches are disabled for ${origin}`)
+          if (netConnect === false) {
+            throw new MockNotMatchedError(`Request to ${origin} does not match any registered mock dispatches and net.connect is disabled. Please register a mock dispatch for this origin.`)
+          }
+          throw new MockNotMatchedError(`Request to ${origin} does not match any registered mock dispatches and net.connect is not enabled for this origin. Please register a mock dispatch for this origin or add this origin to your MockAgent.enableNetConnect call.`)
         }
       }
     } else {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -47,7 +47,7 @@ function getMockDispatch (mockDispatches, key) {
     throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}'`)
   }
 
-  // Match method
+  // Match body
   matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}'`)
@@ -161,14 +161,18 @@ function buildMockDispatch () {
       try {
         mockDispatch.call(this, opts, handler)
       } catch (error) {
-        const netConnect = agent[kGetNetConnect]()
-        if (netConnect === false) {
-          throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} is not allowed (net.connect disabled)`)
-        }
-        if (checkNetConnect(netConnect, origin)) {
-          originalDispatch.call(this, opts, handler)
+        if (error instanceof MockNotMatchedError) {
+          const netConnect = agent[kGetNetConnect]()
+          if (netConnect === false) {
+            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`)
+          }
+          if (checkNetConnect(netConnect, origin)) {
+            originalDispatch.call(this, opts, handler)
+          } else {
+            throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`)
+          }
         } else {
-          throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} is not allowed (net.connect is not enabled for this origin)`)
+          throw error
         }
       }
     } else {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -23,13 +23,11 @@ function matchValue (match, value) {
   return false
 }
 
-function buildMatcher ({ path, method, body }) {
-  return (mockDispatch) => {
-    const pathMatch = matchValue(mockDispatch.path, path)
-    const methodMatch = matchValue(mockDispatch.method, method)
-    const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
-    return pathMatch && methodMatch && bodyMatch
-  }
+function matchKey (mockDispatch, { path, method, body }) {
+  const pathMatch = matchValue(mockDispatch.path, path)
+  const methodMatch = matchValue(mockDispatch.method, method)
+  const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
+  return pathMatch && methodMatch && bodyMatch
 }
 
 function getResponseData (data) {
@@ -37,13 +35,25 @@ function getResponseData (data) {
 }
 
 function getMockDispatch (mockDispatches, key) {
-  const matcher = buildMatcher(key)
-  return mockDispatches.find(dispatch => {
-    if (dispatch.consumed) {
-      return false
-    }
-    return matcher(dispatch)
-  })
+  // Match path
+  let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path }) => matchValue(path, key.path))
+  if (matchedMockDispatches.length === 0) {
+    throw new MockNotMatchedError(`Mock dispatch not matched for path '${key.path}'`)
+  }
+
+  // Match method
+  matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
+  if (matchedMockDispatches.length === 0) {
+    throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}'`)
+  }
+
+  // Match method
+  matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
+  if (matchedMockDispatches.length === 0) {
+    throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}'`)
+  }
+
+  return matchedMockDispatches[0]
 }
 
 function addMockDispatch (mockDispatches, key, data) {
@@ -58,7 +68,7 @@ function deleteMockDispatch (mockDispatches, key) {
     if (!dispatch.consumed) {
       return false
     }
-    return buildMatcher(key)
+    return matchKey(dispatch, key)
   })
   if (index !== -1) {
     mockDispatches.splice(index, 1)
@@ -93,10 +103,6 @@ function mockDispatch (opts, handler) {
   // Get mock dispatch from built key
   const key = buildKey(opts)
   const mockDispatch = getMockDispatch(this[kDispatches], key)
-
-  if (!mockDispatch) {
-    return false
-  }
 
   // Parse mockDispatch data
   const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch
@@ -152,17 +158,17 @@ function buildMockDispatch () {
 
   return function dispatch (opts, handler) {
     if (agent[kIsMockActive]) {
-      let foundMockDispatch = false
-      foundMockDispatch = mockDispatch.call(this, opts, handler)
-      if (!foundMockDispatch) {
+      try {
+        mockDispatch.call(this, opts, handler)
+      } catch (error) {
         const netConnect = agent[kGetNetConnect]()
+        if (netConnect === false) {
+          throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} is not allowed (net.connect disabled)`)
+        }
         if (checkNetConnect(netConnect, origin)) {
           originalDispatch.call(this, opts, handler)
         } else {
-          if (netConnect === false) {
-            throw new MockNotMatchedError(`Request to ${origin} does not match any registered mock dispatches and net.connect is disabled. Please register a mock dispatch for this origin.`)
-          }
-          throw new MockNotMatchedError(`Request to ${origin} does not match any registered mock dispatches and net.connect is not enabled for this origin. Please register a mock dispatch for this origin or add this origin to your MockAgent.enableNetConnect call.`)
+          throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} is not allowed (net.connect is not enabled for this origin)`)
         }
       }
     } else {

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -1826,7 +1826,7 @@ test('MockAgent - enableNetConnect with an unknown input should throw', async (t
   t.throws(() => mockAgent.enableNetConnect({}), new InvalidArgumentError('Unsupported matcher. Must be one of String|Function|RegExp.'))
 })
 
-test('MockAgent - enableNetConnect should throw if dispatch not matched for path and the origin is not allowed by net connect', async (t) => {
+test('MockAgent - enableNetConnect should throw if dispatch not matched for path and the origin was not allowed by net connect', async (t) => {
   t.plan(1)
 
   const server = createServer((req, res) => {
@@ -1854,10 +1854,10 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for path
 
   await t.rejects(request(`${baseUrl}/wrong`, {
     method: 'GET'
-  }), new MockNotMatchedError(`Mock dispatch not matched for path '/wrong': subsequent request to origin ${baseUrl} is not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for path '/wrong': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
-test('MockAgent - enableNetConnect should throw if dispatch not matched for method and the origin is not allowed by net connect', async (t) => {
+test('MockAgent - enableNetConnect should throw if dispatch not matched for method and the origin was not allowed by net connect', async (t) => {
   t.plan(1)
 
   const server = createServer((req, res) => {
@@ -1885,10 +1885,10 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for meth
 
   await t.rejects(request(`${baseUrl}/foo`, {
     method: 'WRONG'
-  }), new MockNotMatchedError(`Mock dispatch not matched for method 'WRONG': subsequent request to origin ${baseUrl} is not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for method 'WRONG': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
-test('MockAgent - enableNetConnect should throw if dispatch not matched for body and the origin is not allowed by net connect', async (t) => {
+test('MockAgent - enableNetConnect should throw if dispatch not matched for body and the origin was not allowed by net connect', async (t) => {
   t.plan(1)
 
   const server = createServer((req, res) => {
@@ -1918,7 +1918,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for body
   await t.rejects(request(`${baseUrl}/foo`, {
     method: 'GET',
     body: 'wrong'
-  }), new MockNotMatchedError(`Mock dispatch not matched for body 'wrong': subsequent request to origin ${baseUrl} is not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for body 'wrong': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
 test('MockAgent - disableNetConnect should throw if dispatch not found by net connect', async (t) => {
@@ -1950,5 +1950,5 @@ test('MockAgent - disableNetConnect should throw if dispatch not found by net co
 
   await t.rejects(request(`${baseUrl}/foo`, {
     method: 'GET'
-  }), new MockNotMatchedError(`Mock dispatch not matched for path '/foo': subsequent request to origin ${baseUrl} is not allowed (net.connect disabled)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for path '/foo': subsequent request to origin ${baseUrl} was not allowed (net.connect disabled)`))
 })

--- a/test/mock-errors.js
+++ b/test/mock-errors.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { test } = require('tap')
+const { mockErrors, errors } = require('..')
+
+test('mockErrors', (t) => {
+  t.plan(1)
+
+  t.test('MockNotMatchedError', t => {
+    t.plan(2)
+
+    t.test('should implement an UndiciError', t => {
+      t.plan(4)
+
+      const mockError = new mockErrors.MockNotMatchedError()
+      t.ok(mockError instanceof errors.UndiciError)
+      t.same(mockError.name, 'MockNotMatchedError')
+      t.same(mockError.code, 'UND_MOCK_ERR_MOCK_NOT_MATCHED')
+      t.same(mockError.message, 'The request does not match any registered mock dispatches')
+    })
+
+    t.test('should set a custom message', t => {
+      t.plan(4)
+
+      const mockError = new mockErrors.MockNotMatchedError('custom message')
+      t.ok(mockError instanceof errors.UndiciError)
+      t.same(mockError.name, 'MockNotMatchedError')
+      t.same(mockError.code, 'UND_MOCK_ERR_MOCK_NOT_MATCHED')
+      t.same(mockError.message, 'custom message')
+    })
+  })
+})

--- a/test/mock-pool.js
+++ b/test/mock-pool.js
@@ -33,7 +33,7 @@ test('MockPool - constructor', t => {
 })
 
 test('MockPool - dispatch', t => {
-  t.plan(1)
+  t.plan(2)
 
   t.test('should handle a single interceptor', (t) => {
     t.plan(1)
@@ -68,6 +68,41 @@ test('MockPool - dispatch', t => {
       onData: () => {},
       onComplete: () => {}
     }))
+  })
+
+  t.test('should directly throw error from mockDispatch function if error is not a MockNotMatchedError', (t) => {
+    t.plan(1)
+
+    const baseUrl = 'http://localhost:9999'
+
+    const mockAgent = new MockAgent()
+    t.teardown(mockAgent.close.bind(mockAgent))
+
+    const mockPool = mockAgent.get(baseUrl)
+
+    this[kUrl] = new URL('http://localhost:9999')
+    mockPool[kDispatches] = [
+      {
+        path: '/foo',
+        method: 'GET',
+        data: {
+          statusCode: 200,
+          data: 'hello',
+          headers: {},
+          trailers: {},
+          error: null
+        }
+      }
+    ]
+
+    t.throws(() => mockPool.dispatch({
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onHeaders: (_statusCode, _headers, resume) => { throw new Error('kaboom') },
+      onData: () => {},
+      onComplete: () => {}
+    }), new Error('kaboom'))
   })
 })
 

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
+const { MockNotMatchedError } = require('../lib/mock/mock-errors')
 const { deleteMockDispatch, getMockDispatch } = require('../lib/mock/mock-utils')
 
 test('deleteMockDispatch - should do nothing if not able to find mock dispatch', (t) => {
@@ -66,7 +67,7 @@ test('getMockDispatch', (t) => {
     })
   })
 
-  t.test('it should return undefined is dispatch not found', (t) => {
+  t.test('it should throw if dispatch not found', (t) => {
     t.plan(1)
     const dispatches = [
       {
@@ -76,10 +77,9 @@ test('getMockDispatch', (t) => {
       }
     ]
 
-    const result = getMockDispatch(dispatches, {
+    t.throws(() => getMockDispatch(dispatches, {
       path: 'wrong',
       method: 'wrong'
-    })
-    t.equal(result, undefined)
+    }), new MockNotMatchedError('Mock dispatch not matched for path \'wrong\''))
   })
 })

--- a/test/types/mock-errors.test-d.ts
+++ b/test/types/mock-errors.test-d.ts
@@ -1,0 +1,19 @@
+import { expectAssignable } from 'tsd'
+import { mockErrors, errors } from '../..'
+
+expectAssignable<errors.UndiciError>(new mockErrors.MockNotMatchedError())
+expectAssignable<mockErrors.MockNotMatchedError>(new mockErrors.MockNotMatchedError())
+expectAssignable<mockErrors.MockNotMatchedError>(new mockErrors.MockNotMatchedError('kaboom'))
+expectAssignable<'MockNotMatchedError'>(new mockErrors.MockNotMatchedError().name)
+expectAssignable<'UND_MOCK_ERR_MOCK_NOT_MATCHED'>(new mockErrors.MockNotMatchedError().code)
+
+{
+  // @ts-ignore
+  function f (): mockErrors.MockNotMatchedError { return }
+
+  const e = f()
+
+  if (e.code === 'UND_MOCK_ERR_MOCK_NOT_MATCHED') {
+    expectAssignable<mockErrors.MockNotMatchedError>(e)
+  }
+}

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -1,6 +1,4 @@
 import Agent from './agent'
-import MockPool from './mock-pool'
-import MockClient from './mock-client'
 import Dispatcher from './dispatcher'
 
 export = MockAgent

--- a/types/mock-errors.d.ts
+++ b/types/mock-errors.d.ts
@@ -1,0 +1,12 @@
+import { UndiciError } from './errors'
+
+export = MockErrors
+
+declare namespace MockErrors {
+  /** The request does not match any registered mock dispatches. */
+  export class MockNotMatchedError extends UndiciError {
+    constructor(message?: string);
+    name: 'MockNotMatchedError';
+    code: 'UND_MOCK_ERR_MOCK_NOT_MATCHED';
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/undici/issues/787

As suggested, I've added the following improvements to help debug when a mock dispatch is not matched

For a missing path:

```txt
Mock dispatch not matched for path '/wrong': subsequent request to origin http://localhost:9999 was not allowed (net.connect is not enabled for this origin)
Mock dispatch not matched for path '/wrong': subsequent request to origin http://localhost:9999 was not allowed (net.connect is disabled)
```

For a missing method:

```txt
Mock dispatch not matched for method 'WRONG': subsequent request to origin http://localhost:9999 was not allowed (net.connect is not enabled for this origin)
Mock dispatch not matched for method 'WRONG': subsequent request to origin http://localhost:9999 was not allowed (net.connect is disabled)
```

For a missing body:

```txt
Mock dispatch not matched for body 'wrong': subsequent request to origin http://localhost:9999 was not allowed (net.connect is not enabled for this origin)
Mock dispatch not matched for body 'wrong': subsequent request to origin http://localhost:9999 was not allowed (net.connect is disabled)
```

I've also exposed the `mockErrors` as a separate object to `errors` so they are not confused, happy to refactor if you would prefer them to be all together :)