### PR TITLE
Create timing info for HTTP(S) network errors

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -808,9 +808,8 @@ function fetchFinale (fetchParams, response) {
     }
 
     // 2. Let processBodyError be this step: run fetchParams’s process response consume body given response and failure.
-    const processBodyError = () => {
-      // TODO (spec): what is failure?
-      fetchParams.processResponseConsumeBody(response, new TypeError())
+    const processBodyError = (failure) => {
+      fetchParams.processResponseConsumeBody(response, failure)
     }
 
     // 3. If response’s body is null, then queue a fetch task to run processBody given null, with fetchParams’s task destination.

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -50,6 +50,7 @@ const { isErrored, isReadable } = require('../core/util')
 const { kIsMockActive } = require('../mock/mock-symbols')
 
 let ReadableStream
+let TransformStream
 
 class Fetch extends EE {
   constructor (dispatcher) {
@@ -740,34 +741,87 @@ function finalizeResponse (fetchParams, response) {
 
 // https://fetch.spec.whatwg.org/#fetch-finale
 function fetchFinale (fetchParams, response) {
-  const context = this
+  // 1. If response is a network error, then:
+  if (response.type === 'error') {
+    // 1. Set response’s URL list to « fetchParams’s request’s URL list[0] ».
+    response.urlList = [fetchParams.request.urlList[0]]
 
-  // 1. If fetchParams’s process response is non-null,
-  // then queue a fetch task to run fetchParams’s process response
-  // given response, with fetchParams’s task destination.
+    // 2. Set response’s timing info to the result of creating an opaque timing info for fetchParams’s timing info.
+    response.timingInfo = createOpaqueTimingInfo({
+      startTime: fetchParams.timingInfo.startTime
+    })
+  }
+
+  // 2. Let processResponseEndOfBody be the following steps:
+  const processResponseEndOfBody = () => {
+    // 1. Set fetchParams’s request’s done flag.
+    fetchParams.request.done = true
+
+    // 2. If fetchParams’s process response end-of-body is not null, then queue a fetch task to run fetchParams’s
+    //    process response end-of-body given response with fetchParams’s task destination.
+    if (fetchParams.processResponseEndOfBody != null) {
+      // TODO (spec): what exactly are we supposed to do with fetchParams.taskDestination?
+      fetchParams.processResponseEndOfBody(response)
+    }
+  }
+
+  // 3. If fetchParams’s process response is non-null, then queue a fetch task to run fetchParams’s process response given response,
+  //    with fetchParams’s task destination.
   if (fetchParams.processResponse != null) {
     fetchParams.processResponse(response)
   }
 
-  // 2. If fetchParams’s process response consume is non-null, then:.
-  //    TODO
-  //    1. Let processBody given nullOrBytes be this step: run fetchParams’s
-  //    process response consume given response and nullOrBytes.on.
-  //    TODO
-  //    2. Let processBodyError be this step: run fetchParams’s process
-  //    response consume given response and failure.on.
-  //    TODO
-  //    3. If response’s body is null, then queue a fetch task to run
-  //    processBody given null, with fetchParams’s task destination.on.
-  //    TODO
-  //    4. Otherwise, fully read response’s body given processBody,
-  //    processBodyError, and fetchParams’s task destination.on.
-  //    TODO
+  // 4. If response’s body is null, then run processResponseEndOfBody.
+  if (response.body == null) {
+    processResponseEndOfBody()
+  }
 
-  // TODO (spec): The spec doesn't specify this but we need to
-  // terminate fetch if we have an error response.
-  if (response.type === 'error') {
-    context.terminate({ reason: response.error })
+  // 5. Otherwise:
+  else {
+    TransformStream ??= require('stream/web').TransformStream
+    // 1. Let transformStream be a new a TransformStream.
+
+    // 2. Let identityTransformAlgorithm be an algorithm which, given chunk, enqueues chunk in transformStream.
+    const identityTransformAlgorithm = (chunk, controller) => {
+      controller.enqueue(chunk)
+    }
+
+    const transformStream = new TransformStream({
+      // 3. Set up transformStream with transformAlgorithm set to identityTransformAlgorithm and
+      //    flushAlgorithm set to processResponseEndOfBody.
+      transform: identityTransformAlgorithm,
+      flush: processResponseEndOfBody
+    })
+
+    // 4. Set response’s body to the result of piping response’s body through transformStream.
+    // Khafra note: although the spec is unclear, only readable streams can be piped through
+    if (response.body != null && isReadable(response.body?.stream)) {
+      response.body = response.body.pipeThrough(transformStream)
+    }
+  }
+
+  // 6. If fetchParams’s process response consume body is non-null, then:
+  if (fetchParams.processResponseConsumeBody != null) {
+    // 1. Let processBody given nullOrBytes be this step: run fetchParams’s process response consume body given response and nullOrBytes.
+    const processBody = (nullOrBytes) => {
+      fetchParams.processResponseConsumeBody(response, nullOrBytes)
+    }
+
+    // 2. Let processBodyError be this step: run fetchParams’s process response consume body given response and failure.
+    const processBodyError = () => {
+      // TODO (spec): what is failure?
+      fetchParams.processResponseConsumeBody(response, new TypeError())
+    }
+
+    // 3. If response’s body is null, then queue a fetch task to run processBody given null, with fetchParams’s task destination.
+    if (response.body == null) {
+      processBody(null)
+    }
+
+    // 4. Otherwise, fully read response’s body given processBody, processBodyError, and fetchParams’s task destination.
+    else {
+      fullyReadBody(processBody, processBodyError, fetchParams.taskDestination)
+    }
   }
 }
 
@@ -1589,11 +1643,9 @@ function httpNetworkFetch (
     //            1. If one or more bytes have been transmitted from response’s
     //            message body, then:
     //            NOTE: See onHeaders
-    //            2. Otherwise, if the bytes transmission for response’s message
+    //            2. Otherwise, if the bytes transmission for response’s message 
     //            body is done normally and stream is readable, then close stream,
-    //            finalize response for fetchParams and response, and abort these
-    //            in-parallel steps.
-    //            NOTE: See onHeaders
+    //            and abort these in-parallel steps.
 
     //    2. If aborted, then:
     function onResponseAborted () {

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -820,7 +820,7 @@ function fetchFinale (fetchParams, response) {
 
     // 4. Otherwise, fully read response’s body given processBody, processBodyError, and fetchParams’s task destination.
     else {
-      fullyReadBody(processBody, processBodyError, fetchParams.taskDestination)
+      fullyReadBody(response.body, processBody, processBodyError, fetchParams.taskDestination)
     }
   }
 }

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -688,7 +688,7 @@ async function mainFetch (fetchParams, recursive = false) {
     // 1. Let processBodyError be this step: run fetch finale given fetchParams
     // and a network error.
     const processBodyError = (reason) =>
-      fetchFinale(fetchParams, makeNetworkError(reason))
+      fetchFinale.call(context, fetchParams, makeNetworkError(reason))
 
     // 2. If request’s response tainting is "opaque", or response’s body is null,
     // then run processBodyError and abort these steps.
@@ -711,7 +711,7 @@ async function mainFetch (fetchParams, recursive = false) {
       response.body = safelyExtractBody(bytes)[0]
 
       // 3. Run fetch finale given fetchParams and response.
-      fetchFinale(fetchParams, response)
+      fetchFinale.call(context, fetchParams, response)
     }
 
     // 4. Fully read response’s body given processBody and processBodyError.
@@ -722,7 +722,7 @@ async function mainFetch (fetchParams, recursive = false) {
     }
   } else {
     // 21. Otherwise, run fetch finale given fetchParams and response.
-    fetchFinale(fetchParams, response)
+    fetchFinale.call(context, fetchParams, response)
   }
 }
 
@@ -741,6 +741,8 @@ function finalizeResponse (fetchParams, response) {
 
 // https://fetch.spec.whatwg.org/#fetch-finale
 function fetchFinale (fetchParams, response) {
+  const context = this
+
   // 1. If response is a network error, then:
   if (response.type === 'error') {
     // 1. Set response’s URL list to « fetchParams’s request’s URL list[0] ».
@@ -826,6 +828,12 @@ function fetchFinale (fetchParams, response) {
         processBodyError
       )
     }
+  }
+
+  // TODO (spec): The spec doesn't specify this but we need to
+  // terminate fetch if we have an error response.
+  if (response.type === 'error') {
+    context.terminate({ reason: response.error })
   }
 }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -819,7 +819,12 @@ function fetchFinale (fetchParams, response) {
 
     // 4. Otherwise, fully read response’s body given processBody, processBodyError, and fetchParams’s task destination.
     else {
-      fullyReadBody(response.body, processBody, processBodyError, fetchParams.taskDestination)
+      // The discussion to use the arrayBuffer method over the spec's fully read body implementation
+      // can be found here https://github.com/nodejs/undici/pull/1147#discussion_r775847886
+      response.body.arrayBuffer().then(
+        processBody,
+        processBodyError
+      )
     }
   }
 }

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -795,7 +795,7 @@ function fetchFinale (fetchParams, response) {
 
     // 4. Set response’s body to the result of piping response’s body through transformStream.
     // Khafra note: although the spec is unclear, only readable streams can be piped through
-    if (response.body != null && isReadable(response.body?.stream)) {
+    if (response.body != null) {
       response.body = response.body.pipeThrough(transformStream)
     }
   }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -339,6 +339,5 @@ module.exports = {
   responseLocationURL,
   isBlobLike,
   isFileLike,
-  isValidReasonPhrase,
-  createDeferredPromise
+  isValidReasonPhrase
 }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -3,7 +3,6 @@
 const { redirectStatus } = require('./constants')
 const { performance } = require('perf_hooks')
 const { isBlobLike, toUSVString, ReadableStreamFrom } = require('../core/util')
-const { isUint8Array } = require('util/types')
 
 let File
 

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -3,6 +3,7 @@
 const { redirectStatus } = require('./constants')
 const { performance } = require('perf_hooks')
 const { isBlobLike, toUSVString, ReadableStreamFrom } = require('../core/util')
+const { isUint8Array } = require('util/types')
 
 let File
 

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -340,5 +340,6 @@ module.exports = {
   responseLocationURL,
   isBlobLike,
   isFileLike,
-  isValidReasonPhrase
+  isValidReasonPhrase,
+  createDeferredPromise
 }


### PR DESCRIPTION
refs: https://github.com/nodejs/undici/issues/1141

Implements spec changes from: https://github.com/whatwg/fetch/commit/ed6221d33338d1046574e81fb9d18f4fc2a35600 
However this should be mostly good, possibly apart from the
TransformStream parts since I never used the api before this...