### PR TITLE
fix(Headers): filter out forbidden headers & `get` should return null on unknown header name

### DIFF
--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -393,7 +393,8 @@ function makeFilteredHeadersList (headersList, filter) {
     get (target, prop) {
       // Override methods used by Headers class.
       if (prop === 'get' || prop === 'has') {
-        return (name) => filter(name) ? target[prop](name) : undefined
+        const defaultReturn = prop === 'has' ? false : null
+        return (name) => filter(name) ? target[prop](name) : defaultReturn
       } else if (prop === Symbol.iterator) {
         return function * () {
           for (const entry of target) {
@@ -420,7 +421,10 @@ function filterResponse (response, type) {
 
     return makeFilteredResponse(response, {
       type: 'basic',
-      headersList: makeFilteredHeadersList(response.headersList, (name) => !forbiddenResponseHeaderNames.includes(name))
+      headersList: makeFilteredHeadersList(
+        response.headersList,
+        (name) => !forbiddenResponseHeaderNames.includes(name.toLowerCase())
+      )
     })
   } else if (type === 'cors') {
     // A CORS filtered response is a filtered response whose type is "cors"


### PR DESCRIPTION
Fixes #1328

Two issues with the recently added filtered lists and using Proxy.