### PR TITLE
Added fetch to our benchmark suite

### DIFF
--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -7,7 +7,7 @@ const os = require('os')
 const path = require('path')
 const { table } = require('table')
 
-const { Pool, Client } = require('..')
+const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
 const iterations = (parseInt(process.env.SAMPLES, 10) || 100) + 1
 const errorThreshold = parseInt(process.env.ERROR_TRESHOLD, 10) || 3
@@ -63,6 +63,8 @@ const dispatcher = new Class(httpBaseOptions.url, {
   connections,
   ...dest
 })
+
+setGlobalDispatcher(new Agent({ pipelining, connections }))
 
 class SimpleRequest {
   constructor (resolve) {
@@ -239,6 +241,13 @@ cronometro(
     'undici - dispatch' () {
       return makeParallelRequests(resolve => {
         dispatcher.dispatch(undiciOptions, new SimpleRequest(resolve))
+      })
+    },
+    'undici - fetch' () {
+      return makeParallelRequests(resolve => {
+        fetch(dest.url).then(res => {
+          res.text().then(resolve)
+        })
       })
     }
   },


### PR DESCRIPTION
`fetch()` has significant bottlenecks, we should track its performance.

```
│ Tests               │ Samples │           Result │ Tolerance │ Difference with slowest │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - fetch      │      20 │  1028.31 req/sec │  ± 2.71 % │                       - │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ http - no keepalive │      10 │  3891.51 req/sec │  ± 2.00 % │              + 278.44 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - pipeline   │      95 │  6034.47 req/sec │  ± 2.95 % │              + 486.83 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ http - keepalive    │      50 │  6382.57 req/sec │  ± 2.98 % │              + 520.68 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - request    │      15 │  8528.35 req/sec │  ± 2.11 % │              + 729.35 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - stream     │      10 │ 10226.33 req/sec │  ± 2.66 % │              + 894.48 % │
|─────────────────────|─────────|──────────────────|───────────|─────────────────────────|
│ undici - dispatch   │      50 │ 11399.31 req/sec │  ± 2.79 % │             + 1008.54 % │
```