### PR TITLE
feat: return body as consumable body

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -104,8 +104,11 @@ class Agent extends Dispatcher {
         throw new InvalidArgumentError('opts must be a object.')
       }
 
-      if (typeof opts.origin !== 'string' || opts.origin === '') {
-        throw new InvalidArgumentError('opts.origin must be a non-empty string.')
+      let key
+      if (opts.origin && (typeof opts.origin === 'string' || opts.origin instanceof URL)) {
+        key = String(opts.origin)
+      } else {
+        throw new InvalidArgumentError('opts.origin must be a non-empty string or URL.')
       }
 
       if (this[kDestroyed]) {
@@ -116,7 +119,7 @@ class Agent extends Dispatcher {
         throw new ClientClosedError()
       }
 
-      const ref = this[kClients].get(opts.origin)
+      const ref = this[kClients].get(key)
 
       let dispatcher = ref ? ref.deref() : null
       if (!dispatcher) {
@@ -126,8 +129,8 @@ class Agent extends Dispatcher {
           .on('disconnect', this[kOnDisconnect])
           .on('connectionError', this[kOnConnectionError])
 
-        this[kClients].set(opts.origin, new WeakRef(dispatcher))
-        this[kFinalizer].register(dispatcher, opts.origin)
+        this[kClients].set(key, new WeakRef(dispatcher))
+        this[kFinalizer].register(dispatcher, key)
       }
 
       const { maxRedirections = this[kMaxRedirections] } = opts

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -96,12 +96,12 @@ class Agent extends Dispatcher {
 
   dispatch (opts, handler) {
     if (!handler || typeof handler !== 'object') {
-      throw new InvalidArgumentError('handler')
+      throw new InvalidArgumentError('handler must be an object.')
     }
 
     try {
       if (!opts || typeof opts !== 'object') {
-        throw new InvalidArgumentError('opts must be a object.')
+        throw new InvalidArgumentError('opts must be an object.')
       }
 
       let key

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -25,7 +25,7 @@ class RequestBody extends Readable {
     this[kReadableDidRead] = false
 
     if (typeof this.readableDidRead !== 'boolean') {
-      EE.prototype.on.call(this, 'data', function () {
+      EE.prototype.once.call(this, 'data', function () {
         this[kReadableDidRead] = true
       })
     }
@@ -63,7 +63,6 @@ class Body {
     if (this.bodyUsed) {
       throw new TypeError('disturbed')
     }
-
     return this[kBody]
   }
 
@@ -72,7 +71,10 @@ class Body {
   }
 
   get body () {
-    return this.readableWebStream()
+    if (!this[kBody].toWeb) {
+      throw new TypeError('not supported')
+    }
+    return this[kBody].toWeb()
   }
 
   async blob () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -66,7 +66,7 @@ class Body {
   }
 
   get bodyUsed () {
-    return this[kUsed]
+    return this[kBody].readableDidRead
   }
 
   get body () {
@@ -82,11 +82,9 @@ class Body {
   }
 
   readableNodeStream () {
-    if (this[kUsed]) {
-      throw new Error('readable consumed') // TODO: Proper error.
+    if (this[kBody].readableDidRead) {
+      throw new TypeError('disturbed') // TODO: Proper error.
     }
-
-    this[kUsed] = true
 
     return this[kBody]
   }

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -84,7 +84,7 @@ class Body {
 
     // TODO: Optimize.
     const sources = []
-    for await (const chunk of this.readableNodeStream()) {
+    for await (const chunk of this.stream) {
       // TOOD: max size?
       sources.push(chunk)
     }
@@ -94,7 +94,7 @@ class Body {
   async buffer () {
     // TODO: Optimize.
     const sources = []
-    for await (const chunk of this.readableNodeStream()) {
+    for await (const chunk of this.stream) {
       // TOOD: max size?
       sources.push(chunk)
     }
@@ -107,16 +107,16 @@ class Body {
     return await blob.arrayBuffer()
   }
 
-  * [Symbol.asyncIterator] () {
+  [Symbol.asyncIterator] () {
     // TODO: Optimize.
-    yield * this.readableNodeStream()
+    return this.stream[Symbol.asyncIterator]()
   }
 
   async text () {
     // TODO: Optimize.
     // TODO: Validate content-type req & res headers?
     let ret = ''
-    for await (const chunk of this.readableNodeStream()) {
+    for await (const chunk of this.stream) {
       // TOOD: max size?
       ret += chunk
     }

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Readable, Writable, Duplex } = require('stream')
+const { Duplex } = require('stream')
 const {
   InvalidArgumentError,
   RequestAbortedError
@@ -65,14 +65,6 @@ class Body {
     this[kUsed] = false
   }
 
-  get bodyUsed () {
-    return this[kBody].readableDidRead
-  }
-
-  get body () {
-    return this.readableWebStream()
-  }
-
   [kPush] (chunk) {
     return this[kBody].push(chunk)
   }
@@ -81,7 +73,7 @@ class Body {
     this[kBody].destroy(err)
   }
 
-  readableNodeStream () {
+  get stream () {
     if (this[kBody].readableDidRead) {
       throw new TypeError('disturbed') // TODO: Proper error.
     }
@@ -89,21 +81,12 @@ class Body {
     return this[kBody]
   }
 
-  readableWebStream () {
-    if (!Readable.prototype.asWeb) {
-      throw new Error('not supported') // TODO: Proper error.
-    }
-
-    // TODO: Optimize.
-    return Readable.prototype.asWeb.call(this.readableNodeStream())
+  get bodyUsed () {
+    return this[kBody].readableDidRead
   }
 
-  writableWebStream () {
-    if (!Writable.prototype.asWeb) {
-      throw new Error('not supported') // TODO: Proper error.
-    }
-
-    return Writable.prototype.asWeb.call(this.writableNodeStream())
+  get body () {
+    return this.readableWebStream()
   }
 
   async blob () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Readable } = require('stream')
+const { Readable, Duplex } = require('stream')
 const {
   InvalidArgumentError,
   RequestAbortedError
@@ -19,9 +19,30 @@ const kDestroy = Symbol('destroy')
 const kPush = Symbol('push')
 const kBody = Symbol('body')
 
-class RequestNodeReadable extends Readable {
+class BodyDuplex extends Duplex {
+  constructor (options) {
+    super(options)
+
+    // https://github.com/nodejs/node/pull/34385
+
+    if (options?.readable === false) {
+      this._readableState.readable = false
+      this._readableState.ended = true
+      this._readableState.endEmitted = true
+    }
+
+    if (options?.writable === false) {
+      this._writableState.writable = false
+      this._writableState.ending = true
+      this._writableState.ended = true
+      this._writableState.finished = true
+    }
+  }
+}
+
+class RequestNodeReadable extends BodyDuplex {
   constructor (resume, abort) {
-    super({ autoDestroy: true, read: resume })
+    super({ autoDestroy: true, read: resume, writable: false })
     this[kAbort] = abort
   }
 
@@ -76,8 +97,16 @@ class Body {
   }
 
   readableNodeStream () {
+    return this.nodeStream()
+  }
+
+  writableNodeStream () {
+    // TODO
+  }
+
+  nodeStream () {
     if (this[kBody]) {
-      throw new Error('consumed') // TODO: Proper error.
+      throw new Error('readable consumed') // TODO: Proper error.
     }
 
     this[kBody] = new RequestNodeReadable(this[kResume], this[kAbort])
@@ -95,12 +124,16 @@ class Body {
   }
 
   readableWebStream () {
-    if (!Readable.prototype.toWeb) {
+    if (!Readable.prototype.asWeb) {
       throw new Error('not supported') // TODO: Proper error.
     }
 
     // TODO: Optimize.
-    return this.readableNodeStream().toWeb()
+    return this.readableNodeStream().asWeb()
+  }
+
+  writableWebStream () {
+    // TODO
   }
 
   async blob () {
@@ -115,6 +148,16 @@ class Body {
       sources.push(chunk)
     }
     return new Blob(sources)
+  }
+
+  async buffer () {
+    // TODO: Optimize.
+    const sources = []
+    for await (const chunk of this.readableNodeStream()) {
+      // TOOD: max size?
+      sources.push(chunk)
+    }
+    return Buffer.concat(sources)
   }
 
   async arrayBuffer () {
@@ -136,7 +179,7 @@ class Body {
       // TOOD: max size?
       ret += chunk
     }
-    return JSON.parse(ret)
+    return ret
   }
 
   async json () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -75,7 +75,7 @@ class Body {
 
   get stream () {
     if (this[kBody].readableDidRead) {
-      throw new TypeError('disturbed') // TODO: Proper error.
+      throw new TypeError('disturbed')
     }
 
     return this[kBody]
@@ -91,7 +91,7 @@ class Body {
 
   async blob () {
     if (!Blob) {
-      throw new Error('not supported') // TODO: Proper error.
+      throw new TypeError('not supported')
     }
 
     // TODO: Optimize.

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -9,6 +9,7 @@ const { Blob } = require('buffer')
 const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
+const EE = require('events')
 
 const kAbort = Symbol('abort')
 const kResume = Symbol('resume')
@@ -24,8 +25,7 @@ class RequestBody extends Readable {
     this[kReadableDidRead] = false
 
     if (typeof this.readableDidRead !== 'boolean') {
-      this.pause()
-      this.once('data', function () {
+      EE.prototype.on.call(this, 'data', function () {
         this[kReadableDidRead] = true
       })
     }

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -5,13 +5,21 @@ const {
   InvalidArgumentError,
   RequestAbortedError
 } = require('../core/errors')
+const { Blob } = require('buffer')
 const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
+const assert = require('assert')
 
 const kAbort = Symbol('abort')
+const kResume = Symbol('resume')
+const kError = Symbol('error')
+const kChunk = Symbol('chunk')
+const kDestroy = Symbol('destroy')
+const kPush = Symbol('push')
+const kBody = Symbol('body')
 
-class RequestResponse extends Readable {
+class RequestNodeReadable extends Readable {
   constructor (resume, abort) {
     super({ autoDestroy: true, read: resume })
     this[kAbort] = abort
@@ -27,6 +35,114 @@ class RequestResponse extends Readable {
     }
 
     callback(err)
+  }
+}
+
+class Body {
+  constructor (resume, abort) {
+    this[kAbort] = abort
+    this[kResume] = resume
+    this[kBody] = null
+    this[kChunk] = null
+    this[kError] = undefined
+  }
+
+  [kPush] (chunk) {
+    if (!this[kBody]) {
+      assert(!this[kChunk])
+      this[kChunk] = chunk
+      return false
+    }
+
+    if (chunk === null) {
+      this[kError] = null
+    }
+
+    return this[kBody].push(chunk)
+  }
+
+  [kDestroy] (err) {
+    if (!err && this[kError] === undefined) {
+      err = new RequestAbortedError()
+    }
+
+    this[kError] = null
+
+    if (this[kBody]) {
+      this[kBody].destroy(err)
+    } else {
+      this[kError] = err
+    }
+  }
+
+  readableNodeStream () {
+    if (this[kBody]) {
+      throw new Error('consumed') // TODO: Proper error.
+    }
+
+    this[kBody] = new RequestNodeReadable(this[kResume], this[kAbort])
+
+    if (this[kChunk]) {
+      this[kBody].push(this[kChunk])
+      this[kChunk] = null
+    }
+
+    if (this[kError] !== undefined) {
+      util.destroy(this[kBody], this[kError])
+    }
+
+    return this[kBody]
+  }
+
+  readableWebStream () {
+    if (!Readable.prototype.toWeb) {
+      throw new Error('not supported') // TODO: Proper error.
+    }
+
+    // TODO: Optimize.
+    return this.readableNodeStream().toWeb()
+  }
+
+  async blob () {
+    if (!Blob) {
+      throw new Error('not supported') // TODO: Proper error.
+    }
+
+    // TODO: Optimize.
+    const sources = []
+    for await (const chunk of this.readableNodeStream()) {
+      // TOOD: max size?
+      sources.push(chunk)
+    }
+    return new Blob(sources)
+  }
+
+  async arrayBuffer () {
+    // TODO: Optimize.
+    const blob = await this.blob()
+    return await blob.arrayBuffer()
+  }
+
+  * [Symbol.asyncIterator] () {
+    // TODO: Optimize.
+    yield * this.readableNodeStream()
+  }
+
+  async text () {
+    // TODO: Optimize.
+    // TODO: Validate content-type req & res headers?
+    let ret = ''
+    for await (const chunk of this.readableNodeStream()) {
+      // TOOD: max size?
+      ret += chunk
+    }
+    return JSON.parse(ret)
+  }
+
+  async json () {
+    // TODO: Optimize.
+    // TODO: Validate content-type req & res headers?
+    return JSON.parse(await this.text())
   }
 }
 
@@ -92,7 +208,7 @@ class RequestHandler extends AsyncResource {
       return
     }
 
-    const body = new RequestResponse(resume, abort)
+    const body = new Body(resume, abort)
 
     this.callback = null
     this.res = body
@@ -109,7 +225,7 @@ class RequestHandler extends AsyncResource {
 
   onData (chunk) {
     const { res } = this
-    return res.push(chunk)
+    return res[kPush](chunk)
   }
 
   onComplete (trailers) {
@@ -119,7 +235,7 @@ class RequestHandler extends AsyncResource {
 
     util.parseHeaders(trailers, this.trailers)
 
-    res.push(null)
+    res[kPush](null)
   }
 
   onError (err) {
@@ -139,13 +255,13 @@ class RequestHandler extends AsyncResource {
       this.res = null
       // Ensure all queued handlers are invoked before destroying res.
       queueMicrotask(() => {
-        util.destroy(res, err)
+        res[kDestroy](err)
       })
     }
 
     if (body) {
       this.body = null
-      util.destroy(body, err)
+      util.destroy(this.body, err)
     }
   }
 }

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -38,7 +38,7 @@ class BodyDuplex extends Duplex {
     }
   }
 }
-class RequestNodeReadable extends BodyDuplex {
+class RequestDuplex extends BodyDuplex {
   constructor (resume, abort) {
     super({ autoDestroy: true, read: resume, writable: false })
     this[kAbort] = abort
@@ -61,7 +61,7 @@ class Body {
   constructor (resume, abort) {
     this[kAbort] = abort
     this[kResume] = resume
-    this[kBody] = new RequestNodeReadable(this[kResume], this[kAbort]).on('error', () => {})
+    this[kBody] = new RequestDuplex(this[kResume], this[kAbort]).on('error', () => {})
     this[kState] = { readable: true, writable: true }
   }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Duplex } = require('stream')
+const { Readable } = require('stream')
 const {
   InvalidArgumentError,
   RequestAbortedError
@@ -15,33 +15,20 @@ const kResume = Symbol('resume')
 const kDestroy = Symbol('destroy')
 const kPush = Symbol('push')
 const kBody = Symbol('body')
-const kUsed = Symbol('state')
+const kReadableDidRead = Symbol('readableDidRead')
 
-// This is needed for pre node 17.
-class BodyDuplex extends Duplex {
-  constructor (options) {
-    super(options)
-
-    // https://github.com/nodejs/node/pull/34385
-
-    if (options?.readable === false) {
-      this._readableState.readable = false
-      this._readableState.ended = true
-      this._readableState.endEmitted = true
-    }
-
-    if (options?.writable === false) {
-      this._writableState.writable = false
-      this._writableState.ending = true
-      this._writableState.ended = true
-      this._writableState.finished = true
-    }
-  }
-}
-class RequestDuplex extends BodyDuplex {
+class RequestBody extends Readable {
   constructor (resume, abort) {
     super({ autoDestroy: true, read: resume, writable: false })
     this[kAbort] = abort
+    this[kReadableDidRead] = false
+
+    if (typeof this.readableDidRead !== 'boolean') {
+      this.pause()
+      this.once('data', function () {
+        this[kReadableDidRead] = true
+      })
+    }
   }
 
   _destroy (err, callback) {
@@ -61,8 +48,7 @@ class Body {
   constructor (resume, abort) {
     this[kAbort] = abort
     this[kResume] = resume
-    this[kBody] = new RequestDuplex(this[kResume], this[kAbort]).on('error', () => {})
-    this[kUsed] = false
+    this[kBody] = new RequestBody(this[kResume], this[kAbort]).on('error', () => {})
   }
 
   [kPush] (chunk) {
@@ -74,7 +60,7 @@ class Body {
   }
 
   get stream () {
-    if (this[kBody].readableDidRead) {
+    if (this.bodyUsed) {
       throw new TypeError('disturbed')
     }
 
@@ -82,7 +68,7 @@ class Body {
   }
 
   get bodyUsed () {
-    return this[kBody].readableDidRead
+    return this[kBody].readableDidRead || this[kBody][kReadableDidRead]
   }
 
   get body () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -65,6 +65,14 @@ class Body {
     this[kState] = { readable: true, writable: true }
   }
 
+  get readable () {
+    return true
+  }
+
+  get writable () {
+    return false
+  }
+
   [kPush] (chunk) {
     return this[kBody].push(chunk)
   }

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -21,7 +21,7 @@ const kBody = Symbol('body')
 
 class BodyDuplex extends Duplex {
   constructor (options) {
-    super(options)
+    super({ autoDestroy: true, ...options })
 
     // https://github.com/nodejs/node/pull/34385
 
@@ -42,7 +42,7 @@ class BodyDuplex extends Duplex {
 
 class RequestNodeReadable extends BodyDuplex {
   constructor (resume, abort) {
-    super({ autoDestroy: true, read: resume, writable: false })
+    super({ read: resume, writable: false })
     this[kAbort] = abort
   }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Readable, Duplex } = require('stream')
+const { Readable, Writable, Duplex } = require('stream')
 const {
   InvalidArgumentError,
   RequestAbortedError
@@ -9,19 +9,18 @@ const { Blob } = require('buffer')
 const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
-const assert = require('assert')
 
 const kAbort = Symbol('abort')
 const kResume = Symbol('resume')
-const kError = Symbol('error')
-const kChunk = Symbol('chunk')
 const kDestroy = Symbol('destroy')
 const kPush = Symbol('push')
 const kBody = Symbol('body')
+const kState = Symbol('state')
 
+// This is needed for pre node 17.
 class BodyDuplex extends Duplex {
   constructor (options) {
-    super({ autoDestroy: true, ...options })
+    super(options)
 
     // https://github.com/nodejs/node/pull/34385
 
@@ -39,10 +38,9 @@ class BodyDuplex extends Duplex {
     }
   }
 }
-
 class RequestNodeReadable extends BodyDuplex {
   constructor (resume, abort) {
-    super({ read: resume, writable: false })
+    super({ autoDestroy: true, read: resume, writable: false })
     this[kAbort] = abort
   }
 
@@ -63,62 +61,49 @@ class Body {
   constructor (resume, abort) {
     this[kAbort] = abort
     this[kResume] = resume
-    this[kBody] = null
-    this[kChunk] = null
-    this[kError] = undefined
+    this[kBody] = new RequestNodeReadable(this[kResume], this[kAbort]).on('error', () => {})
+    this[kState] = { readable: true, writable: true }
   }
 
   [kPush] (chunk) {
-    if (!this[kBody]) {
-      assert(!this[kChunk])
-      this[kChunk] = chunk
-      return false
-    }
-
-    if (chunk === null) {
-      this[kError] = null
-    }
-
     return this[kBody].push(chunk)
   }
 
   [kDestroy] (err) {
-    if (!err && this[kError] === undefined) {
-      err = new RequestAbortedError()
-    }
-
-    this[kError] = null
-
-    if (this[kBody]) {
-      this[kBody].destroy(err)
-    } else {
-      this[kError] = err
-    }
+    this[kBody].destroy(err)
   }
 
   readableNodeStream () {
-    return this.nodeStream()
-  }
-
-  writableNodeStream () {
-    // TODO
-  }
-
-  nodeStream () {
-    if (this[kBody]) {
+    if (!this[kState].readable) {
       throw new Error('readable consumed') // TODO: Proper error.
     }
 
-    this[kBody] = new RequestNodeReadable(this[kResume], this[kAbort])
+    this[kState].readable = false
 
-    if (this[kChunk]) {
-      this[kBody].push(this[kChunk])
-      this[kChunk] = null
+    return this[kBody]
+  }
+
+  writableNodeStream () {
+    if (!this[kState].writable) {
+      throw new Error('writable consumed') // TODO: Proper error.
     }
 
-    if (this[kError] !== undefined) {
-      util.destroy(this[kBody], this[kError])
+    this[kState].writable = false
+
+    return this[kBody]
+  }
+
+  nodeStream () {
+    if (!this[kState].readable) {
+      throw new Error('readable consumed') // TODO: Proper error.
     }
+
+    if (!this[kState].writable) {
+      throw new Error('writable consumed') // TODO: Proper error.
+    }
+
+    this[kState].readable = false
+    this[kState].writable = false
 
     return this[kBody]
   }
@@ -129,11 +114,15 @@ class Body {
     }
 
     // TODO: Optimize.
-    return this.readableNodeStream().asWeb()
+    return Readable.prototype.asWeb.call(this.readableNodeStream())
   }
 
   writableWebStream () {
-    // TODO
+    if (!Writable.prototype.asWeb) {
+      throw new Error('not supported') // TODO: Proper error.
+    }
+
+    return Writable.prototype.asWeb.call(this.writableNodeStream())
   }
 
   async blob () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -15,7 +15,7 @@ const kResume = Symbol('resume')
 const kDestroy = Symbol('destroy')
 const kPush = Symbol('push')
 const kBody = Symbol('body')
-const kState = Symbol('state')
+const kUsed = Symbol('state')
 
 // This is needed for pre node 17.
 class BodyDuplex extends Duplex {
@@ -62,15 +62,15 @@ class Body {
     this[kAbort] = abort
     this[kResume] = resume
     this[kBody] = new RequestDuplex(this[kResume], this[kAbort]).on('error', () => {})
-    this[kState] = { readable: true, writable: true }
+    this[kUsed] = false
   }
 
-  get readable () {
-    return true
+  get bodyUsed () {
+    return this[kUsed]
   }
 
-  get writable () {
-    return false
+  get body () {
+    return this.readableWebStream()
   }
 
   [kPush] (chunk) {
@@ -82,36 +82,11 @@ class Body {
   }
 
   readableNodeStream () {
-    if (!this[kState].readable) {
+    if (this[kUsed]) {
       throw new Error('readable consumed') // TODO: Proper error.
     }
 
-    this[kState].readable = false
-
-    return this[kBody]
-  }
-
-  writableNodeStream () {
-    if (!this[kState].writable) {
-      throw new Error('writable consumed') // TODO: Proper error.
-    }
-
-    this[kState].writable = false
-
-    return this[kBody]
-  }
-
-  nodeStream () {
-    if (!this[kState].readable) {
-      throw new Error('readable consumed') // TODO: Proper error.
-    }
-
-    if (!this[kState].writable) {
-      throw new Error('writable consumed') // TODO: Proper error.
-    }
-
-    this[kState].readable = false
-    this[kState].writable = false
+    this[kUsed] = true
 
     return this[kBody]
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -245,12 +245,12 @@ class Client extends Dispatcher {
 
   dispatch (opts, handler) {
     if (!handler || typeof handler !== 'object') {
-      throw new InvalidArgumentError('handler')
+      throw new InvalidArgumentError('handler must be an object')
     }
 
     try {
       if (!opts || typeof opts !== 'object') {
-        throw new InvalidArgumentError('opts must be a object.')
+        throw new InvalidArgumentError('opts must be an object.')
       }
 
       if (this[kDestroyed]) {
@@ -1093,7 +1093,7 @@ function connect (client) {
   let { host, hostname, protocol, port } = client[kUrl]
 
   // Resolve ipv6
-  if (hostname.startsWith('[')) {
+  if (hostname[0] === '[') {
     const idx = hostname.indexOf(']')
 
     assert(idx !== -1)

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -79,15 +79,17 @@ class Connector {
     socket
       .setNoDelay(true)
       .once(protocol === 'https:' ? 'secureConnect' : 'connect', function () {
-        if (callback) {
-          clearTimeout(timeout)
+        clearTimeout(timeout)
 
+        if (callback) {
           const cb = callback
           callback = null
           cb(null, this)
         }
       })
       .on('error', function (err) {
+        clearTimeout(timeout)
+
         if (callback) {
           const cb = callback
           callback = null

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -97,35 +97,7 @@ class Request {
       throw new InvalidArgumentError('headers must be an object or an array')
     }
 
-    if (typeof handler.onConnect !== 'function') {
-      throw new InvalidArgumentError('invalid onConnect method')
-    }
-
-    if (typeof handler.onError !== 'function') {
-      throw new InvalidArgumentError('invalid onError method')
-    }
-
-    if (typeof handler.onBodySent !== 'function' && handler.onBodySent !== undefined) {
-      throw new InvalidArgumentError('invalid onBodySent method')
-    }
-
-    if (this.upgrade || this.method === 'CONNECT') {
-      if (typeof handler.onUpgrade !== 'function') {
-        throw new InvalidArgumentError('invalid onUpgrade method')
-      }
-    } else {
-      if (typeof handler.onHeaders !== 'function') {
-        throw new InvalidArgumentError('invalid onHeaders method')
-      }
-
-      if (typeof handler.onData !== 'function') {
-        throw new InvalidArgumentError('invalid onData method')
-      }
-
-      if (typeof handler.onComplete !== 'function') {
-        throw new InvalidArgumentError('invalid onComplete method')
-      }
-    }
+    util.validateHandler(handler, method, upgrade)
 
     this.servername = util.getServerName(this.host)
 

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -188,6 +188,42 @@ function isBuffer (buffer) {
   return buffer instanceof Uint8Array || Buffer.isBuffer(buffer)
 }
 
+function validateHandler (handler, method, upgrade) {
+  if (!handler || typeof handler !== 'object') {
+    throw new InvalidArgumentError('handler must be an object')
+  }
+
+  if (typeof handler.onConnect !== 'function') {
+    throw new InvalidArgumentError('invalid onConnect method')
+  }
+
+  if (typeof handler.onError !== 'function') {
+    throw new InvalidArgumentError('invalid onError method')
+  }
+
+  if (typeof handler.onBodySent !== 'function' && handler.onBodySent !== undefined) {
+    throw new InvalidArgumentError('invalid onBodySent method')
+  }
+
+  if (upgrade || method === 'CONNECT') {
+    if (typeof handler.onUpgrade !== 'function') {
+      throw new InvalidArgumentError('invalid onUpgrade method')
+    }
+  } else {
+    if (typeof handler.onHeaders !== 'function') {
+      throw new InvalidArgumentError('invalid onHeaders method')
+    }
+
+    if (typeof handler.onData !== 'function') {
+      throw new InvalidArgumentError('invalid onData method')
+    }
+
+    if (typeof handler.onComplete !== 'function') {
+      throw new InvalidArgumentError('invalid onComplete method')
+    }
+  }
+}
+
 module.exports = {
   nop,
   parseOrigin,
@@ -203,5 +239,6 @@ module.exports = {
   destroy,
   bodyLength,
   deepClone,
-  isBuffer
+  isBuffer,
+  validateHandler
 }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -58,7 +58,7 @@ function parseURL (url) {
   if (!(url instanceof URL)) {
     const port = url.port != null
       ? url.port
-      : { 'http:': 80, 'https:': 443 }[url.protocol]
+      : (url.protocol === 'https:' ? 443 : 80)
     const origin = url.origin != null
       ? url.origin
       : `${url.protocol}//${url.hostname}:${port}`
@@ -75,7 +75,7 @@ function parseURL (url) {
 function parseOrigin (url) {
   url = parseURL(url)
 
-  if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+  if (url.pathname !== '/' || url.search || url.hash) {
     throw new InvalidArgumentError('invalid url')
   }
 
@@ -91,7 +91,7 @@ function getServerName (host) {
 
   let servername = host
 
-  if (servername.startsWith('[')) {
+  if (servername[0] === '[') {
     const idx = servername.indexOf(']')
 
     assert(idx !== -1)

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -12,6 +12,8 @@ class RedirectHandler {
       throw new InvalidArgumentError('maxRedirections must be a positive number')
     }
 
+    util.validateHandler(handler, opts.method, opts.upgrade)
+
     this.dispatcher = dispatcher
     this.location = null
     this.abort = null

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -162,7 +162,7 @@ class Pool extends Dispatcher {
 
   dispatch (opts, handler) {
     if (!handler || typeof handler !== 'object') {
-      throw new InvalidArgumentError('handler')
+      throw new InvalidArgumentError('handler must be an object')
     }
 
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undici",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "An HTTP/1.1 client, written from scratch for Node.js",
   "homepage": "https://undici.nodejs.org",
   "bugs": {

--- a/test/abort-controller.js
+++ b/test/abort-controller.js
@@ -61,10 +61,11 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
       client.request({ path: '/', method: 'GET' }, (err, response) => {
         t.error(err)
         const bufs = []
-        response.body.on('data', (buf) => {
+        const stream = response.body.readableNodeStream()
+        stream.on('data', (buf) => {
           bufs.push(buf)
         })
-        response.body.on('end', () => {
+        stream.on('end', () => {
           t.equal('hello', Buffer.concat(bufs).toString('utf8'))
         })
       })
@@ -136,10 +137,11 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
 
       client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.error(err)
-        response.body.on('data', () => {
+        const stream = response.body.readableNodeStream()
+        stream.on('data', () => {
           abortController.abort()
         })
-        response.body.on('error', err => {
+        stream.on('error', err => {
           t.type(err, errors.RequestAbortedError)
         })
       })

--- a/test/abort-controller.js
+++ b/test/abort-controller.js
@@ -61,7 +61,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
       client.request({ path: '/', method: 'GET' }, (err, response) => {
         t.error(err)
         const bufs = []
-        const stream = response.body.readableNodeStream()
+        const stream = response.body.stream
         stream.on('data', (buf) => {
           bufs.push(buf)
         })
@@ -137,7 +137,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
 
       client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
         t.error(err)
-        const stream = response.body.readableNodeStream()
+        const stream = response.body.stream
         stream.on('data', () => {
           abortController.abort()
         })

--- a/test/agent.js
+++ b/test/agent.js
@@ -280,7 +280,7 @@ test('with globalAgent', t => {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.on('data', (buf) => {
           bufs.push(buf)
         })
@@ -317,7 +317,7 @@ test('with local agent', t => {
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
 
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.on('data', (buf) => {
           bufs.push(buf)
         })

--- a/test/agent.js
+++ b/test/agent.js
@@ -280,10 +280,11 @@ test('with globalAgent', t => {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        body.on('data', (buf) => {
+        const stream = body.readableNodeStream()
+        stream.on('data', (buf) => {
           bufs.push(buf)
         })
-        body.on('end', () => {
+        stream.on('end', () => {
           t.equal(wanted, Buffer.concat(bufs).toString('utf8'))
         })
       })
@@ -315,10 +316,12 @@ test('with local agent', t => {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        body.on('data', (buf) => {
+
+        const stream = body.readableNodeStream()
+        stream.on('data', (buf) => {
           bufs.push(buf)
         })
-        body.on('end', () => {
+        stream.on('end', () => {
           t.equal(wanted, Buffer.concat(bufs).toString('utf8'))
         })
       })

--- a/test/async_hooks.js
+++ b/test/async_hooks.js
@@ -57,7 +57,7 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
@@ -66,7 +66,7 @@ test('async hooks', (t) => {
       client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world2' })
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.once('data', () => {
           t.pass()
           stream.resume()
@@ -80,7 +80,7 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
@@ -90,7 +90,7 @@ test('async hooks', (t) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world' })
 
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.once('data', () => {
           t.pass()
           stream.resume()
@@ -104,7 +104,7 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'HEAD' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
@@ -114,7 +114,7 @@ test('async hooks', (t) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world' })
 
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.once('data', () => {
           t.pass()
           stream.resume()
@@ -164,7 +164,7 @@ test('async hooks client is destroyed', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.resume()
       stream.on('error', (err) => {
         t.ok(err)

--- a/test/async_hooks.js
+++ b/test/async_hooks.js
@@ -57,7 +57,8 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      body.resume()
+      const stream = body.readableNodeStream()
+      stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
       setCurrentTransaction({ hello: 'world2' })
@@ -65,13 +66,13 @@ test('async hooks', (t) => {
       client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world2' })
-
-        body.once('data', () => {
+        const stream = body.readableNodeStream()
+        stream.once('data', () => {
           t.pass()
-          body.resume()
+          stream.resume()
         })
 
-        body.on('end', () => {
+        stream.on('end', () => {
           t.pass()
         })
       })
@@ -79,7 +80,8 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      body.resume()
+      const stream = body.readableNodeStream()
+      stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
       setCurrentTransaction({ hello: 'world' })
@@ -88,12 +90,13 @@ test('async hooks', (t) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world' })
 
-        body.once('data', () => {
+        const stream = body.readableNodeStream()
+        stream.once('data', () => {
           t.pass()
-          body.resume()
+          stream.resume()
         })
 
-        body.on('end', () => {
+        stream.on('end', () => {
           t.pass()
         })
       })
@@ -101,7 +104,8 @@ test('async hooks', (t) => {
 
     client.request({ path: '/', method: 'HEAD' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      body.resume()
+      const stream = body.readableNodeStream()
+      stream.resume()
       t.strictSame(getCurrentTransaction(), null)
 
       setCurrentTransaction({ hello: 'world' })
@@ -110,12 +114,13 @@ test('async hooks', (t) => {
         t.error(err)
         t.strictSame(getCurrentTransaction(), { hello: 'world' })
 
-        body.once('data', () => {
+        const stream = body.readableNodeStream()
+        stream.once('data', () => {
           t.pass()
-          body.resume()
+          stream.resume()
         })
 
-        body.on('end', () => {
+        stream.on('end', () => {
           t.pass()
         })
       })
@@ -159,8 +164,9 @@ test('async hooks client is destroyed', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { body }) => {
       t.error(err)
-      body.resume()
-      body.on('error', (err) => {
+      const stream = body.readableNodeStream()
+      stream.resume()
+      stream.on('error', (err) => {
         t.ok(err)
       })
       t.strictSame(getCurrentTransaction(), null)

--- a/test/client-abort.js
+++ b/test/client-abort.js
@@ -24,7 +24,7 @@ test('aborted response errors', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.destroy()
       body
         .on('error', err => {

--- a/test/client-abort.js
+++ b/test/client-abort.js
@@ -24,7 +24,8 @@ test('aborted response errors', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      body.destroy()
+      const stream = body.readableNodeStream()
+      stream.destroy()
       body
         .on('error', err => {
           t.type(err, errors.RequestAbortedError)

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -18,7 +18,7 @@ test('dispatch invalid opts', (t) => {
     }, null)
   } catch (err) {
     t.type(err, errors.InvalidArgumentError)
-    t.equal(err.message, 'handler')
+    t.equal(err.message, 'handler must be an object')
   }
 
   try {
@@ -29,7 +29,7 @@ test('dispatch invalid opts', (t) => {
     }, 'asd')
   } catch (err) {
     t.type(err, errors.InvalidArgumentError)
-    t.equal(err.message, 'handler')
+    t.equal(err.message, 'handler must be an object')
   }
 
   client.dispatch({

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -45,7 +45,7 @@ test('GET errors and reconnect with pipelining 1', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.on('data', (buf) => {
         bufs.push(buf)
       })
@@ -101,7 +101,7 @@ test('GET errors and reconnect with pipelining 3', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.on('data', (buf) => {
         bufs.push(buf)
       })
@@ -171,7 +171,7 @@ function errorAndPipelining (type) {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.on('data', (buf) => {
           bufs.push(buf)
         })
@@ -241,7 +241,7 @@ function errorAndChunkedEncodingPipelining (type) {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        const stream = body.readableNodeStream()
+        const stream = body.stream
         stream.on('data', (buf) => {
           bufs.push(buf)
         })
@@ -708,7 +708,7 @@ test('GET errors body', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.resume()
       stream.on('error', err => (
         t.ok(err)
@@ -759,7 +759,7 @@ test('validate request body', (t) => {
       body: ''
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -768,7 +768,7 @@ test('validate request body', (t) => {
       body: new Uint8Array()
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -777,7 +777,7 @@ test('validate request body', (t) => {
       body: Buffer.alloc(10)
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })
@@ -908,7 +908,7 @@ test('queued request should not fail on socket destroy', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume().on('error', () => {
+      data.body.stream.resume().on('error', () => {
         t.pass()
       })
       client[kSocket].destroy()
@@ -917,7 +917,7 @@ test('queued request should not fail on socket destroy', (t) => {
         method: 'GET'
       }, (err, data) => {
         t.error(err)
-        data.body.resume().on('end', () => {
+        data.body.stream.resume().on('end', () => {
           t.pass()
         })
       })
@@ -946,7 +946,7 @@ test('queued request should fail on client destroy', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
         .on('error', () => {
           t.pass()
         })
@@ -998,14 +998,14 @@ test('retry idempotent inflight', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
     client.request({
       path: '/',
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -45,10 +45,11 @@ test('GET errors and reconnect with pipelining 1', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      body.on('data', (buf) => {
+      const stream = body.readableNodeStream()
+      stream.on('data', (buf) => {
         bufs.push(buf)
       })
-      body.on('end', () => {
+      stream.on('end', () => {
         t.equal('hello', Buffer.concat(bufs).toString('utf8'))
       })
     })
@@ -100,10 +101,11 @@ test('GET errors and reconnect with pipelining 3', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      body.on('data', (buf) => {
+      const stream = body.readableNodeStream()
+      stream.on('data', (buf) => {
         bufs.push(buf)
       })
-      body.on('end', () => {
+      stream.on('end', () => {
         t.equal('hello', Buffer.concat(bufs).toString('utf8'))
       })
     })
@@ -169,10 +171,11 @@ function errorAndPipelining (type) {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        body.on('data', (buf) => {
+        const stream = body.readableNodeStream()
+        stream.on('data', (buf) => {
           bufs.push(buf)
         })
-        body.on('end', () => {
+        stream.on('end', () => {
           t.equal('hello', Buffer.concat(bufs).toString('utf8'))
         })
       })
@@ -238,10 +241,11 @@ function errorAndChunkedEncodingPipelining (type) {
         t.equal(statusCode, 200)
         t.equal(headers['content-type'], 'text/plain')
         const bufs = []
-        body.on('data', (buf) => {
+        const stream = body.readableNodeStream()
+        stream.on('data', (buf) => {
           bufs.push(buf)
         })
-        body.on('end', () => {
+        stream.on('end', () => {
           t.equal('hello', Buffer.concat(bufs).toString('utf8'))
         })
       })
@@ -704,8 +708,9 @@ test('GET errors body', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.error(err)
-      body.resume()
-      body.on('error', err => (
+      const stream = body.readableNodeStream()
+      stream.resume()
+      stream.on('error', err => (
         t.ok(err)
       ))
     })

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -497,7 +497,7 @@ test('pipeline abort duplex', (t) => {
       method: 'PUT'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
 
       client.pipeline({
         path: '/',

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -149,16 +149,17 @@ test('pipeline 1 is 1 active request', (t) => {
         method: 'GET'
       }, (err, data) => {
         t.error(err)
-        finished(data.body, (err) => {
+        const stream = data.body.stream
+        finished(stream, (err) => {
           t.ok(err)
           client.close((err) => {
             t.error(err)
           })
         })
-        data.body.destroy()
+        stream.destroy()
         res2.end()
       }))
-      data.body.resume()
+      data.body.stream.resume()
       res2.end()
     })
     t.ok(client[kSize] <= client.pipelining)
@@ -194,7 +195,7 @@ test('pipelined chunked POST stream', (t) => {
       path: '/',
       method: 'GET'
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -207,7 +208,7 @@ test('pipelined chunked POST stream', (t) => {
         }
       })
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -215,7 +216,7 @@ test('pipelined chunked POST stream', (t) => {
       path: '/',
       method: 'GET'
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -228,7 +229,7 @@ test('pipelined chunked POST stream', (t) => {
         }
       })
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
   })
@@ -261,7 +262,7 @@ test('pipelined chunked POST iterator', (t) => {
       path: '/',
       method: 'GET'
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -274,7 +275,7 @@ test('pipelined chunked POST iterator', (t) => {
         }
       })()
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -282,7 +283,7 @@ test('pipelined chunked POST iterator', (t) => {
       path: '/',
       method: 'GET'
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
 
@@ -295,7 +296,7 @@ test('pipelined chunked POST iterator', (t) => {
         }
       })()
     }, (err, { body }) => {
-      body.resume()
+      body.stream.resume()
       t.error(err)
     })
   })
@@ -398,7 +399,7 @@ test('pipelining non-idempotent', (t) => {
     }, (err, data) => {
       t.error(err)
       t.equal(ended, true)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })
@@ -455,7 +456,7 @@ function pipeliningNonIdempotentWithBody (bodyType) {
       }, (err, data) => {
         t.error(err)
         t.equal(ended, true)
-        data.body.resume()
+        data.body.stream.resume()
       })
     })
   })

--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -29,6 +29,7 @@ test('multiple reconnect', (t) => {
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       t.error(err)
       data.body
+        .stream
         .resume()
         .on('end', () => {
           t.pass()

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -93,6 +93,7 @@ test('trailers', (t) => {
     })
 
     body
+      .stream
       .on('data', () => t.fail())
       .on('end', () => {
         t.strictSame(trailers, { 'content-md5': 'test' })

--- a/test/client-unref.js
+++ b/test/client-unref.js
@@ -23,14 +23,22 @@ if (isMainThread) {
       })
     })
   })
+
+  tap.test('client automatically closes itself if the server is not there', t => {
+    t.plan(1)
+
+    const url = 'http://localhost:4242' // hopefully empty port
+    const worker = new Worker(__filename, { workerData: { url } })
+    worker.on('exit', code => {
+      t.equal(code, 0)
+    })
+  })
 } else {
   const { Client } = require('..')
 
   const client = new Client(workerData.url)
-  client.request({ path: '/', method: 'GET' }, (err, res) => {
-    if (err) {
-      throw err
-    }
+  client.request({ path: '/', method: 'GET' }, () => {
+    // We do not care about Errors
 
     setTimeout(() => {
       throw new Error()

--- a/test/client.js
+++ b/test/client.js
@@ -778,7 +778,7 @@ test('ignore request header mutations', (t) => {
       headers
     }, (err, { body }) => {
       t.error(err)
-      body.resume()
+      body.stream.resume()
     })
     headers.test = 'asd'
   })
@@ -802,7 +802,7 @@ test('url-like url', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })
@@ -828,7 +828,7 @@ test('an absolute url as path', (t) => {
 
     client.request({ path, method: 'GET' }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })
@@ -885,14 +885,14 @@ test('only one streaming req at a time', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
 
       client.request({
         path: '/',
         method: 'GET'
       }, (err, data) => {
         t.error(err)
-        data.body.resume()
+        data.body.stream.resume()
       })
 
       client.request({
@@ -941,14 +941,14 @@ test('only one async iterating req at a time', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
 
       client.request({
         path: '/',
         method: 'GET'
       }, (err, data) => {
         t.error(err)
-        data.body.resume()
+        data.body.stream.resume()
       })
       const body = wrapWithAsyncIterable(new Readable({
         read () {
@@ -1317,7 +1317,7 @@ test('parser pause with no body timeout', (t) => {
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, body }) => {
       t.error(err)
       t.equal(statusCode, 200)
-      body.resume()
+      body.stream.resume()
     })
   })
 })
@@ -1340,7 +1340,7 @@ test('TypedArray and DataView body', (t) => {
     client.request({ path: '/', method: 'POST', body }, (err, { statusCode, body }) => {
       t.error(err)
       t.equal(statusCode, 200)
-      body.resume()
+      body.stream.resume()
     })
   })
 })
@@ -1376,7 +1376,7 @@ test('async iterator empty chunk continues', (t) => {
     client.request({ path: '/', method: 'POST', body }, (err, { statusCode, body }) => {
       t.error(err)
       t.equal(statusCode, 200)
-      body.resume()
+      body.stream.resume()
     })
   })
 })

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -171,7 +171,7 @@ test('close should still reconnect', (t) => {
     function makeRequest () {
       client.request({ path: '/', method: 'GET' }, (err, data) => {
         t.error(err)
-        data.body.resume()
+        data.body.stream.resume()
       })
       return client[kSize] <= client.pipelining
     }
@@ -203,7 +203,7 @@ test('close should call callback once finished', (t) => {
     function makeRequest () {
       client.request({ path: '/', method: 'GET' }, (err, data) => {
         t.error(err)
-        data.body.resume()
+        data.body.stream.resume()
       })
       return client[kSize] <= client.pipelining
     }

--- a/test/gc.js
+++ b/test/gc.js
@@ -48,7 +48,7 @@ test('gc should collect the client if, and only if, there are no active sockets'
       method: 'GET'
     }, (err, { body }) => {
       t.error(err)
-      body.resume()
+      body.stream.resume()
     })
   })
 })
@@ -92,7 +92,7 @@ test('gc should collect the pool if, and only if, there are no active sockets', 
       method: 'GET'
     }, (err, { body }) => {
       t.error(err)
-      body.resume()
+      body.stream.resume()
     })
   })
 })

--- a/test/get-head-body.js
+++ b/test/get-head-body.js
@@ -30,7 +30,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     const emptyBody = new Readable({
@@ -43,7 +43,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -56,7 +56,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -70,7 +70,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -79,7 +79,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -92,7 +92,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
 
     client.request({
@@ -106,7 +106,7 @@ test('GET and HEAD with body should reset connection', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
   })
 })
@@ -153,7 +153,7 @@ test('HEAD should reset connection', (t) => {
       method: 'HEAD'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
     })
     t.equal(client[kBusy], true)
 
@@ -162,7 +162,7 @@ test('HEAD should reset connection', (t) => {
       method: 'HEAD'
     }, (err, data) => {
       t.error(err)
-      data.body.resume()
+      data.body.stream.resume()
       client.once('disconnect', () => {
         client[kConnect](() => {
           client.request({
@@ -170,10 +170,11 @@ test('HEAD should reset connection', (t) => {
             method: 'HEAD'
           }, (err, data) => {
             t.error(err)
-            data.body.resume()
-            data.body.on('end', () => {
-              t.pass()
-            })
+            data.body.stream
+              .resume()
+              .on('end', () => {
+                t.pass()
+              })
           })
           t.equal(client[kBusy], true)
         })

--- a/test/http-req-destroy.js
+++ b/test/http-req-destroy.js
@@ -19,8 +19,9 @@ function doNotKillReqSocket (bodyType) {
         body: req
       }, (err, response) => {
         t.error(err)
+        const stream = response.body.stream
         setTimeout(() => {
-          response.body.on('data', buf => {
+          stream.on('data', buf => {
             res.write(buf)
             setTimeout(() => {
               res.end()
@@ -51,11 +52,12 @@ function doNotKillReqSocket (bodyType) {
       }, (err, response) => {
         t.error(err)
         const bufs = []
-        response.body.on('data', (buf) => {
+        const stream = response.body.stream
+        stream.on('data', (buf) => {
           bufs.push(buf)
           r.push(null)
         })
-        response.body.on('end', () => {
+        stream.on('end', () => {
           t.equal('hello', Buffer.concat(bufs).toString('utf8'))
         })
       })

--- a/test/https.js
+++ b/test/https.js
@@ -29,10 +29,11 @@ test('https get with tls opts', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      body.on('data', (buf) => {
+      const stream = body.readableNodeStream()
+      stream.on('data', (buf) => {
         bufs.push(buf)
       })
-      body.on('end', () => {
+      stream.on('end', () => {
         t.equal('hello', Buffer.concat(bufs).toString('utf8'))
       })
     })

--- a/test/https.js
+++ b/test/https.js
@@ -29,7 +29,7 @@ test('https get with tls opts', (t) => {
       t.equal(statusCode, 200)
       t.equal(headers['content-type'], 'text/plain')
       const bufs = []
-      const stream = body.readableNodeStream()
+      const stream = body.stream
       stream.on('data', (buf) => {
         bufs.push(buf)
       })

--- a/test/issue-803.js
+++ b/test/issue-803.js
@@ -36,7 +36,7 @@ test('https://github.com/nodejs/undici/issues/803', (t) => {
       t.error(err)
 
       let pos = 0
-      const stream = data.body.readableNodeStream()
+      const stream = data.body.stream
       stream.on('data', (buf) => {
         pos += buf.length
       })

--- a/test/issue-803.js
+++ b/test/issue-803.js
@@ -36,10 +36,11 @@ test('https://github.com/nodejs/undici/issues/803', (t) => {
       t.error(err)
 
       let pos = 0
-      data.body.on('data', (buf) => {
+      const stream = data.body.readableNodeStream()
+      stream.on('data', (buf) => {
         pos += buf.length
       })
-      data.body.on('end', () => {
+      stream.on('end', () => {
         t.equal(pos, SIZE)
       })
     })

--- a/test/issue-810.js
+++ b/test/issue-810.js
@@ -30,7 +30,8 @@ test('https://github.com/mcollina/undici/issues/810', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume().on('end', () => {
+      const stream = data.body.readableNodeStream()
+      stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => (
         t.type(err, errors.HTTPParserError)
@@ -64,7 +65,8 @@ test('https://github.com/mcollina/undici/issues/810 no pipelining', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume().on('end', () => {
+      const stream = data.body.readableNodeStream()
+      stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => {
         t.equal(err.code, 'HPE_CB_MESSAGE_BEGIN')

--- a/test/issue-810.js
+++ b/test/issue-810.js
@@ -30,7 +30,7 @@ test('https://github.com/mcollina/undici/issues/810', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      const stream = data.body.readableNodeStream()
+      const stream = data.body.stream
       stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => (
@@ -65,7 +65,7 @@ test('https://github.com/mcollina/undici/issues/810 no pipelining', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      const stream = data.body.readableNodeStream()
+      const stream = data.body.stream
       stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => {
@@ -95,7 +95,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume().on('end', () => {
+      data.body.stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => {
         t.equal(err.code, 'HPE_CB_MESSAGE_BEGIN')
@@ -124,7 +124,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining 2', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.error(err)
-      data.body.resume().on('end', () => {
+      data.body.stream.resume().on('end', () => {
         t.fail()
       }).on('error', err => {
         t.equal(err.code, 'HPE_INVALID_CONSTANT')

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -92,7 +92,7 @@ test('MockAgent - get', t => {
 })
 
 test('MockAgent - dispatch', t => {
-  t.plan(2)
+  t.plan(3)
 
   t.test('should call the dispatch method of the MockPool', (t) => {
     t.plan(1)
@@ -116,7 +116,8 @@ test('MockAgent - dispatch', t => {
     }, {
       onHeaders: (_statusCode, _headers, resume) => resume(),
       onData: () => {},
-      onComplete: () => {}
+      onComplete: () => {},
+      onError: () => {}
     }))
   })
 
@@ -142,8 +143,92 @@ test('MockAgent - dispatch', t => {
     }, {
       onHeaders: (_statusCode, _headers, resume) => resume(),
       onData: () => {},
-      onComplete: () => {}
+      onComplete: () => {},
+      onError: () => {}
     }))
+  })
+
+  t.test('should throw if handler is not valid on redirect', (t) => {
+    t.plan(7)
+
+    const baseUrl = 'http://localhost:9999'
+
+    const mockAgent = new MockAgent()
+    t.teardown(mockAgent.close.bind(mockAgent))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: 'INVALID'
+    }), new InvalidArgumentError('invalid onError method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: 'INVALID'
+    }), new InvalidArgumentError('invalid onConnect method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: () => {},
+      onBodySent: 'INVALID'
+    }), new InvalidArgumentError('invalid onBodySent method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'CONNECT'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: () => {},
+      onBodySent: () => {},
+      onUpgrade: 'INVALID'
+    }), new InvalidArgumentError('invalid onUpgrade method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: () => {},
+      onBodySent: () => {},
+      onHeaders: 'INVALID'
+    }), new InvalidArgumentError('invalid onHeaders method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: () => {},
+      onBodySent: () => {},
+      onHeaders: () => {},
+      onData: 'INVALID'
+    }), new InvalidArgumentError('invalid onData method'))
+
+    t.throws(() => mockAgent.dispatch({
+      origin: baseUrl,
+      path: '/foo',
+      method: 'GET'
+    }, {
+      onError: (err) => { throw err },
+      onConnect: () => {},
+      onBodySent: () => {},
+      onHeaders: () => {},
+      onData: () => {},
+      onComplete: 'INVALID'
+    }), new InvalidArgumentError('invalid onComplete method'))
   })
 })
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -49,7 +49,7 @@ test('connect/disconnect event(s)', (t) => {
         method: 'GET'
       }, (err, { headers, body }) => {
         t.error(err)
-        body.resume()
+        body.stream.resume()
       })
     }
   })
@@ -185,7 +185,7 @@ test('basic get with async/await', async (t) => {
   t.equal(statusCode, 200)
   t.equal(headers['content-type'], 'text/plain')
 
-  body.resume()
+  body.stream.resume()
   await promisify(eos)(body)
 
   await client.close()

--- a/test/socket-back-pressure.js
+++ b/test/socket-back-pressure.js
@@ -43,7 +43,7 @@ test('socket back-pressure', (t) => {
           setTimeout(() => {
             t.ok(data.body._readableState.length < bytesWritten - data.body._readableState.highWaterMark)
             src.push(null)
-            data.body.resume()
+            data.body.stream.resume()
           }, 1e3)
         })
         .on('end', () => {

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -70,7 +70,7 @@ test('A client should disable session caching', {
         client.request(options, (err, data) => {
           t.error(err)
           clientSessions[options.name] = client[kSocket].getSession()
-          data.body.resume().on('end', () => {
+          data.body.stream.resume().on('end', () => {
             if (queue.length !== 0) {
               return request()
             }
@@ -156,7 +156,7 @@ test('A pool should be able to reuse TLS sessions between clients', {
             path: '/'
           }, (err, data) => {
             if (err) return reject(err)
-            data.body.resume().on('end', resolve)
+            data.body.stream.resume().on('end', resolve)
           })
         })
       }


### PR DESCRIPTION
Change undici.request to return a Body object with
various consume helpers instead of regular node stream.

This aligns with recent work on quic and web streams in
node core.