### PR TITLE
fix: fetch response is not Readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ https://fetch.spec.whatwg.org/
 
 Implements [fetch](https://fetch.spec.whatwg.org/).
 
+Only supported on Node 16+.
+
 This is [experimental](https://nodejs.org/api/documentation.html#documentation_stability_index) and is not yet fully compliant the Fetch Standard. We plan to ship breaking changes to this feature until it is out of experimental.
 
 Arguments:

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -307,36 +307,11 @@ client.dispatch({
 
 ### `Dispatcher.fetch(options)`
 
-Performs a HTTP request.
-
 Implements [fetch](https://fetch.spec.whatwg.org/).
 
+Only supported on Node 16+.
+
 This is [experimental](https://nodejs.org/api/documentation.html#documentation_stability_index) and is not yet fully compliant the Fetch Standard. We plan to ship breaking changes to this feature until it is out of experimental.
-
-Arguments:
-
-* **options** `FetchOptions`
-
-Returns: `Promise<FetchResponse>`
-
-#### Parameter: `FetchOptions`
-
-Extends: [`DispatchOptions`](#parameter-dispatchoptions)
-
-**headers** `HeadersInit`
-**body** `BodyInit?`
-**keepalive** `boolean`
-**signal** `AbortSignal?`
-
-#### Parameter: `FetchResponse`
-
-* **type** `ResponseType`
-* **url** `string`
-* **redirected** `boolean`
-* **status** `number`
-* **ok** `boolean`
-* **statusText** `string` Always empty string.
-* **headers** `Headers`
 
 ### `Dispatcher.pipeline(options, handler)`
 

--- a/lib/api/api-fetch.js
+++ b/lib/api/api-fetch.js
@@ -5,7 +5,6 @@
 const Headers = require('./headers')
 const { kHeadersList } = require('../core/symbols')
 const { Readable } = require('stream')
-const { ReadableStream, TransformStream } = require('stream/web')
 const { METHODS } = require('http')
 const {
   InvalidArgumentError,
@@ -23,6 +22,9 @@ const kStatus = Symbol('status')
 const kUrlList = Symbol('url list')
 const kHeaders = Symbol('headers')
 const kBody = Symbol('body')
+
+let ReadableStream
+let TransformStream
 
 class Response {
   constructor ({
@@ -212,6 +214,9 @@ class FetchHandler extends AsyncResource {
       }
     } else {
       const self = this
+      if (!ReadableStream) {
+        ReadableStream = require('stream/web').ReadableStream
+      }
       response = new Response({
         type: 'default',
         url: this.url,
@@ -438,6 +443,10 @@ function extractBody (body) {
     } else {
       if (body.locked) {
         throw new TypeError('locked')
+      }
+
+      if (!TransformStream) {
+        TransformStream = require('stream/web').TransformStream
       }
 
       // https://streams.spec.whatwg.org/#readablestream-create-a-proxy

--- a/lib/api/api-fetch.js
+++ b/lib/api/api-fetch.js
@@ -2,9 +2,10 @@
 
 'use strict'
 
-const Body = require('./readable')
 const Headers = require('./headers')
 const { kHeadersList } = require('../core/symbols')
+const { Readable } = require('stream')
+const { ReadableStream, TransformStream } = require('stream/web')
 const { METHODS } = require('http')
 const {
   InvalidArgumentError,
@@ -14,37 +15,33 @@ const {
 const util = require('../core/util')
 const { AsyncResource } = require('async_hooks')
 const { addSignal, removeSignal } = require('./abort-signal')
-const { isBlob } = require('buffer')
+const { isBlob, Blob } = require('buffer')
+const assert = require('assert')
 
 const kType = Symbol('type')
 const kStatus = Symbol('status')
 const kUrlList = Symbol('url list')
 const kHeaders = Symbol('headers')
+const kBody = Symbol('body')
 
-class Response extends Body {
+class Response {
   constructor ({
     type,
     url,
-    resume,
-    abort,
+    body,
     statusCode,
     headers,
     context
   }) {
-    super(resume, abort)
-
     this[kType] = type || 'default'
     this[kStatus] = statusCode || 0
-    this[kUrlList] = [url]
-    this[kHeaders] = headers
+    this[kUrlList] = Array.isArray(url) ? url : (url ? [url] : [])
+    this[kHeaders] = headers || new Headers()
+    this[kBody] = body || null
 
     if (context && context.history) {
       this[kUrlList].push(...context.history)
     }
-
-    this.on('error', function () {
-      // Swallow error? Avoid unhandled exception.
-    })
   }
 
   get type () {
@@ -69,7 +66,7 @@ class Response extends Body {
   }
 
   get statusText () {
-    // TODO: Implement
+    // TODO: Implement.
     return ''
   }
 
@@ -77,13 +74,73 @@ class Response extends Body {
     return this[kHeaders]
   }
 
+  async blob () {
+    const chunks = []
+    if (this.body) {
+      if (this.bodyUsed || this.body.locked) {
+        throw new TypeError('unusable')
+      }
+
+      for await (const chunk of this.body) {
+        chunks.push(chunk)
+      }
+    }
+    return new Blob(chunks)
+  }
+
+  async arrayBuffer () {
+    const blob = await this.blob()
+    return await blob.arrayBuffer()
+  }
+
+  async text () {
+    const blob = await this.blob()
+    return await blob.text()
+  }
+
+  async json () {
+    return JSON.parse(await this.text())
+  }
+
+  async formData () {
+    // TODO: Implement.
+    throw new NotSupportedError('formData')
+  }
+
+  get body () {
+    return this[kBody]
+  }
+
+  get bodyUsed () {
+    return util.isDisturbed(this.body)
+  }
+
   clone () {
-    if (this.bodyUsed) {
-      throw TypeError('Cannot clone Response - body is unusable')
+    let body = null
+
+    if (this[kBody]) {
+      if (util.isDisturbed(this[kBody])) {
+        throw new TypeError('disturbed')
+      }
+
+      if (this[kBody].locked) {
+        throw new TypeError('locked')
+      }
+
+      // https://fetch.spec.whatwg.org/#concept-body-clone
+      const [out1, out2] = this[kBody].tee()
+
+      this[kBody] = out1
+      body = out2
     }
 
-    // TODO: Implement.
-    throw new NotSupportedError()
+    return new Response({
+      type: this[kType],
+      statusCode: this[kStatus],
+      url: this[kUrlList],
+      headers: this[kHeaders],
+      body
+    })
   }
 }
 
@@ -93,43 +150,31 @@ class FetchHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    const { signal, method, opaque, body } = opts
+    const { signal, method, opaque } = opts
 
-    try {
-      if (typeof callback !== 'function') {
-        throw new InvalidArgumentError('invalid callback')
-      }
-
-      if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
-        throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
-      }
-
-      if (method === 'CONNECT') {
-        throw new InvalidArgumentError('invalid method')
-      }
-
-      super('UNDICI_FETCH')
-    } catch (err) {
-      if (util.isStream(body)) {
-        util.destroy(body.on('error', util.nop), err)
-      }
-      throw err
+    if (typeof callback !== 'function') {
+      throw new InvalidArgumentError('invalid callback')
     }
+
+    if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
+      throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
+    }
+
+    if (method === 'CONNECT') {
+      throw new InvalidArgumentError('invalid method')
+    }
+
+    super('UNDICI_FETCH')
 
     this.opaque = opaque || null
     this.callback = callback
-    this.res = null
+    this.chunk = undefined
+    this.controller = null
+
     this.abort = null
-    this.body = body
     this.context = null
     this.redirect = opts.redirect || 'follow'
     this.url = new URL(opts.path, opts.origin)
-
-    if (util.isStream(body)) {
-      body.on('error', (err) => {
-        this.onError(err)
-      })
-    }
 
     addSignal(this, signal)
   }
@@ -152,32 +197,43 @@ class FetchHandler extends AsyncResource {
 
     headers = new Headers(headers)
 
-    let body
-
+    let response
     if (headers.has('location')) {
       if (this.redirect === 'manual') {
-        body = new Response({
+        response = new Response({
           type: 'opaqueredirect',
           url: this.url
         })
-        // TODO (fix): Should be "null" body.
-        // TODO (fix): What to do with Readable?
-        util.destroy(body)
       } else {
-        body = new Response({
+        response = new Response({
           type: 'error',
           url: this.url
         })
-        // TODO (fix): Should be "null" body.
-        // TODO (fix): What to do with Readable?
-        util.destroy(body, new Error('redirect'))
       }
     } else {
-      body = new Response({
+      const self = this
+      response = new Response({
         type: 'default',
         url: this.url,
-        resume,
-        abort,
+        body: new ReadableStream({
+          async start (controller) {
+            self.controller = controller
+            if (self.chunk === null) {
+              self.controller.close()
+            } else if (self.chunk) {
+              self.controller.enqueue(self.chunk)
+              self.chunk = null
+            }
+          },
+          async pull () {
+            resume()
+            // TODO: Does this need to await something?
+          },
+          async cancel (reason) {
+            abort()
+            // TODO: Does this need to await something?
+          }
+        }, { highWaterMark: 16384 }),
         statusCode,
         headers,
         context
@@ -185,26 +241,44 @@ class FetchHandler extends AsyncResource {
     }
 
     this.callback = null
-    this.res = body
 
-    this.runInAsyncScope(callback, null, null, body)
+    this.runInAsyncScope(callback, null, null, response)
   }
 
   onData (chunk) {
-    const { res } = this
-    return res.push(chunk)
+    const { controller } = this
+
+    // Copy the Buffer to detach it from Buffer pool.
+    // TODO: Is this required?
+    chunk = new Uint8Array(chunk)
+
+    if (!controller) {
+      assert(this.chunk === undefined)
+      this.chunk = chunk
+      return false
+    }
+
+    controller.enqueue(chunk)
+
+    return controller.desiredSize > 0
   }
 
   onComplete (trailers) {
-    const { res } = this
+    const { controller } = this
 
     removeSignal(this)
 
-    res.push(null)
+    if (!controller) {
+      assert(this.chunk === undefined)
+      this.chunk = null
+      return
+    }
+
+    controller.close()
   }
 
   onError (err) {
-    const { res, callback, body, opaque } = this
+    const { controller, callback, body, opaque } = this
 
     removeSignal(this)
 
@@ -216,11 +290,11 @@ class FetchHandler extends AsyncResource {
       })
     }
 
-    if (res) {
-      this.res = null
+    if (controller) {
+      this.controller = null
       // Ensure all queued handlers are invoked before destroying res.
       queueMicrotask(() => {
-        util.destroy(res, err)
+        controller.cancel(err)
       })
     }
 
@@ -231,88 +305,85 @@ class FetchHandler extends AsyncResource {
   }
 }
 
-function fetch (opts, callback) {
-  if (callback === undefined) {
-    return new Promise((resolve, reject) => {
-      fetch.call(this, opts, (err, data) => {
-        return err ? reject(err) : resolve(data)
-      })
-    })
+function fetch (opts) {
+  // TODO: Should we throw sync or async?
+
+  if (opts.referrer) {
+    // TODO: Implement
+    throw new NotSupportedError()
   }
 
-  try {
-    if (opts.referrer) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
+  if (opts.referrerPolicy) {
+    // TODO: Implement
+    throw new NotSupportedError()
+  }
 
-    if (opts.referrerPolicy) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
+  if (opts.mode) {
+    // TODO: Implement
+    throw new NotSupportedError()
+  }
 
-    if (opts.mode) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
+  if (opts.credentials) {
+    // TODO: Implement
+    throw new NotSupportedError()
+  }
 
-    if (opts.credentials) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
+  if (opts.cache) {
+    // TODO: Implement
+    throw new NotSupportedError()
+  }
 
-    if (opts.cache) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
+  if (opts.redirect != null) {
+    // TODO: Validate
+  } else {
+    opts.redirect = 'follow'
+  }
 
-    if (opts.redirect != null) {
-      // TODO: Validate
+  if (opts.method != null) {
+    opts.method = normalizeAndValidateRequestMethod(opts.method)
+  } else {
+    opts.method = 'GET'
+  }
+
+  if (opts.integrity) {
+    // TODO: Implement
+    throw new NotSupportedError()
+  }
+
+  if (opts.keepalive) {
+    // Ignore
+  }
+
+  const headers = new Headers(opts.headers)
+
+  if (!headers.has('accept')) {
+    headers.set('accept', '*/*')
+  }
+
+  if (!headers.has('accept-language')) {
+    headers.set('accept-language', '*')
+  }
+
+  const [body, contentType] = extractBody(opts.body)
+
+  if (contentType && !headers.has('content-type')) {
+    headers.set('content-type', contentType)
+  }
+
+  return new Promise((resolve, reject) => this.dispatch({
+    path: opts.path,
+    origin: opts.origin,
+    method: opts.method,
+    body: body ? (body.stream || body.source) : null,
+    headers: headers[kHeadersList],
+    maxRedirections: opts.redirect === 'follow' ? 20 : 0 // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
+  }, new FetchHandler(opts, (err, res) => {
+    if (err) {
+      reject(err)
     } else {
-      opts.redirect = 'follow'
+      resolve(res)
     }
-
-    if (opts.integrity) {
-      // TODO: Implement
-      throw new NotSupportedError()
-    }
-
-    if (opts.keepalive) {
-      // Ignore
-    }
-
-    const headers = new Headers(opts.headers)
-
-    if (!headers.has('accept')) {
-      headers.set('accept', '*/*')
-    }
-
-    if (!headers.has('accept-language')) {
-      headers.set('accept-language', '*')
-    }
-
-    const [body, contentType] = extractBody(opts.body)
-
-    if (contentType) {
-      // TODO: Should this also check `!headers.has('content-type')`?
-      headers.set('content-type', contentType)
-    }
-
-    this.dispatch({
-      path: opts.path,
-      origin: opts.origin,
-      method: normalizeAndValidateRequestMethod(opts.method || 'GET'),
-      body,
-      headers: headers ? (headers[kHeadersList] || headers) : null,
-      maxRedirections: opts.redirect === 'follow' ? 20 : 0 // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
-    }, new FetchHandler(opts, callback))
-  } catch (err) {
-    if (typeof callback !== 'function') {
-      throw err
-    }
-    const opaque = opts && opts.opaque
-    queueMicrotask(() => callback(err, { opaque }))
-  }
+  })))
 }
 
 function normalizeAndValidateRequestMethod (method) {
@@ -339,27 +410,45 @@ function extractBody (body) {
     // spec says to run application/x-www-form-urlencoded on body.list
     // this is implemented in Node.js as apart of an URLSearchParams instance toString method
     // See: https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/url.js#L490
-    // And: https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/url.js#L1100
-    return [body.toString(), 'application/x-www-form-urlencoded;charset=UTF-8']
+    // and https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/url.js#L1100
+    return [{
+      source: body.toString()
+    }, 'application/x-www-form-urlencoded;charset=UTF-8']
   } else if (typeof body === 'string') {
-    return [body, 'text/plain;charset=UTF-8']
-  } else if (ArrayBuffer.isView(body)) {
-    return [body, null]
+    return [{
+      source: body
+    }, 'text/plain;charset=UTF-8']
+  } else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+    return [{
+      source: body
+    }, null]
   } else if (isBlob && isBlob(body)) {
-    return [body, null]
-  } else if (
-    typeof body.pipe === 'function' || // node Readable
-    typeof body.pipeTo === 'function' // web ReadableStream
-  ) {
-    if (body.locked) {
-      throw new TypeError('locked')
-    }
-
+    return [{
+      source: body,
+      length: body.size
+    }, body.type || null]
+  } else if (util.isStream(body) || typeof body.pipeThrough === 'function') {
     if (util.isDisturbed(body)) {
       throw new TypeError('disturbed')
     }
 
-    return [body, null]
+    let stream
+    if (util.isStream(body)) {
+      stream = Readable.toWeb(body)
+    } else {
+      if (body.locked) {
+        throw new TypeError('locked')
+      }
+
+      // https://streams.spec.whatwg.org/#readablestream-create-a-proxy
+      const identityTransform = new TransformStream()
+      body.pipeThrough(identityTransform)
+      stream = identityTransform
+    }
+
+    return [{
+      stream
+    }, null]
   } else {
     throw Error('Cannot extract Body from input: ', body)
   }

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,8 +1,13 @@
 'use strict'
 
+const nodeMajor = Number(process.versions.node.split('.')[0])
+
 module.exports.request = require('./api-request')
 module.exports.stream = require('./api-stream')
 module.exports.pipeline = require('./api-pipeline')
 module.exports.upgrade = require('./api-upgrade')
 module.exports.connect = require('./api-connect')
-module.exports.fetch = require('./api-fetch')
+
+if (nodeMajor >= 16) {
+  module.exports.fetch = require('./api-fetch')
+}

--- a/test/client-fetch.js
+++ b/test/client-fetch.js
@@ -6,7 +6,7 @@ const { createServer } = require('http')
 const nodeMajor = Number(process.versions.node.split('.')[0])
 
 test('fetch', {
-  skip: nodeMajor < 14
+  skip: nodeMajor < 16
 }, t => {
   t.test('request json', (t) => {
     t.plan(1)

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -25,9 +25,14 @@ test('20 times GET with pipelining 10', (t) => {
   t.teardown(server.close.bind(server))
 
   // needed to check for a warning on the maxListeners on the socket
-  process.on('warning', t.fail)
+  function onWarning (warning) {
+    if (!/ExperimentalWarning/.test(warning)) {
+      t.fail()
+    }
+  }
+  process.on('warning', onWarning)
   t.teardown(() => {
-    process.removeListener('warning', t.fail)
+    process.removeListener('warning', onWarning)
   })
 
   server.listen(0, () => {

--- a/test/client-write-max-listeners.js
+++ b/test/client-write-max-listeners.js
@@ -30,8 +30,14 @@ test('socket close listener does not leak', (t) => {
     data.body.on('end', () => t.pass()).resume()
   }
 
-  process.on('warning', () => {
-    t.fail()
+  function onWarning (warning) {
+    if (!/ExperimentalWarning/.test(warning)) {
+      t.fail()
+    }
+  }
+  process.on('warning', onWarning)
+  t.teardown(() => {
+    process.removeListener('warning', onWarning)
   })
 
   server.listen(0, () => {

--- a/test/promises.js
+++ b/test/promises.js
@@ -200,9 +200,14 @@ test('20 times GET with pipelining 10, async await support', (t) => {
   t.teardown(server.close.bind(server))
 
   // needed to check for a warning on the maxListeners on the socket
-  process.on('warning', t.fail)
+  function onWarning (warning) {
+    if (!/ExperimentalWarning/.test(warning)) {
+      t.fail()
+    }
+  }
+  process.on('warning', onWarning)
   t.teardown(() => {
-    process.removeListener('warning', t.fail)
+    process.removeListener('warning', onWarning)
   })
 
   server.listen(0, () => {


### PR DESCRIPTION
It's much easier to implement spec compliant fetch API if we don't try to be node streams at the same time.