### PR TITLE
build: add support for `lint-pr` GitHub action workflow 🕺

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] Enables checking on the title of Pull Requests, whether they follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) or not
- [x] Example of usage – https://github.com/geospoc/v-mapbox/actions/workflows/lint-pr.yml