### PR TITLE
fix(request): add check for kAbort type to be a function

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -22,7 +22,7 @@ class RequestResponse extends Readable {
       err = new RequestAbortedError()
     }
 
-    if (err) {
+    if (err && typeof this[kAbort] === 'function') {
       this[kAbort]()
     }
 


### PR DESCRIPTION
when running mocked objects in unit tests kAbort is not set to a function, fixes https://github.com/nodejs/undici/issues/824