### PR TITLE
Fix order of WASM loading

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -24,9 +24,6 @@ const {
   HTTPParserError
 } = require('./core/errors')
 const buildConnector = require('./core/connect')
-const llhttpWasmData = require('./llhttp/llhttp.wasm.js')
-const llhttpSimdWasmData = require('./llhttp/llhttp_simd.wasm.js')
-
 const {
   kUrl,
   kReset,
@@ -413,7 +410,7 @@ const EMPTY_BUF = Buffer.alloc(0)
 async function lazyllhttp () {
   let mod
   try {
-    mod = await WebAssembly.compile(Buffer.from(llhttpSimdWasmData, 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(require('./llhttp/llhttp_simd.wasm.js'), 'base64'))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -421,7 +418,7 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData, 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(require('./llhttp/llhttp.wasm.js'), 'base64'))
   }
 
   return await WebAssembly.instantiate(mod, {

--- a/lib/client.js
+++ b/lib/client.js
@@ -413,7 +413,7 @@ const EMPTY_BUF = Buffer.alloc(0)
 async function lazyllhttp () {
   let mod
   try {
-    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData, 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(llhttpSimdWasmData, 'base64'))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -421,7 +421,7 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(Buffer.from(llhttpSimdWasmData, 'base64'))
+    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData, 'base64'))
   }
 
   return await WebAssembly.instantiate(mod, {


### PR DESCRIPTION
Recent changes to how the wasm is loaded in #1183 have accidentally changed the order of simd/other builds.

You can see in the diff, originally the 

```diff
  try {
-    mod = await WebAssembly.compile(await readFile(resolve(__dirname, './llhttp/llhttp_simd.wasm')))
+    mod = await WebAssembly.compile(Buffer.from(llhttpWasmData, 'base64'))
  } catch (e) {
...
-    mod = await WebAssembly.compile(await readFile(resolve(__dirname, './llhttp/llhttp.wasm')))
+    mod = await WebAssembly.compile(Buffer.from(llhttpSimdWasmData, 'base64'))
  }
```

This makes sense because the simd build should throw when it isnt supported, and the catch loads the basic version.

Currently no one will be using the simd version.

This PR changes the order back, so that simd is loaded first, and on error we can the basic version.

I've also inlined the `require` call to the base64 JS module, this way most of the time the text of the basic version doesnt need to be loaded.