### PR TITLE
Update .socket property of SocketError class

### DIFF
--- a/docs/api/Errors.md
+++ b/docs/api/Errors.md
@@ -23,5 +23,19 @@ import { errors } from 'undici'
 
 ### `SocketError`
 
-The `SocketError` has a `.socket` property which holds the instance of the `Socket` or `TLSSocket` that caused the error.
+The `SocketError` has a `.socket` property which holds socket metadata:
+
+```ts
+interface SocketInfo {
+  localAddress?: string
+  localPort?: number
+  remoteAddress?: string
+  remotePort?: number
+  remoteFamily?: string
+  timeout?: number
+  bytesWritten?: number
+  bytesRead?: number
+}
+```
+
 Be aware that in some cases the `.socket` property can be `null`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -779,13 +779,13 @@ class Parser {
     // TODO: More statusCode validation?
 
     if (statusCode === 100) {
-      util.destroy(socket, new SocketError('bad response'))
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
     /* istanbul ignore if: this can only happen if server is misbehaving */
     if (upgrade && !request.upgrade) {
-      util.destroy(socket, new SocketError('bad upgrade'))
+      util.destroy(socket, new SocketError('bad upgrade', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -1055,7 +1055,7 @@ function onSocketEnd () {
     return
   }
 
-  util.destroy(this, new SocketError('other side closed', this))
+  util.destroy(this, new SocketError('other side closed', util.getSocketInfo(this)))
 }
 
 function onSocketClose () {
@@ -1064,7 +1064,7 @@ function onSocketClose () {
   this[kParser].destroy()
   this[kParser] = null
 
-  const err = this[kError] || new SocketError('closed', this)
+  const err = this[kError] || new SocketError('closed', util.getSocketInfo(this))
 
   client[kSocket] = null
 

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -245,6 +245,19 @@ function isDisturbed (body) {
   ))
 }
 
+function getSocketInfo (socket) {
+  return {
+    localAddress: socket.localAddress,
+    localPort: socket.localPort,
+    remoteAddress: socket.remoteAddress,
+    remotePort: socket.remotePort,
+    remoteFamily: socket.remoteFamily,
+    timeout: socket.timeout,
+    bytesWritten: socket.bytesWritten,
+    bytesRead: socket.bytesRead
+  }
+}
+
 const kEnumerableProperty = Object.create(null)
 kEnumerableProperty.enumerable = true
 
@@ -267,5 +280,6 @@ module.exports = {
   deepClone,
   isBuffer,
   isBlob,
-  validateHandler
+  validateHandler,
+  getSocketInfo
 }

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -6,7 +6,6 @@ const { createServer } = require('http')
 const https = require('https')
 const pem = require('https-pem')
 const net = require('net')
-const tls = require('tls')
 const { Readable } = require('stream')
 
 const { kSocket } = require('../lib/core/symbols')
@@ -1180,7 +1179,7 @@ test('headers overflow', t => {
 })
 
 test('SocketError should expose socket details (net)', (t) => {
-  t.plan(2)
+  t.plan(8)
 
   const server = createServer()
 
@@ -1195,13 +1194,19 @@ test('SocketError should expose socket details (net)', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       t.ok(err instanceof errors.SocketError)
-      t.ok(err.socket instanceof net.Socket)
+      t.equal(err.socket.remoteFamily, 'IPv4')
+      t.equal(err.socket.localAddress, '127.0.0.1')
+      t.equal(err.socket.remoteAddress, '127.0.0.1')
+      t.type(err.socket.localPort, 'number')
+      t.type(err.socket.remotePort, 'number')
+      t.type(err.socket.bytesWritten, 'number')
+      t.type(err.socket.bytesRead, 'number')
     })
   })
 })
 
 test('SocketError should expose socket details (tls)', (t) => {
-  t.plan(2)
+  t.plan(8)
 
   const server = https.createServer(pem)
 
@@ -1220,7 +1225,13 @@ test('SocketError should expose socket details (tls)', (t) => {
 
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       t.ok(err instanceof errors.SocketError)
-      t.ok(err.socket instanceof tls.TLSSocket)
+      t.equal(err.socket.remoteFamily, 'IPv4')
+      t.equal(err.socket.localAddress, '127.0.0.1')
+      t.equal(err.socket.remoteAddress, '127.0.0.1')
+      t.type(err.socket.localPort, 'number')
+      t.type(err.socket.remotePort, 'number')
+      t.type(err.socket.bytesWritten, 'number')
+      t.type(err.socket.bytesRead, 'number')
     })
   })
 })

--- a/test/types/errors.test-d.ts
+++ b/test/types/errors.test-d.ts
@@ -1,7 +1,6 @@
 import { expectAssignable } from 'tsd'
 import { errors } from '../..'
-import { Socket } from 'net'
-import { TLSSocket } from 'tls'
+import { SocketInfo } from '../../types/client'
 
 expectAssignable<errors.UndiciError>(new errors.UndiciError())
 
@@ -54,7 +53,7 @@ expectAssignable<errors.UndiciError>(new errors.SocketError())
 expectAssignable<errors.SocketError>(new errors.SocketError())
 expectAssignable<'SocketError'>(new errors.SocketError().name)
 expectAssignable<'UND_ERR_SOCKET'>(new errors.SocketError().code)
-expectAssignable<Socket | TLSSocket | null>(new errors.SocketError().socket)
+expectAssignable<SocketInfo | null>(new errors.SocketError().socket)
 
 expectAssignable<errors.UndiciError>(new errors.NotSupportedError())
 expectAssignable<errors.NotSupportedError>(new errors.NotSupportedError())

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -39,4 +39,15 @@ declare namespace Client {
     /** @deprecated use the connect option instead */
     tls?: TlsOptions | null;
   }
+
+  export interface SocketInfo {
+    localAddress?: string
+    localPort?: number
+    remoteAddress?: string
+    remotePort?: number
+    remoteFamily?: string
+    timeout?: number
+    bytesWritten?: number
+    bytesRead?: number
+  }
 }

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -1,7 +1,5 @@
-import { Socket } from 'net'
-import { TLSSocket } from 'tls'
-
 export = Errors
+import { SocketInfo } from './client'
 
 declare namespace Errors {
   export class UndiciError extends Error { }
@@ -70,7 +68,7 @@ declare namespace Errors {
   export class SocketError extends UndiciError {
     name: 'SocketError';
     code: 'UND_ERR_SOCKET';
-    socket: Socket | TLSSocket | null
+    socket: SocketInfo | null
   }
 
   /** Encountered unsupported functionality. */


### PR DESCRIPTION
The previous implementation didn't work well, as some of the properties of the `Socket` instance were removed while destroying the socket, making the socket instance useless for debugging purposes.
This pr stores the properties before destroying the socket in a separate object as we previously discussed.

Follow up of https://github.com/nodejs/undici/pull/1041