### PR TITLE
fetch: bypass headerlist.append for known headers

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -458,14 +458,15 @@ function fetching ({
     // TODO
 
     // 3. Append `Accept`/value to request’s header list.
-    request.headersList.append('accept', value)
+    // Note: bypass headersList append
+    request.headersList.push('accept', value)
   }
 
   // 13. If request’s header list does not contain `Accept-Language`, then
   // user agents should append `Accept-Language`/an appropriate value to
   // request’s header list.
   if (!request.headersList.has('accept-language')) {
-    request.headersList.append('accept-language', '*')
+    request.headersList.push('accept-language', '*')
   }
 
   // 14. If request’s priority is null, then use request’s initiator and
@@ -1334,7 +1335,7 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.has('user-agent')) {
-    httpRequest.headersList.append('user-agent', 'undici')
+    httpRequest.headersList.push('user-agent', 'undici')
   }
 
   //    15. If httpRequest’s cache mode is "default" and httpRequest’s header
@@ -1361,7 +1362,7 @@ async function httpNetworkOrCacheFetch (
     !httpRequest.preventNoCacheCacheControlHeaderModification &&
     !httpRequest.headersList.has('cache-control')
   ) {
-    httpRequest.headersList.append('cache-control', 'max-age=0')
+    httpRequest.headersList.push('cache-control', 'max-age=0')
   }
 
   //    17. If httpRequest’s cache mode is "no-store" or "reload", then:
@@ -1369,20 +1370,20 @@ async function httpNetworkOrCacheFetch (
     // 1. If httpRequest’s header list does not contain `Pragma`, then append
     // `Pragma`/`no-cache` to httpRequest’s header list.
     if (!httpRequest.headersList.has('pragma')) {
-      httpRequest.headersList.append('pragma', 'no-cache')
+      httpRequest.headersList.push('pragma', 'no-cache')
     }
 
     // 2. If httpRequest’s header list does not contain `Cache-Control`,
     // then append `Cache-Control`/`no-cache` to httpRequest’s header list.
     if (!httpRequest.headersList.has('cache-control')) {
-      httpRequest.headersList.append('cache-control', 'no-cache')
+      httpRequest.headersList.push('cache-control', 'no-cache')
     }
   }
 
   //    18. If httpRequest’s header list contains `Range`, then append
   //    `Accept-Encoding`/`identity` to httpRequest’s header list.
   if (httpRequest.headersList.has('range')) {
-    httpRequest.headersList.append('accept-encoding', 'identity')
+    httpRequest.headersList.push('accept-encoding', 'identity')
   }
 
   //    19. Modify httpRequest’s header list per HTTP. Do not append a given
@@ -1390,9 +1391,9 @@ async function httpNetworkOrCacheFetch (
   //    TODO: https://github.com/whatwg/fetch/issues/1285#issuecomment-896560129
   if (!httpRequest.headersList.has('accept-encoding')) {
     if (/^https:/.test(requestCurrentURL(httpRequest).protocol)) {
-      httpRequest.headersList.append('accept-encoding', 'br, gzip, deflate')
+      httpRequest.headersList.push('accept-encoding', 'br, gzip, deflate')
     } else {
-      httpRequest.headersList.append('accept-encoding', 'gzip, deflate')
+      httpRequest.headersList.push('accept-encoding', 'gzip, deflate')
     }
   }
 

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -195,7 +195,7 @@ function appendFetchMetadata (httpRequest) {
   header = httpRequest.mode
 
   //  4. Set a structured field value `Sec-Fetch-Mode`/header in r’s header list.
-  httpRequest.headersList.append('sec-fetch-mode', header)
+  httpRequest.headersList.push('sec-fetch-mode', header)
 
   //  https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header
   //  TODO


### PR DESCRIPTION
It avoids the `headerList.append` checks: https://github.com/nodejs/undici/blob/main/lib/fetch/headers.js#L97, when the key/value is set by spec.

It increases the performance by 5 ~ 10% in my tests.