### PR TITLE
feat: onInfo

### DIFF
--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -329,6 +329,7 @@ Extends: [`RequestOptions`](#parameter-requestoptions)
 * **opaque** `unknown`
 * **body** `stream.Readable`
 * **context** `object`
+* **onInfo** `({statusCode: number, headers: Record<string, string | string[]>}) => void | null` (optional) - Default: `null` - Callback collecting all the info headers (HTTP 100-199) received. 
 
 #### Example 1 - Pipeline Echo
 
@@ -411,6 +412,7 @@ Extends: [`DispatchOptions`](#parameter-dispatchoptions)
 
 * **opaque** `unknown` (optional) - Default: `null` - Used for passing through context to `ResponseData`
 * **signal** `AbortSignal | events.EventEmitter | null` (optional) - Default: `null`
+* **onInfo** `({statusCode: number, headers: Record<string, string | string[]>}) => void | null` (optional) - Default: `null` - Callback collecting all the info headers (HTTP 100-199) received. 
 
 The `RequestOptions.method` property should not be value `'CONNECT'`.
 
@@ -578,6 +580,7 @@ Returns: `void | Promise<StreamData>` - Only returns a `Promise` if no `callback
 * **statusCode** `number`
 * **headers** `http.IncomingHttpHeaders`
 * **opaque** `unknown`
+* **onInfo** `({statusCode: number, headers: Record<string, string | string[]>}) => void | null` (optional) - Default: `null` - Callback collecting all the info headers (HTTP 100-199) received. 
 
 #### Parameter: `StreamData`
 

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -69,7 +69,7 @@ class PipelineHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid handler')
     }
 
-    const { signal, method, opaque } = opts
+    const { signal, method, opaque, onInfo } = opts
 
     if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
@@ -79,12 +79,17 @@ class PipelineHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid method')
     }
 
+    if (onInfo && typeof onInfo !== 'function') {
+      throw new InvalidArgumentError('invalid onInfo callback')
+    }
+
     super('UNDICI_PIPELINE')
 
     this.opaque = opaque || null
     this.handler = handler
     this.abort = null
     this.context = null
+    this.onInfo = onInfo || null
 
     this.req = new PipelineRequest().on('error', util.nop)
 
@@ -155,6 +160,9 @@ class PipelineHandler extends AsyncResource {
     const { opaque, handler, context } = this
 
     if (statusCode < 200) {
+      if (this.onInfo) {
+        this.onInfo({ statusCode, headers: util.parseHeaders(headers) })
+      }
       return
     }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -49,7 +49,7 @@ class RequestHandler extends AsyncResource {
     this.body = body
     this.trailers = {}
     this.context = null
-    this.onInfo = onInfo || (() => {})
+    this.onInfo = onInfo || null
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -73,7 +73,9 @@ class RequestHandler extends AsyncResource {
     const { callback, opaque, abort, context } = this
 
     if (statusCode < 200) {
-      this.onInfo({ statusCode, headers })
+      if (this.onInfo) {
+        this.onInfo({ statusCode, headers: util.parseHeaders(headers) })
+      }
       return
     }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -15,7 +15,7 @@ class RequestHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    const { signal, method, opaque, body } = opts
+    const { signal, method, opaque, body, onInfo } = opts
 
     try {
       if (typeof callback !== 'function') {
@@ -28,6 +28,10 @@ class RequestHandler extends AsyncResource {
 
       if (method === 'CONNECT') {
         throw new InvalidArgumentError('invalid method')
+      }
+
+      if (onInfo && typeof onInfo !== 'function') {
+        throw new InvalidArgumentError('invalid onInfo callback')
       }
 
       super('UNDICI_REQUEST')
@@ -45,7 +49,7 @@ class RequestHandler extends AsyncResource {
     this.body = body
     this.trailers = {}
     this.context = null
-    this.onInfo = opts.onInfo || (() => {})
+    this.onInfo = onInfo || (() => {})
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -69,7 +73,7 @@ class RequestHandler extends AsyncResource {
     const { callback, opaque, abort, context } = this
 
     if (statusCode < 200) {
-        this.onInfo({statusCode,headers})
+      this.onInfo({ statusCode, headers })
       return
     }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -45,7 +45,7 @@ class RequestHandler extends AsyncResource {
     this.body = body
     this.trailers = {}
     this.context = null
-    this.onInfo = opts.onInfo || null
+    this.onInfo = opts.onInfo || (() => {})
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -69,9 +69,7 @@ class RequestHandler extends AsyncResource {
     const { callback, opaque, abort, context } = this
 
     if (statusCode < 200) {
-      if(this.onInfo) {
         this.onInfo({statusCode,headers})
-      }
       return
     }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -45,6 +45,7 @@ class RequestHandler extends AsyncResource {
     this.body = body
     this.trailers = {}
     this.context = null
+    this.onInfo = opts.onInfo || null
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -68,6 +69,9 @@ class RequestHandler extends AsyncResource {
     const { callback, opaque, abort, context } = this
 
     if (statusCode < 200) {
+      if(this.onInfo) {
+        this.onInfo({statusCode,headers})
+      }
       return
     }
 

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -16,7 +16,7 @@ class StreamHandler extends AsyncResource {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    const { signal, method, opaque, body } = opts
+    const { signal, method, opaque, body, onInfo } = opts
 
     try {
       if (typeof callback !== 'function') {
@@ -35,6 +35,10 @@ class StreamHandler extends AsyncResource {
         throw new InvalidArgumentError('invalid method')
       }
 
+      if (onInfo && typeof onInfo !== 'function') {
+        throw new InvalidArgumentError('invalid onInfo callback')
+      }
+
       super('UNDICI_STREAM')
     } catch (err) {
       if (util.isStream(body)) {
@@ -51,6 +55,7 @@ class StreamHandler extends AsyncResource {
     this.context = null
     this.trailers = null
     this.body = body
+    this.onInfo = onInfo || null
 
     if (util.isStream(body)) {
       body.on('error', (err) => {
@@ -74,6 +79,9 @@ class StreamHandler extends AsyncResource {
     const { factory, opaque, context } = this
 
     if (statusCode < 200) {
+      if (this.onInfo) {
+        this.onInfo({ statusCode, headers: util.parseHeaders(headers) })
+      }
       return
     }
 

--- a/test/agent.js
+++ b/test/agent.js
@@ -428,7 +428,7 @@ test('with a local agent', t => {
   })
 })
 
-test('fails with invalid URL', t => {
+test('stream: fails with invalid URL', t => {
   t.plan(4)
   t.throws(() => stream(), InvalidArgumentError, 'throws on missing url argument')
   t.throws(() => stream(''), InvalidArgumentError, 'throws on invalid url')
@@ -516,12 +516,42 @@ test('with a local agent', t => {
   })
 })
 
-test('fails with invalid URL', t => {
+test('pipeline: fails with invalid URL', t => {
   t.plan(4)
   t.throws(() => pipeline(), InvalidArgumentError, 'throws on missing url argument')
   t.throws(() => pipeline(''), InvalidArgumentError, 'throws on invalid url')
   t.throws(() => pipeline({}), InvalidArgumentError, 'throws on missing url.origin argument')
   t.throws(() => pipeline({ origin: '' }), InvalidArgumentError, 'throws on invalid url.origin argument')
+})
+
+test('pipeline: fails with invalid onInfo', (t) => {
+  t.plan(2)
+  pipeline({ origin: 'http://localhost', path: '/', onInfo: 'foo' }, () => {}).on('error', (err) => {
+    t.type(err, InvalidArgumentError)
+    t.equal(err.message, 'invalid onInfo callback')
+  })
+})
+
+test('request: fails with invalid onInfo', async (t) => {
+  try {
+    await request({ origin: 'http://localhost', path: '/', onInfo: 'foo' })
+    t.fail('should throw')
+  } catch (e) {
+    t.ok(e)
+    t.equal(e.message, 'invalid onInfo callback')
+  }
+  t.end()
+})
+
+test('stream: fails with invalid onInfo', async (t) => {
+  try {
+    await stream({ origin: 'http://localhost', path: '/', onInfo: 'foo' }, () => new PassThrough())
+    t.fail('should throw')
+  } catch (e) {
+    t.ok(e)
+    t.equal(e.message, 'invalid onInfo callback')
+  }
+  t.end()
 })
 
 test('constructor validations', t => {

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -445,10 +445,6 @@ test('request onInfo callback headers parsing', async (t) => {
       'the body'
     ]
     socket.end(lines.join('\r\n'))
-
-    // Unfortunately calling destroy synchronously might get us flaky results,
-    // therefore we delay it to the next event loop run.
-    setImmediate(socket.destroy.bind(socket))
   })
   t.teardown(server.close.bind(server))
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -370,3 +370,27 @@ test('request post body no extra data handler', { skip: nodeMajor < 16 }, (t) =>
     t.pass()
   })
 })
+
+test('request with onInfo callback', (t) => {
+  t.plan(2)
+  const infos = []
+  const server = createServer((req, res) => {
+    res.writeContinue()
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify({ foo: 'bar' }))
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.destroy.bind(client))
+
+    await client.request({
+      path: '/',
+      method: 'GET',
+      onInfo: (x) => { infos.push(x) }
+    })
+    t.equal(infos.length(), 1)
+    t.pass()
+  })
+})

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, only } = require('tap')
+const { test } = require('tap')
 const { Client, errors } = require('..')
 const { createServer } = require('http')
 const EE = require('events')
@@ -429,7 +429,7 @@ only('request with onInfo callback but socket is destroyed before end of respons
   })
 })
 
-only('request onInfo callback headers parsing', async (t) => {
+test('request onInfo callback headers parsing', async (t) => {
   t.plan(4)
   const infos = []
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -396,7 +396,7 @@ test('request with onInfo callback', (t) => {
   })
 })
 
-only('request with onInfo callback but socket is destroyed before end of response', (t) => {
+test('request with onInfo callback but socket is destroyed before end of response', (t) => {
   t.plan(5)
   const infos = []
   let response

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -17,6 +17,7 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 
   // request
   expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: 'GET' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: '', path: '', method: 'GET', onInfo: ((info) => {}) }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(agent.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
   expectAssignable<void>(agent.request({ origin: '', path: '', method: 'GET' }, (err, data) => {
     expectAssignable<Error | null>(err)

--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -33,6 +33,10 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
+  expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: '', path: '', method: 'GET', onInfo: ((info) => {}) }, data => {
+    expectAssignable<Dispatcher.StreamFactoryData>(data)
+    return new Writable()
+  }))
   expectAssignable<Promise<Dispatcher.StreamData>>(agent.stream({ origin: new URL('http://localhost'), path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
@@ -62,6 +66,10 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 
   // pipeline
   expectAssignable<Duplex>(agent.pipeline({ origin: '', path: '', method: 'GET' }, data => {
+    expectAssignable<Dispatcher.PipelineHandlerData>(data)
+    return new Readable()
+  }))
+  expectAssignable<Duplex>(agent.pipeline({ origin: '', path: '', method: 'GET', onInfo: ((info) => {}) }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -72,6 +72,8 @@ declare namespace Dispatcher {
     signal?: AbortSignal | EventEmitter | null;
     /** Default: 0 */
     maxRedirections?: number;
+    /** Default: `null` */
+    onInfo?: (info: {statusCode: number, headers: Record<string, string | string[]>}) => void;
   }
   export interface PipelineOptions extends RequestOptions {
     /** `true` if the `handler` will return an object stream. Default: `false` */


### PR DESCRIPTION
This is a draft implementation on the onInfo feature proposal. This adds more informations on the context lifecycle of the request. Currently everything is handled in a callback but do we want to have all the infos stored in the request object to be added in the result? With a flag like `verbose` it would make sense otherwise it would fill-up the memory and impact the performances.

If this is ok to implement like so i'll port it to pipeline and stream and add tests for sure. 

## This relates to...

fix: https://github.com/nodejs/undici/issues/481

## Rationale

This adds the possibility to get HTTP info headers through a callback

## Changes

Adding a placeholder for an `onInfo` callback.

### Features

Adds an callback handler on Info Headers

### Bug Fixes

N/A

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
