### PR TITLE
Unify version check code with index.js

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -13,10 +13,9 @@ const channels = {}
 
 let extractBody
 
-const [nodeMajor, nodeMinor] = process.version
-  .slice(1) // remove 'v'
-  .split('.', 2)
-  .map(v => Number(v))
+const nodeVersion = process.versions.node.split('.')
+const nodeMajor = Number(nodeVersion[0])
+const nodeMinor = Number(nodeVersion[1])
 
 try {
   const diagnosticsChannel = require('diagnostics_channel')


### PR DESCRIPTION
Prevent using unnecessary slice method and unify version check code.