### PR TITLE
fix: remove `authorization` header when redirecting to unknown origins

### DIFF
--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -48,7 +48,7 @@ class RedirectHandler {
     // Remove headers referring to the original URL.
     // By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
     // https://tools.ietf.org/html/rfc7231#section-6.4
-    this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303)
+    this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin)
     this.opts.path = path
     this.opts.origin = origin
     this.opts.maxRedirections = 0
@@ -119,19 +119,20 @@ function parseLocation (statusCode, headers) {
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4.4
-function shouldRemoveHeader (header, removeContent) {
+function shouldRemoveHeader (header, removeContent, unknownOrigin) {
   return (
     (header.length === 4 && header.toString().toLowerCase() === 'host') ||
-    (removeContent && header.toString().toLowerCase().indexOf('content-') === 0)
+    (removeContent && header.toString().toLowerCase().indexOf('content-') === 0) ||
+    (header.length === 13 && header.toString().toLowerCase() === 'authorization' && unknownOrigin)
   )
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4
-function cleanRequestHeaders (headers, removeContent) {
+function cleanRequestHeaders (headers, removeContent, unknownOrigin) {
   const ret = []
   if (Array.isArray(headers)) {
     for (let i = 0; i < headers.length; i += 2) {
-      if (!shouldRemoveHeader(headers[i], removeContent)) {
+      if (!shouldRemoveHeader(headers[i], removeContent, unknownOrigin)) {
         ret.push(headers[i], headers[i + 1])
       }
     }
@@ -139,7 +140,7 @@ function cleanRequestHeaders (headers, removeContent) {
     const keys = Object.keys(headers)
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i]
-      if (!shouldRemoveHeader(key, removeContent)) {
+      if (!shouldRemoveHeader(key, removeContent, unknownOrigin)) {
         ret.push(key, headers[key])
       }
     }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -123,7 +123,7 @@ function shouldRemoveHeader (header, removeContent, unknownOrigin) {
   return (
     (header.length === 4 && header.toString().toLowerCase() === 'host') ||
     (removeContent && header.toString().toLowerCase().indexOf('content-') === 0) ||
-    (header.length === 13 && header.toString().toLowerCase() === 'authorization' && unknownOrigin)
+    (unknownOrigin && header.length === 13 && header.toString().toLowerCase() === 'authorization')
   )
 }
 

--- a/test/redirect-stream.js
+++ b/test/redirect-stream.js
@@ -6,7 +6,8 @@ const {
   startRedirectingServer,
   startRedirectingWithBodyServer,
   startRedirectingChainServers,
-  startRedirectingWithoutLocationServer
+  startRedirectingWithoutLocationServer,
+  startRedirectingWithAuthorization
 } = require('./utils/redirecting-servers')
 const { createReadable, createWritable } = require('./utils/stream')
 
@@ -357,4 +358,21 @@ t.test('should handle errors', async t => {
     t.match(error.code, /EADDRNOTAVAIL|ECONNREFUSED/)
     t.equal(body.length, 0)
   }
+})
+
+t.test('removes authorization header on third party origin', async t => {
+  t.plan(1)
+
+  const body = []
+
+  const [server1] = await startRedirectingWithAuthorization(t, 'secret')
+  await stream(`http://${server1}`, {
+    maxRedirections: 10,
+    opaque: body,
+    headers: {
+      authorization: 'secret'
+    }
+  }, ({ statusCode, headers, opaque }) => createWritable(opaque))
+
+  t.equal(body.length, 0)
 })

--- a/test/utils/redirecting-servers.js
+++ b/test/utils/redirecting-servers.js
@@ -152,10 +152,34 @@ async function startRedirectingChainServers (t) {
   return [server1, server2, server3]
 }
 
+async function startRedirectingWithAuthorization (t, authorization) {
+  const server1 = await startServer(t, (req, res) => {
+    if (req.headers.authorization !== authorization) {
+      res.statusCode = 403
+      res.setHeader('Connection', 'close')
+      res.end('')
+      return
+    }
+
+    res.statusCode = 301
+    res.setHeader('Connection', 'close')
+
+    res.setHeader('Location', `http://${server2}`)
+    res.end('')
+  })
+
+  const server2 = await startServer(t, (req, res) => {
+    res.end(req.headers.authorization || '')
+  })
+
+  return [server1, server2]
+}
+
 module.exports = {
   startServer,
   startRedirectingServer,
   startRedirectingWithBodyServer,
   startRedirectingWithoutLocationServer,
-  startRedirectingChainServers
+  startRedirectingChainServers,
+  startRedirectingWithAuthorization
 }


### PR DESCRIPTION
Fixes #872