### PR TITLE
types(fetch): make json method generic

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -38,7 +38,7 @@ export interface BodyMixin {
   readonly arrayBuffer: () => Promise<ArrayBuffer>
   readonly blob: () => Promise<Blob>
   readonly formData: () => Promise<FormData>
-  readonly json: () => Promise<unknown>
+  readonly json: <T>() => Promise<T>
   readonly text: () => Promise<string>
 }
 
@@ -129,7 +129,7 @@ export declare class Request implements BodyMixin {
   readonly arrayBuffer: () => Promise<ArrayBuffer>
   readonly blob: () => Promise<Blob>
   readonly formData: () => Promise<FormData>
-  readonly json: () => Promise<unknown>
+  readonly json: <T>() => Promise<T>
   readonly text: () => Promise<string>
 
   readonly clone: () => Request
@@ -168,7 +168,7 @@ export declare class Response implements BodyMixin {
   readonly arrayBuffer: () => Promise<ArrayBuffer>
   readonly blob: () => Promise<Blob>
   readonly formData: () => Promise<FormData>
-  readonly json: () => Promise<unknown>
+  readonly json: <T>() => Promise<T>
   readonly text: () => Promise<string>
 
   readonly clone: () => Response


### PR DESCRIPTION
This PR makes the `json` method to be generic. This will let TS users provide a return type for the method instead of it just being `unknown`

```ts
import { fetch } from 'undici';

// A shorter version of what GitHub returns
interface Repository {
    id: number;
    node_id: string;
    name: string;
}

const res = await fetch('https://api.github.com/repos/nodejs/undici');
const data = await res.json<Repository>(); // <- We know the shape of 'data' now
``` 