### PR TITLE
chore: add back macos to Node CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1
     with:
-      runs-on: ubuntu-latest, windows-latest
+      runs-on: ubuntu-latest, windows-latest, macos-latest
       test-command: npm run coverage:ci
       post-test-steps: |
         - name: Coverage Report


### PR DESCRIPTION
Match the case of the `macos-latest` workflow label.

Refs: https://github.com/nodejs/undici/issues/1263
Refs: https://github.com/nodejs/undici/pull/1264
Refs: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources