### PR TITLE
Add mock header matching support

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -24,10 +24,10 @@ function matchValue (match, value) {
 }
 
 function matchHeaders (mockDispatch, headers) {
-  if (typeof mockDispatch.headers !== 'object') {
+  if (typeof mockDispatch.headers === 'undefined') {
     return true
   }
-  if (typeof headers !== 'object') {
+  if (typeof headers !== 'object' || typeof mockDispatch.headers !== 'object') {
     return false
   }
   for (const [matchHeaderName, matchHeaderValue] of Object.entries(mockDispatch.headers)) {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -23,11 +23,27 @@ function matchValue (match, value) {
   return false
 }
 
-function matchKey (mockDispatch, { path, method, body }) {
+function matchHeaders (mockDispatch, headers) {
+  if (typeof mockDispatch.headers !== 'object') {
+    return true
+  }
+  if (typeof headers !== 'object') {
+    return false
+  }
+  for (const [matchHeaderName, matchHeaderValue] of Object.entries(mockDispatch.headers)) {
+    if (!matchValue(matchHeaderValue, headers[matchHeaderName])) {
+      return false
+    }
+  }
+  return true
+}
+
+function matchKey (mockDispatch, { path, method, body, headers }) {
   const pathMatch = matchValue(mockDispatch.path, path)
   const methodMatch = matchValue(mockDispatch.method, method)
   const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
-  return pathMatch && methodMatch && bodyMatch
+  const headersMatch = matchHeaders(mockDispatch, headers)
+  return pathMatch && methodMatch && bodyMatch && headersMatch
 }
 
 function getResponseData (data) {
@@ -53,6 +69,12 @@ function getMockDispatch (mockDispatches, key) {
     throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}'`)
   }
 
+  // Match headers
+  matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
+  if (matchedMockDispatches.length === 0) {
+    throw new MockNotMatchedError(`Mock dispatch not matched for headers '${typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers}'`)
+  }
+
   return matchedMockDispatches[0]
 }
 
@@ -76,11 +98,12 @@ function deleteMockDispatch (mockDispatches, key) {
 }
 
 function buildKey (opts) {
-  const { path, method, body } = opts
+  const { path, method, body, headers } = opts
   return {
-    path: path,
-    method: method,
-    body: body
+    path,
+    method,
+    body,
+    headers
   }
 }
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -1343,6 +1343,225 @@ test('MockAgent - should match body with function', async (t) => {
   t.equal(response, 'foo')
 })
 
+test('MockAgent - should match headers with string', async (t) => {
+  t.plan(6)
+
+  const server = createServer((req, res) => {
+    res.end('should not be called')
+    t.fail('should not be called')
+    t.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+
+  const mockPool = mockAgent.get(baseUrl)
+  mockPool.intercept({
+    path: '/foo',
+    method: 'GET',
+    headers: {
+      'User-Agent': 'undici',
+      Host: 'example.com'
+    }
+  }).reply(200, 'foo')
+
+  // Disable net connect so we can make sure it matches properly
+  mockAgent.disableNetConnect()
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET'
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'wrong'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  const { statusCode, body } = await request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'example.com'
+    }
+  })
+  t.equal(statusCode, 200)
+
+  const response = await getResponse(body)
+  t.equal(response, 'foo')
+})
+
+test('MockAgent - should match headers with regex', async (t) => {
+  t.plan(6)
+
+  const server = createServer((req, res) => {
+    res.end('should not be called')
+    t.fail('should not be called')
+    t.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+
+  const mockPool = mockAgent.get(baseUrl)
+  mockPool.intercept({
+    path: '/foo',
+    method: 'GET',
+    headers: {
+      'User-Agent': /^undici$/,
+      Host: /^example.com$/
+    }
+  }).reply(200, 'foo')
+
+  // Disable net connect so we can make sure it matches properly
+  mockAgent.disableNetConnect()
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET'
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'wrong'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  const { statusCode, body } = await request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'example.com'
+    }
+  })
+  t.equal(statusCode, 200)
+
+  const response = await getResponse(body)
+  t.equal(response, 'foo')
+})
+
+test('MockAgent - should match headers with function', async (t) => {
+  t.plan(6)
+
+  const server = createServer((req, res) => {
+    res.end('should not be called')
+    t.fail('should not be called')
+    t.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+
+  const mockPool = mockAgent.get(baseUrl)
+  mockPool.intercept({
+    path: '/foo',
+    method: 'GET',
+    headers: {
+      'User-Agent': (value) => value === 'undici',
+      Host: (value) => value === 'example.com'
+    }
+  }).reply(200, 'foo')
+
+  // Disable net connect so we can make sure it matches properly
+  mockAgent.disableNetConnect()
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET'
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'wrong'
+    }
+  }), MockNotMatchedError, 'should reject with MockNotMatchedError')
+
+  const { statusCode, body } = await request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      foo: 'bar',
+      'User-Agent': 'undici',
+      Host: 'example.com'
+    }
+  })
+  t.equal(statusCode, 200)
+
+  const response = await getResponse(body)
+  t.equal(response, 'foo')
+})
+
 test('MockAgent - should match url with regex', async (t) => {
   t.plan(2)
 
@@ -1919,6 +2138,43 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for body
     method: 'GET',
     body: 'wrong'
   }), new MockNotMatchedError(`Mock dispatch not matched for body 'wrong': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
+})
+
+test('MockAgent - enableNetConnect should throw if dispatch not matched for headers and the origin was not allowed by net connect', async (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    t.fail('should not be called')
+    t.end()
+    res.end('should not be called')
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+
+  const mockPool = mockAgent.get(baseUrl)
+  mockPool.intercept({
+    path: '/foo',
+    method: 'GET',
+    headers: {
+      'User-Agent': 'undici'
+    }
+  }).reply(200, 'foo')
+
+  mockAgent.enableNetConnect('example.com:9999')
+
+  await t.rejects(request(`${baseUrl}/foo`, {
+    method: 'GET',
+    headers: {
+      'User-Agent': 'wrong'
+    }
+  }), new MockNotMatchedError(`Mock dispatch not matched for headers '{"User-Agent":"wrong"}': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
 test('MockAgent - disableNetConnect should throw if dispatch not found by net connect', async (t) => {

--- a/test/types/mock-client.test-d.ts
+++ b/test/types/mock-client.test-d.ts
@@ -7,8 +7,8 @@ import { MockInterceptor } from '../../types/mock-interceptor'
 
   // intercept
   expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '' }))
-  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '', body: '' }))
-  expectAssignable<MockInterceptor>(mockClient.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp('') }))
+  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '', body: '', headers: { 'User-Agent': '' } }))
+  expectAssignable<MockInterceptor>(mockClient.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp(''), headers: { 'User-Agent': new RegExp('') } }))
   expectAssignable<MockInterceptor>(mockClient.intercept({
     path: (path) => {
       expectAssignable<string>(path)
@@ -21,6 +21,12 @@ import { MockInterceptor } from '../../types/mock-interceptor'
     body: (body) => {
       expectAssignable<string>(body)
       return true
+    },
+    headers: {
+      'User-Agent': (header) => {
+        expectAssignable<string>(header)
+        return true
+      }
     }
   }))
 

--- a/test/types/mock-pool.test-d.ts
+++ b/test/types/mock-pool.test-d.ts
@@ -7,8 +7,8 @@ import { MockInterceptor } from '../../types/mock-interceptor'
 
   // intercept
   expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '' }))
-  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '', body: '' }))
-  expectAssignable<MockInterceptor>(mockPool.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp('') }))
+  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '', body: '', headers: { 'User-Agent': '' } }))
+  expectAssignable<MockInterceptor>(mockPool.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp(''), headers: { 'User-Agent': new RegExp('') } }))
   expectAssignable<MockInterceptor>(mockPool.intercept({
     path: (path) => {
       expectAssignable<string>(path)
@@ -21,6 +21,12 @@ import { MockInterceptor } from '../../types/mock-interceptor'
     body: (body) => {
       expectAssignable<string>(body)
       return true
+    },
+    headers: {
+      'User-Agent': (header) => {
+        expectAssignable<string>(header)
+        return true
+      }
     }
   }))
 

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -40,6 +40,8 @@ declare namespace MockInterceptor {
     method: string | RegExp | ((method: string) => boolean);
     /** Body to intercept on. */
     body?: string | RegExp | ((body: string) => boolean);
+    /** Headers to intercept on. */
+    headers?: Record<string, string | RegExp | ((body: string) => boolean)>;
   }
   export interface MockDispatch<TData extends object = object, TError extends Error = Error> extends Options {
     times: number | null;


### PR DESCRIPTION
Closes: https://github.com/nodejs/undici/issues/791

This also adds the following features for the individual header checks:
 - Match headers by string
 - Match headers by regex
 - Match headers by function