### PR TITLE
feat: Allow buffers as mock response data

### DIFF
--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -62,11 +62,13 @@ Returns: `MockInterceptor` corresponding to the input options.
 
 We can define the behaviour of an intercepted request with the following options.
 
-* **reply** `(statusCode: number, replyData: string | object, responseOptions?: MockResponseOptions) => MockScope` - define a reply for a matching request. Default for `responseOptions` is `{}`.
+* **reply** `(statusCode: number, replyData: string | Buffer | object, responseOptions?: MockResponseOptions) => MockScope` - define a reply for a matching request. Default for `responseOptions` is `{}`.
 * **replyWithError** `(error: Error) => MockScope` - define an error for a matching request to throw.
 * **defaultReplyHeaders** `(headers: Record<string, string>) => MockInterceptor` - define default headers to be included in subsequent replies. These are in addition to headers on a specific reply.
 * **defaultReplyTrailers** `(trailers: Record<string, string>) => MockInterceptor` - define default trailers to be included in subsequent replies. These are in addition to trailers on a specific reply.
 * **replyContentLength** `() => MockInterceptor` - define automatically calculated `content-length` headers to be included in subsequent replies.
+
+The reply data of an intercepted request may either be a string, buffer, or JavaScript object. Objects are converted to JSON while strings and buffers are sent as-is.
 
 By default, `reply` and `replyWithError` define the behaviour for the first matching request only. Subsequent requests will not be affected (this can be changed using the returned `MockScope`).
 

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -47,7 +47,13 @@ function matchKey (mockDispatch, { path, method, body, headers }) {
 }
 
 function getResponseData (data) {
-  return typeof data === 'object' ? JSON.stringify(data) : data.toString()
+  if (Buffer.isBuffer(data)) {
+    return data
+  } else if (typeof data === 'object') {
+    return JSON.stringify(data)
+  } else {
+    return data.toString()
+  }
 }
 
 function getMockDispatch (mockDispatches, key) {

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -2,7 +2,11 @@
 
 const { test } = require('tap')
 const { MockNotMatchedError } = require('../lib/mock/mock-errors')
-const { deleteMockDispatch, getMockDispatch } = require('../lib/mock/mock-utils')
+const {
+  deleteMockDispatch,
+  getMockDispatch,
+  getResponseData
+} = require('../lib/mock/mock-utils')
 
 test('deleteMockDispatch - should do nothing if not able to find mock dispatch', (t) => {
   t.plan(1)
@@ -81,5 +85,27 @@ test('getMockDispatch', (t) => {
       path: 'wrong',
       method: 'wrong'
     }), new MockNotMatchedError('Mock dispatch not matched for path \'wrong\''))
+  })
+})
+
+test('getResponseData', (t) => {
+  t.plan(3)
+
+  t.test('it should stringify objects', (t) => {
+    t.plan(1)
+    const responseData = getResponseData({ str: 'string', num: 42 })
+    t.equal(responseData, '{"str":"string","num":42}')
+  })
+
+  t.test('it should return strings untouched', (t) => {
+    t.plan(1)
+    const responseData = getResponseData('test')
+    t.equal(responseData, 'test')
+  })
+
+  t.test('it should return buffers untouched', (t) => {
+    t.plan(1)
+    const responseData = getResponseData(Buffer.from('test'))
+    t.ok(Buffer.isBuffer(responseData))
   })
 })

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -8,6 +8,7 @@ import { MockInterceptor, MockScope } from '../../types/mock-interceptor'
 
   // reply
   expectAssignable<MockScope>(mockInterceptor.reply(200, ''))
+  expectAssignable<MockScope>(mockInterceptor.reply(200, Buffer))
   expectAssignable<MockScope>(mockInterceptor.reply(200, {}))
   expectAssignable<MockScope>(mockInterceptor.reply(200, {}, {}))
   expectAssignable<MockScope>(mockInterceptor.reply(200, {}, { headers: { foo: 'bar' }}))

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -21,7 +21,7 @@ declare class MockScope<TData extends object = object> {
 declare class MockInterceptor {
   constructor(options: MockInterceptor.Options, mockDispatches: MockInterceptor.MockDispatch[]);
   /** Mock an undici request with the defined reply. */
-  reply<TData extends object = object>(statusCode: number, data: TData | string, responseOptions?: MockInterceptor.MockResponseOptions): MockScope<TData>;
+  reply<TData extends object = object>(statusCode: number, data: TData | Buffer| string , responseOptions?: MockInterceptor.MockResponseOptions): MockScope<TData>;
   /** Mock an undici request by throwing the defined reply error. */
   replyWithError<TError extends Error = Error>(error: TError): MockScope;
   /** Set default reply headers on the interceptor for subsequent mocked replies. */


### PR DESCRIPTION
With this change, it's possible to return binary payloads from an intercepted call:

```
const mockImage = readFileSync('/path/to/image/png')
mockPool.intercept({ path: '/foo', method: 'GET' }).reply(200, mockImage)
```

I haven't bothered with docs yet. I'll update them if there's interest in merging this.