### PR TITLE
test(fetch): `File` coverage

### DIFF
--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -9,13 +9,16 @@ const { Blob } = require('buffer')
 const { fetch, Response, Request, FormData, File } = require('../..')
 
 test('args validation', (t) => {
-  t.plan(2)
+  t.plan(3)
 
   t.throws(() => {
     File.prototype.name.call(null)
   }, TypeError)
   t.throws(() => {
     File.prototype.lastModified.call(null)
+  }, TypeError)
+  t.throws(() => {
+    File.prototype[Symbol.toStringTag].call(null)
   }, TypeError)
 })
 


### PR DESCRIPTION
This adds coverage for
https://github.com/nodejs/undici/blob/abf7c4547d1a1aa9e023c0536a890bc0aa183f48/lib/fetch/file.js#L71.

Refs: https://github.com/nodejs/undici/issues/951
Signed-off-by: Darshan Sen <raisinten@gmail.com>