### PR TITLE
fetch: multiple small fixes

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -965,17 +965,7 @@ async function httpRedirectFetch (fetchParams, response) {
     return makeNetworkError()
   }
 
-  // 12. If locationURL’s origin is not same origin with request’s current URL’s
-  // origin and request’s origin is not same origin with request’s current
-  // URL’s origin, then set request’s tainted origin flag.
-  if (
-    !sameOrigin(locationURL, requestCurrentURL(request)) &&
-    request.origin !== locationURL.origin
-  ) {
-    request.taintedOrigin = true
-  }
-
-  // 13. If one of the following is true
+  // 12. If one of the following is true
   // - actualResponse’s status is 301 or 302 and request’s method is `POST`
   // - actualResponse’s status is 303 and request’s method is not `GET` or `HEAD`
   if (
@@ -995,36 +985,36 @@ async function httpRedirectFetch (fetchParams, response) {
     }
   }
 
-  // 14. If request’s body is non-null, then set request’s body to the first return
+  // 13. If request’s body is non-null, then set request’s body to the first return
   // value of safely extracting request’s body’s source.
   if (request.body != null) {
     assert(request.body.source)
     request.body = safelyExtractBody(request.body.source)[0]
   }
 
-  // 15. Let timingInfo be fetchParams’s timing info.
+  // 14. Let timingInfo be fetchParams’s timing info.
   const timingInfo = fetchParams.timingInfo
 
-  // 16. Set timingInfo’s redirect end time and post-redirect start time to the
+  // 15. Set timingInfo’s redirect end time and post-redirect start time to the
   // coarsened shared current time given fetchParams’s cross-origin isolated
   // capability.
   timingInfo.redirectEndTime = timingInfo.postRedirectStartTime =
     coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
 
-  // 17. If timingInfo’s redirect start time is 0, then set timingInfo’s
+  // 16. If timingInfo’s redirect start time is 0, then set timingInfo’s
   //  redirect start time to timingInfo’s start time.
   if (timingInfo.redirectStartTime === 0) {
     timingInfo.redirectStartTime = timingInfo.startTime
   }
 
-  // 18. Append locationURL to request’s URL list.
+  // 17. Append locationURL to request’s URL list.
   request.urlList.push(locationURL)
 
-  // 19. Invoke set request’s referrer policy on redirect on request and
+  // 18. Invoke set request’s referrer policy on redirect on request and
   // actualResponse.
   setRequestReferrerPolicyOnRedirect(request, actualResponse)
 
-  // 20. Return the result of running main fetch given fetchParams and true.
+  // 19. Return the result of running main fetch given fetchParams and true.
   return mainFetch.call(this, fetchParams, true)
 }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -30,7 +30,8 @@ const {
   crossOriginResourcePolicyCheck,
   determineRequestsReferrer,
   coarsenedSharedCurrentTime,
-  createDeferredPromise
+  createDeferredPromise,
+  sameOrigin
 } = require('./util')
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
 const { AbortError } = require('../core/errors')
@@ -480,7 +481,7 @@ async function mainFetch (fetchParams, recursive = false) {
     request.localURLsOnly &&
     !/^(about|blob|data):/.test(requestCurrentURL(request).protocol)
   ) {
-    return makeNetworkError('local URLs only')
+    response = makeNetworkError('local URLs only')
   }
 
   // 4. Run report Content Security Policy violations for request.
@@ -493,7 +494,7 @@ async function mainFetch (fetchParams, recursive = false) {
   // be blocked as mixed content, or should request be blocked by Content
   // Security Policy returns blocked, then set response to a network error.
   if (requestBadPort(request) === 'blocked') {
-    return makeNetworkError('bad port')
+    response = makeNetworkError('bad port')
   }
   // TODO: should fetching request be blocked as mixed content?
   // TODO: should request be blocked by Content Security Policy?
@@ -938,7 +939,7 @@ async function httpRedirectFetch (fetchParams, response) {
   if (
     request.mode === 'cors' &&
     (locationURL.username || locationURL.password) &&
-    request.origin !== locationURL.origin
+    !sameOrigin(request, locationURL)
   ) {
     return makeNetworkError('cross origin not allowed for request mode "cors"')
   }
@@ -968,7 +969,7 @@ async function httpRedirectFetch (fetchParams, response) {
   // origin and request’s origin is not same origin with request’s current
   // URL’s origin, then set request’s tainted origin flag.
   if (
-    locationURL.origin !== requestCurrentURL(request).origin &&
+    !sameOrigin(locationURL, requestCurrentURL(request)) &&
     request.origin !== locationURL.origin
   ) {
     request.taintedOrigin = true

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -121,7 +121,7 @@ class Request {
     // is same origin with origin, then set window to request’s window.
     if (
       request.window instanceof EnvironmentSettingsObject &&
-      request.window.origin === origin
+      sameOrigin(request.window, origin)
     ) {
       window = request.window
     }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -233,7 +233,7 @@ function appendRequestOriginHeader (request) {
         break
       case 'same-origin':
         // If request’s origin is not same origin with request’s current URL’s origin, then set serializedOrigin to `null`.
-        if (request.origin !== requestCurrentURL(request).origin) {
+        if (!sameOrigin(request, requestCurrentURL(request))) {
           serializedOrigin = null
         }
         break
@@ -297,6 +297,25 @@ function tryUpgradeRequestToAPotentiallyTrustworthyURL (request) {
   // TODO
 }
 
+/**
+ * @link {https://html.spec.whatwg.org/multipage/origin.html#same-origin}
+ * @param {URL} A
+ * @param {URL} B
+ */
+ function sameOrigin (A, B) {
+  // 1. If A and B are the same opaque origin, then return true.
+  // "opaque origin" is an internal value we cannot access, ignore.
+
+  // 2. If A and B are both tuple origins and their schemes, 
+  //    hosts, and port are identical, then return true.
+  if (A.protocol === B.protocol && A.hostname === B.hostname && A.port === B.port) {
+    return true
+  }
+
+  // 3. Return false.
+  return false
+}
+
 function createDeferredPromise () {
   let res
   let rej
@@ -339,5 +358,6 @@ module.exports = {
   responseLocationURL,
   isBlobLike,
   isFileLike,
-  isValidReasonPhrase
+  isValidReasonPhrase,
+  sameOrigin
 }

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -56,3 +56,57 @@ test('requestBadPort', (t) => {
     urlList: [new URL('https://asd:7')]
   }))
 })
+
+// https://html.spec.whatwg.org/multipage/origin.html#same-origin
+// look at examples
+test('sameOrigin', (t) => {
+  t.test('first test', (t) => {
+    const A = {
+      protocol: 'https:',
+      hostname: 'example.org',
+      port: ''
+    }
+
+    const B = {
+      protocol: 'https:',
+      hostname: 'example.org',
+      port: ''
+    }
+
+    t.ok(util.sameOrigin(A, B))
+    t.end()
+  })
+
+  t.test('second test', (t) => {
+    const A = {
+      protocol: 'https:',
+      hostname: 'example.org',
+      port: '314'
+    }
+
+    const B = {
+      protocol: 'https:',
+      hostname: 'example.org',
+      port: '420'
+    }
+
+    t.notOk(util.sameOrigin(A, B))
+    t.end()
+  })
+
+  t.test('obviously shouldn\'t be equal', (t) => {
+    t.notOk(util.sameOrigin(
+      { protocol: 'http:', hostname: 'example.org' },
+      { protocol: 'https:', hostname: 'example.org' }
+    ))
+
+    t.notOk(util.sameOrigin(
+      { protocol: 'https:', hostname: 'example.org' },
+      { protocol: 'https:', hostname: 'example.com' }
+    ))
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
This PR contains 3 fetch bug fixes:

- In `mainFetch`, `response` was not being set in 2 places ("then set response to a network error.").
- In [`httpRedirectFetch`](https://fetch.spec.whatwg.org/#http-redirect-fetch), the old step 12 has been removed
- The terms "same origin" actually refers to a [series of steps](https://html.spec.whatwg.org/multipage/origin.html#same-origin) that need to be taken, not just comparing the URL's origin. ([see here](https://github.com/nodejs/undici/pull/1165#issuecomment-1011317842))