### PR TITLE
fix: accept URL origin in Agent

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -104,7 +104,12 @@ class Agent extends Dispatcher {
         throw new InvalidArgumentError('opts must be a object.')
       }
 
-      const { origin } = util.parseOrigin(opts.origin)
+      let key
+      if (opts.origin && (typeof opts.origin === 'string' || opts.origin instanceof URL)) {
+        key = String(opts.origin)
+      } else {
+        throw new InvalidArgumentError('opts.origin must be a non-empty string or URL.')
+      }
 
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
@@ -114,18 +119,18 @@ class Agent extends Dispatcher {
         throw new ClientClosedError()
       }
 
-      const ref = this[kClients].get(origin)
+      const ref = this[kClients].get(key)
 
       let dispatcher = ref ? ref.deref() : null
       if (!dispatcher) {
-        dispatcher = this[kFactory](origin, this[kOptions])
+        dispatcher = this[kFactory](opts.origin, this[kOptions])
           .on('drain', this[kOnDrain])
           .on('connect', this[kOnConnect])
           .on('disconnect', this[kOnDisconnect])
           .on('connectionError', this[kOnConnectionError])
 
-        this[kClients].set(origin, new WeakRef(dispatcher))
-        this[kFinalizer].register(dispatcher, origin)
+        this[kClients].set(key, new WeakRef(dispatcher))
+        this[kFinalizer].register(dispatcher, key)
       }
 
       const { maxRedirections = this[kMaxRedirections] } = opts

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -104,7 +104,7 @@ class Agent extends Dispatcher {
         throw new InvalidArgumentError('opts must be a object.')
       }
 
-      const { origin } = util.parseOrigin(opts.origin);
+      const { origin } = util.parseOrigin(opts.origin)
 
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -104,9 +104,7 @@ class Agent extends Dispatcher {
         throw new InvalidArgumentError('opts must be a object.')
       }
 
-      if (typeof opts.origin !== 'string' || opts.origin === '') {
-        throw new InvalidArgumentError('opts.origin must be a non-empty string.')
-      }
+      const { origin } = util.parseOrigin(opts.origin);
 
       if (this[kDestroyed]) {
         throw new ClientDestroyedError()
@@ -116,18 +114,18 @@ class Agent extends Dispatcher {
         throw new ClientClosedError()
       }
 
-      const ref = this[kClients].get(opts.origin)
+      const ref = this[kClients].get(origin)
 
       let dispatcher = ref ? ref.deref() : null
       if (!dispatcher) {
-        dispatcher = this[kFactory](opts.origin, this[kOptions])
+        dispatcher = this[kFactory](origin, this[kOptions])
           .on('drain', this[kOnDrain])
           .on('connect', this[kOnConnect])
           .on('disconnect', this[kOnDisconnect])
           .on('connectionError', this[kOnConnectionError])
 
-        this[kClients].set(opts.origin, new WeakRef(dispatcher))
-        this[kFinalizer].register(dispatcher, opts.origin)
+        this[kClients].set(origin, new WeakRef(dispatcher))
+        this[kFinalizer].register(dispatcher, origin)
       }
 
       const { maxRedirections = this[kMaxRedirections] } = opts

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -58,7 +58,7 @@ function parseURL (url) {
   if (!(url instanceof URL)) {
     const port = url.port != null
       ? url.port
-      : { 'http:': 80, 'https:': 443 }[url.protocol]
+      : (url.protocol === 'https:' ? 443 : 80)
     const origin = url.origin != null
       ? url.origin
       : `${url.protocol}//${url.hostname}:${port}`
@@ -75,7 +75,7 @@ function parseURL (url) {
 function parseOrigin (url) {
   url = parseURL(url)
 
-  if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+  if (url.pathname !== '/' || url.search || url.hash) {
     throw new InvalidArgumentError('invalid url')
   }
 
@@ -91,7 +91,7 @@ function getServerName (host) {
 
   let servername = host
 
-  if (servername.startsWith('[')) {
+  if (servername[0] === '[') {
     const idx = servername.indexOf(']')
 
     assert(idx !== -1)

--- a/test/agent.js
+++ b/test/agent.js
@@ -556,7 +556,7 @@ test('dispatch validations', t => {
   t.throws(() => dispatcher.dispatch('ASD'), InvalidArgumentError, 'throws on missing handler')
   t.throws(() => dispatcher.dispatch('ASD', noopHandler), InvalidArgumentError, 'throws on invalid opts argument type')
   t.throws(() => dispatcher.dispatch({}, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
-  t.throws(() => dispatcher.dispatch({ origin: '' }, noopHandler), TypeError, 'throws on invalid opts.origin argument')
+  t.throws(() => dispatcher.dispatch({ origin: '' }, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
   t.throws(() => dispatcher.dispatch({}, {}), InvalidArgumentError, 'throws on invalid handler.onError')
 
   server.listen(0, () => {

--- a/test/agent.js
+++ b/test/agent.js
@@ -536,17 +536,36 @@ test('dispatch validations', t => {
   const dispatcher = new Agent()
 
   const noopHandler = {
+    onConnect() {},
+    onHeaders() {},
+    onData() {},
+    onComplete() {
+      server.close()
+    },
     onError (err) {
       throw err
     }
   }
 
-  t.plan(5)
+  const server = http.createServer((req, res) => {
+    res.setHeader('Content-Type', 'text/plain')
+    res.end('asd')
+  })
+
+  t.plan(6)
   t.throws(() => dispatcher.dispatch('ASD'), InvalidArgumentError, 'throws on missing handler')
   t.throws(() => dispatcher.dispatch('ASD', noopHandler), InvalidArgumentError, 'throws on invalid opts argument type')
   t.throws(() => dispatcher.dispatch({}, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
-  t.throws(() => dispatcher.dispatch({ origin: '' }, noopHandler), InvalidArgumentError, 'throws on invalid opts.origin argument')
+  t.throws(() => dispatcher.dispatch({ origin: '' }, noopHandler), TypeError, 'throws on invalid opts.origin argument')
   t.throws(() => dispatcher.dispatch({}, {}), InvalidArgumentError, 'throws on invalid handler.onError')
+
+  server.listen(0, () => {
+    t.doesNotThrow(() => dispatcher.dispatch({
+      origin: new URL(`http://localhost:${server.address().port}`),
+      path: '/',
+      method: 'GET'
+    }, noopHandler))
+  })
 })
 
 test('drain', t => {

--- a/test/agent.js
+++ b/test/agent.js
@@ -536,10 +536,10 @@ test('dispatch validations', t => {
   const dispatcher = new Agent()
 
   const noopHandler = {
-    onConnect() {},
-    onHeaders() {},
-    onData() {},
-    onComplete() {
+    onConnect () {},
+    onHeaders () {},
+    onData () {},
+    onComplete () {
       server.close()
     },
     onError (err) {


### PR DESCRIPTION
Fixes #889

```
szm@solus ~/Desktop/undici $ node benchmarks/benchmark.js 
│ Tests               │ Samples │           Result │ Tolerance │ Difference with slowest │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ http - no keepalive │      60 │  5837.63 req/sec │  ± 2.88 % │                       - │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ http - keepalive    │      15 │  9187.24 req/sec │  ± 2.44 % │               + 57.38 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - pipeline   │      25 │ 13515.93 req/sec │  ± 2.76 % │              + 131.53 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - request    │      10 │ 18800.16 req/sec │  ± 2.41 % │              + 222.05 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - stream     │      20 │ 20052.72 req/sec │  ± 2.55 % │              + 243.51 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - dispatch   │      10 │ 22855.44 req/sec │  ± 2.85 % │              + 291.52 % │
```