### PR TITLE
docs: fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Arguments:
 
 * **url** `string | URL | UrlObject`
 * **options** [`RequestOptions`](./docs/api/Dispatcher.md#parameter-requestoptions)
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcher)
   * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
   * **maxRedirections** `Integer` - Default: `0`
 
@@ -109,7 +109,7 @@ Arguments:
 
 * **url** `string | URL | UrlObject`
 * **options** [`StreamOptions`](./docs/api/Dispatcher.md#parameter-streamoptions)
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcher)
   * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
   * **maxRedirections** `Integer` - Default: `0`
 * **factory** `Dispatcher.stream.factory`
@@ -118,7 +118,7 @@ Returns a promise with the result of the `Dispatcher.stream` method.
 
 Calls `options.dispatcher.stream(options, factory)`.
 
-See [Dispatcher.stream](docs/api/Dispatcher.md#dispatcherstream) for more details.
+See [Dispatcher.stream](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback) for more details.
 
 ### `undici.pipeline([url, options, ]handler): Duplex`
 
@@ -126,7 +126,7 @@ Arguments:
 
 * **url** `string | URL | UrlObject`
 * **options** [`PipelineOptions`](docs/api/Dispatcher.md#parameter-pipelineoptions)
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcher)
   * **method** `String` - Default: `PUT` if `options.body`, otherwise `GET`
   * **maxRedirections** `Integer` - Default: `0`
 * **handler** `Dispatcher.pipeline.handler`
@@ -135,7 +135,7 @@ Returns: `stream.Duplex`
 
 Calls `options.dispatch.pipeline(options, handler)`.
 
-See [Dispatcher.pipeline](docs/api/Dispatcher.md#dispatcherpipeline) for more details.
+See [Dispatcher.pipeline](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler) for more details.
 
 ### `undici.connect([url, options]): Promise`
 
@@ -145,7 +145,7 @@ Arguments:
 
 * **url** `string | URL | UrlObject`
 * **options** [`ConnectOptions`](docs/api/Dispatcher.md#parameter-connectoptions)
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcher)
   * **maxRedirections** `Integer` - Default: `0`
 * **callback** `(err: Error | null, data: ConnectData | null) => void` (optional)
 
@@ -153,7 +153,7 @@ Returns a promise with the result of the `Dispatcher.connect` method.
 
 Calls `options.dispatch.connect(options)`.
 
-See [Dispatcher.connect](docs/api/Dispatcher.md#dispatcherconnect) for more details.
+See [Dispatcher.connect](docs/api/Dispatcher.md#dispatcherconnectoptions-callback) for more details.
 
 ### `undici.fetch(input[, init]): Promise`
 
@@ -170,7 +170,7 @@ Basic usage example:
 
 ```js
     import {fetch} from 'undici';
-    
+
     async function fetchJson() {
         const res = await fetch('https://example.com')
         const json = await res.json()
@@ -180,7 +180,7 @@ Basic usage example:
 
 #### `response.body`
 
-Nodejs has two kinds of streams: [web streams](https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html) which follow the API of the WHATWG web standard found in browsers, and an older Node-specific [streams API](https://nodejs.org/api/stream.html). `response.body` returns a readable web stream. If you would prefer to work with a Node stream you can convert a web stream using `.fromWeb()`. 
+Nodejs has two kinds of streams: [web streams](https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html) which follow the API of the WHATWG web standard found in browsers, and an older Node-specific [streams API](https://nodejs.org/api/stream.html). `response.body` returns a readable web stream. If you would prefer to work with a Node stream you can convert a web stream using `.fromWeb()`.
 
 ```js
     import {fetch} from 'undici';
@@ -208,7 +208,7 @@ garbage collection in Node is less aggressive and deterministic (due to the lack
 of clear idle periods that browser have through the rendering refresh rate)
 which means that leaving the release of connection resources to the garbage collector
 can lead to excessive connection usage, reduced performance (due to less connection re-use),
-and even stalls or deadlocks when running out of connections. Therefore, it is highly 
+and even stalls or deadlocks when running out of connections. Therefore, it is highly
 recommended to always either consume or cancel the response body.
 
 ```js
@@ -234,7 +234,7 @@ Arguments:
 
 * **url** `string | URL | UrlObject`
 * **options** [`UpgradeOptions`](docs/api/Dispatcher.md#parameter-upgradeoptions)
-  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcherdispatcher)
+  * **dispatcher** `Dispatcher` - Default: [getGlobalDispatcher](#undicigetglobaldispatcher)
   * **maxRedirections** `Integer` - Default: `0`
 * **callback** `(error: Error | null, data: UpgradeData) => void` (optional)
 

--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -16,7 +16,7 @@ Returns: `Agent`
 
 ### Parameter: `AgentOptions`
 
-Extends: [`ClientOptions`](docs/api/Pool.md#parameter-pooloptions)
+Extends: [`ClientOptions`](Pool.md#parameter-pooloptions)
 
 * **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)`
 * **maxRedirections** `Integer` - Default: `0`. The number of HTTP redirection to follow unless otherwise specified in `DispatchOptions`.
@@ -25,55 +25,55 @@ Extends: [`ClientOptions`](docs/api/Pool.md#parameter-pooloptions)
 
 ### `Agent.closed`
 
-Implements [Client.closed](docs/api/Client.md#clientclosed)
+Implements [Client.closed](Client.md#clientclosed)
 
 ### `Agent.destroyed`
 
-Implements [Client.destroyed](docs/api/Client.md#clientdestroyed)
+Implements [Client.destroyed](Client.md#clientdestroyed)
 
 ## Instance Methods
 
 ### `Agent.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
+Implements [`Dispatcher.close([callback])`](Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Agent.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
+Implements [`Dispatcher.destroy([error, callback])`](Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `Agent.dispatch(options, handler: AgentDispatchOptions)`
 
-Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handler)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 #### Parameter: `AgentDispatchOptions`
 
-Extends: [`DispatchOptions``](docs/api/Dispatcher.md#parameter-dispatchoptions)
+Extends: [`DispatchOptions``](Dispatcher.md#parameter-dispatchoptions)
 
 * **origin** `string | URL`
 * **maxRedirections** `Integer`.
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
+Implements [`Dispatcher.destroy([error, callback])`](Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `Agent.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
+See [`Dispatcher.connect(options[, callback])`](Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `Agent.dispatch(options, handler)`
 
-Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handler)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Agent.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Agent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Agent.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
+See [`Dispatcher.stream(options, factory[, callback])`](Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Agent.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](Dispatcher.md#dispatcherupgradeoptions-callback).

--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -18,7 +18,7 @@ Returns: `Agent`
 
 Extends: [`ClientOptions`](docs/api/Pool.md#parameter-pooloptions)
 
-* **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)` 
+* **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)`
 * **maxRedirections** `Integer` - Default: `0`. The number of HTTP redirection to follow unless otherwise specified in `DispatchOptions`.
 
 ## Instance Properties
@@ -35,15 +35,15 @@ Implements [Client.destroyed](docs/api/Client.md#clientdestroyed)
 
 ### `Agent.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#clientclose-callback-).
+Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Agent.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
+Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
-### `Agent.dispatch(options, handlers: AgentDispatchOptions)`
+### `Agent.dispatch(options, handler: AgentDispatchOptions)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 #### Parameter: `AgentDispatchOptions`
 
@@ -52,28 +52,28 @@ Extends: [`DispatchOptions``](docs/api/Dispatcher.md#parameter-dispatchoptions)
 * **origin** `string | URL`
 * **maxRedirections** `Integer`.
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
+Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `Agent.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#clientconnectoptions--callback).
+See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
 
-### `Agent.dispatch(options, handlers)`
+### `Agent.dispatch(options, handler)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Agent.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#clientpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Agent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Agent.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#clientstreamoptions-factory--callback).
+See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Agent.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#clientupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).

--- a/docs/api/BalancedPool.md
+++ b/docs/api/BalancedPool.md
@@ -2,7 +2,7 @@
 
 Extends: `undici.Dispatcher`
 
-A pool of [Pool](docs/api/Pool.md) instances connected to multiple upstreams.
+A pool of [Pool](Pool.md) instances connected to multiple upstreams.
 
 Requests are not guaranteed to be dispatched in order of invocation.
 
@@ -17,7 +17,7 @@ Arguments:
 
 The `PoolOptions` are passed to each of the `Pool` instances being created.
 
-See: [`PoolOptions`](docs/api/Pool.md#parameter-pooloptions)
+See: [`PoolOptions`](Pool.md#parameter-pooloptions)
 
 ## Instance Properties
 
@@ -27,11 +27,11 @@ Returns an array of upstreams that were previously added.
 
 ### `BalancedPool.closed`
 
-Implements [Client.closed](docs/api/Client.md#clientclosed)
+Implements [Client.closed](Client.md#clientclosed)
 
 ### `BalancedPool.destroyed`
 
-Implements [Client.destroyed](docs/api/Client.md#clientdestroyed)
+Implements [Client.destroyed](Client.md#clientdestroyed)
 
 ## Instance Methods
 
@@ -49,46 +49,46 @@ Removes an upstream that was previously addded.
 
 ### `BalancedPool.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
+Implements [`Dispatcher.close([callback])`](Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `BalancedPool.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
+Implements [`Dispatcher.destroy([error, callback])`](Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `BalancedPool.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
+See [`Dispatcher.connect(options[, callback])`](Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `BalancedPool.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handlers)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `BalancedPool.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `BalancedPool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `BalancedPool.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
+See [`Dispatcher.stream(options, factory[, callback])`](Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `BalancedPool.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Events
 
 ### Event: `'connect'`
 
-See [Dispatcher Event: `'connect'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'connect'`](Dispatcher.md#event-connect).
 
 ### Event: `'disconnect'`
 
-See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-disconnect).
+See [Dispatcher Event: `'disconnect'`](Dispatcher.md#event-disconnect).
 
 ### Event: `'drain'`
 
-See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).
+See [Dispatcher Event: `'drain'`](Dispatcher.md#event-drain).

--- a/docs/api/BalancedPool.md
+++ b/docs/api/BalancedPool.md
@@ -49,35 +49,35 @@ Removes an upstream that was previously addded.
 
 ### `BalancedPool.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#clientclose-callback-).
+Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `BalancedPool.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
+Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `BalancedPool.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#clientconnectoptions--callback).
+See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `BalancedPool.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `BalancedPool.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#clientpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `BalancedPool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `BalancedPool.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#clientstreamoptions-factory--callback).
+See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `BalancedPool.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#clientupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Events
 
@@ -87,8 +87,8 @@ See [Dispatcher Event: `'connect'`](docs/api/Dispatcher.md#event-connect).
 
 ### Event: `'disconnect'`
 
-See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-disconnect).
 
 ### Event: `'drain'`
 
-See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -77,39 +77,37 @@ const client = new Client('https://localhost:3000', {
 
 ### `Client.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#clientclose-callback-).
+Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Client.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
+Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 Waits until socket is closed before invoking the callback (or returning a promise if no callback is provided).
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
-
 ### `Client.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#clientconnectoptions--callback).
+See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `Client.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Client.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#clientpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Client.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Client.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#clientstreamoptions-factory--callback).
+See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Client.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#clientupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Properties
 
@@ -224,7 +222,7 @@ try {
 
 ### Event: `'drain'`
 
-Emitted when pipeline is no longer [`busy`](#clientbusy).
+Emitted when pipeline is no longer busy.
 
 See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).
 

--- a/docs/api/Client.md
+++ b/docs/api/Client.md
@@ -77,37 +77,37 @@ const client = new Client('https://localhost:3000', {
 
 ### `Client.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
+Implements [`Dispatcher.close([callback])`](Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Client.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
+Implements [`Dispatcher.destroy([error, callback])`](Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 Waits until socket is closed before invoking the callback (or returning a promise if no callback is provided).
 
 ### `Client.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
+See [`Dispatcher.connect(options[, callback])`](Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `Client.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handlers)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Client.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Client.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Client.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
+See [`Dispatcher.stream(options, factory[, callback])`](Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Client.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Properties
 
@@ -133,7 +133,7 @@ Property to get and set the pipelining factor.
 
 ### Event: `'connect'`
 
-See [Dispatcher Event: `'connect'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'connect'`](Dispatcher.md#event-connect).
 
 Parameters:
 
@@ -179,7 +179,7 @@ try {
 
 ### Event: `'disconnect'`
 
-See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-disconnect).
+See [Dispatcher Event: `'disconnect'`](Dispatcher.md#event-disconnect).
 
 Parameters:
 
@@ -224,7 +224,7 @@ try {
 
 Emitted when pipeline is no longer busy.
 
-See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).
+See [Dispatcher Event: `'drain'`](Dispatcher.md#event-drain).
 
 #### Example - Client drain event
 

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -791,11 +791,11 @@ Emitted when dispatcher is no longer busy.
 
 * `http.IncomingHttpHeaders | string[] | null`
 
-Header arguments such as `options.headers` in [`Client.dispatch`](./Client.md#client-dispatchoptions-handlers) can be specified in two forms; either as an object specified by the `http.IncomingHttpHeaders` type, or an array of strings. An array representation of a header list must have an even length or an `InvalidArgumentError` will be thrown.
+Header arguments such as `options.headers` in [`Client.dispatch`](docs/api/Client.md#clientdispatchoptions-handlers) can be specified in two forms; either as an object specified by the `http.IncomingHttpHeaders` type, or an array of strings. An array representation of a header list must have an even length or an `InvalidArgumentError` will be thrown.
 
 Keys are lowercase and values are not modified.
 
-Response headers will derive a `host` from the `url` of the [Client](#class-client) instance if no `host` header was previously specified.
+Response headers will derive a `host` from the `url` of the [Client](docs/api/Client.md#class-client) instance if no `host` header was previously specified.
 
 ### Example 1 - Object
 

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -791,11 +791,11 @@ Emitted when dispatcher is no longer busy.
 
 * `http.IncomingHttpHeaders | string[] | null`
 
-Header arguments such as `options.headers` in [`Client.dispatch`](docs/api/Client.md#clientdispatchoptions-handlers) can be specified in two forms; either as an object specified by the `http.IncomingHttpHeaders` type, or an array of strings. An array representation of a header list must have an even length or an `InvalidArgumentError` will be thrown.
+Header arguments such as `options.headers` in [`Client.dispatch`](Client.md#clientdispatchoptions-handlers) can be specified in two forms; either as an object specified by the `http.IncomingHttpHeaders` type, or an array of strings. An array representation of a header list must have an even length or an `InvalidArgumentError` will be thrown.
 
 Keys are lowercase and values are not modified.
 
-Response headers will derive a `host` from the `url` of the [Client](docs/api/Client.md#class-client) instance if no `host` header was previously specified.
+Response headers will derive a `host` from the `url` of the [Client](Client.md#class-client) instance if no `host` header was previously specified.
 
 ### Example 1 - Object
 

--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -318,7 +318,7 @@ Implements [`Agent.dispatch(options, handlers)`](docs/api/Agent.md#parameter-age
 
 ### `MockAgent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockAgent request
 

--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -14,7 +14,7 @@ Returns: `MockAgent`
 
 ### Parameter: `MockAgentOptions`
 
-Extends: [`AgentOptions`](docs/api/Agent.md#parameter-agentoptions)
+Extends: [`AgentOptions`](Agent.md#parameter-agentoptions)
 
 * **agent** `Agent` (optional) - Default: `new Agent([options])` - a custom agent encapsulated by the MockAgent.
 
@@ -314,11 +314,11 @@ await mockAgent.close()
 
 ### `MockAgent.dispatch(options, handlers)`
 
-Implements [`Agent.dispatch(options, handlers)`](docs/api/Agent.md#parameter-agentdispatchoptions).
+Implements [`Agent.dispatch(options, handlers)`](Agent.md#parameter-agentdispatchoptions).
 
 ### `MockAgent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockAgent request
 

--- a/docs/api/MockClient.md
+++ b/docs/api/MockClient.md
@@ -2,7 +2,7 @@
 
 Extends: `undici.Client`
 
-A mock client class that implements the same api as [MockPool](docs/api/MockPool.md).
+A mock client class that implements the same api as [MockPool](MockPool.md).
 
 ## `new MockClient(origin, [options])`
 
@@ -36,19 +36,19 @@ const mockClient = mockAgent.get('http://localhost:3000')
 
 ### `MockClient.intercept(options)`
 
-Implements: [`MockPool.intercept(options)`](docs/api/MockPool.md#mockpoolinterceptoptions)
+Implements: [`MockPool.intercept(options)`](MockPool.md#mockpoolinterceptoptions)
 
 ### `MockClient.close()`
 
-Implements: [`MockPool.close()`](docs/api/MockPool.md#mockpoolclose)
+Implements: [`MockPool.close()`](MockPool.md#mockpoolclose)
 
 ### `MockClient.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handlers)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `MockClient.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockClient request
 

--- a/docs/api/MockClient.md
+++ b/docs/api/MockClient.md
@@ -44,11 +44,11 @@ Implements: [`MockPool.close()`](docs/api/MockPool.md#mockpoolclose)
 
 ### `MockClient.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `MockClient.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockClient request
 

--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -412,11 +412,11 @@ await mockPool.close()
 
 ### `MockPool.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handlers)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `MockPool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockPool request
 

--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -299,7 +299,7 @@ mockPool.intercept({
 }).defaultReplyTrailers({ foo: 'bar' })
   .reply(200, 'foo')
 
-const { trailers } = await request('http://localhost:3000/foo') 
+const { trailers } = await request('http://localhost:3000/foo')
 
 console.log('trailers', trailers) // trailers { foo: 'bar' }
 ```
@@ -412,11 +412,11 @@ await mockPool.close()
 
 ### `MockPool.dispatch(options, handlers)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `MockPool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 #### Example - MockPool request
 

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -2,7 +2,7 @@
 
 Extends: `undici.Dispatcher`
 
-A pool of [Client](docs/api/Client.md) instances connected to the same upstream target.
+A pool of [Client](Client.md) instances connected to the same upstream target.
 
 Requests are not guaranteed to be dispatched in order of invocation.
 
@@ -15,7 +15,7 @@ Arguments:
 
 ### Parameter: `PoolOptions`
 
-Extends: [`ClientOptions`](docs/api/Client.md#parameter-clientoptions)
+Extends: [`ClientOptions`](Client.md#parameter-clientoptions)
 
 * **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Client(origin, opts)`
 * **connections** `number | null` (optional) - Default: `null` - The number of `Client` instances to create. When set to `null`, the `Pool` instance will create an unlimited amount of `Client` instances.
@@ -24,56 +24,56 @@ Extends: [`ClientOptions`](docs/api/Client.md#parameter-clientoptions)
 
 ### `Pool.closed`
 
-Implements [Client.closed](docs/api/Client.md#clientclosed)
+Implements [Client.closed](Client.md#clientclosed)
 
 ### `Pool.destroyed`
 
-Implements [Client.destroyed](docs/api/Client.md#clientdestroyed)
+Implements [Client.destroyed](Client.md#clientdestroyed)
 
 ## Instance Methods
 
 ### `Pool.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
+Implements [`Dispatcher.close([callback])`](Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Pool.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
+Implements [`Dispatcher.destroy([error, callback])`](Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `Pool.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
+See [`Dispatcher.connect(options[, callback])`](Dispatcher.md#dispatcherconnectoptions-callback).
 
 ### `Pool.dispatch(options, handler)`
 
-Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
+Implements [`Dispatcher.dispatch(options, handler)`](Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Pool.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Pool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Pool.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
+See [`Dispatcher.stream(options, factory[, callback])`](Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Pool.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Events
 
 ### Event: `'connect'`
 
-See [Dispatcher Event: `'connect'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'connect'`](Dispatcher.md#event-connect).
 
 ### Event: `'disconnect'`
 
-See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-disconnect).
+See [Dispatcher Event: `'disconnect'`](Dispatcher.md#event-disconnect).
 
 ### Event: `'drain'`
 
-See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).
+See [Dispatcher Event: `'drain'`](Dispatcher.md#event-drain).

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -34,35 +34,35 @@ Implements [Client.destroyed](docs/api/Client.md#clientdestroyed)
 
 ### `Pool.close([callback])`
 
-Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#clientclose-callback-).
+Implements [`Dispatcher.close([callback])`](docs/api/Dispatcher.md#dispatcherclosecallback-promise).
 
 ### `Pool.destroy([error, callback])`
 
-Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcher-callback-).
+Implements [`Dispatcher.destroy([error, callback])`](docs/api/Dispatcher.md#dispatcherdestroyerror-callback-promise).
 
 ### `Pool.connect(options[, callback])`
 
-See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#clientconnectoptions--callback).
+See [`Dispatcher.connect(options[, callback])`](docs/api/Dispatcher.md#dispatcherconnectoptions-callback).
 
-### `Pool.dispatch(options, handlers)`
+### `Pool.dispatch(options, handler)`
 
-Implements [`Dispatcher.dispatch(options, handlers)`](docs/api/Dispatcher.md#clientdispatchoptions-handlers).
+Implements [`Dispatcher.dispatch(options, handler)`](docs/api/Dispatcher.md#dispatcherdispatchoptions-handler).
 
 ### `Pool.pipeline(options, handler)`
 
-See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#clientpipelineoptions-handler).
+See [`Dispatcher.pipeline(options, handler)`](docs/api/Dispatcher.md#dispatcherpipelineoptions-handler).
 
 ### `Pool.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
 
 ### `Pool.stream(options, factory[, callback])`
 
-See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#clientstreamoptions-factory--callback).
+See [`Dispatcher.stream(options, factory[, callback])`](docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback).
 
 ### `Pool.upgrade(options[, callback])`
 
-See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#clientupgradeoptions-callback).
+See [`Dispatcher.upgrade(options[, callback])`](docs/api/Dispatcher.md#dispatcherupgradeoptions-callback).
 
 ## Instance Events
 
@@ -72,8 +72,8 @@ See [Dispatcher Event: `'connect'`](docs/api/Dispatcher.md#event-connect).
 
 ### Event: `'disconnect'`
 
-See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'disconnect'`](docs/api/Dispatcher.md#event-disconnect).
 
 ### Event: `'drain'`
 
-See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-connect).
+See [Dispatcher Event: `'drain'`](docs/api/Dispatcher.md#event-drain).

--- a/docs/api/ProxyAgent.md
+++ b/docs/api/ProxyAgent.md
@@ -97,4 +97,4 @@ Implements [`Agent.dispatch(options, handlers)`](docs/api/Agent.md#parameter-age
 
 ### `ProxyAgent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#clientrequestoptions--callback).
+See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).

--- a/docs/api/ProxyAgent.md
+++ b/docs/api/ProxyAgent.md
@@ -14,7 +14,7 @@ Returns: `ProxyAgent`
 
 ### Parameter: `ProxyAgentOptions`
 
-Extends: [`AgentOptions`](docs/api/Agent.md#parameter-agentoptions)
+Extends: [`AgentOptions`](Agent.md#parameter-agentoptions)
 
 * **uri** `string` (required) - It can be passed either by a string or a object containing `uri` as string.
 
@@ -93,8 +93,8 @@ await proxyAgent.close()
 
 ### `ProxyAgent.dispatch(options, handlers)`
 
-Implements [`Agent.dispatch(options, handlers)`](docs/api/Agent.md#parameter-agentdispatchoptions).
+Implements [`Agent.dispatch(options, handlers)`](Agent.md#parameter-agentdispatchoptions).
 
 ### `ProxyAgent.request(options[, callback])`
 
-See [`Dispatcher.request(options [, callback])`](docs/api/Dispatcher.md#dispatcherrequestoptions-callback).
+See [`Dispatcher.request(options [, callback])`](Dispatcher.md#dispatcherrequestoptions-callback).

--- a/docs/api/api-lifecycle.md
+++ b/docs/api/api-lifecycle.md
@@ -1,6 +1,6 @@
 # Client Lifecycle
 
-An Undici [Client](docs/api/Client.md) can be best described as a state machine. The following list is a summary of the various state transitions the `Client` will go through in its lifecycle. This document also contains detailed breakdowns of each state.
+An Undici [Client](Client.md) can be best described as a state machine. The following list is a summary of the various state transitions the `Client` will go through in its lifecycle. This document also contains detailed breakdowns of each state.
 
 > This diagram is not a perfect representation of the undici Client. Since the Client class is not actually implemented as a state-machine, actual execution may deviate slightly from what is described below. Consider this as a general resource for understanding the inner workings of the Undici client rather than some kind of formal specification.
 
@@ -29,25 +29,25 @@ An Undici [Client](docs/api/Client.md) can be best described as a state machine.
 
 ### idle
 
-The **idle** state is the initial state of a `Client` instance. While an `origin` is required for instantiating a `Client` instance, the underlying socket connection will not be established until a request is queued using [`Client.dispatch()`](docs/api/Client.md#clientdispatchoptions-handlers). By calling `Client.dispatch()` directly or using one of the multiple implementations ([`Client.connect()`](docs/api/Client.md#clientconnectoptions-callback), [`Client.pipeline()`](docs/api/Client.md#clientpipelineoptions-handler), [`Client.request()`](docs/api/Client.md#clientrequestoptions-callback), [`Client.stream()`](docs/api/Client.md#clientstreamoptions-factory-callback), and [`Client.upgrade()`](docs/api/Client.md#clientupgradeoptions-callback)), the `Client` instance will transition from **idle** to [**pending**](#pending) and then most likely directly to [**processing**](#processing).
+The **idle** state is the initial state of a `Client` instance. While an `origin` is required for instantiating a `Client` instance, the underlying socket connection will not be established until a request is queued using [`Client.dispatch()`](Client.md#clientdispatchoptions-handlers). By calling `Client.dispatch()` directly or using one of the multiple implementations ([`Client.connect()`](Client.md#clientconnectoptions-callback), [`Client.pipeline()`](Client.md#clientpipelineoptions-handler), [`Client.request()`](Client.md#clientrequestoptions-callback), [`Client.stream()`](Client.md#clientstreamoptions-factory-callback), and [`Client.upgrade()`](Client.md#clientupgradeoptions-callback)), the `Client` instance will transition from **idle** to [**pending**](#pending) and then most likely directly to [**processing**](#processing).
 
-Calling [`Client.close()`](docs/api/Client.md#clientclosecallback) or [`Client.destroy()`](docs/api/Client.md#clientdestroyerror-callback) transitions directly to the [**destroyed**](#destroyed) state since the `Client` instance will have no queued requests in this state.
+Calling [`Client.close()`](Client.md#clientclosecallback) or [`Client.destroy()`](Client.md#clientdestroyerror-callback) transitions directly to the [**destroyed**](#destroyed) state since the `Client` instance will have no queued requests in this state.
 
 ### pending
 
-The **pending** state signifies a non-processing `Client`. Upon entering this state, the `Client` establishes a socket connection and emits the [`'connect'`](docs/api/Client.md#event-connect) event signalling a connection was successfully established with the `origin` provided during `Client` instantiation. The internal queue is initially empty, and requests can start queueing.
+The **pending** state signifies a non-processing `Client`. Upon entering this state, the `Client` establishes a socket connection and emits the [`'connect'`](Client.md#event-connect) event signalling a connection was successfully established with the `origin` provided during `Client` instantiation. The internal queue is initially empty, and requests can start queueing.
 
-Calling [`Client.close()`](docs/api/Client.md#clientclosecallback) with queued requests, transitions the `Client` to the [**processing**](#processing) state. Without queued requests, it transitions to the [**destroyed**](#destroyed) state.
+Calling [`Client.close()`](Client.md#clientclosecallback) with queued requests, transitions the `Client` to the [**processing**](#processing) state. Without queued requests, it transitions to the [**destroyed**](#destroyed) state.
 
-Calling [`Client.destroy()`](docs/api/Client.md#clientdestroyerror-callback) transitions directly to the [**destroyed**](#destroyed) state regardless of existing requests.
+Calling [`Client.destroy()`](Client.md#clientdestroyerror-callback) transitions directly to the [**destroyed**](#destroyed) state regardless of existing requests.
 
 ### processing
 
-The **processing** state is a state machine within itself. It initializes to the [**processing.running**](#running) state. The [`Client.dispatch()`](docs/api/Client.md#clientdispatchoptions-handlers), [`Client.close()`](docs/api/Client.md#clientclosecallback), and [`Client.destroy()`](docs/api/Client.md#clientdestroyerror-callback) can be called at any time while the `Client` is in this state. `Client.dispatch()` will add more requests to the queue while existing requests continue to be processed. `Client.close()` will transition to the [**processing.closing**](#closing) state. And `Client.destroy()` will transition to [**destroyed**](#destroyed).
+The **processing** state is a state machine within itself. It initializes to the [**processing.running**](#running) state. The [`Client.dispatch()`](Client.md#clientdispatchoptions-handlers), [`Client.close()`](Client.md#clientclosecallback), and [`Client.destroy()`](Client.md#clientdestroyerror-callback) can be called at any time while the `Client` is in this state. `Client.dispatch()` will add more requests to the queue while existing requests continue to be processed. `Client.close()` will transition to the [**processing.closing**](#closing) state. And `Client.destroy()` will transition to [**destroyed**](#destroyed).
 
 #### running
 
-In the **processing.running** sub-state, queued requests are being processed in a FIFO order. If a request body requires draining, the *needDrain* event transitions to the [**processing.busy**](#busy) sub-state. The *close* event transitions the Client to the [**process.closing**](#closing) sub-state. If all queued requests are processed and neither [`Client.close()`](docs/api/Client.md#clientclosecallback) nor [`Client.destroy()`](docs/api/Client.md#clientdestroyerror-callback) are called, then the [**processing**](#processing) machine will trigger a *keepalive* event transitioning the `Client` back to the [**pending**](#pending) state. During this time, the `Client` is waiting for the socket connection to timeout, and once it does, it triggers the *timeout* event and transitions to the [**idle**](#idle) state.
+In the **processing.running** sub-state, queued requests are being processed in a FIFO order. If a request body requires draining, the *needDrain* event transitions to the [**processing.busy**](#busy) sub-state. The *close* event transitions the Client to the [**process.closing**](#closing) sub-state. If all queued requests are processed and neither [`Client.close()`](Client.md#clientclosecallback) nor [`Client.destroy()`](Client.md#clientdestroyerror-callback) are called, then the [**processing**](#processing) machine will trigger a *keepalive* event transitioning the `Client` back to the [**pending**](#pending) state. During this time, the `Client` is waiting for the socket connection to timeout, and once it does, it triggers the *timeout* event and transitions to the [**idle**](#idle) state.
 
 #### busy
 
@@ -55,7 +55,7 @@ This sub-state is only entered when a request body is an instance of [Stream](ht
 
 #### closing
 
-This sub-state is only entered when a `Client` instance has queued requests and the [`Client.close()`](docs/api/Client.md#clientclosecallback) method is called. In this state, the `Client` instance continues to process requests as usual, with the one exception that no additional requests can be queued. Once all of the queued requests are processed, the `Client` will trigger the *done* event gracefully entering the [**destroyed**](#destroyed) state without an error.
+This sub-state is only entered when a `Client` instance has queued requests and the [`Client.close()`](Client.md#clientclosecallback) method is called. In this state, the `Client` instance continues to process requests as usual, with the one exception that no additional requests can be queued. Once all of the queued requests are processed, the `Client` will trigger the *done* event gracefully entering the [**destroyed**](#destroyed) state without an error.
 
 ### destroyed
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
       themeColor: '#2B91F0',
       noCompileLinks: [
         'benchmarks/.*'
-      ]
+      ],
+      relativePath: true
     }
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
- swept through local links and fixed broken anchors
- updated local links to relative
    - absolute paths break links when you're browsing docs in the repo, e.g. `https://github.com/nodejs/undici/blob/main/docs/api/docs/api/Client.md`. Absolute paths were apparently added because of docsify, which by default does not recognize relative paths. This can be fixed by setting [`relativePath`](https://docsify.js.org/#/configuration?id=relativepath) to `true` in docsify configs