### PR TITLE
Expose the socket in case of SocketError

### DIFF
--- a/docs/api/Errors.md
+++ b/docs/api/Errors.md
@@ -20,3 +20,7 @@ import { errors } from 'undici'
 | `ResponseContentLengthMismatchError` | `UND_ERR_RES_CONTENT_LENGTH_MISMATCH` | response body does not match content-length header |
 | `InformationalError`                 | `UND_ERR_INFO`                        | expected error with reason                         |
 | `TrailerMismatchError`               | `UND_ERR_TRAILER_MISMATCH`            | trailers did not match specification               |
+
+### `SocketError`
+
+The `SocketError` has a `.socket` property which holds the instance of the `Socket` or `TLSSocket` that caused the error.

--- a/docs/api/Errors.md
+++ b/docs/api/Errors.md
@@ -24,3 +24,4 @@ import { errors } from 'undici'
 ### `SocketError`
 
 The `SocketError` has a `.socket` property which holds the instance of the `Socket` or `TLSSocket` that caused the error.
+Be aware that in some cases the `.socket` property can be `null`.

--- a/lib/api/api-connect.js
+++ b/lib/api/api-connect.js
@@ -40,7 +40,7 @@ class ConnectHandler extends AsyncResource {
   }
 
   onHeaders () {
-    throw new SocketError('bad connect')
+    throw new SocketError('bad connect', null)
   }
 
   onUpgrade (statusCode, headers, socket) {

--- a/lib/api/api-upgrade.js
+++ b/lib/api/api-upgrade.js
@@ -42,7 +42,7 @@ class UpgradeHandler extends AsyncResource {
   }
 
   onHeaders () {
-    throw new SocketError('bad upgrade')
+    throw new SocketError('bad upgrade', null)
   }
 
   onUpgrade (statusCode, headers, socket) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1049,7 +1049,7 @@ function onSocketClose () {
   this[kParser].destroy()
   this[kParser] = null
 
-  const err = this[kError] || new SocketError('closed')
+  const err = this[kError] || new SocketError('closed', this)
 
   client[kSocket] = null
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1040,7 +1040,7 @@ function onSocketEnd () {
     return
   }
 
-  util.destroy(this, new SocketError('other side closed'))
+  util.destroy(this, new SocketError('other side closed', this))
 }
 
 function onSocketClose () {

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -147,12 +147,13 @@ class ClientClosedError extends UndiciError {
 }
 
 class SocketError extends UndiciError {
-  constructor (message) {
+  constructor (message, socket) {
     super(message)
     Error.captureStackTrace(this, SocketError)
     this.name = 'SocketError'
     this.message = message || 'Socket error'
     this.code = 'UND_ERR_SOCKET'
+    this.socket = socket
   }
 }
 

--- a/test/types/errors.test-d.ts
+++ b/test/types/errors.test-d.ts
@@ -1,5 +1,7 @@
 import { expectAssignable } from 'tsd'
 import { errors } from '../..'
+import { Socket } from 'net'
+import { TLSSocket } from 'tls'
 
 expectAssignable<errors.UndiciError>(new errors.UndiciError())
 
@@ -52,6 +54,7 @@ expectAssignable<errors.UndiciError>(new errors.SocketError())
 expectAssignable<errors.SocketError>(new errors.SocketError())
 expectAssignable<'SocketError'>(new errors.SocketError().name)
 expectAssignable<'UND_ERR_SOCKET'>(new errors.SocketError().code)
+expectAssignable<Socket | TLSSocket>(new errors.SocketError().socket)
 
 expectAssignable<errors.UndiciError>(new errors.NotSupportedError())
 expectAssignable<errors.NotSupportedError>(new errors.NotSupportedError())

--- a/test/types/errors.test-d.ts
+++ b/test/types/errors.test-d.ts
@@ -54,7 +54,7 @@ expectAssignable<errors.UndiciError>(new errors.SocketError())
 expectAssignable<errors.SocketError>(new errors.SocketError())
 expectAssignable<'SocketError'>(new errors.SocketError().name)
 expectAssignable<'UND_ERR_SOCKET'>(new errors.SocketError().code)
-expectAssignable<Socket | TLSSocket>(new errors.SocketError().socket)
+expectAssignable<Socket | TLSSocket | null>(new errors.SocketError().socket)
 
 expectAssignable<errors.UndiciError>(new errors.NotSupportedError())
 expectAssignable<errors.NotSupportedError>(new errors.NotSupportedError())

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -70,7 +70,7 @@ declare namespace Errors {
   export class SocketError extends UndiciError {
     name: 'SocketError';
     code: 'UND_ERR_SOCKET';
-    socket: Socket | TLSSocket
+    socket: Socket | TLSSocket | null
   }
 
   /** Encountered unsupported functionality. */

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -1,3 +1,6 @@
+import { Socket } from 'net'
+import { TLSSocket } from 'tls'
+
 export = Errors
 
 declare namespace Errors {
@@ -67,6 +70,7 @@ declare namespace Errors {
   export class SocketError extends UndiciError {
     name: 'SocketError';
     code: 'UND_ERR_SOCKET';
+    socket: Socket | TLSSocket
   }
 
   /** Encountered unsupported functionality. */


### PR DESCRIPTION
If a `SocketError` happens, a user might want to dig deeper to understand why it has happened. For example, they might want to read the socket local/remote address of the socket.
This pr adds a `.socket` property to the `SocketError` which holds the socket that caused the error.