### PR TITLE
Add diagnostic on consume finish

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -80,7 +80,7 @@ class RequestHandler extends AsyncResource {
     }
 
     const parsedHeaders = util.parseHeaders(headers)
-    const body = new Readable(resume, abort, parsedHeaders['content-type'])
+    const body = new Readable(resume, abort, parsedHeaders['content-type'], context)
 
     this.callback = null
     this.res = body

--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -15,9 +15,21 @@ const kReading = Symbol('kReading')
 const kBody = Symbol('kBody')
 const kAbort = Symbol('abort')
 const kContentType = Symbol('kContentType')
+const kContext = Symbol('context')
+
+const channels = {}
+
+try {
+  const diagnosticsChannel = require('diagnostics_channel')
+  channels.consumeFinish = diagnosticsChannel.channel('undici:consume:finish')
+  channels.consumeError = diagnosticsChannel.channel('undici:consume:error')
+} catch {
+  channels.consumeFinish = { hasSubscribers: false }
+  channels.consumeError = { hasSubscribers: false }
+}
 
 module.exports = class BodyReadable extends Readable {
-  constructor (resume, abort, contentType = '') {
+  constructor (resume, abort, contentType = '', context) {
     super({
       autoDestroy: true,
       read: resume,
@@ -26,6 +38,7 @@ module.exports = class BodyReadable extends Readable {
 
     this._readableState.dataEmitted = false
 
+    this[kContext] = context
     this[kAbort] = abort
     this[kConsume] = null
     this[kBody] = null
@@ -100,24 +113,42 @@ module.exports = class BodyReadable extends Readable {
     return super.push(chunk)
   }
 
+  async consume(type) {
+    try {
+      const body = await consume(this, type);
+      
+      if (channels.consumeFinish.hasSubscribers) {
+        channels.consumeFinish.publish({ body, socket: this[kContext].socket })
+      }
+
+      return body;
+    } catch (err) {
+      if (channels.consumeError.hasSubscribers) {
+        channels.consumeError.publish({ error: err, socket: this[kContext].socket })
+      }
+
+      throw err
+    }
+  }
+
   // https://fetch.spec.whatwg.org/#dom-body-text
   async text () {
-    return consume(this, 'text')
+    return this.consume('text')
   }
 
   // https://fetch.spec.whatwg.org/#dom-body-json
   async json () {
-    return consume(this, 'json')
+    return this.consume('json')
   }
 
   // https://fetch.spec.whatwg.org/#dom-body-blob
   async blob () {
-    return consume(this, 'blob')
+    return this.consume('blob')
   }
 
   // https://fetch.spec.whatwg.org/#dom-body-arraybuffer
   async arrayBuffer () {
-    return consume(this, 'arrayBuffer')
+    return this.consume('arrayBuffer')
   }
 
   // https://fetch.spec.whatwg.org/#dom-body-formdata

--- a/lib/client.js
+++ b/lib/client.js
@@ -1448,7 +1448,7 @@ function write (client, request) {
       errorRequest(client, request, err || new RequestAbortedError())
 
       util.destroy(socket, new InformationalError('aborted'))
-    })
+    }, { socket })
   } catch (err) {
     errorRequest(client, request, err)
   }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -158,11 +158,11 @@ class Request {
     }
   }
 
-  onConnect (abort) {
+  onConnect (abort, context) {
     assert(!this.aborted)
     assert(!this.completed)
 
-    return this[kHandler].onConnect(abort)
+    return this[kHandler].onConnect(abort, context)
   }
 
   onHeaders (statusCode, headers, resume, statusText) {

--- a/lib/handler/redirect.js
+++ b/lib/handler/redirect.js
@@ -73,9 +73,9 @@ class RedirectHandler {
     }
   }
 
-  onConnect (abort) {
+  onConnect (abort, context) {
     this.abort = abort
-    this.handler.onConnect(abort, { history: this.history })
+    this.handler.onConnect(abort, { ...context, history: this.history })
   }
 
   onUpgrade (statusCode, headers, socket) {


### PR DESCRIPTION
On my way to close this https://github.com/nodejs/undici/issues/1173

Didn't know how to pass the request context to the Readable object, @mcollina obviously suggested to pass it on the constructor. :)

Using the "onConnect" context to include the reference to the socket in the context.

Bench main:

 ```
[bench:run] │ Tests               │ Samples │        Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │  7.76 req/sec │  ± 0.74 % │                       - │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      10 │  7.90 req/sec │  ± 0.38 % │                + 1.79 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      10 │ 51.38 req/sec │  ± 1.45 % │              + 561.73 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      10 │ 51.70 req/sec │  ± 1.20 % │              + 565.88 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      10 │ 52.96 req/sec │  ± 1.81 % │              + 582.15 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      10 │ 57.64 req/sec │  ± 1.60 % │              + 642.46 % │
[bench:run]
[bench:run] │ Tests               │ Samples │          Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │ 4134.68 req/sec │  ± 2.23 % │                       - │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      10 │ 5133.15 req/sec │  ± 1.35 % │               + 24.15 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      10 │ 6337.97 req/sec │  ± 2.84 % │               + 53.29 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      15 │ 6388.91 req/sec │  ± 2.45 % │               + 54.52 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      10 │ 6862.55 req/sec │  ± 2.03 % │               + 65.98 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      15 │ 7207.77 req/sec │  ± 2.17 % │               + 74.32 % │
```


bench branch


```
[bench:run] │ Tests               │ Samples │        Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │  7.71 req/sec │  ± 0.80 % │                       - │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      10 │  7.84 req/sec │  ± 0.52 % │                + 1.71 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      10 │ 52.34 req/sec │  ± 1.87 % │              + 578.72 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      10 │ 53.23 req/sec │  ± 1.14 % │              + 590.24 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      10 │ 53.98 req/sec │  ± 1.92 % │              + 600.06 % │
[bench:run] |─────────────────────|─────────|───────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      10 │ 54.13 req/sec │  ± 1.21 % │              + 601.97 % │
[bench:run]
[bench:run] │ Tests               │ Samples │          Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │      10 │ 4318.55 req/sec │  ± 2.06 % │                       - │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │      15 │ 5360.76 req/sec │  ± 2.16 % │               + 24.13 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │      15 │ 6352.82 req/sec │  ± 2.14 % │               + 47.11 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │      15 │ 6540.60 req/sec │  ± 2.59 % │               + 51.45 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │      10 │ 6858.88 req/sec │  ± 2.61 % │               + 58.82 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │      15 │ 7286.48 req/sec │  ± 2.39 % │               + 68.73 % │
```