### PR TITLE
docs: expand mixins information, notate body reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ _Note: Once a mixin has been called, the `ReadableStream` the body represents ca
 
 Should you need to access the `body` in plain-text after using a mixin, the best practice is to use the `.text()` mixin first, and manually parse the text to the desired format.
 
-If the scenario arises where you absolutely must have a copy of the result stream, [`.clone`](https://fetch.spec.whatwg.org/#dom-request-clone) can be used _before_ using a `body` mixin, or [`body.pipeThrough`](https://streams.spec.whatwg.org/#readablestream-pipe-through) with a user-defined stream [§](https://web.dev/fetch-upload-streaming), such as [`TransformStream`]https://nodejs.org/api/stream.html#duplex-and-transform-streams.
-
 For more information about their behavior, please reference the body mixin from the [Fetch Standard](https://fetch.spec.whatwg.org/#body-mixin).
 
 ## Common API Methods

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console.log('trailers', trailers)
 
 ## Body Mixins
 
-The `body` mixins are the most common way to format the request/response body from a [`ReadableStream`](https://streams.spec.whatwg.org/#readablestream). Mixins include:
+The `body` mixins are the most common way to format the request/response body. Mixins include:
 
 - [`.formData()`](https://fetch.spec.whatwg.org/#dom-body-formdata)
 - [`.json()`](https://fetch.spec.whatwg.org/#dom-body-json)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ console.log('data', await body.json())
 console.log('trailers', trailers)
 ```
 
-_Note: Once a mixin has been called, the `ReadableStream` the body represents cannot be reused, thus calling additional mixins on `.body`, e.g. `.body.json(); .body.text()` will result in an error `TypeError: unusable` being thrown and returned through the `Promise` rejection._
+_Note: Once a mixin has been called then the body cannot be reused, thus calling additional mixins on `.body`, e.g. `.body.json(); .body.text()` will result in an error `TypeError: unusable` being thrown and returned through the `Promise` rejection._
 
 Should you need to access the `body` in plain-text after using a mixin, the best practice is to use the `.text()` mixin first, and manually parse the text to the desired format.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ for await (const data of body) {
 console.log('trailers', trailers)
 ```
 
-Using [the body mixin from the Fetch Standard](https://fetch.spec.whatwg.org/#body-mixin).
+## Body Mixins
+
+The `body` mixins are the most common way to format the request/response body from a [`ReadableStream`](https://streams.spec.whatwg.org/#readablestream). Mixins include:
+
+- [`.formData()`](https://fetch.spec.whatwg.org/#dom-body-formdata)
+- [`.json()`](https://fetch.spec.whatwg.org/#dom-body-json)
+- [`.text()`](https://fetch.spec.whatwg.org/#dom-body-text)
+
+Example usage:
 
 ```js
 import { request } from 'undici'
@@ -82,6 +90,14 @@ console.log('headers', headers)
 console.log('data', await body.json())
 console.log('trailers', trailers)
 ```
+
+_Note: Once a mixin has been called, the `ReadableStream` the body represents cannot be reused, thus calling additional mixins on `.body`, e.g. `.body.json(); .body.text()` will result in an error `TypeError: unusable` being thrown and returned through the `Promise` rejection._
+
+Should you need to access the `body` in plain-text after using a mixin, the best practice is to use the `.text()` mixin first, and manually parse the text to the desired format.
+
+If the scenario arises where you absolutely must have a copy of the result stream, [`.clone`](https://fetch.spec.whatwg.org/#dom-request-clone) can be used _before_ using a `body` mixin, or [`body.pipeThrough`](https://streams.spec.whatwg.org/#readablestream-pipe-through) with a user-defined stream [§](https://web.dev/fetch-upload-streaming), such as [`TransformS tream`]https://nodejs.org/api/stream.html#duplex-and-transform-streams.
+
+For more information about their behavior, please reference the body mixin from the [Fetch Standard](https://fetch.spec.whatwg.org/#body-mixin).
 
 ## Common API Methods
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ _Note: Once a mixin has been called, the `ReadableStream` the body represents ca
 
 Should you need to access the `body` in plain-text after using a mixin, the best practice is to use the `.text()` mixin first, and manually parse the text to the desired format.
 
-If the scenario arises where you absolutely must have a copy of the result stream, [`.clone`](https://fetch.spec.whatwg.org/#dom-request-clone) can be used _before_ using a `body` mixin, or [`body.pipeThrough`](https://streams.spec.whatwg.org/#readablestream-pipe-through) with a user-defined stream [§](https://web.dev/fetch-upload-streaming), such as [`TransformS tream`]https://nodejs.org/api/stream.html#duplex-and-transform-streams.
+If the scenario arises where you absolutely must have a copy of the result stream, [`.clone`](https://fetch.spec.whatwg.org/#dom-request-clone) can be used _before_ using a `body` mixin, or [`body.pipeThrough`](https://streams.spec.whatwg.org/#readablestream-pipe-through) with a user-defined stream [§](https://web.dev/fetch-upload-streaming), such as [`TransformStream`]https://nodejs.org/api/stream.html#duplex-and-transform-streams.
 
 For more information about their behavior, please reference the body mixin from the [Fetch Standard](https://fetch.spec.whatwg.org/#body-mixin).
 


### PR DESCRIPTION
This PR proposes to resolve the documentation issue outlined in #1208.

I referenced the `fetch` spec in some ways I felt read naturally, and attempted to structure the docs in a way that it would read/flow from most common use cases and wanted-info to most obscure or infrequently used. Added a little sugar to references that users might find useful or interesting. I'm not married to any part of it, but want to make sure that we're pointing users in the right direction for using mixins and potential pitfalls, especially those who have been using alternatives to fetch and aren't up to speed.