### PR TITLE
fix: guard against user throw in onError

### DIFF
--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -232,3 +232,7 @@ server.listen(() => {
   })
 })
 ```
+
+### Event: `'error'`
+
+Invoked for users errors such as throwing in the `onError` handler.

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -202,7 +202,7 @@ Returns: `void`
 #### Parameter: `DispatchHandlers`
 
 * **onConnect** `(abort: () => void, context: object) => void` - Invoked before request is dispatched on socket. May be invoked multiple times when a request is retried when the request at the head of the pipeline fails.
-* **onError** `(error: Error) => void` - Invoked when an error has occurred.
+* **onError** `(error: Error) => void` - Invoked when an error has occurred. May not throw.
 * **onUpgrade** `(statusCode: number, headers: Buffer[], socket: Duplex) => void` (optional) - Invoked when request is upgraded. Required if `DispatchOptions.upgrade` is defined or `DispatchOptions.method === 'CONNECT'`.
 * **onHeaders** `(statusCode: number, headers: Buffer[], resume: () => void) => boolean` - Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. Not required for `upgrade` requests.
 * **onData** `(chunk: Buffer) => boolean` - Invoked when response payload data is received. Not required for `upgrade` requests.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1175,7 +1175,6 @@ function _resume (client, sync) {
         })
         .on('error', function (err) {
           errorRequest(client, request, err)
-          assert(request.aborted)
         })
         .on('end', function () {
           util.destroy(this)

--- a/lib/client.js
+++ b/lib/client.js
@@ -329,8 +329,7 @@ class Client extends Dispatcher {
     const requests = this[kQueue].splice(this[kPendingIdx])
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
-      request.onError(err)
-      assert(request.aborted)
+      errorRequest(this, request, err)
     }
 
     this[kClosed] = true
@@ -853,8 +852,7 @@ class Parser {
     try {
       request.onComplete(headers)
     } catch (err) {
-      request.onError(err)
-      assert(request.aborted)
+      errorRequest(client, request, err)
     }
 
     client[kQueue][client[kRunningIdx]++] = null
@@ -933,8 +931,7 @@ function onSocketError (err) {
     assert(client[kRunning] === 0)
     while (client[kPending] > 0 && client[kQueue][client[kPendingIdx]].servername === client[kServerName]) {
       const request = client[kQueue][client[kPendingIdx]++]
-      request.onError(err)
-      assert(request.aborted)
+      errorRequest(client, request, err)
     }
   } else if (
     client[kRunning] === 0 &&
@@ -948,8 +945,7 @@ function onSocketError (err) {
     const requests = client[kQueue].splice(client[kRunningIdx])
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
-      request.onError(err)
-      assert(request.aborted)
+      errorRequest(client, request, err)
     }
     assert(client[kSize] === 0)
   }
@@ -984,16 +980,14 @@ function onSocketClose () {
     const requests = client[kQueue].splice(client[kRunningIdx])
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
-      request.onError(err)
-      assert(request.aborted)
+      errorRequest(client, request, err)
     }
   } else if (client[kRunning] > 0 && err.code !== 'UND_ERR_INFO') {
     // Fail head of pipeline.
     const request = client[kQueue][client[kRunningIdx]]
     client[kQueue][client[kRunningIdx]++] = null
 
-    request.onError(err)
-    assert(request.aborted)
+    errorRequest(client, request, err)
   }
 
   client[kPendingIdx] = client[kRunningIdx]
@@ -1180,7 +1174,7 @@ function _resume (client, sync) {
           assert(false)
         })
         .on('error', function (err) {
-          request.onError(err)
+          errorRequest(client, request, err)
           assert(request.aborted)
         })
         .on('end', function () {
@@ -1250,8 +1244,7 @@ function write (client, request) {
 
   if (request.contentLength !== null && request.contentLength !== contentLength) {
     if (client[kStrictContentLength]) {
-      request.onError(new RequestContentLengthMismatchError())
-      assert(request.aborted)
+      errorRequest(client, request, new RequestContentLengthMismatchError())
       return false
     }
 
@@ -1266,14 +1259,12 @@ function write (client, request) {
         return
       }
 
-      request.onError(err || new RequestAbortedError())
-      assert(request.aborted)
+      errorRequest(client, request, err || new RequestAbortedError())
 
       util.destroy(socket, new InformationalError('aborted'))
     })
   } catch (err) {
-    request.onError(err)
-    assert(request.aborted)
+    errorRequest(client, request, err)
   }
 
   if (request.aborted) {
@@ -1484,6 +1475,15 @@ function write (client, request) {
   }
 
   return true
+}
+
+function errorRequest (client, request, err) {
+  try {
+    request.onError(err)
+    assert(request.aborted)
+  } catch (err) {
+    client.emit('error', err)
+  }
 }
 
 module.exports = Client


### PR DESCRIPTION
Consistently propagate unallowed throws in request.onError.