### PR TITLE
fetch: remove unnecessary new URL calls

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -768,7 +768,7 @@ async function schemeFetch (fetchParams) {
   const {
     protocol: scheme,
     pathname: path
-  } = new URL(requestCurrentURL(request))
+  } = requestCurrentURL(request)
 
   // switch on request’s current URL’s scheme, and run the associated steps:
   switch (scheme) {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -803,8 +803,7 @@ function makeRequest (init) {
     ...init,
     headersList: init.headersList
       ? new HeadersList(init.headersList)
-      : new HeadersList(),
-    urlList: init.urlList ? [...init.urlList.map((url) => new URL(url))] : []
+      : new HeadersList()
   }
   request.url = request.urlList[0]
   return request


### PR DESCRIPTION
Those `new URL` calls seem unnecessary. Its basically doing `new URL(new URL(x))`

It bumps the performance by 10% on avg.