### PR TITLE
fetch: fix small spec inconsistency

### DIFF
--- a/lib/fetch/constants.js
+++ b/lib/fetch/constants.js
@@ -58,6 +58,7 @@ const requestCache = [
   'only-if-cached'
 ]
 
+// https://fetch.spec.whatwg.org/#forbidden-response-header-name
 const forbiddenResponseHeaderNames = ['set-cookie', 'set-cookie2']
 
 const requestBodyHeader = [

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -8,7 +8,7 @@ const { responseURL, isValidReasonPhrase, toUSVString } = require('./util')
 const {
   redirectStatus,
   nullBodyStatus,
-  forbiddenHeaderNames
+  forbiddenResponseHeaderNames
 } = require('./constants')
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
 const { kHeadersList } = require('../core/symbols')
@@ -366,6 +366,7 @@ function makeNetworkError (reason) {
   })
 }
 
+// https://fetch.spec.whatwg.org/#concept-filtered-response
 function filterResponse (response, type) {
   // Set response to the following filtered response with response as its
   // internal response, depending on request’s response tainting:
@@ -376,7 +377,7 @@ function filterResponse (response, type) {
 
     const headers = []
     for (let n = 0; n < response.headersList.length; n += 2) {
-      if (!forbiddenHeaderNames.includes(response.headersList[n])) {
+      if (!forbiddenResponseHeaderNames.includes(response.headersList[n])) {
         headers.push(response.headersList[n + 0], response.headersList[n + 1])
       }
     }


### PR DESCRIPTION
This condition is not *yet* possible to meet so I couldn't add a test
(sorry!). 

- `response` is always null https://github.com/nodejs/undici/blob/09059fb491b4158a25981eb5598262b43a18c6ae/lib/fetch/index.js#L475
- which means it is set here https://github.com/nodejs/undici/blob/09059fb491b4158a25981eb5598262b43a18c6ae/lib/fetch/index.js#L529 which always either returns a network error or sets the `responseTainting` to either `opaque` or `cors`.
- Then this condition runs if there wasn't a network error (`response.status === 0` would be a network error) https://github.com/nodejs/undici/blob/09059fb491b4158a25981eb5598262b43a18c6ae/lib/fetch/index.js#L605
- Therefore responseTainting is never basic as of now.

The spec says that "[a] basic filtered response is a filtered response
whose type is "basic" and header list excludes any headers in internal
response’s header list whose name is a forbidden response-header name."
The library was incorrectly excluding valid headers.

If `data:`, `blob:`, `about:`, or `file:` URIs are ever supported, this
change will be needed.