### PR TITLE
docs: fix DispatchOptions markdown format

### DIFF
--- a/docs/api/Agent.md
+++ b/docs/api/Agent.md
@@ -47,7 +47,7 @@ Implements [`Dispatcher.dispatch(options, handler)`](Dispatcher.md#dispatcherdis
 
 #### Parameter: `AgentDispatchOptions`
 
-Extends: [`DispatchOptions``](Dispatcher.md#parameter-dispatchoptions)
+Extends: [`DispatchOptions`](Dispatcher.md#parameter-dispatchoptions)
 
 * **origin** `string | URL`
 * **maxRedirections** `Integer`.


### PR DESCRIPTION
Removed an unexpected ` quote in the Agent.md file.