### PR TITLE
fix(types): add missing string[] option for passed headers

### DIFF
--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -71,6 +71,9 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 
   // upgrade
   expectAssignable<Promise<Dispatcher.UpgradeData>>(client.upgrade({ path: '' }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(client.upgrade({ path: '', headers: [] }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(client.upgrade({ path: '', headers: {} }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(client.upgrade({ path: '', headers: null }))
   expectAssignable<void>(client.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)
@@ -78,6 +81,9 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 
   // connect
   expectAssignable<Promise<Dispatcher.ConnectData>>(client.connect({ path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(client.connect({ path: '', headers: [] }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(client.connect({ path: '', headers: {} }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(client.connect({ path: '', headers: null }))
   expectAssignable<void>(client.connect({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
@@ -85,6 +91,9 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 
   // dispatch
   expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: [] }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: {} }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: null }, {}))
   expectAssignable<void>(client.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // close

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -10,6 +10,9 @@ expectAssignable<Dispatcher>(new Dispatcher())
 
   // dispatch
   expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: [] }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: {} }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: null }, {}))
   expectAssignable<void>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 
   // connect

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -26,10 +26,10 @@ declare class Dispatcher extends EventEmitter {
   /** Upgrade to a different protocol. */
   upgrade(options: Dispatcher.UpgradeOptions): Promise<Dispatcher.UpgradeData>;
   upgrade(options: Dispatcher.UpgradeOptions, callback: (err: Error | null, data: Dispatcher.UpgradeData) => void): void;
-  /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returnning a promise if no callback is provided). */
+  /** Closes the client and gracefully waits for enqueued requests to complete before invoking the callback (or returning a promise if no callback is provided). */
   close(): Promise<void>;
   close(callback: () => void): void;
-  /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returnning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
+  /** Destroy the client abruptly with the given err. All the pending and running requests will be asynchronously aborted and error. Waits until socket is closed before invoking the callback (or returning a promise if no callback is provided). Since this operation is asynchronously dispatched there might still be some progress on dispatched requests. */
   destroy(): Promise<void>;
   destroy(err: Error | null): Promise<void>;
   destroy(callback: () => void): void;
@@ -44,8 +44,8 @@ declare namespace Dispatcher {
     /** Default: `null` */
     body?: string | Buffer | Uint8Array | Readable | null;
     /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
-    /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceeding requests in the pipeline has completed. Default: `true` if `method` is `HEAD` or `GET`. */
+    headers?: IncomingHttpHeaders | string[] | null;
+    /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceding requests in the pipeline have completed. Default: `true` if `method` is `HEAD` or `GET`. */
     idempotent?: boolean;
     /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
     upgrade?: boolean | string | null
@@ -53,7 +53,7 @@ declare namespace Dispatcher {
   export interface ConnectOptions {
     path: string;
     /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
+    headers?: IncomingHttpHeaders | string[] | null;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
     /** This argument parameter is passed through to `ConnectData` */
@@ -74,7 +74,7 @@ declare namespace Dispatcher {
     /** Default: `'GET'` */
     method?: string;
     /** Default: `null` */
-    headers?: IncomingHttpHeaders | null;
+    headers?: IncomingHttpHeaders | string[] | null;
     /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
     protocol?: string;
     /** Default: `null` */


### PR DESCRIPTION
matches typescript types to [UndiciHeaders](https://github.com/nodejs/undici/blob/main/docs/api/Dispatcher.md#parameter-undiciheaders)