### PR TITLE
fix(headers): iterate over cloned list

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -313,20 +313,23 @@ class Headers {
   }
 
   * keys () {
-    for (let index = 0; index < this[kHeadersList].length; index += 2) {
-      yield this[kHeadersList][index]
+    const clone = this[kHeadersList].slice()
+    for (let index = 0; index < clone.length; index += 2) {
+      yield clone[index]
     }
   }
 
   * values () {
-    for (let index = 1; index < this[kHeadersList].length; index += 2) {
-      yield this[kHeadersList][index]
+    const clone = this[kHeadersList].slice()
+    for (let index = 1; index < clone.length; index += 2) {
+      yield clone[index]
     }
   }
 
   * entries () {
-    for (let index = 0; index < this[kHeadersList].length; index += 2) {
-      yield [this[kHeadersList][index], this[kHeadersList][index + 1]]
+    const clone = this[kHeadersList].slice()
+    for (let index = 0; index < clone.length; index += 2) {
+      yield [clone[index], clone[index + 1]]
     }
   }
 

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -280,7 +280,7 @@ tap.test('Headers set', t => {
 })
 
 tap.test('Headers as Iterable', t => {
-  t.plan(7)
+  t.plan(8)
 
   t.test('should freeze values while iterating', t => {
     t.plan(1)
@@ -298,6 +298,28 @@ tap.test('Headers as Iterable', t => {
       headers.set(`x-${key}`, val)
     }
     t.strictSame([...headers], expected)
+  })
+
+  t.test('prevent infinite, continuous iteration', t => {
+    t.plan(2)
+
+    const headers = new Headers({
+      z: 1,
+      y: 2,
+      x: 3
+    })
+
+    const order = []
+    for (const [key] of headers) {
+      order.push(key)
+      headers.set(key + key, 1)
+    }
+
+    t.strictSame(order, ['x', 'y', 'z'])
+    t.strictSame(
+      [...headers.keys()],
+      ['x', 'xx', 'y', 'yy', 'z', 'zz']
+    )
   })
 
   t.test('returns combined and sorted entries using .forEach()', t => {

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -280,7 +280,25 @@ tap.test('Headers set', t => {
 })
 
 tap.test('Headers as Iterable', t => {
-  t.plan(6)
+  t.plan(7)
+
+  t.test('should freeze values while iterating', t => {
+    t.plan(1)
+    const init = [
+      ['foo', '123'],
+      ['bar', '456']
+    ]
+    const expected = [
+      ['x-bar', '456'],
+      ['x-foo', '123']
+    ]
+    const headers = new Headers(init)
+    for (const [key, val] of headers) {
+      headers.delete(key)
+      headers.set(`x-${key}`, val)
+    }
+    t.strictSame([...headers], expected)
+  })
 
   t.test('returns combined and sorted entries using .forEach()', t => {
     t.plan(12)


### PR DESCRIPTION
This matches the browser behavior, example:

```js
let demo = new Headers({ foo: '123', bar: '456' });

for (let [k,v] of demo) { 
  demo.delete(k);
  demo.set(`x-${k}`, v);
}

[...demo];
//=> [
//=>   ['x-bar', '456'],
//=>   ['x-foo', '123'],
//=> ]
```

> **Note:** This is included as a test