### PR TITLE
Fix broken bench scripts

### DIFF
--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -166,7 +166,6 @@ function printResults (results) {
 
 const experiments = {
   'http - no keepalive' () {
-    console.log('aaa')
     return makeParallelRequests(resolve => {
       http.get(httpNoKeepAliveOptions, res => {
         res

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -165,44 +165,11 @@ function printResults (results) {
 }
 
 const experiments = {
-    'http - no keepalive' () {
-      console.log('aaa')
-      return makeParallelRequests(resolve => {
-        http.get(httpNoKeepAliveOptions, res => {
-          res
-            .pipe(
-              new Writable({
-                write (chunk, encoding, callback) {
-                  callback()
-                }
-              })
-            )
-            .on('finish', resolve)
-        })
-      })
-    },
-    'http - keepalive' () {
-      return makeParallelRequests(resolve => {
-        http.get(httpKeepAliveOptions, res => {
-          res
-            .pipe(
-              new Writable({
-                write (chunk, encoding, callback) {
-                  callback()
-                }
-              })
-            )
-            .on('finish', resolve)
-        })
-      })
-    },
-    'undici - pipeline' () {
-      return makeParallelRequests(resolve => {
-        dispatcher
-          .pipeline(undiciOptions, data => {
-            return data.body
-          })
-          .end()
+  'http - no keepalive' () {
+    console.log('aaa')
+    return makeParallelRequests(resolve => {
+      http.get(httpNoKeepAliveOptions, res => {
+        res
           .pipe(
             new Writable({
               write (chunk, encoding, callback) {
@@ -212,40 +179,73 @@ const experiments = {
           )
           .on('finish', resolve)
       })
-    },
-    'undici - request' () {
-      return makeParallelRequests(resolve => {
-        dispatcher.request(undiciOptions).then(({ body }) => {
-          body
-            .pipe(
-              new Writable({
-                write (chunk, encoding, callback) {
-                  callback()
-                }
-              })
-            )
-            .on('finish', resolve)
-        })
-      })
-    },
-    'undici - stream' () {
-      return makeParallelRequests(resolve => {
-        return dispatcher
-          .stream(undiciOptions, () => {
-            return new Writable({
+    })
+  },
+  'http - keepalive' () {
+    return makeParallelRequests(resolve => {
+      http.get(httpKeepAliveOptions, res => {
+        res
+          .pipe(
+            new Writable({
               write (chunk, encoding, callback) {
                 callback()
               }
             })
+          )
+          .on('finish', resolve)
+      })
+    })
+  },
+  'undici - pipeline' () {
+    return makeParallelRequests(resolve => {
+      dispatcher
+        .pipeline(undiciOptions, data => {
+          return data.body
+        })
+        .end()
+        .pipe(
+          new Writable({
+            write (chunk, encoding, callback) {
+              callback()
+            }
           })
-          .then(resolve)
+        )
+        .on('finish', resolve)
+    })
+  },
+  'undici - request' () {
+    return makeParallelRequests(resolve => {
+      dispatcher.request(undiciOptions).then(({ body }) => {
+        body
+          .pipe(
+            new Writable({
+              write (chunk, encoding, callback) {
+                callback()
+              }
+            })
+          )
+          .on('finish', resolve)
       })
-    },
-    'undici - dispatch' () {
-      return makeParallelRequests(resolve => {
-        dispatcher.dispatch(undiciOptions, new SimpleRequest(resolve))
-      })
-    }
+    })
+  },
+  'undici - stream' () {
+    return makeParallelRequests(resolve => {
+      return dispatcher
+        .stream(undiciOptions, () => {
+          return new Writable({
+            write (chunk, encoding, callback) {
+              callback()
+            }
+          })
+        })
+        .then(resolve)
+    })
+  },
+  'undici - dispatch' () {
+    return makeParallelRequests(resolve => {
+      dispatcher.dispatch(undiciOptions, new SimpleRequest(resolve))
+    })
+  }
 }
 
 if (process.env.PORT) {
@@ -260,7 +260,7 @@ if (process.env.PORT) {
 }
 
 cronometro(
-  experiments, 
+  experiments,
   {
     iterations,
     errorThreshold,

--- a/benchmarks/wait.js
+++ b/benchmarks/wait.js
@@ -6,7 +6,17 @@ const waitOn = require('wait-on')
 
 const socketPath = path.join(os.tmpdir(), 'undici.sock')
 
+let resources
+if (process.env.PORT) {
+  resources = [`http-get://localhost:${process.env.PORT}/`]
+} else {
+  resources = [`http-get://unix:${socketPath}:/`]
+}
+
 waitOn({
-  resources: [`http-get://unix:${socketPath}:/`],
+  resources,
   timeout: 5000
-}).catch(() => process.exit(1))
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "test:typescript": "tsd",
     "coverage": "nyc --reporter=text --reporter=html npm run test",
     "coverage:ci": "nyc --reporter=lcov npm run test",
-    "bench": "concurrently -k -s first npm:bench:server npm:bench:run",
+    "bench": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench:run",
     "bench:server": "node benchmarks/server.js",
     "prebench:run": "node benchmarks/wait.js",
-    "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js && CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
+    "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js; CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
     "serve:website": "docsify serve .",
     "prepare": "husky install",
     "fuzz": "jsfuzz test/fuzzing/fuzz.js corpus"


### PR DESCRIPTION
Our bench CI job is not working anymore. This PR partially fixes it _but_ the number of iterations do not work anymore.


```
[bench:run] │ Tests               │ Samples │          Result │ Tolerance │ Difference with slowest │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - fetch      │       1 │  596.19 req/sec │  ± 0.00 % │                       - │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - no keepalive │       1 │ 1123.28 req/sec │  ± 0.00 % │               + 88.41 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ http - keepalive    │       1 │ 1943.09 req/sec │  ± 0.00 % │              + 225.92 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - request    │       1 │ 2084.66 req/sec │  ± 0.00 % │              + 249.66 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - pipeline   │       1 │ 2142.13 req/sec │  ± 0.00 % │              + 259.30 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - stream     │       1 │ 2847.98 req/sec │  ± 0.00 % │              + 377.69 % │
[bench:run] |─────────────────────|─────────|─────────────────|───────────|─────────────────────────|
[bench:run] │ undici - dispatch   │       1 │ 2941.40 req/sec │  ± 0.00 % │              + 393.36 % │
```
