### PR TITLE
fix: do not set decoders when there will be no body (#1359)

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1962,16 +1962,18 @@ async function httpNetworkFetch (
           const decoders = []
 
           // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-          for (const coding of codings) {
-            if (/(x-)?gzip/.test(coding)) {
-              decoders.push(zlib.createGunzip())
-            } else if (/(x-)?deflate/.test(coding)) {
-              decoders.push(zlib.createInflate())
-            } else if (coding === 'br') {
-              decoders.push(zlib.createBrotliDecompress())
-            } else {
-              decoders.length = 0
-              break
+          if (request.method !== 'HEAD' && request.method !== 'CONNECT' && !nullBodyStatus.includes(status)) {
+            for (const coding of codings) {
+              if (/(x-)?gzip/.test(coding)) {
+                decoders.push(zlib.createGunzip())
+              } else if (/(x-)?deflate/.test(coding)) {
+                decoders.push(zlib.createInflate())
+              } else if (coding === 'br') {
+                decoders.push(zlib.createBrotliDecompress())
+              } else {
+                decoders.length = 0
+                break
+              }
             }
           }
 


### PR DESCRIPTION
This PR makes sure no decoding attempt is done when there will be no body.

Fixes: #1359 