### PR TITLE
fix(mock): matching the complete header list when using fetch

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -33,6 +33,14 @@ function lowerCaseEntries (headers) {
 
 function matchHeaders (mockDispatch, headers) {
   if (typeof mockDispatch.headers === 'function') {
+    if (Array.isArray(headers)) { // fetch HeadersList
+      const clone = headers.slice()
+      const entries = []
+      for (let index = 0; index < clone.length; index += 2) {
+        entries.push([clone[index], clone[index + 1]])
+      }
+      headers = Object.fromEntries(entries)
+    }
     return mockDispatch.headers(headers ? lowerCaseEntries(headers) : {})
   }
   if (typeof mockDispatch.headers === 'undefined') {

--- a/test/node-fetch/mock.js
+++ b/test/node-fetch/mock.js
@@ -83,4 +83,31 @@ describe('node-fetch with MockAgent', () => {
     expect(res.status).to.equal(200)
     expect(await res.json()).to.deep.equal({ success: true })
   })
+
+  it('should match the headers with a matching function', async () => {
+    const mockAgent = new MockAgent()
+    setGlobalDispatcher(mockAgent)
+    const mockPool = mockAgent.get('http://localhost:3000')
+
+    mockPool
+      .intercept({
+        path: '/test',
+        method: 'GET',
+        headers (headers) {
+          expect(headers).to.be.an('object')
+          expect(headers).to.have.property('user-agent', 'undici')
+          return true
+        }
+      })
+      .reply(200, { success: true })
+      .persist()
+
+    const res = await fetch('http://localhost:3000/test', {
+      method: 'GET',
+      headers: new Headers({ 'User-Agent': 'undici' })
+    })
+
+    expect(res.status).to.equal(200)
+    expect(await res.json()).to.deep.equal({ success: true })
+  })
 })


### PR DESCRIPTION
Fixes the ability to match a mock on the complete header when using fetch. This ability was introduced in [v4.16.0](https://github.com/nodejs/undici/releases/tag/v4.16.0), specifically #1275.

The issue is in the fact that when using fetch the matcher argument is not a plain object but rather HeadersList.