### PR TITLE
tests: fix CI failure

### DIFF
--- a/test/node-fetch/main.js
+++ b/test/node-fetch/main.js
@@ -780,9 +780,8 @@ describe('node-fetch', () => {
           }
         )
       ]
-      setTimeout(() => {
-        controller.abort()
-      }, 100)
+
+      controller.abort()
 
       return Promise.all(fetches.map(fetched => expect(fetched)
         .to.eventually.be.rejected
@@ -806,9 +805,8 @@ describe('node-fetch', () => {
           }
         )
       ]
-      setTimeout(() => {
-        controller.abort()
-      }, 100)
+
+      controller.abort()
 
       return Promise.all(fetches.map(fetched => expect(fetched)
         .to.eventually.be.rejected


### PR DESCRIPTION
Fixes #1221 

Detailing the issue: https://github.com/nodejs/undici/issues/1221#issuecomment-1069403588
tl;dr delaying the abort made the test flaky

One thing to note: the node-fetch tests here are outdated as of https://github.com/node-fetch/node-fetch/commit/015798edc60f6b480b3df2412f4069df05cb86d5 but they use ESM and rely heavily on internal methods that would require a lot of work to port over. I also don't know if any other tests are flaky, so the node-fetch suite might still cause issues.