### PR TITLE
Types: changes origin to be optional on Client and Pool

### DIFF
--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -21,6 +21,7 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   // request
   expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: '' }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ path: '/', method: 'GET' }))
   expectAssignable<void>(client.request({ origin: '', path: '', method: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
@@ -93,6 +94,7 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   }))
 
   // dispatch
+  expectAssignable<void>(client.dispatch({ path: '', method: '' }, {}))
   expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '' }, {}))
   expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: [] }, {}))
   expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: {} }, {}))

--- a/test/types/pool.test-d.ts
+++ b/test/types/pool.test-d.ts
@@ -18,6 +18,7 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   expectAssignable<boolean>(pool.destroyed)
 
   // request
+  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ path: '', method: '' }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: '' }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }))
   expectAssignable<void>(pool.request({ origin: '', path: '', method: '' }, (err, data) => {
@@ -86,6 +87,7 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   }))
 
   // dispatch
+  expectAssignable<void>(pool.dispatch({ path: '', method: '' }, {}))
   expectAssignable<void>(pool.dispatch({ origin: '', path: '', method: '' }, {}))
   expectAssignable<void>(pool.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
 

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url'
 import { TlsOptions } from 'tls'
-import Dispatcher from './dispatcher'
+import Dispatcher, { DispatchOptions, RequestOptions } from './dispatcher'
 
 export = Client
 
@@ -13,6 +13,11 @@ declare class Client extends Dispatcher {
   closed: boolean;
   /** `true` after `client.destroyed()` has been called or `client.close()` has been called and the client shutdown has completed. */
   destroyed: boolean;
+  /** Dispatches a request. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
+  dispatch(options: Client.ClientDispatchOptions, handler: Dispatcher.DispatchHandlers): void;
+  /** Performs an HTTP request. */
+  request(options: Client.ClientRequestOptions): Promise<Dispatcher.ResponseData>;
+  request(options: Client.ClientRequestOptions, callback: (err: Error | null, data: Dispatcher.ResponseData) => void): void;
 }
 
 declare namespace Client {
@@ -44,5 +49,13 @@ declare namespace Client {
     socketPath?: string | null;
     timeout?: number | null;
     servername?: string | null;
+  }
+
+  export interface ClientDispatchOptions extends Partial<DispatchOptions> {
+    origin?: string | URL;
+  }
+
+  export interface ClientRequestOptions extends Partial<RequestOptions> {
+    origin?: string | URL;
   }
 }

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -1,5 +1,5 @@
 import Client from './client'
-import Dispatcher from './dispatcher'
+import Dispatcher, { DispatchOptions, RequestOptions } from './dispatcher'
 import { URL } from 'url'
 
 export = Pool
@@ -10,6 +10,11 @@ declare class Pool extends Dispatcher {
   closed: boolean;
   /** `true` after `pool.destroyed()` has been called or `pool.close()` has been called and the pool shutdown has completed. */
   destroyed: boolean;
+  /** Dispatches a request. This API is expected to evolve through semver-major versions and is less stable than the preceding higher level APIs. It is primarily intended for library developers who implement higher level APIs on top of this. */
+  dispatch(options: Pool.PoolDispatchOptions, handler: Dispatcher.DispatchHandlers): void;
+  /** Performs an HTTP request. */
+  request(options: Pool.PoolRequestOptions): Promise<Dispatcher.ResponseData>;
+  request(options: Pool.PoolRequestOptions, callback: (err: Error | null, data: Dispatcher.ResponseData) => void): void;
 }
 
 declare namespace Pool {
@@ -18,5 +23,13 @@ declare namespace Pool {
     factory?(origin: URL, opts: object): Dispatcher;
     /** The max number of clients to create. `null` if no limit. Default `null`. */
     connections?: number | null;
+  }
+
+  export interface PoolDispatchOptions extends Partial<DispatchOptions> {
+    origin?: string | URL;
+  }
+
+  export interface PoolRequestOptions extends Partial<RequestOptions> {
+    origin?: string | URL;
   }
 }


### PR DESCRIPTION
After PR https://github.com/nodejs/undici/pull/733 `origin` was set to be optional on Client and Pool. This PR fixes the type definitions of `origin` to be optional on `dispatch` and `request` of Client and Pool

Related issue: https://github.com/nodejs/undici/issues/900