### PR TITLE
fix: revert incorrect servername fix

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -78,13 +78,7 @@ function parseOrigin (url) {
   return url
 }
 
-function getServerName (host) {
-  if (!host) {
-    return null
-  }
-
-  assert.strictEqual(typeof host, 'string')
-
+function getHostname (host) {
   if (host[0] === '[') {
     const idx = host.indexOf(']')
 
@@ -96,6 +90,23 @@ function getServerName (host) {
   if (idx === -1) return host
 
   return host.substr(0, idx)
+}
+
+// IP addresses are not valid server names per RFC6066
+// > Currently, the only server names supported are DNS hostnames
+function getServerName (host) {
+  if (!host) {
+    return null
+  }
+
+  assert.strictEqual(typeof host, 'string')
+
+  const servername = getHostname(host)
+  if (net.isIP(servername)) {
+    return ''
+  }
+
+  return servername
 }
 
 function deepClone (obj) {

--- a/test/util.js
+++ b/test/util.js
@@ -21,10 +21,11 @@ test('isStream', (t) => {
 })
 
 test('getServerName', (t) => {
-  t.plan(4)
-
-  t.equal(util.getServerName('1.1.1.1'), '1.1.1.1')
-  t.equal(util.getServerName('1.1.1.1:443'), '1.1.1.1')
+  t.plan(6)
+  t.equal(util.getServerName('1.1.1.1'), '')
+  t.equal(util.getServerName('1.1.1.1:443'), '')
   t.equal(util.getServerName('example.com'), 'example.com')
   t.equal(util.getServerName('example.com:80'), 'example.com')
+  t.equal(util.getServerName('[2606:4700:4700::1111]'), '')
+  t.equal(util.getServerName('[2606:4700:4700::1111]:443'), '')
 })


### PR DESCRIPTION
This reverts commit 2ee6e3736c66becea6a14b5aa1693bc06565ecce which incorrectly allowed IP server names.

Sorry for my mistake. Got confused by https://github.com/nodejs/node/blob/e5670f49682ced87451e5fc1e56d7d3fc396c6f2/lib/internal/http2/core.js#L623-L639 incorrectly returning `https://false:443` for IP addresses. However, I did not investigate further. Per [RFC6066](https://datatracker.ietf.org/doc/html/rfc6066#section-3):

> Currently, the only server names supported are DNS hostnames;
> [...]
> "HostName" contains the fully qualified DNS hostname of the server
> [...]
> Literal IPv4 and IPv6 addresses are not permitted in "HostName".

Again I'm deeply sorry for my mistake.

---

Node.js also gives a warning when the servername is an IP address. I must've missed it somehow :(