### PR TITLE
fix: redirect handler should not modify stream state

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -134,7 +134,7 @@ class Agent extends Dispatcher {
       }
 
       const { maxRedirections = this[kMaxRedirections] } = opts
-      if (maxRedirections) {
+      if (maxRedirections != null && maxRedirections !== 0) {
         opts = { ...opts, maxRedirections: 0 } // Stop sub dispatcher from also redirecting.
         handler = new RedirectHandler(this, maxRedirections, opts, handler)
       }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -134,7 +134,7 @@ class Agent extends Dispatcher {
       }
 
       const { maxRedirections = this[kMaxRedirections] } = opts
-      if (maxRedirections != null) {
+      if (maxRedirections) {
         opts = { ...opts, maxRedirections: 0 } // Stop sub dispatcher from also redirecting.
         handler = new RedirectHandler(this, maxRedirections, opts, handler)
       }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -91,6 +91,10 @@ class RedirectHandler {
   }
 
   onHeaders (statusCode, headers, resume, statusText) {
+    if (this.maxRedirections === 0) {
+      return this.handler.onHeaders(statusCode, headers, resume, statusText)
+    }
+
     this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body)
       ? null
       : parseLocation(statusCode, headers)

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -39,10 +39,6 @@ class RedirectHandler {
     this.handler = handler
     this.history = []
 
-    if (this.maxRedirections === 0) {
-      return
-    }
-
     if (util.isStream(this.opts.body)) {
       // TODO (fix): Provide some way for the user to cache the file to e.g. /tmp
       // so that it can be dispatched again?
@@ -91,10 +87,6 @@ class RedirectHandler {
   }
 
   onHeaders (statusCode, headers, resume, statusText) {
-    if (this.maxRedirections === 0) {
-      return this.handler.onHeaders(statusCode, headers, resume, statusText)
-    }
-
     this.location = this.history.length >= this.maxRedirections || util.isDisturbed(this.opts.body)
       ? null
       : parseLocation(statusCode, headers)

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -4,6 +4,7 @@ const util = require('../core/util')
 const { kBodyUsed } = require('../core/symbols')
 const assert = require('assert')
 const { InvalidArgumentError } = require('../core/errors')
+const EE = require('events')
 
 const redirectableStatusCodes = [300, 301, 302, 303, 307, 308]
 
@@ -51,8 +52,7 @@ class RedirectHandler {
 
       if (typeof this.opts.body.readableDidRead !== 'boolean') {
         this.opts.body[kBodyUsed] = false
-        // TODO (fix): Don't mutate readable state...
-        this.opts.body.on('data', function () {
+        EE.prototype.on.call(this.opts.body, 'data', function () {
           this[kBodyUsed] = true
         })
       }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -52,7 +52,7 @@ class RedirectHandler {
 
       if (typeof this.opts.body.readableDidRead !== 'boolean') {
         this.opts.body[kBodyUsed] = false
-        EE.prototype.once.call(this.opts.body, 'data', function () {
+        EE.prototype.on.call(this.opts.body, 'data', function () {
           this[kBodyUsed] = true
         })
       }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -52,7 +52,7 @@ class RedirectHandler {
 
       if (typeof this.opts.body.readableDidRead !== 'boolean') {
         this.opts.body[kBodyUsed] = false
-        EE.prototype.on.call(this.opts.body, 'data', function () {
+        EE.prototype.once.call(this.opts.body, 'data', function () {
           this[kBodyUsed] = true
         })
       }

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -39,6 +39,10 @@ class RedirectHandler {
     this.handler = handler
     this.history = []
 
+    if (this.maxRedirections === 0) {
+      return
+    }
+
     if (util.isStream(this.opts.body)) {
       // TODO (fix): Provide some way for the user to cache the file to e.g. /tmp
       // so that it can be dispatched again?


### PR DESCRIPTION
Use EE.prototype.on to avoid mutating stream flowing
state.