### PR TITLE
fix: expose socketPath in Client.Options type

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -41,6 +41,8 @@ declare namespace Client {
     tls?: TlsOptions | null;
     /** */
     maxRequestsPerClient?: number;
+    /** An IPC endpoint, either Unix domain socket or Windows named pipe. */
+    socketPath?: string | null;
   }
 
   export interface SocketInfo {


### PR DESCRIPTION
The `Client` constructor accepts a `socketPath` argument,
but this was not reflected in the typescript definition.