### PR TITLE
feat(fetch): add support for file urls in fetch

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -52,6 +52,7 @@ const { PassThrough, pipeline } = require('stream')
 const { isErrored, isReadable } = require('../core/util')
 const { kIsMockActive } = require('../mock/mock-symbols')
 const { dataURLProcessor } = require('./dataURL')
+const fs = require('fs')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -882,7 +883,7 @@ async function schemeFetch (fetchParams) {
     case 'file:': {
       // For now, unfortunate as it is, file URLs are left as an exercise for the reader.
       // When in doubt, return a network error.
-      return makeNetworkError('not implemented... yet...')
+      return fileFetch.call(this, fetchParams)
     }
     case 'http:':
     case 'https:': {
@@ -1988,6 +1989,74 @@ function httpNetworkFetch (
       }
     )
   })
+}
+
+async function fileFetch (fetchParams) {
+  const { request } = fetchParams
+  const url = requestCurrentURL(request)
+  const context = this
+  if (request.method !== 'GET') {
+    return makeNetworkError(`Fetching files only supports the GET method. Received ${request.method}`)
+  }
+
+  let stream
+  let file
+
+  try {
+    file = await fs.promises.open(url)
+    if (context.terminated) {
+      if (context.terminated.aborted) {
+        throw new AbortError()
+      } else {
+        throw new Error('terminated')
+      }
+    }
+    stream = file.createReadStream({ autoClose: true })
+  } catch (originalError) {
+    if (stream) {
+      stream.destroy(originalError)
+    } else if (file) {
+      try {
+        await file.close()
+      } catch (closeError) {
+        return createAggregateNetworkError(originalError, closeError)
+      }
+    }
+    return makeNetworkError(originalError)
+  }
+
+  try {
+    function onTerminated () {
+      const aborted = context.terminated.aborted
+      if (aborted) {
+        response.aborted = true
+        stream.destroy(new AbortError())
+      } else {
+        stream.destroy(new TypeError('terminated'))
+      }
+    }
+    function streamClose () {
+      context.off('terminated', onTerminated)
+    }
+    const response = makeResponse({
+      status: 200,
+      statusText: 'OK',
+      headersList: [],
+      body: safelyExtractBody(stream)[0]
+    })
+    context.on('terminated', onTerminated)
+    stream.on('close', streamClose)
+    return response
+  } catch (err) {
+    stream.destroy(err)
+    return makeNetworkError(err)
+  }
+}
+
+function createAggregateNetworkError (originalError, secondError) {
+  const err = new AggregateError([originalError, secondError], originalError.message)
+  err.code = originalError.code
+  return makeNetworkError(err)
 }
 
 module.exports = fetch

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -7,6 +7,8 @@ const { createServer } = require('http')
 const { ReadableStream } = require('stream/web')
 const { Blob } = require('buffer')
 const { fetch, Response, Request, FormData, File, FileLike } = require('../..')
+const { join } = require('path')
+const { pathToFileURL } = require('url')
 
 test('function signature', (t) => {
   t.plan(2)
@@ -331,4 +333,24 @@ test('post FormData with File', (t) => {
     t.ok(/asd1/.test(result))
     t.ok(/filename123/.test(result))
   })
+})
+
+test('fetch file', async (t) => {
+  t.plan(1)
+  const fileToRead = pathToFileURL(join(__dirname, '..', 'fixtures', 'file.text'))
+  const body = await fetch(fileToRead)
+  const text = await body.text()
+  t.equal(text, 'hello world')
+})
+
+test('fetch file does not exist', async (t) => {
+  t.plan(2)
+  const fileToRead = pathToFileURL(join(__dirname, '..', 'fixtures', 'does-not-exist.text'))
+  try {
+    await fetch(fileToRead)
+    t.fail('fetch should have thrown')
+  } catch (err) {
+    t.ok(err.cause)
+    t.equal(err.cause.code, 'ENOENT')
+  }
 })

--- a/test/fixtures/file.text
+++ b/test/fixtures/file.text
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
This PR adds support for file urls in fetch

refs: https://github.com/nodejs/node/issues/42003

According to the fetch spec, file urls are "left as an exercise for the reader."
https://fetch.spec.whatwg.org/#scheme-fetch