### PR TITLE
feature: add onBodyChunkSent callback to dispatch

### DIFF
--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -205,6 +205,7 @@ Returns: `void`
 * **onHeaders** `(statusCode: number, headers: Buffer[], resume: () => void) => boolean` - Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. Not required for `upgrade` requests.
 * **onData** `(chunk: Buffer) => boolean` - Invoked when response payload data is received. Not required for `upgrade` requests.
 * **onComplete** `(trailers: Buffer[]) => void` - Invoked when response payload and trailers have been received and the request has completed. Not required for `upgrade` requests.
+* **onBodyChunkSent** `(chunk: string | Buffer | Uint8Array) => void` - Invoked when a body chunk is sent to the server. Not required. For a stream or iterable body this will be invoked for every chunk. For other body types, it will be invoked once after the body is sent.
 
 #### Example 1 - Dispatch GET request
 

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -205,7 +205,7 @@ Returns: `void`
 * **onHeaders** `(statusCode: number, headers: Buffer[], resume: () => void) => boolean` - Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. Not required for `upgrade` requests.
 * **onData** `(chunk: Buffer) => boolean` - Invoked when response payload data is received. Not required for `upgrade` requests.
 * **onComplete** `(trailers: Buffer[]) => void` - Invoked when response payload and trailers have been received and the request has completed. Not required for `upgrade` requests.
-* **onBodyChunkSent** `(chunk: string | Buffer | Uint8Array) => void` - Invoked when a body chunk is sent to the server. Not required. For a stream or iterable body this will be invoked for every chunk. For other body types, it will be invoked once after the body is sent.
+* **onBodySent** `(chunk: string | Buffer | Uint8Array) => void` - Invoked when a body chunk is sent to the server. Not required. For a stream or iterable body this will be invoked for every chunk. For other body types, it will be invoked once after the body is sent.
 
 #### Example 1 - Dispatch GET request
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1430,12 +1430,9 @@ function write (client, request) {
 
     socket.cork()
     socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'ascii')
-    const endCallback = request.onBodyChunkSent
-      ? () => request.onBodyChunkSent(body)
-      : undefined
-    socket.write(body, endCallback)
+    socket.write(body)
     socket.uncork()
-
+    request.onBodySent(body)
     if (!expectsPayload) {
       socket[kReset] = true
     }
@@ -1497,13 +1494,11 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
       }
 
       bytesWritten += len
-      const endCallback = request.onBodyChunkSent
-        ? () => request.onBodyChunkSent(chunk)
-        : undefined
 
-      if (!socket.write(chunk, endCallback) && this.pause) {
+      if (!socket.write(chunk) && this.pause) {
         this.pause()
       }
+      request.onBodySent(chunk)
     } catch (err) {
       util.destroy(this, err)
     }
@@ -1668,14 +1663,10 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
       }
 
       bytesWritten += len
-
-      const endCallback = request.onBodyChunkSent
-        ? () => request.onBodyChunkSent(chunk)
-        : undefined
-
-      if (!socket.write(chunk, endCallback)) {
+      if (!socket.write(chunk)) {
         await waitForDrain()
       }
+      request.onBodySent(chunk)
 
       if (socket[kError]) {
         throw socket[kError]

--- a/lib/client.js
+++ b/lib/client.js
@@ -1430,7 +1430,10 @@ function write (client, request) {
 
     socket.cork()
     socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'ascii')
-    socket.write(body)
+    const endCallback = request.onBodyChunkSent
+      ? () => request.onBodyChunkSent(body)
+      : undefined
+    socket.write(body, endCallback)
     socket.uncork()
 
     if (!expectsPayload) {
@@ -1494,8 +1497,11 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
       }
 
       bytesWritten += len
+      const endCallback = request.onBodyChunkSent
+        ? () => request.onBodyChunkSent(chunk)
+        : undefined
 
-      if (!socket.write(chunk) && this.pause) {
+      if (!socket.write(chunk, endCallback) && this.pause) {
         this.pause()
       }
     } catch (err) {
@@ -1663,7 +1669,11 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
 
       bytesWritten += len
 
-      if (!socket.write(chunk)) {
+      const endCallback = request.onBodyChunkSent
+        ? () => request.onBodyChunkSent(chunk)
+        : undefined
+
+      if (!socket.write(chunk, endCallback)) {
         await waitForDrain()
       }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -105,16 +105,8 @@ class Request {
       throw new InvalidArgumentError('invalid onError method')
     }
 
-    if (typeof handler.onBodyChunkSent !== 'function' && handler.onBodyChunkSent !== undefined) {
-      throw new InvalidArgumentError('invalid onBodyChunkSent method')
-    } else if (typeof handler.onBodyChunkSent === 'function') {
-      this.onBodyChunkSent = (chunk) => {
-        try {
-          this[kHandler].onBodyChunkSent(chunk)
-        } catch (err) {
-          this.onError(err)
-        }
-      }
+    if (typeof handler.onBodySent !== 'function' && handler.onBodySent !== undefined) {
+      throw new InvalidArgumentError('invalid onBodySent method')
     }
 
     if (this.upgrade || this.method === 'CONNECT') {
@@ -138,6 +130,16 @@ class Request {
     this.servername = util.getServerName(this.host)
 
     this[kHandler] = handler
+  }
+
+  onBodySent (chunk) {
+    if (this[kHandler].onBodySent) {
+      try {
+        this[kHandler].onBodySent(chunk)
+      } catch (err) {
+        this.onError(err)
+      }
+    }
   }
 
   onConnect (abort) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -105,6 +105,18 @@ class Request {
       throw new InvalidArgumentError('invalid onError method')
     }
 
+    if (typeof handler.onBodyChunkSent !== 'function' && handler.onBodyChunkSent !== undefined) {
+      throw new InvalidArgumentError('invalid onBodyChunkSent method')
+    } else if (typeof handler.onBodyChunkSent === 'function') {
+      this.onBodyChunkSent = (chunk) => {
+        try {
+          this[kHandler].onBodyChunkSent(chunk)
+        } catch (err) {
+          this.onError(err)
+        }
+      }
+    }
+
     if (this.upgrade || this.method === 'CONNECT') {
       if (typeof handler.onUpgrade !== 'function') {
         throw new InvalidArgumentError('invalid onUpgrade method')

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -104,6 +104,12 @@ class RedirectHandler {
       this.handler.onComplete(trailers)
     }
   }
+
+  onBodySent (chunk) {
+    if (this.handler.onBodySent) {
+      this.handler.onBodySent(chunk)
+    }
+  }
 }
 
 function parseLocation (statusCode, headers) {

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -632,7 +632,7 @@ test('dispatch pool onError missing', (t) => {
   })
 })
 
-test('dispatch onBodyChunkSent not a function', (t) => {
+test('dispatch onBodySent not a function', (t) => {
   t.plan(2)
   const server = http.createServer((req, res) => {
     res.end('ad')
@@ -647,19 +647,19 @@ test('dispatch onBodyChunkSent not a function', (t) => {
       path: '/',
       method: 'GET'
     }, {
-      onBodyChunkSent: '42',
+      onBodySent: '42',
       onConnect () {},
       onHeaders () {},
       onData () {},
       onError (err) {
         t.equal(err.code, 'UND_ERR_INVALID_ARG')
-        t.equal(err.message, 'invalid onBodyChunkSent method')
+        t.equal(err.message, 'invalid onBodySent method')
       }
     })
   })
 })
 
-test('dispatch onBodyChunkSent buffer', (t) => {
+test('dispatch onBodySent buffer', (t) => {
   const server = http.createServer((req, res) => {
     res.end('ad')
   })
@@ -674,7 +674,7 @@ test('dispatch onBodyChunkSent buffer', (t) => {
       method: 'POST',
       body
     }, {
-      onBodyChunkSent (chunk) {
+      onBodySent (chunk) {
         t.equal(chunk.toString(), body)
       },
       onError (err) {
@@ -690,7 +690,7 @@ test('dispatch onBodyChunkSent buffer', (t) => {
   })
 })
 
-test('dispatch onBodyChunkSent stream', (t) => {
+test('dispatch onBodySent stream', (t) => {
   const server = http.createServer((req, res) => {
     res.end('ad')
   })
@@ -708,7 +708,7 @@ test('dispatch onBodyChunkSent stream', (t) => {
       method: 'POST',
       body
     }, {
-      onBodyChunkSent (chunk) {
+      onBodySent (chunk) {
         t.equal(chunks[currentChunk++], chunk)
         sentBytes += Buffer.byteLength(chunk)
       },
@@ -727,7 +727,7 @@ test('dispatch onBodyChunkSent stream', (t) => {
   })
 })
 
-test('dispatch onBodyChunkSent async-iterable', (t) => {
+test('dispatch onBodySent async-iterable', (t) => {
   const server = http.createServer((req, res) => {
     res.end('ad')
   })
@@ -744,7 +744,7 @@ test('dispatch onBodyChunkSent async-iterable', (t) => {
       method: 'POST',
       body: chunks
     }, {
-      onBodyChunkSent (chunk) {
+      onBodySent (chunk) {
         t.equal(chunks[currentChunk++], chunk)
         sentBytes += Buffer.byteLength(chunk)
       },

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -136,7 +136,7 @@ declare namespace Dispatcher {
     /** Invoked when response payload and trailers have been received and the request has completed. */
     onComplete?(trailers: string[] | null): void;
     /** Invoked when a body chunk is sent to the server. May be invoked multiple times for chunked requests */
-    onBodyChunkSent?(chunkSize: number, totalBytesSent: number): void;
+    onBodySent?(chunkSize: number, totalBytesSent: number): void;
   }
   export type PipelineHandler = (data: PipelineHandlerData) => Readable;
 }

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -135,6 +135,8 @@ declare namespace Dispatcher {
     onData?(chunk: Buffer): boolean;
     /** Invoked when response payload and trailers have been received and the request has completed. */
     onComplete?(trailers: string[] | null): void;
+    /** Invoked when a body chunk is sent to the server. May be invoked multiple times for chunked requests */
+    onBodyChunkSent?(chunkSize: number, totalBytesSent: number): void;
   }
   export type PipelineHandler = (data: PipelineHandlerData) => Readable;
 }


### PR DESCRIPTION
Add a callback that's called when a body chunk is sent to the server to `dispatch`.

The callback is invoked only after `stream.write` calls the end callback (I wasn't sure if it should be called synchronously with the call to `write` or not).
For stream bodies, the callback will get invoked after every chunk is written, and for other types (buffer etc.) it will be invoked once after the whole body is sent.

refs: https://github.com/nodejs/undici/issues/820