### PR TITLE
 refactor: reduce code duplication

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1478,16 +1478,6 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
 
     assert(socket.destroyed || (socket[kWriting] && client[kRunning] <= 1))
 
-    if (!err) {
-      try {
-        writer.end()
-      } catch (er) {
-        err = er
-      }
-    }
-
-    writer.destroy(err)
-
     socket
       .off('drain', onDrain)
       .off('error', onFinished)
@@ -1497,6 +1487,16 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
       .removeListener('end', onFinished)
       .removeListener('error', onFinished)
       .removeListener('close', onAbort)
+
+    if (!err) {
+      try {
+        writer.end()
+      } catch (er) {
+        err = er
+      }
+    }
+
+    writer.destroy(err)
 
     // TODO (fix): Avoid using err.message for logic.
     if (err && (err.code !== 'UND_ERR_INFO' || err.message !== 'reset')) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -66,8 +66,6 @@ const {
   kMaxRedirections
 } = require('./core/symbols')
 
-function noop () {}
-
 class Client extends Dispatcher {
   constructor (url, {
     maxHeaderSize,
@@ -1444,55 +1442,19 @@ function write (client, request) {
 function writeStream ({ client, request, socket, contentLength, header, expectsPayload }) {
   const { body } = request
 
-  socket[kWriting] = true
-
   assert(contentLength !== 0 || client[kRunning] === 0, 'stream body cannot be pipelined')
 
   let finished = false
-  let bytesWritten = 0
+
+  const writer = new AsyncWriter({ socket, request, contentLength, client, expectsPayload, header })
 
   const onData = function (chunk) {
     try {
       assert(!finished)
 
-      const len = Buffer.byteLength(chunk)
-      if (!len) {
-        return
-      }
-
-      // TODO: What if not ended and bytesWritten === contentLength?
-      // We should defer writing chunks.
-      if (contentLength !== null && bytesWritten + len > contentLength) {
-        if (client[kStrictContentLength]) {
-          util.destroy(socket, new RequestContentLengthMismatchError())
-          return
-        }
-
-        process.emitWarning(new RequestContentLengthMismatchError())
-      }
-
-      if (bytesWritten === 0) {
-        if (!expectsPayload) {
-          socket[kReset] = true
-        }
-
-        if (contentLength === null) {
-          socket.write(`${header}transfer-encoding: chunked\r\n`, 'ascii')
-        } else {
-          socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'ascii')
-        }
-      }
-
-      if (contentLength === null) {
-        socket.write(`\r\n${len.toString(16)}\r\n`, 'ascii')
-      }
-
-      bytesWritten += len
-
-      if (!socket.write(chunk) && this.pause) {
+      if (!writer.write(chunk) && this.pause) {
         this.pause()
       }
-      request.onBodySent(chunk)
     } catch (err) {
       util.destroy(this, err)
     }
@@ -1514,20 +1476,20 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
 
     finished = true
 
-    assert(socket.destroyed || (socket[kWriting] && client[kRunning] <= 1))
-    socket[kWriting] = false
-
-    if (!err && contentLength !== null && bytesWritten !== contentLength) {
-      if (client[kStrictContentLength]) {
-        err = new RequestContentLengthMismatchError()
-      } else {
-        process.emitWarning(new RequestContentLengthMismatchError())
+    if (!err) {
+      try {
+        writer.end()
+      } catch (er) {
+        err = er
       }
     }
 
+    writer.destroy(err)
+
     socket
-      .removeListener('drain', onDrain)
-      .removeListener('error', onFinished)
+      .off('drain', onDrain)
+      .off('error', onFinished)
+
     body
       .removeListener('data', onData)
       .removeListener('end', onFinished)
@@ -1540,40 +1502,6 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
     } else {
       util.destroy(body)
     }
-
-    if (err) {
-      assert(client[kRunning] <= 1, 'pipeline should only contain this request')
-      util.destroy(socket, err)
-    }
-
-    if (socket.destroyed) {
-      return
-    }
-
-    if (bytesWritten === 0) {
-      if (expectsPayload) {
-        // https://tools.ietf.org/html/rfc7230#section-3.3.2
-        // A user agent SHOULD send a Content-Length in a request message when
-        // no Transfer-Encoding is sent and the request method defines a meaning
-        // for an enclosed payload body.
-
-        socket.write(`${header}content-length: 0\r\n\r\n`, 'ascii')
-      } else {
-        socket.write(`${header}\r\n`, 'ascii')
-      }
-    } else if (contentLength === null) {
-      socket.write('\r\n0\r\n\r\n', 'ascii')
-    }
-
-    // TODO (fix): Add comment clarifying what this does?
-    if (socket[kParser].timeout && socket[kParser].timeoutType === TIMEOUT_HEADERS) {
-      // istanbul ignore else: only for jest
-      if (socket[kParser].timeout.refresh) {
-        socket[kParser].timeout.refresh()
-      }
-    }
-
-    resume(client)
   }
 
   body
@@ -1592,31 +1520,32 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
 
   assert(contentLength !== 0 || client[kRunning] === 0, 'iterator body cannot be pipelined')
 
-  let callback = noop
+  let callback = null
   function onDrain () {
-    const cb = callback
-    callback = noop
-    cb()
+    if (callback) {
+      const cb = callback
+      callback = null
+      cb()
+    }
   }
 
-  const waitForDrain = () => new Promise((resolve) => {
+  const waitForDrain = () => new Promise((resolve, reject) => {
     /* istanbul ignore next: assertion */
-    assert(callback === noop)
+    assert(callback === null)
 
     /* istanbul ignore else: only for Node 12 */
-    if (!socket[kError]) {
-      callback = resolve
+    if (socket[kError]) {
+      reject(socket[kError])
     } else {
-      resolve()
+      callback = resolve
     }
   })
 
-  socket[kWriting] = true
   socket
     .on('close', onDrain)
     .on('drain', onDrain)
 
-  let bytesWritten = 0
+  const writer = new AsyncWriter({ socket, request, contentLength, client, expectsPayload, header })
   try {
     // TODO (fix): What if socket errors while waiting for body?
     // It's up to the user to somehow abort the async iterable.
@@ -1625,50 +1554,90 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
         throw socket[kError]
       }
 
-      const len = Buffer.byteLength(chunk)
-      if (!len) {
-        continue
-      }
-
-      // TODO: What if not ended and bytesWritten === contentLength?
-      // We should defer writing chunks.
-      if (contentLength !== null && bytesWritten + len > contentLength) {
-        if (client[kStrictContentLength]) {
-          throw new RequestContentLengthMismatchError()
-        }
-
-        process.emitWarning(new RequestContentLengthMismatchError())
-      }
-
-      if (bytesWritten === 0) {
-        if (!expectsPayload) {
-          socket[kReset] = true
-        }
-
-        if (contentLength === null) {
-          socket.write(`${header}transfer-encoding: chunked\r\n`, 'ascii')
-        } else {
-          socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'ascii')
-        }
-      }
-
-      if (contentLength === null) {
-        socket.write(`\r\n${len.toString(16)}\r\n`, 'ascii')
-      }
-
-      bytesWritten += len
-      if (!socket.write(chunk)) {
+      if (!writer.write(chunk)) {
         await waitForDrain()
-      }
-      request.onBodySent(chunk)
-
-      if (socket[kError]) {
-        throw socket[kError]
       }
     }
 
+    writer.end()
+  } catch (err) {
+    writer.destroy(err)
+  } finally {
+    socket
+      .off('close', onDrain)
+      .off('drain', onDrain)
+  }
+}
+
+class AsyncWriter {
+  constructor ({ socket, request, contentLength, client, expectsPayload, header }) {
+    this.socket = socket
+    this.request = request
+    this.contentLength = contentLength
+    this.client = client
+    this.bytesWritten = 0
+    this.expectsPayload = expectsPayload
+    this.header = header
+
+    socket[kWriting] = true
+  }
+
+  write (chunk) {
+    const { socket, request, contentLength, client, bytesWritten, expectsPayload, header } = this
+
     if (socket[kError]) {
       throw socket[kError]
+    }
+
+    const len = Buffer.byteLength(chunk)
+    if (!len) {
+      return true
+    }
+
+    // TODO: What if not ended and bytesWritten === contentLength?
+    // We should defer writing chunks.
+    if (contentLength !== null && bytesWritten + len > contentLength) {
+      if (client[kStrictContentLength]) {
+        throw new RequestContentLengthMismatchError()
+      }
+
+      process.emitWarning(new RequestContentLengthMismatchError())
+    }
+
+    if (bytesWritten === 0) {
+      if (!expectsPayload) {
+        socket[kReset] = true
+      }
+
+      if (contentLength === null) {
+        socket.write(`${header}transfer-encoding: chunked\r\n`, 'ascii')
+      } else {
+        socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'ascii')
+      }
+    }
+
+    if (contentLength === null) {
+      socket.write(`\r\n${len.toString(16)}\r\n`, 'ascii')
+    }
+
+    this.bytesWritten += len
+
+    const ret = socket.write(chunk)
+    request.onBodySent(chunk)
+    return ret
+  }
+
+  end () {
+    const { socket, contentLength, client, bytesWritten, expectsPayload, header } = this
+
+    socket[kWriting] = false
+
+    if (socket[kError]) {
+      throw socket[kError]
+    }
+
+    if (socket.destroyed) {
+      return
     }
 
     if (bytesWritten === 0) {
@@ -1703,14 +1672,17 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
     }
 
     resume(client)
-  } catch (err) {
-    assert(client[kRunning] <= 1, 'pipeline should only contain this request')
-    util.destroy(socket, err)
-  } finally {
+  }
+
+  destroy (err) {
+    const { socket, client } = this
+
     socket[kWriting] = false
-    socket
-      .off('close', onDrain)
-      .off('drain', onDrain)
+
+    if (err) {
+      assert(client[kRunning] <= 1, 'pipeline should only contain this request')
+      util.destroy(socket, err)
+    }
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1476,6 +1476,8 @@ function writeStream ({ client, request, socket, contentLength, header, expectsP
 
     finished = true
 
+    assert(socket.destroyed || (socket[kWriting] && client[kRunning] <= 1))
+
     if (!err) {
       try {
         writer.end()
@@ -1587,6 +1589,10 @@ class AsyncWriter {
 
     if (socket[kError]) {
       throw socket[kError]
+    }
+
+    if (socket.destroyed) {
+      return false
     }
 
     const len = Buffer.byteLength(chunk)

--- a/lib/client.js
+++ b/lib/client.js
@@ -1535,7 +1535,6 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
     /* istanbul ignore next: assertion */
     assert(callback === null)
 
-    /* istanbul ignore else: only for Node 12 */
     if (socket[kError]) {
       reject(socket[kError])
     } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1532,7 +1532,6 @@ async function writeIterable ({ client, request, socket, contentLength, header, 
   }
 
   const waitForDrain = () => new Promise((resolve, reject) => {
-    /* istanbul ignore next: assertion */
     assert(callback === null)
 
     if (socket[kError]) {


### PR DESCRIPTION
writeIterable and writeStream shared a lot of duplicate logic. 