### PR TITLE
 fix: method is not required for request api

### DIFF
--- a/test/types/api.test-d.ts
+++ b/test/types/api.test-d.ts
@@ -4,6 +4,7 @@ import { Dispatcher, request, stream, pipeline, connect, upgrade } from '../..'
 
 // request
 expectAssignable<Promise<Dispatcher.ResponseData>>(request(''))
+expectAssignable<Promise<Dispatcher.ResponseData>>(request('', { }))
 expectAssignable<Promise<Dispatcher.ResponseData>>(request('', { method: 'GET' }))
 
 // stream

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -13,7 +13,7 @@ export {
 /** Performs an HTTP request. */
 declare function request(
   url: string | URL | UrlObject,
-  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path'>,
+  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions, 'origin' | 'path' | 'method'> & Partial<Pick<Dispatcher.RequestOptions, 'method'>>,
 ): Promise<Dispatcher.ResponseData>;
 
 /** A faster version of `request`. */


### PR DESCRIPTION
DispatchOptions passed to the request api doesn't **NEED** to have a `method` param since it defaults to `'GET'` (or `'PUT'` if there is an optional body).

https://github.com/nodejs/undici/blob/6c2c6addcced5284144e876bce1b827717a03e47/index.js#L83-L88

```ts
const { request } = require('undici');

// Doesn't have method param
const options = {};

// method defaults to "GET"
request('http://example.com', options).then(console.log)
```

Why is this important? If `method` is required it makes it awkward to use a default object that does't specify the method rather than letting it get computed automatically later on.

> Property 'method' is missing in type '{}' but required in type

```ts
const foo = (url, options = {}) => {
    // do stuff with options
    return request(url, options);
};
```


