### PR TITLE
feat(fetch): add support for file urls in fetch

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1,5 +1,5 @@
 // https://github.com/Ethan-Arrowood/undici-fetch
-
+/* globals AggregateError */
 'use strict'
 
 const {
@@ -52,6 +52,7 @@ const { PassThrough, pipeline } = require('stream')
 const { isErrored, isReadable } = require('../core/util')
 const { kIsMockActive } = require('../mock/mock-symbols')
 const { dataURLProcessor } = require('./dataURL')
+const fs = require('fs')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -476,7 +477,7 @@ async function mainFetch (fetchParams, recursive = false) {
 
   // 1. Let request be fetchParams’s request.
   const request = fetchParams.request
-
+  const url = requestCurrentURL(request)
   // 2. Let response be null.
   let response = null
 
@@ -484,7 +485,7 @@ async function mainFetch (fetchParams, recursive = false) {
   // not local, then set response to a network error.
   if (
     request.localURLsOnly &&
-    !/^(about|blob|data):/.test(requestCurrentURL(request).protocol)
+    !/^(about|blob|data|file):/.test(url.protocol)
   ) {
     response = makeNetworkError('local URLs only')
   }
@@ -534,6 +535,10 @@ async function mainFetch (fetchParams, recursive = false) {
   if (response === null) {
     response = await (async () => {
       const currentURL = requestCurrentURL(request)
+
+      if (currentURL.protocol === 'file:') {
+        return fileFetch.call(this, request, url)
+      }
 
       if (
         // - request’s current URL’s origin is same origin with request’s origin,
@@ -587,7 +592,7 @@ async function mainFetch (fetchParams, recursive = false) {
       }
 
       // request’s current URL’s scheme is not an HTTP(S) scheme
-      if (!/^https?:/.test(requestCurrentURL(request).protocol)) {
+      if (!/^https?:/.test(url.protocol)) {
         // Return a network error.
         return makeNetworkError('URL scheme must be a HTTP(S) scheme')
       }
@@ -618,6 +623,10 @@ async function mainFetch (fetchParams, recursive = false) {
   // 12. If recursive is true, then return response.
   if (recursive) {
     return response
+  }
+
+  if (/file?:/.test(url.protocol)) {
+    return fetchFinale(fetchParams, response)
   }
 
   // 13. If response is not a network error and response is not a filtered
@@ -762,8 +771,8 @@ async function schemeFetch (fetchParams) {
   switch (scheme) {
     case 'about:': {
       // If request’s current URL’s path is the string "blank", then return a new response
-      // whose status message is `OK`, header list is « (`Content-Type`, `text/html;charset=utf-8`) », 
-      // and body is the empty byte sequence. 
+      // whose status message is `OK`, header list is « (`Content-Type`, `text/html;charset=utf-8`) »,
+      // and body is the empty byte sequence.
       if (path === 'blank') {
         const resp = makeResponse({
           statusText: 'OK',
@@ -771,7 +780,7 @@ async function schemeFetch (fetchParams) {
             'content-type', 'text/html;charset=utf-8'
           ]
         })
-        
+
         resp.urlList = [new URL('about:blank')]
         return resp
       }
@@ -784,12 +793,12 @@ async function schemeFetch (fetchParams) {
 
       context.on('terminated', onRequestAborted)
 
-      // 1. Run these steps, but abort when the ongoing fetch is terminated: 
+      // 1. Run these steps, but abort when the ongoing fetch is terminated:
       //  1a. Let blob be request’s current URL’s blob URL entry’s object.
       //      https://w3c.github.io/FileAPI/#blob-url-entry
       //      P.S. Thank God this method is available in node.
       const currentURL = requestCurrentURL(request)
-      
+
       // https://github.com/web-platform-tests/wpt/blob/7b0ebaccc62b566a1965396e5be7bb2bc06f841f/FileAPI/url/resources/fetch-tests.js#L52-L56
       // Buffer.resolveObjectURL does not ignore URL queries.
       if (currentURL.search.length !== 0) {
@@ -803,7 +812,7 @@ async function schemeFetch (fetchParams) {
         return makeNetworkError('invalid method')
       }
 
-      //  3a. Let response be a new response whose status message is `OK`. 
+      //  3a. Let response be a new response whose status message is `OK`.
       const response = makeResponse({ statusText: 'OK', urlList: [currentURL] })
 
       //  4a. Append (`Content-Length`, blob’s size attribute value) to response’s header list.
@@ -1988,6 +1997,84 @@ function httpNetworkFetch (
       }
     )
   })
+}
+
+async function fileFetch (request, url) {
+  const context = this
+  if (request.method !== 'GET') {
+    return makeNetworkError(`Fetching files only supports the GET method. Received ${request.method}`)
+  }
+
+  let stream
+  let file
+
+  try {
+    const path = url.href.substring('file://'.length)
+    file = await fs.promises.open(path)
+    if (context.terminated) {
+      if (context.terminated.aborted) {
+        throw new AbortError()
+      } else {
+        throw new Error('terminated')
+      }
+    }
+    stream = file.createReadStream({ autoClose: true })
+  } catch (originalError) {
+    if (stream) {
+      stream.destroy(originalError)
+    } else if (file) {
+      try {
+        await file.close()
+      } catch (closeError) {
+        return createAggregateNetworkError(originalError, closeError)
+      }
+    }
+    return makeNetworkError(originalError)
+  }
+
+  try {
+    function onTerminated () {
+      const aborted = context.terminated.aborted
+      if (aborted) {
+        response.aborted = true
+        stream.destroy(new AbortError())
+      } else {
+        stream.destroy(new TypeError('terminated'))
+      }
+    }
+    function streamClose () {
+      context.off('terminated', onTerminated)
+    }
+    const response = makeResponse({
+      status: 200,
+      statusText: 'OK',
+      headersList: [],
+      body: safelyExtractBody(stream)[0]
+    })
+    context.on('terminated', onTerminated)
+    stream.on('close', streamClose)
+    return response
+  } catch (err) {
+    stream.destroy(err)
+    return makeNetworkError(err)
+  }
+}
+
+function createAggregateNetworkError (originalError, secondError) {
+  const err = new AggregateError([originalError, secondError], originalError.message)
+  err.code = originalError.code
+  return makeNetworkError(err)
+}
+
+function createDeferredPromise () {
+  let res
+  let rej
+  const promise = new Promise((resolve, reject) => {
+    res = resolve
+    rej = reject
+  })
+
+  return { promise, resolve: res, reject: rej }
 }
 
 module.exports = fetch

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -7,6 +7,7 @@ const { createServer } = require('http')
 const { ReadableStream } = require('stream/web')
 const { Blob } = require('buffer')
 const { fetch, Response, Request, FormData, File, FileLike } = require('../..')
+const { join } = require('path')
 
 test('function signature', (t) => {
   t.plan(2)
@@ -331,4 +332,24 @@ test('post FormData with File', (t) => {
     t.ok(/asd1/.test(result))
     t.ok(/filename123/.test(result))
   })
+})
+
+test('fetch file', async (t) => {
+  t.plan(1)
+  const fileToRead = join(__dirname, '..', 'fixtures', 'file.text')
+  const body = await fetch(`file://${fileToRead}`)
+  const text = await body.text()
+  t.equal(text, 'hello world')
+})
+
+test('fetch file does not exist', async (t) => {
+  t.plan(2)
+  const fileToRead = join(__dirname, '..', 'fixtures', 'does-not-exist.text')
+  try {
+    await fetch(`file://${fileToRead}`)
+    t.fail('fetch should have thrown')
+  } catch (err) {
+    t.ok(err.cause)
+    t.equal(err.cause.code, 'ENOENT')
+  }
 })

--- a/test/fixtures/file.text
+++ b/test/fixtures/file.text
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
This PR adds support for file urls in fetch

refs: https://github.com/nodejs/node/issues/42003

According to the fetch spec, files urls are "left as an exercise for the reader."
https://fetch.spec.whatwg.org/#scheme-fetch