### PR TITLE
fix: remove esbuild from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "docs"
   ],
   "scripts": {
-    "build:node": "esbuild index.js --bundle --platform=node --outfile=undici.js",
+    "build:node": "npx esbuild@0.14.25 index.js --bundle --platform=node --outfile=undici.js",
     "prebuild:wasm": "docker build -t llhttp_wasm_builder -f build/Dockerfile .",
     "build:wasm": "node build/wasm.js --docker",
     "lint": "standard | snazzy",
@@ -75,7 +75,6 @@
     "cronometro": "^0.8.0",
     "delay": "^5.0.0",
     "docsify-cli": "^4.4.3",
-    "esbuild": "^0.14.14",
     "formdata-node": "^4.3.1",
     "https-pem": "^2.0.0",
     "husky": "^7.0.2",


### PR DESCRIPTION
It breaks AIX in CITGM. Use npx instead.