### PR TITLE
chore: ignore wasm file for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+lib/llhttp/llhttp_simd.wasm
+lib/llhttp/llhttp.wasm


### PR DESCRIPTION
After https://github.com/nodejs/undici/pull/1183, WASM files are no more necessary to be shipped as part of the NPM bundle