### PR TITLE
feat: normalize origin for BalancedPool addUpstream/removeUpstream

### DIFF
--- a/lib/balanced-pool.js
+++ b/lib/balanced-pool.js
@@ -14,6 +14,7 @@ const {
 } = require('./pool-base')
 const Pool = require('./pool')
 const { kUrl } = require('./core/symbols')
+const { parseOrigin } = require('./core/util')
 const kFactory = Symbol('factory')
 
 const kOptions = Symbol('options')
@@ -44,22 +45,26 @@ class BalancedPool extends PoolBase {
   }
 
   addUpstream (upstream) {
+    const upstreamOrigin = parseOrigin(upstream).origin
+
     if (this[kClients].find((pool) => (
-      pool[kUrl].origin === upstream &&
+      pool[kUrl].origin === upstreamOrigin &&
       pool.closed !== true &&
       pool.destroyed !== true
     ))) {
       return this
     }
 
-    this[kAddClient](this[kFactory](upstream, Object.assign({}, this[kOptions])))
+    this[kAddClient](this[kFactory](upstreamOrigin, Object.assign({}, this[kOptions])))
 
     return this
   }
 
   removeUpstream (upstream) {
+    const upstreamOrigin = parseOrigin(upstream).origin
+
     const pool = this[kClients].find((pool) => (
-      pool[kUrl].origin === upstream &&
+      pool[kUrl].origin === upstreamOrigin &&
       pool.closed !== true &&
       pool.destroyed !== true
     ))

--- a/test/balanced-pool.js
+++ b/test/balanced-pool.js
@@ -18,6 +18,13 @@ test('upstream add/remove/get', async (t) => {
   client.removeUpstream('http://localhost:2424')
   t.same(client.upstreams, [])
 
+  client.addUpstream('http://localhost:80')
+  client.addUpstream('http://localhost:80')
+  client.addUpstream(new URL('http://localhost:80'))
+  t.same(client.upstreams, ['http://localhost'])
+  client.removeUpstream('http://localhost:80')
+  t.same(client.upstreams, [])
+
   t.throws(() => client.dispatch())
 
   const p = client.close()


### PR DESCRIPTION
Fixes #1250.

Calls `parseOrigin` on upstream addition/removal to ensure that finding an existing upstream by `origin` works when deduplicating/removing an upstream.