### PR TITLE
feat: HTTP/2

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1395,7 +1395,11 @@ function write (client, request) {
   let header
 
   if (upgrade) {
-    header = `${method} ${path} HTTP/1.1\r\nconnection: upgrade\r\nupgrade: ${upgrade}\r\n`
+    let connectionString = "upgrade";
+    if (headers.toLowerCase().includes("http2-settings")) {
+      connectionString += ", http2-settings";
+    }
+    header = `${method} ${path} HTTP/1.1\r\nconnection: ${connectionString}\r\nupgrade: ${upgrade}\r\n`
   } else if (client[kPipelining]) {
     header = `${method} ${path} HTTP/1.1\r\nconnection: keep-alive\r\n`
   } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1395,9 +1395,9 @@ function write (client, request) {
   let header
 
   if (upgrade) {
-    let connectionString = "upgrade";
-    if (headers.toLowerCase().includes("http2-settings")) {
-      connectionString += ", http2-settings";
+    let connectionString = 'upgrade'
+    if (headers.toLowerCase().includes('http2-settings')) {
+      connectionString += ', http2-settings'
     }
     header = `${method} ${path} HTTP/1.1\r\nconnection: ${connectionString}\r\nupgrade: ${upgrade}\r\n`
   } else if (client[kPipelining]) {

--- a/lib/http2client.js
+++ b/lib/http2client.js
@@ -1,0 +1,50 @@
+const FRAME_TYPES = [
+	"DATA", // standard request / response payloads
+	"HEADERS", // starts stream, carries request headers
+	"PRIORITY", // advises the priority of a stream
+	"RST_STREAM", // immediately terminates a stream
+	"SETTINGS", // inform other end of endpoint config
+	"PUSH_PROMISE", // pre-warns peer of wanted streams
+	"PING",
+	"GOAWAY", // graceful version of RST_STREAM
+	"WINDOW_UPDATE", // defines flow-control
+	"CONTINUATION" // continue a sequence of headers
+];
+
+function parseHttp2Settings(settings) {
+	// under RFC7540 section 3.2.1, the settings must be a base64url encoded
+	// SETTINGS frame. 16 bit identifiers, 32 bit values. */
+	let parsed = "";
+	for (let i = 0; i < Object.keys(settings).length; i += 2) {
+		parsed += `${settings[i]}${settings[i + 1]}\r\n`;
+	}
+
+	// base64url polyfill, courtesy of @panva
+	let encoded;
+	if (Buffer.isEncoding("base64url")) {
+		encoded = Buffer.from(parsed)
+			.toString("base64url")
+			.replace(/[=]+$/g, "");
+	} else {
+		encoded = Buffer.from(parsed)
+			.toString("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/[=]+$/g, "");
+	}
+	return encoded;
+}
+
+function http2Connect(url, options) {
+	if (url.protocol === "https:") {
+		throw new Error("Invalid protocol - httpConnect upgrades http streams");
+	}
+	throw new Error("UNIMPLEMENTED");
+}
+
+function https2Connect(url, options) {
+	if (url.protocol === "http:") {
+		throw new Error("Invalid protocol - https2Connect upgrades https streams");
+	}
+	throw new Error("UNIMPLEMENTED");
+}

--- a/lib/http2client.js
+++ b/lib/http2client.js
@@ -43,19 +43,24 @@ function parseHttp2Settings(settings) {
 
 function http2Connect(client) {
 	assert(!client[kSocket]);
-	const { protocol, port, hostname } = client[kUrl];
+	const { protocol, port, hostname, pathname } = client[kUrl];
 	if (protocol === "https:") {
 		throw new Error("Invalid protocol - httpConnect upgrades http streams");
 	}
 	// TODO: allow ALT-SVC
 	client.upgrade({
+		path: pathname,
 		protocol: "h2c",
 		headers: {
-			"Connection": "Upgrade, HTTP2-Settings",
-			"Upgrade": "h2c",
-			"HTTP2-Settings": parseHttp2Settings(client[kHTTP2Opts])
+			"HTTP2-Settings": parseHttp2Settings(client[kHTTP2Opts] || {})
 		}
-	});
+	})
+		.then((res) => {
+			// upgrade successful, validate response and use http2
+		})
+		.catch((err) => {
+			// continue as normal
+		});
 }
 
 function https2Connect(client) {
@@ -65,3 +70,5 @@ function https2Connect(client) {
 	}
 	// TODO: tls negotiation comes FIRST
 }
+
+module.exports = http2Connect;

--- a/lib/http2client.js
+++ b/lib/http2client.js
@@ -1,79 +1,80 @@
-"use strict";
+'use strict'
 /* eslint-disable no-unused-vars, max-len, id-length */
 
-const assert = require("assert");
-const { kUrl, kSocket, kHTTP2Opts } = require("./core/symbols");
+const assert = require('assert')
+const { kUrl, kSocket, kHTTP2Opts } = require('./core/symbols')
 
 const FRAME_TYPES = [
-	"DATA", // standard request / response payloads
-	"HEADERS", // starts stream, carries request headers
-	"PRIORITY", // advises the priority of a stream
-	"RST_STREAM", // immediately terminates a stream
-	"SETTINGS", // inform other end of endpoint config
-	"PUSH_PROMISE", // pre-warns peer of wanted streams
-	"PING",
-	"GOAWAY", // graceful version of RST_STREAM
-	"WINDOW_UPDATE", // defines flow-control
-	"CONTINUATION" // continue a sequence of headers
-];
+  'DATA', // standard request / response payloads
+  'HEADERS', // starts stream, carries request headers
+  'PRIORITY', // advises the priority of a stream
+  'RST_STREAM', // immediately terminates a stream
+  'SETTINGS', // inform other end of endpoint config
+  'PUSH_PROMISE', // pre-warns peer of wanted streams
+  'PING',
+  'GOAWAY', // graceful version of RST_STREAM
+  'WINDOW_UPDATE', // defines flow-control
+  'CONTINUATION' // continue a sequence of headers
+]
 
-function parseHttp2Settings(settings) {
-	// under RFC7540 section 3.2.1, the settings must be a base64url encoded
-	// SETTINGS frame. 16 bit identifiers, 32 bit values. */
-	let parsed = "";
-	for (let i = 0; i < Object.keys(settings).length; i += 2) {
-		parsed += `${settings[i]}${settings[i + 1]}\r\n`;
-	}
+function parseHttp2Settings (settings) {
+  // under RFC7540 section 3.2.1, the settings must be a base64url encoded
+  // SETTINGS frame. 16 bit identifiers, 32 bit values. */
+  let parsed = ''
+  for (let i = 0; i < Object.keys(settings).length; i += 2) {
+    parsed += `${settings[i]}${settings[i + 1]}\r\n`
+  }
 
-	// base64url polyfill, courtesy of @panva
-	let encoded;
-	if (Buffer.isEncoding("base64url")) {
-		encoded = Buffer.from(parsed)
-			.toString("base64url")
-			.replace(/[=]+$/g, "");
-	} else {
-		encoded = Buffer.from(parsed)
-			.toString("base64")
-			.replace(/\+/g, "-")
-			.replace(/\//g, "_")
-			.replace(/[=]+$/g, "");
-	}
-	return encoded;
+  // base64url polyfill, courtesy of @panva
+  let encoded
+  if (Buffer.isEncoding('base64url')) {
+    encoded = Buffer.from(parsed)
+      .toString('base64url')
+      .replace(/[=]+$/g, '')
+  } else {
+    encoded = Buffer.from(parsed)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/[=]+$/g, '')
+  }
+  return encoded
 }
 
-function http2Connect(client) {
-	assert(!client[kSocket]);
-	const { protocol, port, hostname, pathname } = client[kUrl];
-	if (protocol === "https:") {
-		throw new Error("Invalid protocol - httpConnect upgrades http streams");
-	}
-	// TODO: allow ALT-SVC
-	client.upgrade({
-		path: pathname,
-		protocol: "h2c",
-		headers: {
-			"HTTP2-Settings": parseHttp2Settings(client[kHTTP2Opts] || {})
-		}
-	})
-		.then((res) => {
-			console.log("hi");
-			console.log(res);
-		})
-		.catch((err) => {
-			if (err.code === "UND_ERR_SOCKET" && err.message === "bad upgrade") {
-				// do not upgrade
-			} else {
-				throw err;
-			}
-		});
+function http2Connect (client) {
+  assert(!client[kSocket])
+  const { protocol, port, hostname, pathname } = client[kUrl]
+  if (protocol === 'https:') {
+    throw new Error('Invalid protocol - httpConnect upgrades http streams')
+  }
+  // TODO: allow ALT-SVC
+  client
+    .upgrade({
+      path: pathname,
+      protocol: 'h2c',
+      headers: {
+        'HTTP2-Settings': parseHttp2Settings(client[kHTTP2Opts] || {})
+      }
+    })
+    .then(res => {
+      console.log('hi')
+      console.log(res)
+    })
+    .catch(err => {
+      if (err.code === 'UND_ERR_SOCKET' && err.message === 'bad upgrade') {
+        // do not upgrade
+      } else {
+        throw err
+      }
+    })
 }
 
-function https2Connect(client) {
-	const { protocol, port, hostname } = client[kUrl];
-	if (protocol === "http:") {
-		throw new Error("Invalid protocol - https2Connect upgrades https streams");
-	}
-	// TODO: tls negotiation comes FIRST
+function https2Connect (client) {
+  const { protocol, port, hostname } = client[kUrl]
+  if (protocol === 'http:') {
+    throw new Error('Invalid protocol - https2Connect upgrades https streams')
+  }
+  // TODO: tls negotiation comes FIRST
 }
 
-module.exports = http2Connect;
+module.exports = http2Connect

--- a/lib/http2client.js
+++ b/lib/http2client.js
@@ -1,3 +1,9 @@
+"use strict";
+/* eslint-disable no-unused-vars, max-len, id-length */
+
+const assert = require("assert");
+const { kUrl, kSocket, kHTTP2Opts } = require("./core/symbols");
+
 const FRAME_TYPES = [
 	"DATA", // standard request / response payloads
 	"HEADERS", // starts stream, carries request headers
@@ -35,16 +41,27 @@ function parseHttp2Settings(settings) {
 	return encoded;
 }
 
-function http2Connect(url, options) {
-	if (url.protocol === "https:") {
+function http2Connect(client) {
+	assert(!client[kSocket]);
+	const { protocol, port, hostname } = client[kUrl];
+	if (protocol === "https:") {
 		throw new Error("Invalid protocol - httpConnect upgrades http streams");
 	}
-	throw new Error("UNIMPLEMENTED");
+	// TODO: allow ALT-SVC
+	client.upgrade({
+		protocol: "h2c",
+		headers: {
+			"Connection": "Upgrade, HTTP2-Settings",
+			"Upgrade": "h2c",
+			"HTTP2-Settings": parseHttp2Settings(client[kHTTP2Opts])
+		}
+	});
 }
 
-function https2Connect(url, options) {
-	if (url.protocol === "http:") {
+function https2Connect(client) {
+	const { protocol, port, hostname } = client[kUrl];
+	if (protocol === "http:") {
 		throw new Error("Invalid protocol - https2Connect upgrades https streams");
 	}
-	throw new Error("UNIMPLEMENTED");
+	// TODO: tls negotiation comes FIRST
 }

--- a/lib/http2client.js
+++ b/lib/http2client.js
@@ -56,10 +56,15 @@ function http2Connect(client) {
 		}
 	})
 		.then((res) => {
-			// upgrade successful, validate response and use http2
+			console.log("hi");
+			console.log(res);
 		})
 		.catch((err) => {
-			// continue as normal
+			if (err.code === "UND_ERR_SOCKET" && err.message === "bad upgrade") {
+				// do not upgrade
+			} else {
+				throw err;
+			}
 		});
 }
 


### PR DESCRIPTION
Inherited from #720 

This relates to...
HTTP/2-3 #399 

## Rationale
HTTP/2 support is one of the few things currently missing from Undici
that sets it behind native Node http.

## Changes
This pull request is a work in progress. There are no changes just
yet. The plan, however, as discussed in the original issue, is to
implement HTTP/2 support around a Dispatcher instance for Pool,
Client and Agent.

Implementation can work in one of the following ways (see RFC7540 and
RFC8740):

## Prior knowledge
- Servers using HTTP/2 can advertise the capability via methods like ALT-SVC
Under RFC7540 Section 3.5, the HTTP/2 connection preface must be sent
All future frames may immediately use the HTTP/2
HTTP/1.1 Initialization (servers where HTTP/2 support status is unknown)
Without prior knowledge, the client should start an HTTP/1.1 connection
using the Upgrade header (h2c for http URI schema, h2 for TLS) and
HTTP2-Settings header
- If the response is a HTTP 101 Switching Protocols request, the request
will be accompanied by a response to prior requests and the connection can
upgrade to HTTP/2. If the response is normal, exempli gratia, a HTTP 200 OK,
the client must not switch to HTTP/2.
As for HTTPS, TLS negotiation must occur prior to any upgrade to HTTP/2.

## Features
HTTP/2 variants of Pool, Client and Agent. Alternatively, an option in the
aforementioned classes that causes them to attempt a HTTP/2 upgrade.

## Bug Fixes
N/A.

## Breaking Changes and Deprecations
N/A.

##Status
KEY: S = Skipped, x = complete

- [ ] I have read and agreed to the Developer's Certificate of Origin
- [ ] Tested
- [ ] Benchmarked (optional)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready