### PR TITLE
fix(fetch): add missing ReadableStream interface to response.body

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -1,5 +1,6 @@
 import { URL } from 'url'
 import { Blob } from 'buffer'
+import { ReadableStream } from 'stream/web'
 import { expectType, expectError } from 'tsd'
 import {
   BodyInit,
@@ -141,6 +142,7 @@ expectType<string>(response.statusText)
 expectType<ResponseType>(response.type)
 expectType<string>(response.url)
 expectType<boolean>(response.redirected)
+expectType<ReadableStream | null>(response.body)
 expectType<boolean>(response.bodyUsed)
 expectType<Promise<ArrayBuffer>>(response.arrayBuffer())
 expectType<Promise<Blob>>(response.blob())

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -4,6 +4,7 @@
 
 import { Blob } from 'buffer'
 import { URL, URLSearchParams } from 'url'
+import { ReadableStream } from 'stream/web'
 import { FormData } from './formdata'
 
 export type RequestInfo = string | URL | Request
@@ -12,13 +13,6 @@ export declare function fetch (
   input: RequestInfo,
   init?: RequestInit
 ): Promise<Response>
-
-declare class ControlledAsyncIterable implements AsyncIterable<Uint8Array> {
-  constructor (input: AsyncIterable<Uint8Array> | Iterable<Uint8Array>)
-  data: AsyncIterable<Uint8Array>
-  disturbed: boolean
-  readonly [Symbol.asyncIterator]: () => AsyncIterator<Uint8Array>
-}
 
 export type BodyInit =
   | ArrayBuffer
@@ -32,7 +26,7 @@ export type BodyInit =
   | string
 
 export interface BodyMixin {
-  readonly body: ControlledAsyncIterable | null
+  readonly body: ReadableStream | null
   readonly bodyUsed: boolean
 
   readonly arrayBuffer: () => Promise<ArrayBuffer>
@@ -139,7 +133,7 @@ export declare class Request implements BodyMixin {
   readonly keepalive: boolean
   readonly signal: AbortSignal
 
-  readonly body: ControlledAsyncIterable | null
+  readonly body: ReadableStream | null
   readonly bodyUsed: boolean
 
   readonly arrayBuffer: () => Promise<ArrayBuffer>
@@ -178,7 +172,7 @@ export declare class Response implements BodyMixin {
   readonly url: string
   readonly redirected: boolean
 
-  readonly body: ControlledAsyncIterable | null
+  readonly body: ReadableStream | null
   readonly bodyUsed: boolean
 
   readonly arrayBuffer: () => Promise<ArrayBuffer>


### PR DESCRIPTION
Add missing ReadableStream type to fetch response.body (relate to #1308).

Hope i have not missed something, ~~maybe we need a seperate type for `(ControlledAsyncIterable & ReadableStream) | null` ?~~