### PR TITLE
DispatchOptions: add types for headersTimeout, bodyTimeout; add origin in docs

### DIFF
--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -188,6 +188,7 @@ Returns: `void`
 
 #### Parameter: `DispatchOptions`
 
+* **origin** `string | URL`
 * **path** `string`
 * **method** `string`
 * **body** `string | Buffer | Uint8Array | stream.Readable | Iterable | AsyncIterable | null` (optional) - Default: `null`

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -47,7 +47,11 @@ declare namespace Dispatcher {
     /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceding requests in the pipeline have completed. Default: `true` if `method` is `HEAD` or `GET`. */
     idempotent?: boolean;
     /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
-    upgrade?: boolean | string | null
+    upgrade?: boolean | string | null;
+    /** The amount of time the parser will wait to receive the complete HTTP headers. Defaults to 30 seconds. */
+    headersTimeout?: number | null;
+    /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use 0 to disable it entirely. Defaults to 30 seconds. */
+    bodyTimeout?: number | null;
   }
   export interface ConnectOptions {
     path: string;


### PR DESCRIPTION
Add types for 

- DispatchOptions.headersTimeout
- DispatchOptions.bodyTimeout

Add in docs

- DispatchOptions.origin

Reference

- https://github.com/nodejs/undici/issues/874#issuecomment-880227931