### PR TITLE
fix: connector types

### DIFF
--- a/test/types/connector.test-d.ts
+++ b/test/types/connector.test-d.ts
@@ -1,6 +1,7 @@
-import { expectAssignable } from 'tsd'
+import {expectAssignable} from 'tsd'
 import { Client, buildConnector } from '../..'
-import { TLSSocket } from 'tls'
+import {ConnectionOptions, TLSSocket} from 'tls'
+import {NetConnectOpts} from "net";
 
 const connector = buildConnector({ rejectUnauthorized: false })
 expectAssignable<Client>(new Client('', {
@@ -19,3 +20,11 @@ expectAssignable<Client>(new Client('', {
     })
   }
 }))
+
+expectAssignable<buildConnector.BuildOptions>({
+  checkServerIdentity: () => undefined,
+  port: 80,
+});
+// This needs to be partial as required arguments (port) have a default in lib/core/connect.js
+expectAssignable<ConnectionOptions>({} as buildConnector.BuildOptions);
+expectAssignable<Partial<NetConnectOpts>>({} as buildConnector.BuildOptions);

--- a/test/types/connector.test-d.ts
+++ b/test/types/connector.test-d.ts
@@ -1,7 +1,7 @@
 import {expectAssignable} from 'tsd'
 import { Client, buildConnector } from '../..'
 import {ConnectionOptions, TLSSocket} from 'tls'
-import {NetConnectOpts} from "net";
+import {IpcNetConnectOpts, NetConnectOpts, TcpNetConnectOpts} from "net";
 
 const connector = buildConnector({ rejectUnauthorized: false })
 expectAssignable<Client>(new Client('', {
@@ -22,9 +22,6 @@ expectAssignable<Client>(new Client('', {
 }))
 
 expectAssignable<buildConnector.BuildOptions>({
-  checkServerIdentity: () => undefined,
-  port: 80,
+  checkServerIdentity: () => undefined, // Test if ConnectionOptions is assignable
+  localPort: 1234, // Test if TcpNetConnectOpts is assignable
 });
-// This needs to be partial as required arguments (port) have a default in lib/core/connect.js
-expectAssignable<ConnectionOptions>({} as buildConnector.BuildOptions);
-expectAssignable<Partial<NetConnectOpts>>({} as buildConnector.BuildOptions);

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -1,11 +1,11 @@
 import {TLSSocket, ConnectionOptions} from 'tls'
-import {NetConnectOpts, Socket} from 'net'
+import {IpcNetConnectOpts, Socket, TcpNetConnectOpts} from 'net'
 
 export = buildConnector
 declare function buildConnector (options?: buildConnector.BuildOptions): typeof buildConnector.connector
 
 declare namespace buildConnector {
-  export interface BuildOptions extends ConnectionOptions, NetConnectOpts {
+  export type BuildOptions = (ConnectionOptions | TcpNetConnectOpts | IpcNetConnectOpts ) & {
     maxCachedSessions?: number | null;
     socketPath?: string | null;
     timeout?: number | null;

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -9,6 +9,7 @@ declare namespace buildConnector {
     maxCachedSessions?: number | null;
     socketPath?: string | null;
     timeout?: number | null;
+    port?: number;
   }
 
   export interface Options {

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -1,17 +1,11 @@
-import { URL } from 'url'
-import { TLSSocket, TlsOptions } from 'tls'
-import { Socket } from 'net'
+import {TLSSocket, ConnectionOptions} from 'tls'
+import {NetConnectOpts, Socket} from 'net'
 
 export = buildConnector
 declare function buildConnector (options?: buildConnector.BuildOptions): typeof buildConnector.connector
 
 declare namespace buildConnector {
-  export interface BuildOptions extends TlsOptions {
-    maxCachedSessions?: number | null;
-    socketPath?: string | null;
-    timeout?: number | null;
-    servername?: string | null;
-  }
+  export type BuildOptions = ConnectionOptions | NetConnectOpts
 
   export interface Options {
     hostname: string

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -5,7 +5,7 @@ export = buildConnector
 declare function buildConnector (options?: buildConnector.BuildOptions): typeof buildConnector.connector
 
 declare namespace buildConnector {
-  export type BuildOptions = (ConnectionOptions | TcpNetConnectOpts | IpcNetConnectOpts ) & {
+  export type BuildOptions = (ConnectionOptions | TcpNetConnectOpts | IpcNetConnectOpts) & {
     maxCachedSessions?: number | null;
     socketPath?: string | null;
     timeout?: number | null;

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -5,7 +5,11 @@ export = buildConnector
 declare function buildConnector (options?: buildConnector.BuildOptions): typeof buildConnector.connector
 
 declare namespace buildConnector {
-  export type BuildOptions = ConnectionOptions | NetConnectOpts
+  export type BuildOptions = (ConnectionOptions | NetConnectOpts) & {
+    maxCachedSessions?: number | null;
+    socketPath?: string | null;
+    timeout?: number | null;
+  }
 
   export interface Options {
     hostname: string

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -5,7 +5,7 @@ export = buildConnector
 declare function buildConnector (options?: buildConnector.BuildOptions): typeof buildConnector.connector
 
 declare namespace buildConnector {
-  export type BuildOptions = (ConnectionOptions | NetConnectOpts) & {
+  export interface BuildOptions extends ConnectionOptions, NetConnectOpts {
     maxCachedSessions?: number | null;
     socketPath?: string | null;
     timeout?: number | null;


### PR DESCRIPTION
This PR fixes an issue with the type `buildConnector.BuildOptions`.

The `buildConnector.BuildOptions` are used for 2 different methods, `tls.connect(opts)` for https, and `net.connect(opt)` for all other protocols. `TlsOptions` does not include all possible options that can be passed to those methods.

- `tls.connect(opt)` accepts the type `ConnectOptions`
- `net.connect(opt)` accepts the type `NetConnectOpts`