### PR TITLE
fix: remove hash from intercept dispatch key

### DIFF
--- a/lib/mock/mock-interceptor.js
+++ b/lib/mock/mock-interceptor.js
@@ -66,6 +66,14 @@ class MockInterceptor {
     if (typeof opts.method === 'undefined') {
       throw new InvalidArgumentError('opts.method must be defined')
     }
+    // See https://github.com/nodejs/undici/issues/1245
+    // As per RFC 3986, clients are not supposed to send URI 
+    // fragments to servers when they retrieve a document,
+    if (typeof opts.path === 'string') {
+      // Matches https://github.com/nodejs/undici/blob/main/lib/fetch/index.js#L1811
+      const parsedURL = new URL(opts.path, 'data://')
+      opts.path = parsedURL.pathname + parsedURL.search
+    }
 
     this[kDispatchKey] = buildKey(opts)
     this[kDispatches] = mockDispatches

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -3,7 +3,21 @@
 const { test } = require('tap')
 const { MockInterceptor, MockScope } = require('../lib/mock/mock-interceptor')
 const MockAgent = require('../lib/mock/mock-agent');
+const { kDispatchKey } = require('../lib/mock/mock-symbols');
 const { InvalidArgumentError } = require('../lib/core/errors')
+
+
+test('MockInterceptor - path', t => {
+  t.plan(1)
+  t.test('should remove hash fragment from paths', t => {
+    t.plan(1)
+    const mockInterceptor = new MockInterceptor({
+      path: '#foobar',
+      method: ''
+    }, [])
+    t.equal(mockInterceptor[kDispatchKey].path, '')
+  })
+})
 
 test('MockInterceptor - reply', t => {
   t.plan(2)


### PR DESCRIPTION
See https://github.com/nodejs/undici/issues/1245

As per RFC 3986, clients are not supposed to send URI  fragments to servers when they retrieve a document.