### PR TITLE
docs: spelling fixes to diagnostic channel

### DIFF
--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -2,8 +2,8 @@
 
 Stability: Experimental.
 
-Undici support the [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) (currently available only on Node.js v16+).
-It is the preferred way to instrument Undici and retrieve internal informations.
+Undici supports the [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html) (currently available only on Node.js v16+).
+It is the preferred way to instrument Undici and retrieve internal information.
 
 The channels available are the following.
 
@@ -39,7 +39,7 @@ diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) =>
 
 ## `undici:request:headers`
 
-This message is published after the response headers have been received, i.e. the reponse has been completed.
+This message is published after the response headers have been received, i.e. the response has been completed.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
@@ -55,7 +55,7 @@ diagnosticsChannel.channel('undici:request:headers').subscribe(({ request, respo
 
 ## `undici:request:trailers`
 
-This message is published after the response body and trailers have been received, i.e. the reponse has been completed.
+This message is published after the response body and trailers have been received, i.e. the response has been completed.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
@@ -82,9 +82,9 @@ diagnosticsChannel.channel('undici:request:error').subscribe(({ request, error }
 
 ## `undici:client:sendHeaders`
 
-This message is published right before first byte of the request is written to the socket.
+This message is published right before the first byte of the request is written to the socket.
 
-*Note*: It will publish the exact headers that will be sent to the server in raw foramt. 
+*Note*: It will publish the exact headers that will be sent to the server in raw format.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
@@ -97,7 +97,7 @@ diagnosticsChannel.channel('undici:client:sendHeaders').subscribe(({ request, he
 
 ## `undici:client:beforeConnect`
 
-This message is published before creating a new connection for **any** request. 
+This message is published before creating a new connection for **any** request.
 You can not assume that this event is related to any specific request.
 
 ```js
@@ -111,7 +111,7 @@ diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(({ connectPa
 
 ## `undici:client:connected`
 
-This message is published after connection established.
+This message is published after a connection is established.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'


### PR DESCRIPTION
Fixed spelling mistakes in Diagnostic Channel API docs