### PR TITLE
fix: Improve BodyReadable type definition

### DIFF
--- a/test/types/readable.test-d.ts
+++ b/test/types/readable.test-d.ts
@@ -1,0 +1,34 @@
+import { expectAssignable } from 'tsd'
+import BodyReadable from '../../types/readable'
+import { Blob } from 'buffer'
+
+expectAssignable<BodyReadable>(new BodyReadable())
+
+{
+  const readable = new BodyReadable()
+
+  // dump
+  expectAssignable<Promise<void>>(readable.dump())
+  expectAssignable<Promise<void>>(readable.dump({ limit: 123 }))
+
+  // text
+  expectAssignable<Promise<string>>(readable.text())
+
+  // json
+  expectAssignable<Promise<any>>(readable.json())
+
+  // blob
+  expectAssignable<Promise<Blob>>(readable.blob())
+
+  // arrayBuffer
+  expectAssignable<Promise<ArrayBuffer>>(readable.arrayBuffer())
+
+  // formData
+  expectAssignable<Promise<never>>(readable.formData())
+
+  // bodyUsed
+  expectAssignable<boolean>(readable.bodyUsed)
+
+  // body
+  expectAssignable<never | undefined>(readable.body)
+}

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -3,6 +3,7 @@ import { Duplex, Readable, Writable } from 'stream'
 import { EventEmitter } from 'events'
 import { IncomingHttpHeaders } from 'http'
 import { Blob } from 'buffer'
+import BodyReadable from './readable'
 
 type AbortSignal = unknown;
 
@@ -75,7 +76,7 @@ declare namespace Dispatcher {
     /** Default: 0 */
     maxRedirections?: number;
     /** Default: `null` */
-    onInfo?: (info: {statusCode: number, headers: Record<string, string | string[]>}) => void;
+    onInfo?: (info: { statusCode: number, headers: Record<string, string | string[]> }) => void;
     /** Default: `null` */
     responseHeader?: 'raw' | null;
   }
@@ -107,7 +108,7 @@ declare namespace Dispatcher {
   export interface ResponseData {
     statusCode: number;
     headers: IncomingHttpHeaders;
-    body: Readable & BodyMixin;
+    body: BodyReadable & BodyMixin;
     trailers: Record<string, string>;
     opaque: unknown;
     context: object;
@@ -116,7 +117,7 @@ declare namespace Dispatcher {
     statusCode: number;
     headers: IncomingHttpHeaders;
     opaque: unknown;
-    body: Readable;
+    body: BodyReadable;
     context: object;
   }
   export interface StreamData {

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -1,0 +1,15 @@
+import { Readable } from "stream";
+
+export = BodyReadable
+
+declare class BodyReadable extends Readable {
+  constructor(
+    resume: (this: Readable, size: number) => void | null,
+    abort: () => void | null,
+    contentType: string
+  )
+  /** Dumps the response body by reading `limit` number of bytes.
+   * @param opts.limit Number of bytes to read (optional) - Default: 262144
+   */
+  dump(opts?: { limit: number }): Promise<void>
+}

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -1,13 +1,59 @@
 import { Readable } from "stream";
+import { Blob } from 'buffer'
 
 export = BodyReadable
 
 declare class BodyReadable extends Readable {
   constructor(
-    resume: (this: Readable, size: number) => void | null,
-    abort: () => void | null,
-    contentType: string
+    resume?: (this: Readable, size: number) => void | null,
+    abort?: () => void | null,
+    contentType?: string
   )
+
+  /** Consumes and returns the body as a string
+   *  https://fetch.spec.whatwg.org/#dom-body-text
+   */
+  text(): Promise<string>
+
+  /** Consumes and returns the body as a JavaScript Object
+   *  https://fetch.spec.whatwg.org/#dom-body-json
+   */
+  json(): Promise<any>
+
+  /** Consumes and returns the body as a Blob
+   *  https://fetch.spec.whatwg.org/#dom-body-blob
+   */
+  blob(): Promise<Blob>
+
+  /** Consumes and returns the body as an ArrayBuffer
+   *  https://fetch.spec.whatwg.org/#dom-body-arraybuffer
+   */
+  arrayBuffer(): Promise<ArrayBuffer>
+
+  /** Not implemented
+   *
+   *  https://fetch.spec.whatwg.org/#dom-body-formdata
+   */
+  formData(): Promise<never>
+
+  /** Returns true if the body is not null and the body has been consumed
+   *
+   *  Otherwise, returns false
+   *
+   * https://fetch.spec.whatwg.org/#dom-body-bodyused
+   */
+  readonly bodyUsed: boolean
+
+  /** Throws on node 16.6.0
+   *
+   *  If body is null, it should return null as the body
+   *
+   *  If body is not null, should return the body as a ReadableStream
+   *
+   *  https://fetch.spec.whatwg.org/#dom-body-body
+   */
+  readonly body: never | undefined
+
   /** Dumps the response body by reading `limit` number of bytes.
    * @param opts.limit Number of bytes to read (optional) - Default: 262144
    */


### PR DESCRIPTION
Updates the `body` to use `BodyReadable`. Currently, body was using an intersection between `Readable` and `BodyMixin`. 

This actually exposes the `dump` function in TypeScript now.

Let me know if the `resume` and `abort` are actually nullable. I looked at the code and `abort` is `null` initially. `resume` seems to be optional for `Readable`

Fixes #1256 