### PR TITLE
Types: improve connect options

### DIFF
--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -29,8 +29,13 @@ Returns: `Client`
 
 #### Parameter: `ConnectOptions`
 
+Every Tls option, see [here](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
+Furthermore, the following options can be passed:
+
 * **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
 * **maxCachedSessions** `number | null` (optional) - Default: `100` - Maximum number of TLS cached sessions. Use 0 to disable TLS session caching. Default: 100.
+* **timeout** `number | null` (optional) -  Default `10e3`
+* **servername** `string | null` (optional)
 
 ### Example - Basic Client instantiation
 

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -6,7 +6,7 @@ import { URL } from 'url'
 expectAssignable<Client>(new Client(''))
 expectAssignable<Client>(new Client('', {}))
 expectAssignable<Client>(new Client('', {
-  tls: { rejectUnauthorized: false }
+  connect: { rejectUnauthorized: false }
 }))
 expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -5,6 +5,9 @@ import { URL } from 'url'
 
 expectAssignable<Client>(new Client(''))
 expectAssignable<Client>(new Client('', {}))
+expectAssignable<Client>(new Client('', {
+  tls: { rejectUnauthorized: false }
+}))
 expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
 
 {

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -26,7 +26,7 @@ declare namespace Client {
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
     pipelining?: number | null;
     /** **/
-    connect?: object | Function | null;
+    connect?: ConnectOptions | Function | null;
     /** The maximum length of request headers in bytes. Default: `16384` (16KiB). */
     maxHeaderSize?: number | null;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `30e3` milliseconds (30s). */
@@ -35,7 +35,14 @@ declare namespace Client {
     headersTimeout?: number | null;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
     strictContentLength?: boolean;
-    /** An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback). Default: `null`. */
+    /** @deprecated use the connect option instead */
     tls?: TlsOptions | null;
+  }
+
+  export interface ConnectOptions extends TlsOptions {
+    maxCachedSessions?: number | null;
+    socketPath?: string | null;
+    timeout?: number | null;
+    servername?: string | null;
   }
 }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,4 +1,5 @@
 import { URL } from 'url'
+import { TlsOptions } from 'tls'
 import Dispatcher from './dispatcher'
 
 export = Client
@@ -33,6 +34,8 @@ declare namespace Client {
     /** The amount of time the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `30e3` milliseconds (30s). */
     headersTimeout?: number | null;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
-    strictContentLength?: boolean
+    strictContentLength?: boolean;
+    /** An options object which in the case of `https` will be passed to [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback). Default: `null`. */
+    tls?: TlsOptions | null;
   }
 }


### PR DESCRIPTION
It looks like the `tls` options has been removed form the types by accident, this pr adds it back.