### PR TITLE
feat: allow `FormData` bodies in `request`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,6 +67,12 @@ const {
 const kClosedResolve = Symbol('kClosedResolve')
 
 const channels = {}
+const [nodeMajor, nodeMinor] = process.version
+  .slice(1) // remove 'v'
+  .split('.', 2)
+  .map(v => Number(v))
+
+let extractBody
 
 try {
   const diagnosticsChannel = require('diagnostics_channel')
@@ -1580,10 +1586,26 @@ async function writeIterable ({ body, client, request, socket, contentLength, he
     .on('close', onDrain)
     .on('drain', onDrain)
 
+  let bodyAsyncIterable = body
+
+  if (util.isFormDataLike(body)) {
+    if (nodeMajor < 16 || (nodeMajor > 16 && nodeMinor < 5)) {
+      throw new InvalidArgumentError('Form-Data bodies are only supported in node v16.5 and newer.')
+    }
+
+    if (!extractBody) {
+      extractBody = require('./fetch/body.js').extractBody
+    }
+
+    const [bodyStream, contentType] = extractBody(body)
+    header += `content-type: ${contentType}\r\n`
+    bodyAsyncIterable = bodyStream.stream
+  }
+
   const writer = new AsyncWriter({ socket, request, contentLength, client, expectsPayload, header })
   try {
     // It's up to the user to somehow abort the async iterable.
-    for await (const chunk of body) {
+    for await (const chunk of bodyAsyncIterable) {
       if (socket[kError]) {
         throw socket[kError]
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1589,7 +1589,7 @@ async function writeIterable ({ body, client, request, socket, contentLength, he
   let bodyAsyncIterable = body
 
   if (util.isFormDataLike(body)) {
-    if (nodeMajor < 16 || (nodeMajor > 16 && nodeMinor < 5)) {
+    if (nodeMajor < 16 || (nodeMajor === 16 && nodeMinor < 5)) {
       throw new InvalidArgumentError('Form-Data bodies are only supported in node v16.5 and newer.')
     }
 

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -324,6 +324,10 @@ function ReadableStreamFrom (iterable) {
   )
 }
 
+function isFormDataLike (chunk) {
+  return chunk && chunk.constructor && chunk.constructor.name === 'FormData'
+}
+
 const kEnumerableProperty = Object.create(null)
 kEnumerableProperty.enumerable = true
 
@@ -352,5 +356,6 @@ module.exports = {
   ReadableStreamFrom,
   isBuffer,
   validateHandler,
-  getSocketInfo
+  getSocketInfo,
+  isFormDataLike
 }

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -703,3 +703,21 @@ test('request with FormData body', { skip: nodeMajor < 16 }, (t) => {
     t.ok(bodyReceived.endsWith(boundary + '--'))
   })
 })
+
+test('request with FormData body on node < 16', { skip: nodeMajor >= 16 }, async (t) => {
+  t.plan(1)
+
+  // a FormData polyfill, for example
+  class FormData {}
+
+  const fd = new FormData()
+
+  const client = new Client('http://localhost:3000')
+  t.teardown(client.destroy.bind(client))
+
+  await t.rejects(client.request({
+    path: '/',
+    method: 'POST',
+    body: fd
+  }), errors.InvalidArgumentError)
+})

--- a/test/types/formdata.test-d.ts
+++ b/test/types/formdata.test-d.ts
@@ -1,6 +1,10 @@
 import { Blob } from 'buffer'
+import { Readable } from 'stream'
 import { expectAssignable, expectType } from 'tsd'
-import { File, FormData } from "../.."
+import { File, FormData } from '../..'
+import { DispatchOptions } from '../../types/dispatcher'
+
+declare const dispatcherOptions: DispatchOptions
 
 declare const blob: Blob
 const formData = new FormData()
@@ -20,3 +24,4 @@ expectAssignable<IterableIterator<string>>(formData.keys())
 expectAssignable<IterableIterator<File | string>>(formData.values())
 expectAssignable<IterableIterator<[string, File | string]>>(formData.entries())
 expectAssignable<IterableIterator<[string, File | string]>>(formData[Symbol.iterator]())
+expectAssignable<string | Buffer | Uint8Array | FormData | Readable | undefined | null>(dispatcherOptions.body)

--- a/test/utils/formdata.js
+++ b/test/utils/formdata.js
@@ -1,0 +1,49 @@
+const busboy = require('busboy')
+
+function parseFormDataString (
+  body,
+  contentType
+) {
+  const cache = {
+    fileMap: new Map(),
+    fields: []
+  }
+
+  const bb = busboy({
+    headers: {
+      'content-type': contentType
+    }
+  })
+
+  return new Promise((resolve, reject) => {
+    bb.on('file', (name, file, info) => {
+      cache.fileMap.set(name, { data: [], info })
+
+      file.on('data', (data) => {
+        const old = cache.fileMap.get(name)
+
+        cache.fileMap.set(name, {
+          data: [...old.data, data],
+          info: old.info
+        })
+      }).on('end', () => {
+        const old = cache.fileMap.get(name)
+
+        cache.fileMap.set(name, {
+          data: Buffer.concat(old.data),
+          info: old.info
+        })
+      })
+    })
+
+    bb.on('field', (key, value) => cache.fields.push({ key, value }))
+    bb.on('close', () => resolve(cache))
+    bb.on('error', (e) => reject(e))
+
+    bb.end(body)
+  })
+}
+
+module.exports = {
+  parseFormDataString
+}

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events'
 import { IncomingHttpHeaders } from 'http'
 import { Blob } from 'buffer'
 import BodyReadable from './readable'
+import { FormData } from './formdata'
 
 type AbortSignal = unknown;
 
@@ -43,7 +44,7 @@ declare namespace Dispatcher {
     path: string;
     method: HttpMethod;
     /** Default: `null` */
-    body?: string | Buffer | Uint8Array | Readable | null;
+    body?: string | Buffer | Uint8Array | Readable | null | FormData;
     /** Default: `null` */
     headers?: IncomingHttpHeaders | string[] | null;
     /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceding requests in the pipeline have completed. Default: `true` if `method` is `HEAD` or `GET`. */


### PR DESCRIPTION
Fixes #1330 

Allows sending a FormData body to `undici.request`.