### PR TITLE
Fix lint error

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run lint
 npm run test

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1586,7 +1586,7 @@ function httpNetworkFetch (
 
     // 7. Let newConnection be "yes" if forceNewConnection is true; otherwise
     // "no".
-    const newConnection = forceNewConnection ? 'yes' : 'no'
+    const newConnection = forceNewConnection ? 'yes' : 'no' // eslint-disable-line no-unused-vars
 
     // 8. Switch on request’s mode:
     if (request.mode === 'websocket') {


### PR DESCRIPTION
## Changes

- This PR suppresses lint error on WIP implementation.
- This PR adds the lint command to the pre-commit hook.

## References

https://github.com/nodejs/undici/runs/5610494557?check_suite_focus=true

```
> undici@4.1[6](https://github.com/nodejs/undici/runs/5610494557?check_suite_focus=true#step:5:6).0 lint
> standard | snazzy

standard: Use JavaScript Standard Style (https://standardjs.com)

/home/runner/work/undici/undici/lib/fetch/index.js
  15[8](https://github.com/nodejs/undici/runs/5610494557?check_suite_focus=true#step:5:8)[9](https://github.com/nodejs/undici/runs/5610494557?check_suite_focus=true#step:5:9):[11](https://github.com/nodejs/undici/runs/5610494557?check_suite_focus=true#step:5:11)  error  'newConnection' is assigned a value but never used

✖ 1 problem
Error: Process completed with exit code 1.
```