### PR TITLE
add fetch to namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,4 +41,5 @@ declare namespace Undici {
   var MockPool: typeof import('./types/mock-pool');
   var MockAgent: typeof import('./types/mock-agent');
   var mockErrors: typeof import('./types/mock-errors');
+  var fetch: typeof import('./types/fetch').fetch;
 }

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,7 +1,8 @@
 import { expectAssignable } from 'tsd'
-import Undici, { Pool, Client, errors } from '../..'
+import Undici, { Pool, Client, errors, fetch } from '../..'
 
 expectAssignable<Pool>(Undici('', {}))
 expectAssignable<Pool>(new Undici.Pool('', {}))
 expectAssignable<Client>(new Undici.Client('', {}))
 expectAssignable<typeof errors>(Undici.errors)
+expectAssignable<typeof fetch>(Undici.fetch)


### PR DESCRIPTION
Not sure how I missed this previously. This adds `fetch` to the namespace so you can do:

```ts
import undici from 'undici'
undici.fetch(/* ... */)
```

Includes a test as well.