### PR TITLE
fix: Rename `File.filename` property to `File.name`

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -95,7 +95,7 @@ function extractBody (object, keepalive = false) {
           yield enc.encode(
             prefix +
               `; name="${escape(normalizeLinefeeds(name))}"` +
-              (value.filename ? `; filename="${escape(value.filename)}"` : '') +
+              (value.name ? `; filename="${escape(value.name)}"` : '') +
               '\r\n' +
               `Content-Type: ${
                 value.type || 'application/octet-stream'

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -45,17 +45,17 @@ class File extends Blob {
 
     super(fileBits, { type: t })
     this[kState] = {
-      filename: n,
+      name: n,
       lastModified: d
     }
   }
 
-  get filename () {
+  get name () {
     if (!(this instanceof File)) {
       throw new TypeError('Illegal invocation')
     }
 
-    return this[kState].filename
+    return this[kState].name
   }
 
   get lastModified () {

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -12,7 +12,7 @@ test('args validation', (t) => {
   t.plan(2)
 
   t.throws(() => {
-    File.prototype.filename.call(null)
+    File.prototype.name.call(null)
   }, TypeError)
   t.throws(() => {
     File.prototype.lastModified.call(null)

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -82,8 +82,8 @@ test('append file', (t) => {
 
   t.equal(form.has('asd'), true)
   t.equal(form.has('asd2'), true)
-  t.equal(form.get('asd').filename, 'asd2')
-  t.equal(form.get('asd2').filename, 'asd2')
+  t.equal(form.get('asd').name, 'asd2')
+  t.equal(form.get('asd2').name, 'asd2')
   form.delete('asd')
   t.equal(form.get('asd'), null)
   t.equal(form.has('asd2'), true)


### PR DESCRIPTION
File class does not have `filename` property, only `name`.
This PR fixes File class, tests and `multipart/form-data` encoder.

See:
* https://developer.mozilla.org/en-US/docs/Web/API/File#instance_properties
* https://w3c.github.io/FileAPI/#dfn-name