### PR TITLE
fetch: allow file:// URL & relative paths

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -52,10 +52,14 @@ const { PassThrough, pipeline } = require('stream')
 const { isErrored, isReadable } = require('../core/util')
 const { kIsMockActive } = require('../mock/mock-symbols')
 const { dataURLProcessor } = require('./dataURL')
+const { readFile, stat } = require('fs/promises')
+const { emitWarning } = require('process')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
 let ReadableStream
+
+let fileURLExperimentalWarning = false
 
 class Fetch extends EE {
   constructor (dispatcher) {
@@ -882,7 +886,40 @@ async function schemeFetch (fetchParams) {
     case 'file:': {
       // For now, unfortunate as it is, file URLs are left as an exercise for the reader.
       // When in doubt, return a network error.
-      return makeNetworkError('not implemented... yet...')
+      if (!fileURLExperimentalWarning) {
+        fileURLExperimentalWarning = true
+        emitWarning(
+          'fetching file:// URLs is not standardized. This feature could change at any time',
+          'ExperimentalWarning'
+        )
+      }
+
+      const currentURL = requestCurrentURL(request)
+
+      /** @type {import('fs').Stats} */
+      let fileStats;
+      let fileContent;
+
+      try {
+        fileStats = await stat(currentURL)
+      } catch {
+        return makeNetworkError(`invalid file at ${currentURL}`)
+      }
+
+      if (!fileStats.isFile()) {
+        return makeNetworkError(`${currentURL} is not a file path.`)
+      }
+
+      try {
+        fileContent = await readFile(currentURL)
+      } catch (e) {
+        return makeNetworkError(e.toString())
+      }
+
+      return makeResponse({
+        statusText: 'OK',
+        body: fileContent
+      })
     }
     case 'http:':
     case 'https:': {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -23,6 +23,9 @@ const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = require('./symbols')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
+const { pathToFileURL } = require('url')
+const { cwd } = require('process')
+const { sep } = require('path')
 
 let TransformStream
 
@@ -57,8 +60,15 @@ class Request {
     const input = args[0] instanceof Request ? args[0] : toUSVString(args[0])
     const init = args.length >= 1 ? args[1] ?? {} : {}
 
-    // TODO
-    this[kRealm] = { settingsObject: {} }
+    // TODO: add remaining properties and choose default values
+    // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
+    this[kRealm] = {
+      settingsObject: {
+        // An API base URL: A URL used by APIs called by scripts that use
+        // this environment settings object to parse URLs
+        baseUrl: new URL(pathToFileURL(cwd() + sep))
+      }
+    }
 
     // 1. Let request be null.
     let request = null


### PR DESCRIPTION
This PR enables fetching relative URLs and file:// URLs. This hopefully fixes issues with WPTs!

Relative URLs are typically handled in browsers because of the environment setting object's base URL. For examples:
```js
// base = https://fetch.spec.whatwg.org/some/path/ [notice trailing /]
fetch('./test'); // fetches https://fetch.spec.whatwg.org/some/path/test

// base = https://fetch.spec.whatwg.org/some/path [no trailing /]
fetch('./test'); // fetches https://fetch.spec.whatwg.org/some/test
```
However, in node, there isn't really a good alternative to base URL as there is no concept of location/origin. Therefore, the 'best' solution (as far as I could think of) was to just use `file://` uris instead and having the "base" be the current working directory.

cc. @targos, hi 😄 

- No tests yet because it needs some discussion.
- Currently allows some "unintended" behavior such as being able to fetch any file, even outside of the cwd.
- There is no spec for `file://` urls so once it is standardized, this will need to be updated.