### PR TITLE
fetch: avoid async iteration when request.body is null

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1664,7 +1664,13 @@ async function httpNetworkFetch (
   //        2. Otherwise, return a network error.
 
   // To transmit request’s body body, run these steps:
-  const requestBody = (async function * () {
+  let requestBody = null
+  // 1. If body is null and fetchParams’s process request end-of-body is
+  // non-null, then queue a fetch task given fetchParams’s process request
+  // end-of-body and fetchParams’s task destination.
+  if (request.body == null && fetchParams.processRequestEndOfBody) {
+    queueMicrotask(() => fetchParams.processRequestEndOfBody())
+  } else if (request.body != null) {
     // 2. Otherwise, if body is non-null:
 
     //    1. Let processBodyChunk given bytes be these steps:
@@ -1713,15 +1719,17 @@ async function httpNetworkFetch (
 
     // 4. Incrementally read request’s body given processBodyChunk, processEndOfBody,
     // processBodyError, and fetchParams’s task destination.
-    try {
-      for await (const bytes of request.body.stream) {
-        yield * processBodyChunk(bytes)
+    requestBody = (async function * () {
+      try {
+        for await (const bytes of request.body.stream) {
+          yield * processBodyChunk(bytes)
+        }
+        processEndOfBody()
+      } catch (err) {
+        processBodyError(err)
       }
-      processEndOfBody()
-    } catch (err) {
-      processBodyError(err)
-    }
-  })()
+    })()
+  }
 
   try {
     const { body, status, statusText, headersList } = await dispatch({ body: requestBody })
@@ -1905,27 +1913,12 @@ async function httpNetworkFetch (
 
   async function dispatch ({ body }) {
     const url = requestCurrentURL(request)
-    // To transmit request’s body body, run these steps:
-    let bodyRequest
-    // 1. If body is null and fetchParams’s process request end-of-body is
-    // non-null, then queue a fetch task given fetchParams’s process request
-    // end-of-body and fetchParams’s task destination.
-    if (request.body == null) {
-      if (fetchParams.processRequestEndOfBody) {
-        queueMicrotask(() => fetchParams.processRequestEndOfBody())
-      }
-      bodyRequest = null
-    } else {
-      // 2. requestBody
-      bodyRequest = fetchParams.controller.dispatcher[kIsMockActive] ? request.body && request.body.source : body
-    }
-
     return new Promise((resolve, reject) => fetchParams.controller.dispatcher.dispatch(
       {
         path: url.pathname + url.search,
         origin: url.origin,
         method: request.method,
-        body: bodyRequest,
+        body: fetchParams.controller.dispatcher[kIsMockActive] ? request.body && request.body.source : body,
         headers: request.headersList,
         maxRedirections: 0
       },

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1665,68 +1665,61 @@ async function httpNetworkFetch (
 
   // To transmit request’s body body, run these steps:
   const requestBody = (async function * () {
-    // 1. If body is null and fetchParams’s process request end-of-body is
-    // non-null, then queue a fetch task given fetchParams’s process request
-    // end-of-body and fetchParams’s task destination.
-    if (request.body == null && fetchParams.processRequestEndOfBody) {
-      queueMicrotask(() => fetchParams.processRequestEndOfBody())
-    } else if (request.body != null) {
-      // 2. Otherwise, if body is non-null:
+    // 2. Otherwise, if body is non-null:
 
-      //    1. Let processBodyChunk given bytes be these steps:
-      const processBodyChunk = async function * (bytes) {
-        // 1. If the ongoing fetch is terminated, then abort these steps.
-        if (isCancelled(fetchParams)) {
-          return
-        }
-
-        // 2. Run this step in parallel: transmit bytes.
-        yield bytes
-
-        // 3. If fetchParams’s process request body is non-null, then run
-        // fetchParams’s process request body given bytes’s length.
-        fetchParams.processRequestBodyChunkLength?.(bytes.byteLength)
+    //    1. Let processBodyChunk given bytes be these steps:
+    const processBodyChunk = async function * (bytes) {
+      // 1. If the ongoing fetch is terminated, then abort these steps.
+      if (isCancelled(fetchParams)) {
+        return
       }
 
-      // 2. Let processEndOfBody be these steps:
-      const processEndOfBody = () => {
-        // 1. If fetchParams is canceled, then abort these steps.
-        if (isCancelled(fetchParams)) {
-          return
-        }
+      // 2. Run this step in parallel: transmit bytes.
+      yield bytes
 
-        // 2. If fetchParams’s process request end-of-body is non-null,
-        // then run fetchParams’s process request end-of-body.
-        if (fetchParams.processRequestEndOfBody) {
-          fetchParams.processRequestEndOfBody()
-        }
+      // 3. If fetchParams’s process request body is non-null, then run
+      // fetchParams’s process request body given bytes’s length.
+      fetchParams.processRequestBodyChunkLength?.(bytes.byteLength)
+    }
+
+    // 2. Let processEndOfBody be these steps:
+    const processEndOfBody = () => {
+      // 1. If fetchParams is canceled, then abort these steps.
+      if (isCancelled(fetchParams)) {
+        return
       }
 
-      // 3. Let processBodyError given e be these steps:
-      const processBodyError = (e) => {
-        // 1. If fetchParams is canceled, then abort these steps.
-        if (isCancelled(fetchParams)) {
-          return
-        }
+      // 2. If fetchParams’s process request end-of-body is non-null,
+      // then run fetchParams’s process request end-of-body.
+      if (fetchParams.processRequestEndOfBody) {
+        fetchParams.processRequestEndOfBody()
+      }
+    }
 
-        // 2. If e is an "AbortError" DOMException, then abort fetchParams’s controller.
-        if (e.name === 'AbortError') {
-          fetchParams.controller.abort()
-        } else {
-          fetchParams.controller.terminate(e)
-        }
+    // 3. Let processBodyError given e be these steps:
+    const processBodyError = (e) => {
+      // 1. If fetchParams is canceled, then abort these steps.
+      if (isCancelled(fetchParams)) {
+        return
       }
 
-      // 4. Incrementally read request’s body given processBodyChunk, processEndOfBody,
-      // processBodyError, and fetchParams’s task destination.
-      try {
-        for await (const bytes of request.body.stream) {
-          yield * processBodyChunk(bytes)
-        }
-        processEndOfBody()
-      } catch (err) {
-        processBodyError(err)
+      // 2. If e is an "AbortError" DOMException, then abort fetchParams’s controller.
+      if (e.name === 'AbortError') {
+        fetchParams.controller.abort()
+      } else {
+        fetchParams.controller.terminate(e)
       }
+    }
+
+    // 4. Incrementally read request’s body given processBodyChunk, processEndOfBody,
+    // processBodyError, and fetchParams’s task destination.
+    try {
+      for await (const bytes of request.body.stream) {
+        yield * processBodyChunk(bytes)
+      }
+      processEndOfBody()
+    } catch (err) {
+      processBodyError(err)
     }
   })()
 
@@ -1912,12 +1905,27 @@ async function httpNetworkFetch (
 
   async function dispatch ({ body }) {
     const url = requestCurrentURL(request)
+    // To transmit request’s body body, run these steps:
+    let bodyRequest
+    // 1. If body is null and fetchParams’s process request end-of-body is
+    // non-null, then queue a fetch task given fetchParams’s process request
+    // end-of-body and fetchParams’s task destination.
+    if (request.body == null) {
+      if (fetchParams.processRequestEndOfBody) {
+        queueMicrotask(() => fetchParams.processRequestEndOfBody())
+      }
+      bodyRequest = null
+    } else {
+      // 2. requestBody
+      bodyRequest = fetchParams.controller.dispatcher[kIsMockActive] ? request.body && request.body.source : body
+    }
+
     return new Promise((resolve, reject) => fetchParams.controller.dispatcher.dispatch(
       {
         path: url.pathname + url.search,
         origin: url.origin,
         method: request.method,
-        body: fetchParams.controller.dispatcher[kIsMockActive] ? request.body && request.body.source : body,
+        body: bodyRequest,
         headers: request.headersList,
         maxRedirections: 0
       },


### PR DESCRIPTION
It avoids treating `request.body` as an async iterator when it's null.

In my local tests, it increases the performance by almost 10%.