### PR TITLE
fix: broken link for examples on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,10 @@
       auto2top: true,
       subMaxLevel: 3,
       maxLevel: 3,
-      themeColor: '#2B91F0'
+      themeColor: '#2B91F0',
+      noCompileLinks: [
+        'benchmarks/.*'
+      ]
     }
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
Fixes the broken `examples` link for website

Related issue: https://github.com/nodejs/undici/issues/868

**Broken link (current behaviour)**
![broken_example](https://user-images.githubusercontent.com/20289185/126730736-97c6888d-4f38-4680-b1a7-0e5918272337.gif)

**Fixed link**
![fixed_example](https://user-images.githubusercontent.com/20289185/126730740-aaf95be6-5990-437b-a1bb-7b78d8d3a390.gif)

Solution using `noCompileLinks` that was created from a similar problem. More details on Docsify issue: https://github.com/docsifyjs/docsify/issues/203