### PR TITLE
Fix `blob.type` not having the response type

### DIFF
--- a/lib/api/api-fetch.js
+++ b/lib/api/api-fetch.js
@@ -86,7 +86,8 @@ class Response {
         chunks.push(chunk)
       }
     }
-    return new Blob(chunks)
+
+    return new Blob(chunks, { type: this.headers.get('Content-Type') || '' })
   }
 
   async arrayBuffer () {

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -71,14 +71,15 @@ class RequestHandler extends AsyncResource {
       return
     }
 
-    const body = new Readable(resume, abort)
+    const parsedHeaders = util.parseHeaders(headers)
+    const body = new Readable(resume, abort, parsedHeaders['content-type'])
 
     this.callback = null
     this.res = body
 
     this.runInAsyncScope(callback, null, null, {
       statusCode,
-      headers: util.parseHeaders(headers),
+      headers: parsedHeaders,
       trailers: this.trailers,
       opaque,
       body,

--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -13,9 +13,10 @@ const kConsume = Symbol('kConsume')
 const kReading = Symbol('kReading')
 const kBody = Symbol('kBody')
 const kAbort = Symbol('abort')
+const kContentType = Symbol('kContentType')
 
 module.exports = class BodyReadable extends Readable {
-  constructor (resume, abort) {
+  constructor (resume, abort, contentType = '') {
     super({ autoDestroy: true, read: resume })
 
     this._readableState.dataEmitted = false
@@ -23,6 +24,7 @@ module.exports = class BodyReadable extends Readable {
     this[kAbort] = abort
     this[kConsume] = null
     this[kBody] = null
+    this[kContentType] = contentType
 
     // Is stream being consumed through Readable API?
     // This is an optimization so that we avoid checking
@@ -229,7 +231,7 @@ function consumeEnd (consume) {
       if (!Blob) {
         Blob = require('buffer').Blob
       }
-      resolve(new Blob(body))
+      resolve(new Blob(body, { type: stream[kContentType] }))
     }
 
     consumeFinish(consume)

--- a/test/client-fetch.js
+++ b/test/client-fetch.js
@@ -53,5 +53,21 @@ test('fetch', {
     })
   })
 
+  t.test('should set type of blob object to the value of the `Content-Type` header from response', (t) => {
+    t.plan(1)
+
+    const obj = { asd: true }
+    const server = createServer((req, res) => {
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(obj))
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, async () => {
+      const response = await fetch(`http://localhost:${server.address().port}`)
+      t.equal('application/json', (await response.blob()).type)
+    })
+  })
+
   t.end()
 })

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -228,6 +228,31 @@ test('request text', (t) => {
   })
 })
 
+test('request blob', (t) => {
+  t.plan(2)
+
+  const obj = { asd: true }
+  const server = createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(obj))
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.destroy.bind(client))
+
+    const { body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+
+    const blob = await body.blob()
+    t.strictSame(obj, JSON.parse(await blob.text()))
+    t.equal(blob.type, 'application/json')
+  })
+})
+
 test('request arrayBuffer', (t) => {
   t.plan(1)
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -9,6 +9,8 @@ const { Readable } = require('stream')
 const net = require('net')
 const { promisify } = require('util')
 
+const nodeMajor = Number(process.versions.node.split('.')[0])
+
 test('request abort before headers', (t) => {
   t.plan(6)
 
@@ -228,7 +230,7 @@ test('request text', (t) => {
   })
 })
 
-test('request blob', (t) => {
+test('request blob', { skip: nodeMajor < 16 }, (t) => {
   t.plan(2)
 
   const obj = { asd: true }


### PR DESCRIPTION
#### Description

Closes #925 

Sets the `type` property in `Blob` objects, to the value found in `content-type` response header.