### PR TITLE
feat: expose pool aggregate statistics

### DIFF
--- a/docs/api/BalancedPool.md
+++ b/docs/api/BalancedPool.md
@@ -34,6 +34,10 @@ Implements [Client.closed](Client.md#clientclosed)
 
 Implements [Client.destroyed](Client.md#clientdestroyed)
 
+### `Pool.stats`
+
+Returns [`PoolStats`](PoolStats.md) instance for this pool.
+
 ## Instance Methods
 
 ### `BalancedPool.addUpstream(upstream)`

--- a/docs/api/Pool.md
+++ b/docs/api/Pool.md
@@ -30,6 +30,10 @@ Implements [Client.closed](Client.md#clientclosed)
 
 Implements [Client.destroyed](Client.md#clientdestroyed)
 
+### `Pool.stats`
+
+Returns [`PoolStats`](PoolStats.md) instance for this pool.
+
 ## Instance Methods
 
 ### `Pool.close([callback])`

--- a/docs/api/PoolStats.md
+++ b/docs/api/PoolStats.md
@@ -1,0 +1,35 @@
+# Class: PoolStats
+
+Aggregate stats for a [Pool](Pool.md) or [BalancedPool](BalancedPool.md).
+
+## `new PoolStats(pool)`
+
+Arguments:
+
+* **pool** `Pool` - Pool or BalancedPool from which to return stats.
+
+## Instance Properties
+
+### `PoolStats.connected`
+
+Number of open socket connections in this pool.
+
+### `PoolStats.free`
+
+Number of open socket connections in this pool that do not have an active request.
+
+### `PoolStats.pending`
+
+Number of pending requests across all clients in this pool.
+
+### `PoolStats.queued`
+
+Number of queued requests across all clients in this pool.
+
+### `PoolStats.running`
+
+Number of currently active requests across all clients in this pool.
+
+### `PoolStats.size`
+
+Number of active, pending, or queued requests across all clients in this pool.

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -22,6 +22,8 @@ module.exports = {
   kPending: Symbol('pending'),
   kSize: Symbol('size'),
   kBusy: Symbol('busy'),
+  kQueued: Symbol('queued'),
+  kFree: Symbol('free'),
   kConnected: Symbol('connected'),
   kClosed: Symbol('closed'),
   kNeedDrain: Symbol('need drain'),

--- a/lib/pool-base.js
+++ b/lib/pool-base.js
@@ -7,7 +7,8 @@ const {
   InvalidArgumentError
 } = require('./core/errors')
 const FixedQueue = require('./node/fixed-queue')
-const { kSize, kRunning, kPending, kBusy, kUrl } = require('./core/symbols')
+const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl } = require('./core/symbols')
+const PoolStats = require('./pool-stats')
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -19,10 +20,10 @@ const kOnDrain = Symbol('onDrain')
 const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
 const kOnConnectionError = Symbol('onConnectionError')
-const kQueued = Symbol('queued')
 const kGetDispatcher = Symbol('get dispatcher')
 const kAddClient = Symbol('add client')
 const kRemoveClient = Symbol('remove client')
+const kStats = Symbol('stats')
 
 class PoolBase extends Dispatcher {
   constructor () {
@@ -77,10 +78,20 @@ class PoolBase extends Dispatcher {
     this[kOnConnectionError] = (origin, targets, err) => {
       pool.emit('connectionError', origin, [pool, ...targets], err)
     }
+
+    this[kStats] = new PoolStats(this)
   }
 
   get [kBusy] () {
     return this[kNeedDrain]
+  }
+
+  get [kConnected] () {
+    return this[kClients].filter(client => client[kConnected]).length
+  }
+
+  get [kFree] () {
+    return this[kClients].filter(client => client[kConnected] && !client[kNeedDrain]).length
   }
 
   get [kPending] () {
@@ -105,6 +116,10 @@ class PoolBase extends Dispatcher {
       ret += size
     }
     return ret
+  }
+
+  get stats() {
+    return this[kStats];
   }
 
   get destroyed () {

--- a/lib/pool-stats.js
+++ b/lib/pool-stats.js
@@ -1,0 +1,34 @@
+const { kFree, kConnected, kPending, kQueued, kRunning, kSize } = require('./core/symbols')
+const kPool = Symbol('pool')
+
+class PoolStats {
+  constructor(pool) {
+    this[kPool] = pool
+  }
+
+  get connected() {
+    return this[kPool][kConnected]
+  }
+
+  get free() {
+    return this[kPool][kFree]
+  }
+
+  get pending() {
+    return this[kPool][kPending]
+  }
+
+  get queued() {
+    return this[kPool][kQueued]
+  }
+
+  get running() {
+    return this[kPool][kRunning]
+  }
+
+  get size() {
+    return this[kPool][kSize]
+  }
+}
+
+module.exports = PoolStats


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

In achieving parity with the node.js agent, I'd like to be able to get aggregate statistics about requests and connections in undici. This is possible today, but requires using private symbols.

Addresses #1254, relates to #693 -- I just now noticed that one, so will review it to see if there's any feedback that can be applied here.

## Rationale

I currently use the node.js agent and send its stats to prometheus; I'd like to send the same ones for undici to be able to instrument the switchover and ensure everything is working properly.

## Changes

* Expose a `stats` getter on pools.

### Features

* Access aggregate statistics about undici Pools via a `stats` object.

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
  - I didn't benchmark it because the new methods aren't in the normal request path and are only intended to be called periodically; eyeballing it I believe it should scale roughly O(n) with number of active requests.
- [x] Documented
- [] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
