### PR TITLE
make types use promise instead of promiselike

### DIFF
--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -16,8 +16,8 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   expectAssignable<boolean>(agent.destroyed)
 
   // request
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: '' }))
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }))
   expectAssignable<void>(agent.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
@@ -28,11 +28,11 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   }))
 
   // stream
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -70,14 +70,14 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   }))
 
   // upgrade
-  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(agent.upgrade({ path: '' }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(agent.upgrade({ path: '' }))
   expectAssignable<void>(agent.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // connect
-  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(agent.connect({ path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(agent.connect({ path: '' }))
   expectAssignable<void>(agent.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
@@ -88,13 +88,13 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: '', maxRedirections: 1 }, {}))
 
   // close
-  expectAssignable<PromiseLike<void>>(agent.close())
+  expectAssignable<Promise<void>>(agent.close())
   expectAssignable<void>(agent.close(() => {}))
 
   // destroy
-  expectAssignable<PromiseLike<void>>(agent.destroy())
-  expectAssignable<PromiseLike<void>>(agent.destroy(new Error()))
-  expectAssignable<PromiseLike<void>>(agent.destroy(null))
+  expectAssignable<Promise<void>>(agent.destroy())
+  expectAssignable<Promise<void>>(agent.destroy(new Error()))
+  expectAssignable<Promise<void>>(agent.destroy(null))
   expectAssignable<void>(agent.destroy(() => {}))
   expectAssignable<void>(agent.destroy(new Error(), () => {}))
   expectAssignable<void>(agent.destroy(null, () => {}))

--- a/test/types/api.test-d.ts
+++ b/test/types/api.test-d.ts
@@ -3,11 +3,11 @@ import { expectAssignable } from 'tsd'
 import { Dispatcher, request, stream, pipeline, connect, upgrade } from '../..'
 
 // request
-expectAssignable<PromiseLike<Dispatcher.ResponseData>>(request(''))
-expectAssignable<PromiseLike<Dispatcher.ResponseData>>(request('', { method: '' }))
+expectAssignable<Promise<Dispatcher.ResponseData>>(request(''))
+expectAssignable<Promise<Dispatcher.ResponseData>>(request('', { method: '' }))
 
 // stream
-expectAssignable<PromiseLike<Dispatcher.StreamData>>(stream('', { method: '' }, data => {
+expectAssignable<Promise<Dispatcher.StreamData>>(stream('', { method: '' }, data => {
   expectAssignable<Dispatcher.StreamFactoryData>(data)
   return new Writable()
 }))
@@ -19,9 +19,9 @@ expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
 }))
 
 // connect
-expectAssignable<PromiseLike<Dispatcher.ConnectData>>(connect(''))
-expectAssignable<PromiseLike<Dispatcher.ConnectData>>(connect('', {}))
+expectAssignable<Promise<Dispatcher.ConnectData>>(connect(''))
+expectAssignable<Promise<Dispatcher.ConnectData>>(connect('', {}))
 
 // upgrade
-expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(upgrade(''))
-expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(upgrade('', {}))
+expectAssignable<Promise<Dispatcher.UpgradeData>>(upgrade(''))
+expectAssignable<Promise<Dispatcher.UpgradeData>>(upgrade('', {}))

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -16,8 +16,8 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   expectAssignable<boolean>(client.destroyed)
 
   // request
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: '' }))
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }))
   expectAssignable<void>(client.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
@@ -28,11 +28,11 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   }))
 
   // stream
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(client.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: '', path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(client.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -70,14 +70,14 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   }))
 
   // upgrade
-  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(client.upgrade({ path: '' }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(client.upgrade({ path: '' }))
   expectAssignable<void>(client.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // connect
-  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(client.connect({ path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(client.connect({ path: '' }))
   expectAssignable<void>(client.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
@@ -88,13 +88,13 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   expectAssignable<void>(client.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // close
-  expectAssignable<PromiseLike<void>>(client.close())
+  expectAssignable<Promise<void>>(client.close())
   expectAssignable<void>(client.close(() => {}))
 
   // destroy
-  expectAssignable<PromiseLike<void>>(client.destroy())
-  expectAssignable<PromiseLike<void>>(client.destroy(new Error()))
-  expectAssignable<PromiseLike<void>>(client.destroy(null))
+  expectAssignable<Promise<void>>(client.destroy())
+  expectAssignable<Promise<void>>(client.destroy(new Error()))
+  expectAssignable<Promise<void>>(client.destroy(null))
   expectAssignable<void>(client.destroy(() => {}))
   expectAssignable<void>(client.destroy(new Error(), () => {}))
   expectAssignable<void>(client.destroy(null, () => {}))

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -13,15 +13,15 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<void>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // connect
-  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(dispatcher.connect({ path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ path: '' }))
   expectAssignable<void>(dispatcher.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
   }))
 
   // request
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: '' }))
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }))
   expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
@@ -42,11 +42,11 @@ expectAssignable<Dispatcher>(new Dispatcher())
   }))
 
   // stream
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(dispatcher.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -74,20 +74,20 @@ expectAssignable<Dispatcher>(new Dispatcher())
   ))
 
   // upgrade
-  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '' }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '' }))
   expectAssignable<void>(dispatcher.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // close
-  expectAssignable<PromiseLike<void>>(dispatcher.close())
+  expectAssignable<Promise<void>>(dispatcher.close())
   expectAssignable<void>(dispatcher.close(() => {}))
 
   // destroy
-  expectAssignable<PromiseLike<void>>(dispatcher.destroy())
-  expectAssignable<PromiseLike<void>>(dispatcher.destroy(new Error()))
-  expectAssignable<PromiseLike<void>>(dispatcher.destroy(null))
+  expectAssignable<Promise<void>>(dispatcher.destroy())
+  expectAssignable<Promise<void>>(dispatcher.destroy(new Error()))
+  expectAssignable<Promise<void>>(dispatcher.destroy(null))
   expectAssignable<void>(dispatcher.destroy(() => {}))
   expectAssignable<void>(dispatcher.destroy(new Error(), () => {}))
   expectAssignable<void>(dispatcher.destroy(null, () => {}))

--- a/test/types/pool.test-d.ts
+++ b/test/types/pool.test-d.ts
@@ -18,8 +18,8 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   expectAssignable<boolean>(pool.destroyed)
 
   // request
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: '' }))
-  expectAssignable<PromiseLike<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }))
   expectAssignable<void>(pool.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
@@ -30,11 +30,11 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   }))
 
   // stream
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(pool.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: '', path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<PromiseLike<Dispatcher.StreamData>>(pool.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -72,14 +72,14 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   }))
 
   // upgrade
-  expectAssignable<PromiseLike<Dispatcher.UpgradeData>>(pool.upgrade({ path: '' }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(pool.upgrade({ path: '' }))
   expectAssignable<void>(pool.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)
   }))
 
   // connect
-  expectAssignable<PromiseLike<Dispatcher.ConnectData>>(pool.connect({ path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(pool.connect({ path: '' }))
   expectAssignable<void>(pool.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
@@ -90,13 +90,13 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   expectAssignable<void>(pool.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // close
-  expectAssignable<PromiseLike<void>>(pool.close())
+  expectAssignable<Promise<void>>(pool.close())
   expectAssignable<void>(pool.close(() => {}))
 
   // destroy
-  expectAssignable<PromiseLike<void>>(pool.destroy())
-  expectAssignable<PromiseLike<void>>(pool.destroy(new Error()))
-  expectAssignable<PromiseLike<void>>(pool.destroy(null))
+  expectAssignable<Promise<void>>(pool.destroy())
+  expectAssignable<Promise<void>>(pool.destroy(new Error()))
+  expectAssignable<Promise<void>>(pool.destroy(null))
   expectAssignable<void>(pool.destroy(() => {}))
   expectAssignable<void>(pool.destroy(new Error(), () => {}))
   expectAssignable<void>(pool.destroy(null, () => {}))

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -14,14 +14,14 @@ export {
 declare function request(
   url: string | URL | UrlObject,
   options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path'>,
-): PromiseLike<Dispatcher.ResponseData>;
+): Promise<Dispatcher.ResponseData>;
 
 /** A faster version of `request`. */
 declare function stream(
   url: string | URL | UrlObject,
   options: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path'>,
   factory: Dispatcher.StreamFactory
-): PromiseLike<Dispatcher.StreamData>;
+): Promise<Dispatcher.StreamData>;
 
 /** For easy use with `stream.pipeline`. */
 declare function pipeline(
@@ -34,10 +34,10 @@ declare function pipeline(
 declare function connect(
   url: string | URL | UrlObject,
   options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.ConnectOptions, 'origin' | 'path'>
-): PromiseLike<Dispatcher.ConnectData>;
+): Promise<Dispatcher.ConnectData>;
 
 /** Upgrade to a different protocol. */
 declare function upgrade(
   url: string | URL | UrlObject,
   options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.UpgradeOptions, 'origin' | 'path'>
-): PromiseLike<Dispatcher.UpgradeData>;
+): Promise<Dispatcher.UpgradeData>;

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -13,25 +13,25 @@ declare class Dispatcher extends EventEmitter {
   /** Dispatches a request. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
   dispatch(options: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandlers): void;
   /** Starts two-way communications with the requested resource. */
-  connect(options: Dispatcher.ConnectOptions): PromiseLike<Dispatcher.ConnectData>;
+  connect(options: Dispatcher.ConnectOptions): Promise<Dispatcher.ConnectData>;
   connect(options: Dispatcher.ConnectOptions, callback: (err: Error | null, data: Dispatcher.ConnectData) => void): void;
   /** Performs an HTTP request. */
-  request(options: Dispatcher.RequestOptions): PromiseLike<Dispatcher.ResponseData>;
+  request(options: Dispatcher.RequestOptions): Promise<Dispatcher.ResponseData>;
   request(options: Dispatcher.RequestOptions, callback: (err: Error | null, data: Dispatcher.ResponseData) => void): void;
   /** For easy use with `stream.pipeline`. */
   pipeline(options: Dispatcher.PipelineOptions, handler: Dispatcher.PipelineHandler): Duplex;
   /** A faster version of `Dispatcher.request`. */
-  stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory): PromiseLike<Dispatcher.StreamData>;
+  stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory): Promise<Dispatcher.StreamData>;
   stream(options: Dispatcher.RequestOptions, factory: Dispatcher.StreamFactory, callback: (err: Error | null, data: Dispatcher.StreamData) => void): void;
   /** Upgrade to a different protocol. */
-  upgrade(options: Dispatcher.UpgradeOptions): PromiseLike<Dispatcher.UpgradeData>;
+  upgrade(options: Dispatcher.UpgradeOptions): Promise<Dispatcher.UpgradeData>;
   upgrade(options: Dispatcher.UpgradeOptions, callback: (err: Error | null, data: Dispatcher.UpgradeData) => void): void;
   /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returnning a promise if no callback is provided). */
-  close(): PromiseLike<void>;
+  close(): Promise<void>;
   close(callback: () => void): void;
   /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returnning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
-  destroy(): PromiseLike<void>;
-  destroy(err: Error | null): PromiseLike<void>;
+  destroy(): Promise<void>;
+  destroy(err: Error | null): Promise<void>;
   destroy(callback: () => void): void;
   destroy(err: Error | null, callback: () => void): void;
 }


### PR DESCRIPTION
Been starting to use Undici in a TS project and realized I couldn't call `.catch` on the methods! This should fix it.