### PR TITLE
Allow string[] as Record value on HeadersInit

### DIFF
--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -17,7 +17,7 @@ const {
 } = require('../../lib/fetch/constants')
 
 tap.test('Headers initialization', t => {
-  t.plan(6)
+  t.plan(7)
 
   t.test('allows undefined', t => {
     t.plan(1)
@@ -96,6 +96,20 @@ tap.test('Headers initialization', t => {
     t.throws(() => new Headers([
       ['key', 'value', 'value2']
     ]), 'throws when too many arguments are passed')
+  })
+
+  t.test('accepts headers as objects with array values', t => {
+    t.plan(1)
+    const headers = new Headers({
+      a: ['1', '2'],
+      b: ['3', '4'],
+      c: '5'
+    })
+    t.same(headers.entries(), [
+      ['a', '1,2'],
+      ['b', '3,4'],
+      ['c', '5']
+    ])
   })
 })
 

--- a/test/node-fetch/headers.js
+++ b/test/node-fetch/headers.js
@@ -279,4 +279,24 @@ describe('Headers', () => {
     // eslint-disable-next-line quotes
     expect(format(headers)).to.equal("{ a: [ '1', '3' ], b: '2', host: 'thehost' }")
   })
+
+  it('shoud accept headers as objects with array values', () => {
+    const headers = new Headers({
+      a: ['1', '2'],
+      b: ['3', '4'],
+      c: '5'
+    })
+    expect(headers).to.have.property('forEach')
+
+    const result = []
+    for (const [key, value] of headers.entries()) {
+      result.push([key, value])
+    }
+
+    expect(result).to.deep.equal([
+      ['a', '1,2'],
+      ['b', '3,4'],
+      ['c', '5']
+    ])
+  })
 })

--- a/test/node-fetch/headers.js
+++ b/test/node-fetch/headers.js
@@ -279,24 +279,4 @@ describe('Headers', () => {
     // eslint-disable-next-line quotes
     expect(format(headers)).to.equal("{ a: [ '1', '3' ], b: '2', host: 'thehost' }")
   })
-
-  it('shoud accept headers as objects with array values', () => {
-    const headers = new Headers({
-      a: ['1', '2'],
-      b: ['3', '4'],
-      c: '5'
-    })
-    expect(headers).to.have.property('forEach')
-
-    const result = []
-    for (const [key, value] of headers.entries()) {
-      result.push([key, value])
-    }
-
-    expect(result).to.deep.equal([
-      ['a', '1,2'],
-      ['b', '3,4'],
-      ['c', '5']
-    ])
-  })
 })

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -42,7 +42,7 @@ export interface BodyMixin {
   readonly text: () => Promise<string>
 }
 
-export type HeadersInit = string[][] | Record<string, string> | Headers
+export type HeadersInit = string[][] | Record<string, string | string[]> | Headers
 
 export declare class Headers implements Iterable<[string, string]> {
   constructor (init?: HeadersInit)

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -42,7 +42,7 @@ export interface BodyMixin {
   readonly text: () => Promise<string>
 }
 
-export type HeadersInit = string[][] | Record<string, string | string[]> | Headers
+export type HeadersInit = string[][] | Record<string, string | ReadonlyArray<string>> | Headers
 
 export declare class Headers implements Iterable<[string, string]> {
   constructor (init?: HeadersInit)
@@ -107,7 +107,7 @@ export interface RequestInit {
   readonly window?: null
 }
 
-export type ReferrerPolicy = 
+export type ReferrerPolicy =
   | ''
   | 'no-referrer'
   | 'no-referrer-when-downgrade'


### PR DESCRIPTION
This is a TypeScript-only change, undici already handles Records with string[] values: https://runkit.com/embed/972d5c6lsor2

A test was created to ensure this feature works properly