### PR TITLE
fix: default mock interceptor to GET

### DIFF
--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -72,11 +72,7 @@ const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const { statusCode, body } = await request('http://localhost:3000/foo')
 
@@ -95,11 +91,7 @@ import { MockAgent, request } from 'undici'
 const mockAgent = new MockAgent()
 
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,
@@ -121,11 +113,7 @@ import { MockAgent, request } from 'undici'
 const mockAgent = new MockAgent()
 
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,
@@ -147,11 +135,7 @@ import { MockAgent, request } from 'undici'
 const mockAgent = new MockAgent({ connections: 1 })
 
 const mockClient = mockAgent.get('http://localhost:3000')
-
-mockClient.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockClient.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,
@@ -174,16 +158,8 @@ const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
-
-mockPool.intercept({
-  path: '/hello',
-  method: 'GET'
-}).reply(200, 'hello')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
+mockPool.intercept({ path: '/hello'}).reply(200, 'hello')
 
 const result1 = await request('http://localhost:3000/foo')
 
@@ -250,11 +226,7 @@ const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
 const mockPool = mockAgent.get(new RegExp('http://localhost:3000'))
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET',
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,
@@ -277,11 +249,7 @@ const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
 const mockPool = mockAgent.get((origin) => origin === 'http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,
@@ -328,11 +296,7 @@ import { MockAgent } from 'undici'
 const mockAgent = new MockAgent()
 
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET'
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,

--- a/docs/api/MockClient.md
+++ b/docs/api/MockClient.md
@@ -58,10 +58,7 @@ import { MockAgent } from 'undici'
 const mockAgent = new MockAgent({ connections: 1 })
 
 const mockClient = mockAgent.get('http://localhost:3000')
-mockClient.intercept({
-  path: '/foo',
-  method: 'GET',
-}).reply(200, 'foo')
+mockClient.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,

--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -95,11 +95,7 @@ setGlobalDispatcher(mockAgent)
 
 // MockPool
 const mockPool = mockAgent.get('http://localhost:3000')
-
-mockPool.intercept({
-  path: '/foo',
-  method: 'GET',
-}).reply(200, 'foo')
+mockPool.intercept({ path: '/foo' }).reply(200, 'foo')
 
 const {
   statusCode,

--- a/lib/mock/mock-interceptor.js
+++ b/lib/mock/mock-interceptor.js
@@ -64,7 +64,7 @@ class MockInterceptor {
       throw new InvalidArgumentError('opts.path must be defined')
     }
     if (typeof opts.method === 'undefined') {
-      throw new InvalidArgumentError('opts.method must be defined')
+      opts.method = 'GET'
     }
     // See https://github.com/nodejs/undici/issues/1245
     // As per RFC 3986, clients are not supposed to send URI

--- a/test/mock-client.js
+++ b/test/mock-client.js
@@ -147,14 +147,13 @@ test('MockClient - intercept validation', (t) => {
     t.throws(() => mockClient.intercept({}), new InvalidArgumentError('opts.path must be defined'))
   })
 
-  t.test('it should error if no method specified in the intercept', t => {
+  t.test('it should default to GET if no method specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent({ connections: 1 })
     t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get('http://localhost:9999')
-
-    t.throws(() => mockClient.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
+    t.doesNotThrow(() => mockClient.intercept({ path: '/foo' }))
   })
 })
 

--- a/test/mock-pool.js
+++ b/test/mock-pool.js
@@ -147,14 +147,13 @@ test('MockPool - intercept validation', (t) => {
     t.throws(() => mockPool.intercept({}), new InvalidArgumentError('opts.path must be defined'))
   })
 
-  t.test('it should error if no method specified in the intercept', t => {
+  t.test('it should default to GET if no method specified in the intercept', t => {
     t.plan(1)
     const mockAgent = new MockAgent()
     t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get('http://localhost:9999')
-
-    t.throws(() => mockPool.intercept({ path: '/foo' }), new InvalidArgumentError('opts.method must be defined'))
+    t.doesNotThrow(() => mockPool.intercept({ path: '/foo' }))
   })
 })
 

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -5,6 +5,7 @@ import { MockInterceptor, MockScope } from '../../types/mock-interceptor'
 {
   const mockPool: MockPool = new MockAgent().get('')
   const mockInterceptor = mockPool.intercept({ path: '', method: 'GET' })
+  const mockInterceptorDefaultMethod = mockPool.intercept({ path: '' })
 
   // reply
   expectAssignable<MockScope>(mockInterceptor.reply(200, ''))

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -44,8 +44,8 @@ declare namespace MockInterceptor {
   export interface Options {
     /** Path to intercept on. */
     path: string | RegExp | ((path: string) => boolean);
-    /** Method to intercept on. */
-    method: string | RegExp | ((method: string) => boolean);
+    /** Method to intercept on. Defaults to GET. */
+    method?: string | RegExp | ((method: string) => boolean);
     /** Body to intercept on. */
     body?: string | RegExp | ((body: string) => boolean);
     /** Headers to intercept on. */


### PR DESCRIPTION
I am in the process of migrating an open source project from `node-fetch` to `undici`.  I am making heavy use of `nock`, which doesn't exactly work here :) One of the things I noticed is that nock tends to default to assuming `GET` on interceptors, and I think it's a fairly accepted norm in terms of request libraries.  This change makes `method` optional on the `MockClient.intercept` method, and defaults it to a `GET` in that case.  

```js
const mock = new MockAgent();
const scope = mock
      .get('http://fake.local')
      .intercept({path: '/'}) // look ma, no {method: 'GET'}!
      .reply(200);
```

Not sure if this is a desirable API change or not, but thought it would aid in making the transition from `nock` to here a tad easier.  