### PR TITLE
Store origin on request to facilitate instrumentation

### DIFF
--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -15,6 +15,7 @@ This message is published when a new outgoing request is created.
 import diagnosticsChannel from 'diagnostics_channel'
 
 diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
+  console.log('origin', request.origin)
   console.log('completed', request.completed)
   console.log('method', request.method)
   console.log('path', request.path)

--- a/lib/client.js
+++ b/lib/client.js
@@ -284,7 +284,7 @@ class Client extends Dispatcher {
 
       const origin = opts.origin || this[kUrl].origin
 
-      const request = new Request({ origin, ...opts }, handler)
+      const request = new Request(origin, opts, handler)
 
       this[kQueue].push(request)
       if (this[kResuming]) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -282,7 +282,9 @@ class Client extends Dispatcher {
         handler = new RedirectHandler(this, maxRedirections, opts, handler)
       }
 
-      const request = new Request(opts, handler)
+      const origin = opts.origin || this[kUrl].origin
+
+      const request = new Request({ origin, ...opts }, handler)
 
       this[kQueue].push(request)
       if (this[kResuming]) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -28,6 +28,7 @@ try {
 
 class Request {
   constructor ({
+    origin,
     path,
     method,
     body,
@@ -92,6 +93,8 @@ class Request {
     this.upgrade = upgrade || null
 
     this.path = path
+
+    this.origin = origin
 
     this.idempotent = idempotent == null
       ? method === 'HEAD' || method === 'GET'

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -27,8 +27,7 @@ try {
 }
 
 class Request {
-  constructor ({
-    origin,
+  constructor (origin, {
     path,
     method,
     body,

--- a/test/diagnostics-channel/get.js
+++ b/test/diagnostics-channel/get.js
@@ -35,6 +35,7 @@ const reqHeaders = {
 let _req
 diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
   _req = request
+  t.equal(request.origin, `http://localhost:${server.address().port}/`)
   t.equal(request.completed, false)
   t.equal(request.method, 'GET')
   t.equal(request.path, '/')

--- a/test/diagnostics-channel/get.js
+++ b/test/diagnostics-channel/get.js
@@ -14,7 +14,7 @@ try {
 const { Client } = require('../..')
 const { createServer } = require('http')
 
-t.plan(31)
+t.plan(32)
 
 const server = createServer((req, res) => {
   res.setHeader('Content-Type', 'text/plain')
@@ -35,7 +35,7 @@ const reqHeaders = {
 let _req
 diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
   _req = request
-  t.equal(request.origin, `http://localhost:${server.address().port}/`)
+  t.equal(request.origin, `http://localhost:${server.address().port}`)
   t.equal(request.completed, false)
   t.equal(request.method, 'GET')
   t.equal(request.path, '/')


### PR DESCRIPTION
## This relates to...

Fix for issue #1052 

## Rationale
When instrumenting with APM's it is valuable to have the full origin for the request so we can perform filtering.
This is also required at the time the request is created as this is usually when tracing headers are injected.

## Changes

Adds `origin` member on the `Request` entity for propagation through the diagnostics channels

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
