### PR TITLE
Fix `toWebReadable` finishing too early

### DIFF
--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -180,7 +180,7 @@ function toWebReadable (streamReadable) {
     } else {
       // Must not use `process.nextTick()`,
       // see https://github.com/nodejs/node/issues/39758
-      Promise.resolve().then(() => {
+      queueMicrotask(() => {
         controller.close()
       })
     }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -178,7 +178,11 @@ function toWebReadable (streamReadable) {
     if (err) {
       controller.error(err)
     } else {
-      controller.close()
+      // Must not use `process.nextTick()`,
+      // see https://github.com/nodejs/node/issues/39758
+      Promise.resolve().then(() => {
+        controller.close()
+      })
     }
   })
 

--- a/test/node-fetch/response.js
+++ b/test/node-fetch/response.js
@@ -112,7 +112,7 @@ describe('Response', () => {
     })
   }
 
-  xit('should support clone() method', () => {
+  it('should support clone() method', () => {
     const body = stream.Readable.from('a=1')
     const res = new Response(body, {
       headers: {


### PR DESCRIPTION
Other `clone` tests error that `clone().buffer` is not a function