### PR TITLE
types: HttpMethod type

### DIFF
--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -16,28 +16,28 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   expectAssignable<boolean>(agent.destroyed)
 
   // request
-  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: '' }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }))
-  expectAssignable<void>(agent.request({ origin: '', path: '', method: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: 'GET' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
+  expectAssignable<void>(agent.request({ origin: '', path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
-  expectAssignable<void>(agent.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+  expectAssignable<void>(agent.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // stream
-  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(agent.stream(
-    { origin: '', path: '', method: '' },
+    { origin: '', path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -48,7 +48,7 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
     }
   ))
   expectAssignable<void>(agent.stream(
-    { origin: new URL('http://localhost'), path: '', method: '' },
+    { origin: new URL('http://localhost'), path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -60,11 +60,11 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   ))
 
   // pipeline
-  expectAssignable<Duplex>(agent.pipeline({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Duplex>(agent.pipeline({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
-  expectAssignable<Duplex>(agent.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Duplex>(agent.pipeline({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
@@ -84,8 +84,8 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   }))
 
   // dispatch
-  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: '' }, {}))
-  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: '', maxRedirections: 1 }, {}))
+  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
+  expectAssignable<void>(agent.dispatch({ origin: '', path: '', method: 'GET', maxRedirections: 1 }, {}))
 
   // close
   expectAssignable<Promise<void>>(agent.close())

--- a/test/types/api.test-d.ts
+++ b/test/types/api.test-d.ts
@@ -4,16 +4,16 @@ import { Dispatcher, request, stream, pipeline, connect, upgrade } from '../..'
 
 // request
 expectAssignable<Promise<Dispatcher.ResponseData>>(request(''))
-expectAssignable<Promise<Dispatcher.ResponseData>>(request('', { method: '' }))
+expectAssignable<Promise<Dispatcher.ResponseData>>(request('', { method: 'GET' }))
 
 // stream
-expectAssignable<Promise<Dispatcher.StreamData>>(stream('', { method: '' }, data => {
+expectAssignable<Promise<Dispatcher.StreamData>>(stream('', { method: 'GET' }, data => {
   expectAssignable<Dispatcher.StreamFactoryData>(data)
   return new Writable()
 }))
 
 // pipeline
-expectAssignable<Duplex>(pipeline('', { method: '' }, data => {
+expectAssignable<Duplex>(pipeline('', { method: 'GET' }, data => {
   expectAssignable<Dispatcher.PipelineHandlerData>(data)
   return new Readable()
 }))

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -19,28 +19,28 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   expectAssignable<boolean>(client.destroyed)
 
   // request
-  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: '' }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }))
-  expectAssignable<void>(client.request({ origin: '', path: '', method: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: '', path: '', method: 'GET' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: 'GET' }))
+  expectAssignable<void>(client.request({ origin: '', path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
-  expectAssignable<void>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: '' }, (err, data) => {
+  expectAssignable<void>(client.request({ origin: new URL('http://localhost:3000'), path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // stream
-  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(client.stream({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(client.stream(
-    { origin: '', path: '', method: '' },
+    { origin: '', path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -51,7 +51,7 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
     }
   ))
   expectAssignable<void>(client.stream(
-    { origin: new URL('http://localhost'), path: '', method: '' },
+    { origin: new URL('http://localhost'), path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -63,11 +63,11 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   ))
 
   // pipeline
-  expectAssignable<Duplex>(client.pipeline({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Duplex>(client.pipeline({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
-  expectAssignable<Duplex>(client.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Duplex>(client.pipeline({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
@@ -93,11 +93,11 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   }))
 
   // dispatch
-  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '' }, {}))
-  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: [] }, {}))
-  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: {} }, {}))
-  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: '', headers: null }, {}))
-  expectAssignable<void>(client.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: 'GET' }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: 'GET', headers: [] }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: 'GET', headers: {} }, {}))
+  expectAssignable<void>(client.dispatch({ origin: '', path: '', method: 'GET', headers: null }, {}))
+  expectAssignable<void>(client.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(client.close())

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -10,12 +10,12 @@ expectAssignable<Dispatcher>(new Dispatcher())
   const dispatcher = new Dispatcher()
 
   // dispatch
-  expectAssignable<void>(dispatcher.dispatch({ path: '', method: '' }, {}))
-  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '' }, {}))
-  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: [] }, {}))
-  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: {} }, {}))
-  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: '', headers: null }, {}))
-  expectAssignable<void>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ path: '', method: 'GET' }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: 'GET' }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: [] }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: {} }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: null }, {}))
+  expectAssignable<void>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
 
   // connect
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ path: '', maxRedirections: 0 }))
@@ -25,38 +25,38 @@ expectAssignable<Dispatcher>(new Dispatcher())
   }))
 
   // request
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: '', maxRedirections: 0 }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }))
-  expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', maxRedirections: 0 }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
+  expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
-  expectAssignable<void>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+  expectAssignable<void>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // pipeline
-  expectAssignable<Duplex>(dispatcher.pipeline({ origin: '', path: '', method: '', maxRedirections: 0 }, data => {
+  expectAssignable<Duplex>(dispatcher.pipeline({ origin: '', path: '', method: 'GET', maxRedirections: 0 }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
-  expectAssignable<Duplex>(dispatcher.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Duplex>(dispatcher.pipeline({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
 
   // stream
-  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: '', maxRedirections: 0 }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: 'GET', maxRedirections: 0 }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(dispatcher.stream(
-    { origin: '', path: '', method: '' },
+    { origin: '', path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -67,7 +67,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
     }
   ))
   expectAssignable<void>(dispatcher.stream(
-    { origin: new URL('http://localhost'), path: '', method: '' },
+    { origin: new URL('http://localhost'), path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()

--- a/test/types/mock-agent.test-d.ts
+++ b/test/types/mock-agent.test-d.ts
@@ -39,10 +39,10 @@ expectAssignable<MockAgent>(new MockAgent({}))
   expectAssignable<void>(mockAgent.disableNetConnect())
 
   // dispatch
-  expectAssignable<void>(mockAgent.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(mockAgent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
 
   // intercept
-  expectAssignable<MockInterceptor>((mockAgent.get('foo')).intercept({ path: '', method: '' }))
+  expectAssignable<MockInterceptor>((mockAgent.get('foo')).intercept({ path: '', method: 'GET' }))
 }
 
 {

--- a/test/types/mock-client.test-d.ts
+++ b/test/types/mock-client.test-d.ts
@@ -6,8 +6,8 @@ import { MockInterceptor } from '../../types/mock-interceptor'
   const mockClient: MockClient = new MockAgent({ connections: 1 }).get('')
 
   // intercept
-  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '' }))
-  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: '', body: '', headers: { 'User-Agent': '' } }))
+  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: 'GET' }))
+  expectAssignable<MockInterceptor>(mockClient.intercept({ path: '', method: 'GET', body: '', headers: { 'User-Agent': '' } }))
   expectAssignable<MockInterceptor>(mockClient.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp(''), headers: { 'User-Agent': new RegExp('') } }))
   expectAssignable<MockInterceptor>(mockClient.intercept({
     path: (path) => {
@@ -31,7 +31,7 @@ import { MockInterceptor } from '../../types/mock-interceptor'
   }))
 
   // dispatch
-  expectAssignable<void>(mockClient.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(mockClient.dispatch({ origin: '', path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(mockClient.close())

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -4,7 +4,7 @@ import { MockInterceptor, MockScope } from '../../types/mock-interceptor'
 
 {
   const mockPool: MockPool = new MockAgent().get('')
-  const mockInterceptor = mockPool.intercept({ path: '', method: '' })
+  const mockInterceptor = mockPool.intercept({ path: '', method: 'GET' })
 
   // reply
   expectAssignable<MockScope>(mockInterceptor.reply(200, ''))
@@ -33,7 +33,7 @@ import { MockInterceptor, MockScope } from '../../types/mock-interceptor'
 
 {
   const mockPool: MockPool = new MockAgent().get('')
-  const mockScope = mockPool.intercept({ path: '', method: '' }).reply(200, '')
+  const mockScope = mockPool.intercept({ path: '', method: 'GET' }).reply(200, '')
 
   // delay
   expectAssignable<MockScope>(mockScope.delay(1))

--- a/test/types/mock-pool.test-d.ts
+++ b/test/types/mock-pool.test-d.ts
@@ -6,8 +6,8 @@ import { MockInterceptor } from '../../types/mock-interceptor'
   const mockPool: MockPool = new MockAgent({ connections: 1 }).get('')
 
   // intercept
-  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '' }))
-  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: '', body: '', headers: { 'User-Agent': '' } }))
+  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: 'GET' }))
+  expectAssignable<MockInterceptor>(mockPool.intercept({ path: '', method: 'GET', body: '', headers: { 'User-Agent': '' } }))
   expectAssignable<MockInterceptor>(mockPool.intercept({ path: new RegExp(''), method: new RegExp(''), body: new RegExp(''), headers: { 'User-Agent': new RegExp('') } }))
   expectAssignable<MockInterceptor>(mockPool.intercept({
     path: (path) => {
@@ -31,7 +31,7 @@ import { MockInterceptor } from '../../types/mock-interceptor'
   }))
 
   // dispatch
-  expectAssignable<void>(mockPool.dispatch({ origin: '', path: '', method: '' }, {}))
+  expectAssignable<void>(mockPool.dispatch({ origin: '', path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(mockPool.close())

--- a/test/types/pool.test-d.ts
+++ b/test/types/pool.test-d.ts
@@ -18,28 +18,28 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   expectAssignable<boolean>(pool.destroyed)
 
   // request
-  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: '' }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }))
-  expectAssignable<void>(pool.request({ origin: '', path: '', method: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: '', path: '', method: 'GET' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(pool.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
+  expectAssignable<void>(pool.request({ origin: '', path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
-  expectAssignable<void>(pool.request({ origin: new URL('http://localhost'), path: '', method: '' }, (err, data) => {
+  expectAssignable<void>(pool.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ResponseData>(data)
   }))
 
   // stream
-  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
-  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(pool.stream({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
   expectAssignable<void>(pool.stream(
-    { origin: '', path: '', method: '' },
+    { origin: '', path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -50,7 +50,7 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
     }
   ))
   expectAssignable<void>(pool.stream(
-    { origin: new URL('http://localhost'), path: '', method: '' },
+    { origin: new URL('http://localhost'), path: '', method: 'GET' },
     data => {
       expectAssignable<Dispatcher.StreamFactoryData>(data)
       return new Writable()
@@ -62,11 +62,11 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   ))
 
   // pipeline
-  expectAssignable<Duplex>(pool.pipeline({ origin: '', path: '', method: '' }, data => {
+  expectAssignable<Duplex>(pool.pipeline({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
-  expectAssignable<Duplex>(pool.pipeline({ origin: new URL('http://localhost'), path: '', method: '' }, data => {
+  expectAssignable<Duplex>(pool.pipeline({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
@@ -86,8 +86,8 @@ expectAssignable<Pool>(new Pool('', { connections: 1 }))
   }))
 
   // dispatch
-  expectAssignable<void>(pool.dispatch({ origin: '', path: '', method: '' }, {}))
-  expectAssignable<void>(pool.dispatch({ origin: new URL('http://localhost'), path: '', method: '' }, {}))
+  expectAssignable<void>(pool.dispatch({ origin: '', path: '', method: 'GET' }, {}))
+  expectAssignable<void>(pool.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(pool.close())

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -40,7 +40,7 @@ declare namespace Dispatcher {
   export interface DispatchOptions {
     origin?: string | URL;
     path: string;
-    method: string;
+    method: HttpMethod;
     /** Default: `null` */
     body?: string | Buffer | Uint8Array | Readable | null;
     /** Default: `null` */
@@ -144,6 +144,7 @@ declare namespace Dispatcher {
     onBodySent?(chunkSize: number, totalBytesSent: number): void;
   }
   export type PipelineHandler = (data: PipelineHandlerData) => Readable;
+  export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
 
   /** 
    * @link https://fetch.spec.whatwg.org/#body-mixin


### PR DESCRIPTION
fix: #934

Add the easiness of use for TypeScript developers and ensure valid value to be set for `method` parameters.