### PR TITLE
fix: don't rely on `allowSyntheticDefaultImports`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
-import Dispatcher from './types/dispatcher'
+import Dispatcher = require('./types/dispatcher')
 import { setGlobalDispatcher, getGlobalDispatcher } from './types/global-dispatcher'
-import Pool from './types/pool'
-import Client from './types/client'
-import buildConnector from './types/connector'
-import errors from './types/errors'
-import Agent from './types/agent'
-import MockClient from './types/mock-client'
-import MockPool from './types/mock-pool'
-import MockAgent from './types/mock-agent'
-import mockErrors from './types/mock-errors'
+import Pool = require('./types/pool')
+import Client = require('./types/client')
+import buildConnector = require('./types/connector')
+import errors = require('./types/errors')
+import Agent = require('./types/agent')
+import MockClient = require('./types/mock-client')
+import MockPool = require('./types/mock-pool')
+import MockAgent = require('./types/mock-agent')
+import mockErrors = require('./types/mock-errors')
 import { request, pipeline, stream, connect, upgrade } from './types/api'
 
 export * from './types/fetch'

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url'
-import Dispatcher from './dispatcher'
-import Pool from './pool'
+import Dispatcher = require('./dispatcher')
+import Pool = require('./pool')
 
 export = Agent
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -1,6 +1,6 @@
 import { URL, UrlObject } from 'url'
 import { Duplex } from 'stream'
-import Dispatcher from './dispatcher'
+import Dispatcher = require('./dispatcher')
 
 export {
   request,

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,7 +1,8 @@
 import { URL } from 'url'
 import { TlsOptions } from 'tls'
-import Dispatcher, { DispatchOptions, RequestOptions } from './dispatcher'
-import buildConnector from './connector'
+import Dispatcher = require('./dispatcher')
+import { DispatchOptions, RequestOptions } from './dispatcher'
+import buildConnector = require('./connector')
 
 export = Client
 

--- a/types/global-dispatcher.d.ts
+++ b/types/global-dispatcher.d.ts
@@ -1,4 +1,4 @@
-import Dispatcher from "./dispatcher";
+import Dispatcher = require("./dispatcher");
 
 export {
   getGlobalDispatcher,

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -1,5 +1,5 @@
-import Agent from './agent'
-import Dispatcher from './dispatcher'
+import Agent = require('./agent')
+import Dispatcher = require('./dispatcher')
 import { Interceptable } from './mock-interceptor'
 
 export = MockAgent

--- a/types/mock-client.d.ts
+++ b/types/mock-client.d.ts
@@ -1,6 +1,6 @@
-import Client from './client'
-import Dispatcher from './dispatcher'
-import MockAgent from './mock-agent'
+import Client = require('./client')
+import Dispatcher = require('./dispatcher')
+import MockAgent = require('./mock-agent')
 import { MockInterceptor, Interceptable } from './mock-interceptor'
 
 export = MockClient

--- a/types/mock-pool.d.ts
+++ b/types/mock-pool.d.ts
@@ -1,7 +1,7 @@
-import Pool from './pool'
-import MockAgent from './mock-agent'
+import Pool = require('./pool')
+import MockAgent = require('./mock-agent')
 import { Interceptable, MockInterceptor } from './mock-interceptor'
-import Dispatcher from './dispatcher'
+import Dispatcher = require('./dispatcher')
 
 export = MockPool
 

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -1,5 +1,5 @@
-import Client from './client'
-import Dispatcher from './dispatcher'
+import Client = require('./client')
+import Dispatcher = require('./dispatcher')
 import { URL } from 'url'
 
 export = Pool


### PR DESCRIPTION
This PR contains changes that correspond with the best practices for default imports set forth in the DefinitelyTyped documentation. Please refer to "[`esModuleInterop`/`allowSyntheticDefaultImports`](https://github.com/DefinitelyTyped/DefinitelyTyped#esmoduleinteropallowsyntheticdefaultimports)" for more information.

Fixes #1058