### PR TITLE
chore: html reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:tap": "tap test/*.js test/diagnostics-channel/*.js",
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",
     "test:typescript": "tsd",
-    "coverage": "nyc npm run test",
+    "coverage": "nyc --reporter=text --reporter=html npm run test",
     "coverage:ci": "nyc --reporter=lcov npm run test",
     "bench": "concurrently -k -s first npm:bench:server npm:bench:run",
     "bench:server": "node benchmarks/server.js",


### PR DESCRIPTION
This PR changes the `coverage` command to output an HTML coverage report in addition to the default text coverage report. https://github.com/istanbuljs/nyc#common-configuration-options
