### PR TITLE
chore: remove bench:simd script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "coverage": "standard | snazzy && tap test/*.js",
     "coverage:ci": "npm run coverage -- --coverage-report=lcovonly",
     "bench": "concurrently -k -s first npm:bench:server npm:bench:run",
-    "bench:simd": "concurrently -k -s first npm:bench:server npm:bench:run:simd",
     "bench:server": "node benchmarks/server.js",
     "prebench:run": "node benchmarks/wait.js",
     "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js && CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",


### PR DESCRIPTION
Reason: We now always use simd.

Refs: https://github.com/nodejs/undici/pull/735#issuecomment-836255542
Commit: https://github.com/nodejs/undici/commit/50cbeb6622ca4b39c282454ca8efc7accdf13bc0