### PR TITLE
fix: Include final URL in redirect history.

### DIFF
--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -91,11 +91,13 @@ class RedirectHandler {
       ? null
       : parseLocation(statusCode, headers)
 
+    if(this.opts.origin) {
+      this.history.push(new URL(this.opts.path, this.opts.origin))
+    }
+
     if (!this.location) {
       return this.handler.onHeaders(statusCode, headers, resume, statusText)
     }
-
-    this.history.push(new URL(this.opts.path, this.opts.origin))
 
     const { origin, pathname, search } = util.parseURL(new URL(this.location, this.opts.origin))
     const path = search ? `${pathname}${search}` : pathname

--- a/test/utils/redirecting-servers.js
+++ b/test/utils/redirecting-servers.js
@@ -31,6 +31,9 @@ async function startRedirectingServer (t) {
 
     if (isNaN(code) || code < 0) {
       code = 302
+    } else if(code < 300) {
+      res.statusCode = code
+      redirections = 5
     }
 
     if (isNaN(redirections) || redirections < 0) {
@@ -49,7 +52,7 @@ async function startRedirectingServer (t) {
     if (redirections === 5) {
       res.setHeader('Connection', 'close')
       res.write(
-        `${req.method}${query ? ` ${query}` : ''} :: ${Object.entries(req.headers)
+        `${req.method} /${redirections}${query ? ` ${query}` : ''} :: ${Object.entries(req.headers)
           .map(([k, v]) => `${k}@${v}`)
           .join(' ')}`
       )


### PR DESCRIPTION
In the current implementation, a URL is added to `context.history` only if in the response there is a redirect to follow.
Unfortunately, this results in the final URL of the redirects chain to never be present in the history and apparently there are no other ways to get such URL.

This PR fixes this problem by appending each URL visited. In case of no redirections, the `context.history` will contain just one element.

Hope this helps!