### PR TITLE
fix: concat multibyte characters

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -219,9 +219,9 @@ function consumeEnd (consume) {
 
   try {
     if (type === 'text') {
-      resolve(body.join(''))
+      resolve(Buffer.concat(body))
     } else if (type === 'json') {
-      resolve(JSON.parse(body.join('')))
+      resolve(JSON.parse(Buffer.concat(body)))
     } else if (type === 'arrayBuffer') {
       const dst = new Uint8Array(length)
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -210,6 +210,27 @@ test('request json', (t) => {
   })
 })
 
+test('request long multibyte json', (t) => {
+  t.plan(1)
+
+  const obj = { asd: 'あ'.repeat(100000) }
+  const server = createServer((req, res) => {
+    res.end(JSON.stringify(obj))
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.destroy.bind(client))
+
+    const { body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+    t.strictSame(obj, await body.json())
+  })
+})
+
 test('request text', (t) => {
   t.plan(1)
 
@@ -230,6 +251,28 @@ test('request text', (t) => {
     t.strictSame(JSON.stringify(obj), await body.text())
   })
 })
+
+test('request long multibyte text', (t) => {
+  t.plan(1)
+
+  const obj = { asd: 'あ'.repeat(100000) }
+  const server = createServer((req, res) => {
+    res.end(JSON.stringify(obj))
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.destroy.bind(client))
+
+    const { body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+    t.strictSame(JSON.stringify(obj), await body.text())
+  })
+})
+
 
 test('request blob', { skip: nodeMajor < 16 }, (t) => {
   t.plan(2)


### PR DESCRIPTION
move from `Array.join()` to `Buffer.concat()` to fix bugs in multibyte characters.

Fixes: https://github.com/nodejs/undici/issues/1119