### PR TITLE
fix: Do not use WeakRef on mocks.

### DIFF
--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -20,6 +20,16 @@ const { InvalidArgumentError } = require('../core/errors')
 const Dispatcher = require('../dispatcher')
 const { WeakRef } = require('../compat/dispatcher-weakref')()
 
+class FakeWeakRef {
+  constructor (value) {
+    this.value = value
+  }
+
+  deref () {
+    return this.value
+  }
+}
+
 class MockAgent extends Dispatcher {
   constructor (opts) {
     super(opts)
@@ -86,7 +96,7 @@ class MockAgent extends Dispatcher {
   }
 
   [kMockAgentSet] (origin, dispatcher) {
-    this[kClients].set(origin, new WeakRef(dispatcher))
+    this[kClients].set(origin, new FakeWeakRef(dispatcher))
   }
 
   [kFactory] (origin) {

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -18,7 +18,6 @@ const MockPool = require('./mock-pool')
 const { matchValue, buildMockOptions } = require('./mock-utils')
 const { InvalidArgumentError } = require('../core/errors')
 const Dispatcher = require('../dispatcher')
-const { WeakRef } = require('../compat/dispatcher-weakref')()
 
 class FakeWeakRef {
   constructor (value) {

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2369,6 +2369,13 @@ test('MockAgent - clients are not garbage collected', async (t) => {
   const dispatcher = new MockAgent()
   dispatcher.disableNetConnect()
 
+  // When Node 16 is the minimum supported, this can be replaced by simply requiring setTimeout from timers/promises
+  function sleep (delay) {
+    return new Promise(resolve => {
+      setTimeout(resolve, delay)
+    })
+  }
+
   // Purposely create the pool inside a function so that the reference is lost
   function intercept () {
     // Create the pool and add a lot of intercepts
@@ -2387,7 +2394,7 @@ test('MockAgent - clients are not garbage collected', async (t) => {
   const results = new Set()
   for (let i = 0; i < samples; i++) {
     // Let's make some time pass to allow garbage collection to happen
-    await require('timers/promises').setTimeout(10)
+    await sleep(10)
 
     const { statusCode } = await request(`${baseUrl}/foo/${i}`, { method: 'GET', dispatcher })
     results.add(statusCode)

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2350,7 +2350,6 @@ test('MockAgent - headers function interceptor', async (t) => {
   }
 })
 
-
 test('MockAgent - clients are not garbage collected', async (t) => {
   const samples = 250
   t.plan(2)
@@ -2371,23 +2370,22 @@ test('MockAgent - clients are not garbage collected', async (t) => {
   dispatcher.disableNetConnect()
 
   // Purposely create the pool inside a function so that the reference is lost
-  function intercept() {
+  function intercept () {
     // Create the pool and add a lot of intercepts
     const pool = dispatcher.get(baseUrl)
 
-    for(let i = 0; i < samples; i++) {
+    for (let i = 0; i < samples; i++) {
       pool.intercept({
         path: `/foo/${i}`,
-        method: 'GET',
+        method: 'GET'
       }).reply(200, Buffer.alloc(1024 * 1024))
-      .persist()
     }
   }
 
   intercept()
 
   const results = new Set()
-  for(let i = 0; i < samples; i++) {
+  for (let i = 0; i < samples; i++) {
     // Let's make some time pass to allow garbage collection to happen
     await require('timers/promises').setTimeout(10)
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2349,3 +2349,52 @@ test('MockAgent - headers function interceptor', async (t) => {
     t.equal(statusCode, 200)
   }
 })
+
+
+test('MockAgent - clients are not garbage collected', async (t) => {
+  const samples = 250
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    t.fail('should not be called')
+    t.end()
+    res.end('should not be called')
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+
+  // Create the dispatcher and isable net connect so we can make sure it matches properly
+  const dispatcher = new MockAgent()
+  dispatcher.disableNetConnect()
+
+  // Purposely create the pool inside a function so that the reference is lost
+  function intercept() {
+    // Create the pool and add a lot of intercepts
+    const pool = dispatcher.get(baseUrl)
+
+    for(let i = 0; i < samples; i++) {
+      pool.intercept({
+        path: `/foo/${i}`,
+        method: 'GET',
+      }).reply(200, Buffer.alloc(1024 * 1024))
+      .persist()
+    }
+  }
+
+  intercept()
+
+  const results = new Set()
+  for(let i = 0; i < samples; i++) {
+    // Let's make some time pass to allow garbage collection to happen
+    await require('timers/promises').setTimeout(10)
+
+    const { statusCode } = await request(`${baseUrl}/foo/${i}`, { method: 'GET', dispatcher })
+    results.add(statusCode)
+  }
+
+  t.equal(results.size, 1)
+  t.ok(results.has(200))
+})


### PR DESCRIPTION
This PR fixes a very hard to spot bug that happens under these conditions:

1. You use mocks and setup some interceptors.
2. The pool/client (`mockAgent.get`) is setup within a function and no reference to the pool/client is returned.
3. A lot of request (same or different url doesn't matter) are performed and a lot of data is returned.
4. Some time passes (either with setTimeout or just with regular application I/O delays)

What happens is that the original pool/client is garbage collected and thus all the set interceptors are gone, leading to either test failure or unwanted network activity.

The PR fixes that by using a `FakeWeakRef` in the `MockAgent` that keeps a reference to the pool and thus no garbage collection happens.