### PR TITLE
types: Align `RequestInit` type with lib.dom.ts type

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -42,7 +42,7 @@ export interface BodyMixin {
   readonly text: () => Promise<string>
 }
 
-export type HeadersInit = Iterable<[string, string]> | Record<string, string>
+export type HeadersInit = string[][] | Record<string, string> | Headers
 
 export declare class Headers implements Iterable<[string, string]> {
   constructor (init?: HeadersInit)
@@ -96,11 +96,28 @@ export interface RequestInit {
   readonly method?: string
   readonly keepalive?: boolean
   readonly headers?: HeadersInit
-  readonly body?: BodyInit
+  readonly body?: BodyInit;
   readonly redirect?: RequestRedirect
   readonly integrity?: string
   readonly signal?: AbortSignal
+  readonly cache?: RequestCache
+  readonly credentials?: RequestCredentials
+  readonly mode?: RequestMode;
+  readonly referrer?: string;
+  readonly referrerPolicy?: ReferrerPolicy;
+  readonly window?: null; 
 }
+
+export type ReferrerPolicy = 
+  | ''
+  | 'no-referrer'
+  | 'no-referrer-when-downgrade'
+  | 'origin'
+  | 'origin-when-cross-origin'
+  | 'same-origin'
+  | 'strict-origin'
+  | 'strict-origin-when-cross-origin'
+  | 'unsafe-url';
 
 export type RequestMode = 'cors' | 'navigate' | 'no-cors' | 'same-origin'
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

#1172

## Rationale

Types for `RequestInit` should be fully compatible with typescript dom types.

## Changes

Adds all properties to `RequestInit` that were missing based on the typescript dom types. This adjusts the `Headers` subtype to also follow the typescript definitions.

### Features

N/A

### Bug Fixes

closes #1172

### Breaking Changes and Deprecations

N/A

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [X] Tested
- [ ] Benchmarked \(**optional**)
- [X] Documented
- [X] Review ready
- [ ] In review
- \[ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
