### PR TITLE
perf: use bigger HWM by default

### DIFF
--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -23,9 +23,10 @@ if (cluster.isPrimary) {
     cluster.fork()
   }
 } else {
+  const buf = Buffer.alloc(64 * 1024, '_')
   const server = createServer((req, res) => {
     setTimeout(function () {
-      res.end('hello world')
+      res.end(buf)
     }, timeout)
   }).listen(port)
   server.keepAliveTimeout = 600e3

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -29,6 +29,7 @@ function buildConnector ({ maxCachedSessions, socketPath, timeout, ...opts }) {
       const session = sessionCache.get(servername) || null
 
       socket = tls.connect({
+        highWaterMark: 16384, // TLS in node can't have bigger HWM anyway...
         ...options,
         servername,
         session,
@@ -61,6 +62,7 @@ function buildConnector ({ maxCachedSessions, socketPath, timeout, ...opts }) {
         })
     } else {
       socket = net.connect({
+        highWaterMark: 64 * 1024, // Same as nodejs fs streams.
         ...options,
         port: port || 80,
         host: hostname


### PR DESCRIPTION
Node's default HWM is rather small... this can give a slight performance improvement especially for large bodies.