### PR TITLE
Fix import of `ProxyAgent`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ import MockClient = require('./types/mock-client')
 import MockPool = require('./types/mock-pool')
 import MockAgent = require('./types/mock-agent')
 import mockErrors = require('./types/mock-errors')
-import ProxyAgent from './types/proxy-agent'
+import ProxyAgent = require('./types/proxy-agent')
 import { request, pipeline, stream, connect, upgrade } from './types/api'
 
 export * from './types/fetch'


### PR DESCRIPTION
ProxyAgent is imported with the assumption that `allowSyntheticDefaultImports` is enabled. The aforementioned option is disabled by default. As a result, users are required to enable `allowSyntheticDefaultImports` in order to have an error-free TypeScript experience.

https://github.com/nodejs/undici/pull/1070#discussion_r796794771