### PR TITLE
fix: fetch - don't coerce null or undefined integrity to a string

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -140,35 +140,35 @@ class Request {
     request = makeRequest({
       // URL request’s URL.
       // undici implementation note: this is set as the first item in request's urlList in makeRequest
-      // method request’s method. 
+      // method request’s method.
       method: request.method,
       // header list A copy of request’s header list.
       // undici implementation note: headersList is cloned in makeRequest
       headersList: request.headersList,
-      // unsafe-request flag Set. 
+      // unsafe-request flag Set.
       unsafeRequest: request.unsafeRequest,
       // client This’s relevant settings object.
       client: request.client,
       // window window.
       window,
-      // priority request’s priority. 
+      // priority request’s priority.
       priority: request.priority,
       // origin request’s origin. The propagation of the origin is only significant for navigation requests
-      // being handled by a service worker. In this scenario a request can have an origin that is different 
+      // being handled by a service worker. In this scenario a request can have an origin that is different
       // from the current client.
       origin: request.origin,
       // referrer request’s referrer.
-      referrer: request.referrer, 
+      referrer: request.referrer,
       // referrer policy request’s referrer policy.
       referrerPolicy: request.referrerPolicy,
       // mode request’s mode.
-      mode: request.mode, 
+      mode: request.mode,
       // credentials mode request’s credentials mode.
       credentials: request.credentials,
       // cache mode request’s cache mode.
       cache: request.cache,
       // redirect mode request’s redirect mode.
-      redirect: request.redirect, 
+      redirect: request.redirect,
       // integrity metadata request’s integrity metadata.
       integrity: request.integrity,
       // keepalive request’s keepalive.
@@ -320,7 +320,7 @@ class Request {
     }
 
     // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
-    if ('integrity' in init) {
+    if ('integrity' in init && init.integrity != null) {
       request.integrity = String(init.integrity)
     }
 

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -149,6 +149,18 @@ test('arg validation', (t) => {
   t.end()
 })
 
+test('undefined integrity', t => {
+  const req = new Request('http://asd', { integrity: undefined })
+  t.equal(req.integrity, '')
+  t.end()
+})
+
+test('null integrity', t => {
+  const req = new Request('http://asd', { integrity: null })
+  t.equal(req.integrity, '')
+  t.end()
+})
+
 test('undefined signal', t => {
   const req = new Request('http://asd', { signal: undefined })
   t.equal(req.signal.aborted, false)


### PR DESCRIPTION
Fixes #1176