### PR TITLE
fix(fetch): avoid optional chaining for node 12

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -34,7 +34,7 @@ class File extends Blob {
     //    lastModified dictionary member. If it is not provided, set d to the
     //    current date and time represented as the number of milliseconds since
     //    the Unix Epoch (which is the equivalent of Date.now() [ECMA-262]).
-    const d = options.lastModified ?? Date.now()
+    const d = options.lastModified || Date.now()
 
     // 4. Return a new File object F such that:
     // F refers to the bytes byte sequence.
@@ -67,4 +67,4 @@ class File extends Blob {
   }
 }
 
-module.exports = { File: globalThis.File ?? File }
+module.exports = { File: globalThis.File || File }

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -211,4 +211,4 @@ function makeEntry (name, value, filename) {
   return entry
 }
 
-module.exports = { FormData: globalThis.FormData ?? FormData }
+module.exports = { FormData: globalThis.FormData || FormData }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -164,7 +164,7 @@ class Headers {
         "Failed to construct 'Headers': The provided value is not of type '(record<ByteString, ByteString> or sequence<sequence<ByteString>>"
       )
     }
-    const init = args.length >= 1 ? args[0] ?? {} : {}
+    const init = args.length >= 1 ? args[0] || {} : {}
 
     this[kHeadersList] = new HeadersList()
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -54,7 +54,7 @@ const registry = new FinalizationRegistry((abort) => {
 })
 
 // https://fetch.spec.whatwg.org/#fetch-method
-async function fetch (...args) {
+async function fetch(...args) {
   if (args.length < 1) {
     throw new TypeError(
       `Failed to execute 'fetch' on 'Window': 1 argument required, but only ${args.length} present.`
@@ -78,7 +78,7 @@ async function fetch (...args) {
     terminated: false,
     connection: null,
     dump: false,
-    terminate ({ reason, aborted } = {}) {
+    terminate({ reason, aborted } = {}) {
       if (this.terminated) {
         return
       }
@@ -116,7 +116,7 @@ async function fetch (...args) {
 
   // 5. Let globalObject be request’s client’s global object.
   // TODO: What if request.client is null?
-  const globalObject = request.client?.globalObject
+  const globalObject = request.client && request.client.globalObject
 
   // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
   // request’s service-workers mode to "none".
@@ -205,9 +205,9 @@ async function fetch (...args) {
   return p.promise
 }
 
-function finalizeAndReportTiming (response, initiatorType = 'other') {
+function finalizeAndReportTiming(response, initiatorType = 'other') {
   // 1. If response’s URL list is null or empty, then return.
-  if (!response.urlList?.length) {
+  if (!response.urlList || response.urlList.length === 0) {
     return
   }
 
@@ -260,12 +260,12 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
 }
 
 // https://w3c.github.io/resource-timing/#dfn-mark-resource-timing
-function markResourceTiming () {
+function markResourceTiming() {
   // TODO
 }
 
 // https://fetch.spec.whatwg.org/#abort-fetch
-function abortFetch (p, request, responseObject) {
+function abortFetch(p, request, responseObject) {
   const context = this
 
   // 1. Let error be an "AbortError" DOMException.
@@ -296,7 +296,7 @@ function abortFetch (p, request, responseObject) {
 }
 
 // https://fetch.spec.whatwg.org/#fetching
-function fetching ({ request, processResponse, processResponseDone }) {
+function fetching({ request, processResponse, processResponseDone }) {
   // 1. Let taskDestination be null.
   let taskDestination = null
 
@@ -358,7 +358,7 @@ function fetching ({ request, processResponse, processResponseDone }) {
   if (request.window === 'client') {
     // TODO: What if request.client is null?
     request.window =
-      request.client?.globalObject instanceof Window
+      request.client && request.client.globalObject instanceof Window
         ? request.client
         : 'no-window'
   }
@@ -367,7 +367,7 @@ function fetching ({ request, processResponse, processResponseDone }) {
   // client’s origin.
   if (request.origin === 'client') {
     // TODO: What if request.client is null?
-    request.origin = request.client?.origin
+    request.origin = request.client && request.client.origin
   }
 
   // 10. If request’s policy container is "client", then:
@@ -435,7 +435,7 @@ function fetching ({ request, processResponse, processResponseDone }) {
 }
 
 // https://fetch.spec.whatwg.org/#concept-main-fetch
-async function mainFetch (fetchParams, recursive = false) {
+async function mainFetch(fetchParams, recursive = false) {
   const context = this
 
   // 1. Let request be fetchParams’s request.
@@ -697,7 +697,7 @@ async function mainFetch (fetchParams, recursive = false) {
 }
 
 // https://fetch.spec.whatwg.org/#finalize-response
-function finalizeResponse (fetchParams, response) {
+function finalizeResponse(fetchParams, response) {
   // 1. Set fetchParams’s request’s done flag.
   fetchParams.request.done = true
 
@@ -710,7 +710,7 @@ function finalizeResponse (fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-finale
-function fetchFinale (fetchParams, response) {
+function fetchFinale(fetchParams, response) {
   const context = this
 
   // 1. If fetchParams’s process response is non-null,
@@ -743,7 +743,7 @@ function fetchFinale (fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#http-fetch
-async function httpFetch (fetchParams) {
+async function httpFetch(fetchParams) {
   const context = this
 
   // 1. Let request be fetchParams’s request.
@@ -846,7 +846,7 @@ async function httpFetch (fetchParams) {
 }
 
 // https://fetch.spec.whatwg.org/#http-redirect-fetch
-async function httpRedirectFetch (fetchParams, response) {
+async function httpRedirectFetch(fetchParams, response) {
   // 1. Let request be fetchParams’s request.
   const request = fetchParams.request
 
@@ -985,7 +985,7 @@ async function httpRedirectFetch (fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
-async function httpNetworkOrCacheFetch (
+async function httpNetworkOrCacheFetch(
   fetchParams,
   isAuthenticationFetch = false,
   isNewConnectionFetch = false
@@ -1325,7 +1325,7 @@ async function httpNetworkOrCacheFetch (
 }
 
 // https://fetch.spec.whatwg.org/#http-network-fetch
-function httpNetworkFetch (
+function httpNetworkFetch(
   fetchParams,
   includeCredentials = false,
   forceNewConnection = false
@@ -1341,7 +1341,7 @@ function httpNetworkFetch (
       destroyed: false,
       errored: false,
       dump: false,
-      destroy (err) {
+      destroy(err) {
         if (this.destroyed) {
           return
         }
@@ -1448,13 +1448,13 @@ function httpNetworkFetch (
     //        2. Otherwise, return a network error.
 
     // To transmit request’s body body, run these steps:
-    const body = (async function * () {
+    const body = (async function* () {
       try {
         // 1. If body is null and fetchParams’s process request end-of-body is
         // non-null, then queue a fetch task given fetchParams’s process request
         // end-of-body and fetchParams’s task destination.
-        if (request.body === null) {
-          fetchParams.processEndOfBody?.()
+        if (request.body === null && fetchParams.processEndOfBody) {
+          fetchParams.processEndOfBody()
           return
         }
 
@@ -1472,7 +1472,9 @@ function httpNetworkFetch (
 
           // 3. If fetchParams’s process request body is non-null, then run
           // fetchParams’s process request body given bytes’s length.
-          fetchParams.processRequestBody?.(bytes.byteLength)
+          if (fetchParams.processEndOfBody) {
+            fetchParams.processRequestBody(bytes.byteLength)
+          }
         }
 
         // 2. Let processEndOfBody be these steps:
@@ -1484,7 +1486,9 @@ function httpNetworkFetch (
 
         //    2. If fetchParams’s process request end-of-body is non-null,
         //    then run fetchParams’s process request end-of-body.
-        fetchParams.processRequestEndOfBody?.()
+        if (fetchParams.processRequestEndOfBody) {
+          fetchParams.processRequestEndOfBody()
+        }
       } catch (e) {
         // 3. Let processBodyError given e be these steps:
 
@@ -1503,7 +1507,7 @@ function httpNetworkFetch (
     })()
 
     // 9. If aborted, then:
-    function onRequestAborted () {
+    function onRequestAborted() {
       // 1. Let aborted be the termination’s aborted flag.
       const aborted = context.terminated.aborted
 
@@ -1545,17 +1549,17 @@ function httpNetworkFetch (
 
     const stream = new ReadableStream(
       {
-        async start (controller) {
+        async start(controller) {
           connection.controller = controller
         },
-        async pull () {
+        async pull() {
           if (pullAlgorithm) {
             pullAlgorithm()
           } else {
             pullAlgorithm = null
           }
         },
-        async cancel (reason) {
+        async cancel(reason) {
           cancelAlgorithm()
         }
       },
@@ -1581,7 +1585,7 @@ function httpNetworkFetch (
     //            NOTE: See onHeaders
 
     //    2. If aborted, then:
-    function onResponseAborted () {
+    function onResponseAborted() {
       // 1. Finalize response for fetchParams and response.
       finalizeResponse(fetchParams, response)
 
@@ -1622,7 +1626,7 @@ function httpNetworkFetch (
       {
         decoder: null,
 
-        onConnect (abort) {
+        onConnect(abort) {
           if (connection.destroyed) {
             abort(new AbortError())
           } else {
@@ -1630,7 +1634,7 @@ function httpNetworkFetch (
           }
         },
 
-        onHeaders (status, headersList, resume, statusText) {
+        onHeaders(status, headersList, resume, statusText) {
           if (status < 200) {
             return
           }
@@ -1657,12 +1661,14 @@ function httpNetworkFetch (
 
           context.on('terminated', onResponseAborted)
 
-          const codings =
-            headers
-              .get('content-encoding')
-              ?.toLowerCase()
-              .split(',')
-              .map((x) => x.trim()) ?? []
+          const contentEncoding = headers.get('content-encoding')
+          if (contentEncoding) {
+            const codings =
+              contentEncoding
+                .toLowerCase()
+                .split(',')
+                .map((x) => x.trim()) ?? []
+          }
 
           const decoders = []
 
@@ -1687,7 +1693,7 @@ function httpNetworkFetch (
               this.decoder = compose(...decoders)
             } else {
               this.decoder = new PassThrough()
-              iterator = pipeline(this.decoder, ...decoders, () => {})[
+              iterator = pipeline(this.decoder, ...decoders, () => { })[
                 Symbol.asyncIterator
               ]()
             }
@@ -1742,7 +1748,7 @@ function httpNetworkFetch (
             }
 
             // 5. Increase timingInfo’s decoded body size by bytes’s length.
-            timingInfo.decodedBodySize += bytes?.byteLength ?? 0
+            timingInfo.decodedBodySize += bytes ? (bytes.byteLength || 0) : 0
 
             // 6. If bytes is failure, then terminate the ongoing fetch.
             if (bytes instanceof Error) {
@@ -1774,7 +1780,7 @@ function httpNetworkFetch (
           return true
         },
 
-        onData (chunk) {
+        onData(chunk) {
           if (connection.dump) {
             return
           }
@@ -1797,11 +1803,11 @@ function httpNetworkFetch (
           return this.decoder.write(bytes)
         },
 
-        async onComplete () {
+        async onComplete() {
           this.decoder.end()
         },
 
-        onError (error) {
+        onError(error) {
           context.off('terminated', onResponseAborted)
           context.off('terminated', onRequestAborted)
 
@@ -1818,7 +1824,7 @@ function httpNetworkFetch (
   })
 }
 
-function createDeferredPromise () {
+function createDeferredPromise() {
   let res
   let rej
   const promise = new Promise((resolve, reject) => {

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -54,7 +54,7 @@ const registry = new FinalizationRegistry((abort) => {
 })
 
 // https://fetch.spec.whatwg.org/#fetch-method
-async function fetch(...args) {
+async function fetch (...args) {
   if (args.length < 1) {
     throw new TypeError(
       `Failed to execute 'fetch' on 'Window': 1 argument required, but only ${args.length} present.`
@@ -78,7 +78,7 @@ async function fetch(...args) {
     terminated: false,
     connection: null,
     dump: false,
-    terminate({ reason, aborted } = {}) {
+    terminate ({ reason, aborted } = {}) {
       if (this.terminated) {
         return
       }
@@ -205,7 +205,7 @@ async function fetch(...args) {
   return p.promise
 }
 
-function finalizeAndReportTiming(response, initiatorType = 'other') {
+function finalizeAndReportTiming (response, initiatorType = 'other') {
   // 1. If response’s URL list is null or empty, then return.
   if (!response.urlList || response.urlList.length === 0) {
     return
@@ -260,12 +260,12 @@ function finalizeAndReportTiming(response, initiatorType = 'other') {
 }
 
 // https://w3c.github.io/resource-timing/#dfn-mark-resource-timing
-function markResourceTiming() {
+function markResourceTiming () {
   // TODO
 }
 
 // https://fetch.spec.whatwg.org/#abort-fetch
-function abortFetch(p, request, responseObject) {
+function abortFetch (p, request, responseObject) {
   const context = this
 
   // 1. Let error be an "AbortError" DOMException.
@@ -296,7 +296,7 @@ function abortFetch(p, request, responseObject) {
 }
 
 // https://fetch.spec.whatwg.org/#fetching
-function fetching({ request, processResponse, processResponseDone }) {
+function fetching ({ request, processResponse, processResponseDone }) {
   // 1. Let taskDestination be null.
   let taskDestination = null
 
@@ -435,7 +435,7 @@ function fetching({ request, processResponse, processResponseDone }) {
 }
 
 // https://fetch.spec.whatwg.org/#concept-main-fetch
-async function mainFetch(fetchParams, recursive = false) {
+async function mainFetch (fetchParams, recursive = false) {
   const context = this
 
   // 1. Let request be fetchParams’s request.
@@ -697,7 +697,7 @@ async function mainFetch(fetchParams, recursive = false) {
 }
 
 // https://fetch.spec.whatwg.org/#finalize-response
-function finalizeResponse(fetchParams, response) {
+function finalizeResponse (fetchParams, response) {
   // 1. Set fetchParams’s request’s done flag.
   fetchParams.request.done = true
 
@@ -710,7 +710,7 @@ function finalizeResponse(fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-finale
-function fetchFinale(fetchParams, response) {
+function fetchFinale (fetchParams, response) {
   const context = this
 
   // 1. If fetchParams’s process response is non-null,
@@ -846,7 +846,7 @@ async function httpFetch(fetchParams) {
 }
 
 // https://fetch.spec.whatwg.org/#http-redirect-fetch
-async function httpRedirectFetch(fetchParams, response) {
+async function httpRedirectFetch (fetchParams, response) {
   // 1. Let request be fetchParams’s request.
   const request = fetchParams.request
 
@@ -985,7 +985,7 @@ async function httpRedirectFetch(fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
-async function httpNetworkOrCacheFetch(
+async function httpNetworkOrCacheFetch (
   fetchParams,
   isAuthenticationFetch = false,
   isNewConnectionFetch = false
@@ -1325,7 +1325,7 @@ async function httpNetworkOrCacheFetch(
 }
 
 // https://fetch.spec.whatwg.org/#http-network-fetch
-function httpNetworkFetch(
+function httpNetworkFetch (
   fetchParams,
   includeCredentials = false,
   forceNewConnection = false
@@ -1341,7 +1341,7 @@ function httpNetworkFetch(
       destroyed: false,
       errored: false,
       dump: false,
-      destroy(err) {
+      destroy (err) {
         if (this.destroyed) {
           return
         }
@@ -1448,7 +1448,7 @@ function httpNetworkFetch(
     //        2. Otherwise, return a network error.
 
     // To transmit request’s body body, run these steps:
-    const body = (async function* () {
+    const body = (async function * () {
       try {
         // 1. If body is null and fetchParams’s process request end-of-body is
         // non-null, then queue a fetch task given fetchParams’s process request
@@ -1507,7 +1507,7 @@ function httpNetworkFetch(
     })()
 
     // 9. If aborted, then:
-    function onRequestAborted() {
+    function onRequestAborted () {
       // 1. Let aborted be the termination’s aborted flag.
       const aborted = context.terminated.aborted
 
@@ -1552,14 +1552,14 @@ function httpNetworkFetch(
         async start(controller) {
           connection.controller = controller
         },
-        async pull() {
+        async pull () {
           if (pullAlgorithm) {
             pullAlgorithm()
           } else {
             pullAlgorithm = null
           }
         },
-        async cancel(reason) {
+        async cancel (reason) {
           cancelAlgorithm()
         }
       },
@@ -1585,7 +1585,7 @@ function httpNetworkFetch(
     //            NOTE: See onHeaders
 
     //    2. If aborted, then:
-    function onResponseAborted() {
+    function onResponseAborted () {
       // 1. Finalize response for fetchParams and response.
       finalizeResponse(fetchParams, response)
 
@@ -1626,7 +1626,7 @@ function httpNetworkFetch(
       {
         decoder: null,
 
-        onConnect(abort) {
+        onConnect (abort) {
           if (connection.destroyed) {
             abort(new AbortError())
           } else {
@@ -1634,7 +1634,7 @@ function httpNetworkFetch(
           }
         },
 
-        onHeaders(status, headersList, resume, statusText) {
+        onHeaders (status, headersList, resume, statusText) {
           if (status < 200) {
             return
           }
@@ -1780,7 +1780,7 @@ function httpNetworkFetch(
           return true
         },
 
-        onData(chunk) {
+        onData (chunk) {
           if (connection.dump) {
             return
           }
@@ -1803,11 +1803,11 @@ function httpNetworkFetch(
           return this.decoder.write(bytes)
         },
 
-        async onComplete() {
+        async onComplete () {
           this.decoder.end()
         },
 
-        onError(error) {
+        onError (error) {
           context.off('terminated', onResponseAborted)
           context.off('terminated', onRequestAborted)
 
@@ -1824,7 +1824,7 @@ function httpNetworkFetch(
   })
 }
 
-function createDeferredPromise() {
+function createDeferredPromise () {
   let res
   let rej
   const promise = new Promise((resolve, reject) => {

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -71,7 +71,7 @@ async function fetch (...args) {
   }
 
   const resource = args[0]
-  const init = args.length >= 1 ? args[1] ?? {} : {}
+  const init = args.length >= 1 ? args[1] || {} : {}
 
   const context = Object.assign(new EE(), {
     dispatcher: this,
@@ -1359,7 +1359,7 @@ function httpNetworkFetch (
 
         if (this.controller) {
           try {
-            this.controller.error(err ?? new AbortError())
+            this.controller.error(err || new AbortError())
             this.controller = null
           } catch (err) {
             // Will throw TypeError if body is not readable.
@@ -1662,13 +1662,7 @@ function httpNetworkFetch (
           context.on('terminated', onResponseAborted)
 
           const contentEncoding = headers.get('content-encoding')
-          if (contentEncoding) {
-            const codings =
-              contentEncoding
-                .toLowerCase()
-                .split(',')
-                .map((x) => x.trim()) ?? []
-          }
+          const codings = contentEncoding ? contentEncoding.toLowerCase().split(',').map((x) => x.trim()) : []
 
           const decoders = []
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -743,7 +743,7 @@ function fetchFinale (fetchParams, response) {
 }
 
 // https://fetch.spec.whatwg.org/#http-fetch
-async function httpFetch(fetchParams) {
+async function httpFetch (fetchParams) {
   const context = this
 
   // 1. Let request be fetchParams’s request.
@@ -1549,7 +1549,7 @@ function httpNetworkFetch (
 
     const stream = new ReadableStream(
       {
-        async start(controller) {
+        async start (controller) {
           connection.controller = controller
         },
         async pull () {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -51,7 +51,7 @@ class Request {
       )
     }
     const input = args[0] instanceof Request ? args[0] : toUSVString(args[0])
-    const init = args.length >= 1 ? args[1] ?? {} : {}
+    const init = args.length >= 1 ? args[1] || {} : {}
 
     // TODO
     this[kRealm] = { settingsObject: {} }
@@ -85,7 +85,7 @@ class Request {
       if (parsedURL.username || parsedURL.password) {
         throw new TypeError(
           'Request cannot be constructed from a URL that includes credentials: ' +
-            input
+          input
         )
       }
 
@@ -424,7 +424,7 @@ class Request {
 
     // 37. Let inputOrInitBody be initBody if it is non-null; otherwise
     // inputBody.
-    const inputOrInitBody = initBody ?? inputBody
+    const inputOrInitBody = initBody || inputBody
 
     // 38. If inputOrInitBody is non-null and inputOrInitBody’s source is
     // null, then:

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -98,7 +98,7 @@ class Response {
     }
 
     const body = args.length >= 1 ? args[0] : null
-    const init = args.length >= 2 ? args[1] ?? {} : {}
+    const init = args.length >= 2 ? args[1] || {} : {}
 
     // TODO
     this[kRealm] = { settingsObject: {} }


### PR DESCRIPTION
I'm not so sure about this PR, but undici-fetch introduced some optional chaining syntax which breaks Node.js 12. I think we can avoid this.