### PR TITLE
fix(fetch): makeNetworkError called twice when httpNetworkFetch run error

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -2029,7 +2029,7 @@ async function httpNetworkFetch (
 
           fetchParams.controller.terminate(error)
 
-          reject(makeNetworkError(error))
+          reject(error)
         }
       }
     ))

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -332,3 +332,13 @@ test('post FormData with File', (t) => {
     t.ok(/filename123/.test(result))
   })
 })
+
+test('invalid url', async (t) => {
+  t.plan(1)
+
+  try {
+    await fetch('http://invalid')
+  } catch (e) {
+    t.match(e.cause.message, 'invalid')
+  }
+})


### PR DESCRIPTION
fixes: https://github.com/nodejs/node/issues/42804

the error will be warped again by `makeNetworkError` at L1751:

https://github.com/nodejs/undici/blob/b6a72620a67236ea84160a0ae3d505b3d77a2214/lib/fetch/index.js#L1734-L1752