### PR TITLE
fix: remove logical assignment operator

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -792,7 +792,8 @@ async function schemeFetch (fetchParams) {
       return makeNetworkError('invalid path called')
     }
     case 'blob:': {
-      resolveObjectURL ??= require('buffer').resolveObjectURL
+      
+      resolveObjectURL = resolveObjectURL || require('buffer').resolveObjectURL
 
       // 1. Run these steps, but abort when the ongoing fetch is terminated:
       //    1. Let blob be request’s current URL’s blob URL entry’s object.

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -792,7 +792,6 @@ async function schemeFetch (fetchParams) {
       return makeNetworkError('invalid path called')
     }
     case 'blob:': {
-      
       resolveObjectURL = resolveObjectURL || require('buffer').resolveObjectURL
 
       // 1. Run these steps, but abort when the ongoing fetch is terminated:


### PR DESCRIPTION
Hey, a user of one of our libraries [reported an unexpected syntax error on Node.js 14](https://github.com/graphprotocol/graph-client/issues/34), which I tracked down to this line.

The package.json of this project lists [`"node": ">=12.18"` in the engines](https://github.com/nodejs/undici/blob/8b1dcd44755d7c9bfba06066518f4c01629ad1c0/package.json#L96-L98).

[Logical Assignment is only supported since Node.js 15.14](https://node.green/#ES2021-features-Logical-Assignment).

To me, it seems like this usage here got added unexpectedly.

___

We would love to prevent such things in the future by setting up a GitHub action that runs eslint with the following rule: https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features/es-syntax.md

Would that be something you are interested in?