### PR TITLE
fix: incorrect http(s) regexp

### DIFF
--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -61,7 +61,7 @@ function requestBadPort (request) {
 
   // 2. If url’s scheme is an HTTP(S) scheme and url’s port is a bad port,
   // then return blocked.
-  if (/^http?s/.test(url.protocol) && badPorts.includes(url.port)) {
+  if (/^https?:/.test(url.protocol) && badPorts.includes(url.port)) {
     return 'blocked'
   }
 

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -47,10 +47,13 @@ test('responseLocationURL', (t) => {
 })
 
 test('requestBadPort', (t) => {
-  t.plan(2)
+  t.plan(3)
 
   t.equal('allowed', util.requestBadPort({
     urlList: [new URL('https://asd')]
+  }))
+  t.equal('blocked', util.requestBadPort({
+    urlList: [new URL('http://asd:7')]
   }))
   t.equal('blocked', util.requestBadPort({
     urlList: [new URL('https://asd:7')]


### PR DESCRIPTION
`/^http?s/` is matched for `htts` and `https`.
It should fix to `/^https?:/` (matched for `http:` and `https:`)