### PR TITLE
fix(types): callback body can be any input type

### DIFF
--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -1,6 +1,10 @@
 import { expectAssignable } from 'tsd'
-import { MockAgent, MockPool } from '../..'
+import { MockAgent, MockPool, BodyInit, Dispatcher } from '../..'
 import { MockInterceptor, MockScope } from '../../types/mock-interceptor'
+
+declare const mockResponseCallbackOptions: MockInterceptor.MockResponseCallbackOptions;
+
+expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCallbackOptions.body)
 
 {
   const mockPool: MockPool = new MockAgent().get('')

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -1,6 +1,6 @@
 import { IncomingHttpHeaders } from 'http'
 import Dispatcher from './dispatcher';
-import { Headers } from './fetch'
+import { BodyInit, Headers } from './fetch'
 
 export {
   Interceptable,
@@ -71,7 +71,7 @@ declare namespace MockInterceptor {
     path: string;
     origin: string;
     method: string;
-    body?: string;
+    body?: BodyInit | Dispatcher.DispatchOptions['body'];
     headers: Headers;
     maxRedirections: number;
   }


### PR DESCRIPTION
Partially fixes #1322

This sets the callback option body type to the input types supported by undici. Replication with `Uint8Array`, `Buffer`, etc. can be shown in the code provided in the issue.

(this is a types-only change)