### PR TITLE
Fix for ignoring explicit empty host header values

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1481,7 +1481,7 @@ function write (client, request) {
 
   let header = `${method} ${path} HTTP/1.1\r\n`
 
-  if (host) {
+  if (typeof host === 'string') {
     header += `host: ${host}\r\n`
   } else {
     header += client[kHostHeader]

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -281,6 +281,34 @@ test('request text', (t) => {
   })
 })
 
+test('empty host header', (t) => {
+  t.plan(3)
+
+  const server = createServer((req, res) => {
+    res.end(req.headers.host)
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const serverAddress = `localhost:${server.address().port}`;
+    const client = new Client(`http://${serverAddress}`)
+    t.teardown(client.destroy.bind(client))
+
+    const getWithHost = async (host, wanted) => {
+      const { body } = await client.request({
+        path: '/',
+        method: 'GET',
+        headers: { host }
+      })
+      t.strictSame(await body.text(), wanted)
+    }
+
+    await getWithHost('test', 'test')
+    await getWithHost(undefined, serverAddress)
+    await getWithHost('', '')
+  })
+})
+
 test('request long multibyte text', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
## This relates to...

#1257

## Rationale

Includes a failing test and a suggestion for how that test can be made to pass.

## Changes

- Added test confirming that the correct host header is being sent when: 1) it is a non-empty string; 2) it is `undefined`; and 3) it is an empty string.
- Added a change to distinguish empty strings from other falsy values when building the request.

### Features

N/A

### Bug Fixes

Fixes #1257

### Breaking Changes and Deprecations

Anyone relying on being able to explicitly set a header to an empty string and have that default to the target host will observe a change in behaviour.

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
