### PR TITLE
fix(scripts): add `bench:run:simd` with --experimental-wasm-simd enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i undici
 
 The benchmark is a simple `hello world` [example](benchmarks/benchmark.js) using a
 number of unix sockets (connections) with a pipelining depth of 10 running on Node 16.
-The benchmarks have the [simd](https://github.com/WebAssembly/simd) feature enabled.
+The benchmarks below have the [simd](https://github.com/WebAssembly/simd) feature enabled.
 
 ### Connections 1
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "bench:simd": "concurrently -k -s first npm:bench:server npm:bench:run:simd",
     "bench:server": "node benchmarks/server.js",
     "prebench:run": "node benchmarks/wait.js",
-    "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js && CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
+    "bench:run": "CONNECTIONS=1 node benchmarks/benchmark.js && CONNECTIONS=50 node benchmarks/benchmark.js",
+    "bench:run:simd": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js && CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
     "serve:website": "docsify serve .",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Fixes https://github.com/nodejs/undici/issues/795

<details>
<summary>System Information</summary>

```console
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.15.7
BuildVersion:	19H1030

$ sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz

$ node -v
v16.1.0
```

</details>

<details>
<summary>npm run bench</summary>

```console
$ npm run bench

> undici@4.0.0-rc.3 bench
> concurrently -k -s first npm:bench:server npm:bench:run

[bench:server] 
[bench:server] > undici@4.0.0-rc.3 bench:server
[bench:server] > node benchmarks/server.js
[bench:server] 
[bench:run] 
[bench:run] > undici@4.0.0-rc.3 prebench:run
[bench:run] > node benchmarks/wait.js
[bench:run] 
[bench:run] 
[bench:run] > undici@4.0.0-rc.3 bench:run
[bench:run] > CONNECTIONS=1 node benchmarks/benchmark.js && CONNECTIONS=50 node benchmarks/benchmark.js
[bench:run] 
[bench:run] │ Tests               │ Samples │        Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │  5.59 req/sec │  ± 1.41 % │                       - │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      15 │  6.17 req/sec │  ± 2.82 % │               + 10.31 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      10 │ 47.48 req/sec │  ± 1.66 % │              + 748.65 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      15 │ 49.37 req/sec │  ± 2.78 % │              + 782.48 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      15 │ 49.76 req/sec │  ± 2.53 % │              + 789.42 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      10 │ 51.32 req/sec │  ± 2.51 % │              + 817.29 % │
[bench:run] 
[bench:run] │ Tests               │ Samples │           Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │  3946.75 req/sec │  ± 1.11 % │                       - │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      15 │  8132.11 req/sec │  ± 2.41 % │              + 106.05 % │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      50 │ 10858.42 req/sec │  ± 2.88 % │              + 175.12 % │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      30 │ 15833.75 req/sec │  ± 2.76 % │              + 301.18 % │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      15 │ 17526.51 req/sec │  ± 2.97 % │              + 344.07 % │
[bench:run] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      15 │ 17744.76 req/sec │  ± 2.72 % │              + 349.60 % │
[bench:run] 
[bench:run] npm run bench:run exited with code 0
--> Sending SIGTERM to other processes..
[bench:server] npm run bench:server exited with code SIGTERM
```

</details>

<details>
<summary>npm run bench:simd</summary>

```console
$ npm run bench:simd

> undici@4.0.0-rc.3 bench:simd
> concurrently -k -s first npm:bench:server npm:bench:run:simd

[bench:server] 
[bench:server] > undici@4.0.0-rc.3 bench:server
[bench:server] > node benchmarks/server.js
[bench:server] 
[bench:run:simd] 
[bench:run:simd] > undici@4.0.0-rc.3 bench:run:simd
[bench:run:simd] > CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js && CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js
[bench:run:simd] 
[bench:run:simd] │ Tests               │ Samples │        Result │ Tolerance │ Difference with slowest │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ http - no keepalive │      10 │  5.45 req/sec │  ± 1.68 % │                       - │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ http - keepalive    │      10 │  5.88 req/sec │  ± 1.93 % │                + 7.80 % │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - pipeline   │      10 │ 47.30 req/sec │  ± 1.74 % │              + 767.71 % │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - stream     │      15 │ 47.68 req/sec │  ± 2.83 % │              + 774.79 % │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - dispatch   │      20 │ 55.65 req/sec │  ± 2.85 % │              + 920.98 % │
[bench:run:simd] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - request    │      10 │ 56.09 req/sec │  ± 2.82 % │              + 929.06 % │
[bench:run:simd] 
[bench:run:simd] │ Tests               │ Samples │           Result │ Tolerance │ Difference with slowest │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ http - no keepalive │      15 │  4305.53 req/sec │  ± 2.81 % │                       - │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ http - keepalive    │      15 │  7711.98 req/sec │  ± 2.86 % │               + 79.12 % │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - pipeline   │      45 │ 10418.97 req/sec │  ± 2.92 % │              + 141.99 % │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - request    │      10 │ 16144.10 req/sec │  ± 1.96 % │              + 274.96 % │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - stream     │      15 │ 16690.28 req/sec │  ± 2.68 % │              + 287.65 % │
[bench:run:simd] |─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
[bench:run:simd] │ undici - dispatch   │      25 │ 19697.36 req/sec │  ± 2.93 % │              + 357.49 % │
[bench:run:simd] 
[bench:run:simd] npm run bench:run:simd exited with code 0
--> Sending SIGTERM to other processes..
[bench:server] npm run bench:server exited with code SIGTERM
```

</details>