### PR TITLE
fix: ProxyAgent dispatch options receives a header array when using fetch

### DIFF
--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -193,7 +193,7 @@ Returns: `Boolean` - `false` if dispatcher is busy and further dispatch calls wo
 * **path** `string`
 * **method** `string`
 * **body** `string | Buffer | Uint8Array | stream.Readable | Iterable | AsyncIterable | null` (optional) - Default: `null`
-* **headers** `UndiciHeaders` (optional) - Default: `null`
+* **headers** `UndiciHeaders | string[]` (optional) - Default: `null`.
 * **idempotent** `boolean` (optional) - Default: `true` if `method` is `'HEAD'` or `'GET'` - Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceding requests in the pipeline has completed.
 * **blocking** `boolean` (optional) - Default: `false` - Whether the response is expected to take a long time and would end up blocking the pipeline. When this is set to `true` further pipelining will be avoided on the same connection until headers have been received.
 * **upgrade** `string | null` (optional) - Default: `null` - Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`.

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -66,7 +66,7 @@ function buildHeaders (headers) {
     /** @type {Record<string, string>} */
     const headersPair = {}
 
-    for (let i = 0; i < headers.length; i++) {
+    for (let i = 0; i < headers.length; i += 2) {
       headersPair[headers[i]] = headers[i + 1]
     }
 

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -23,7 +23,7 @@ class ProxyAgent extends DispatcherBase {
         origin: this[kProxy].uri,
         path: opts.origin + opts.path,
         headers: {
-          ...opts.headers,
+          ...buildHeaders(opts.headers),
           host
         }
       },
@@ -53,6 +53,27 @@ function buildProxyOptions (opts) {
     uri: opts.uri,
     protocol: opts.protocol || 'https'
   }
+}
+
+/**
+ * @param {string[] | Record<string, string>} headers
+ * @returns {Record<string, string>}
+ */
+function buildHeaders (headers) {
+  // When using undici.fetch, the headers list is stored
+  // as an array.
+  if (Array.isArray(headers)) {
+    /** @type {Record<string, string>} */
+    const headersPair = {}
+
+    for (let i = 0; i < headers.length; i++) {
+      headersPair[headers[i]] = headers[i + 1]
+    }
+
+    return headersPair
+  }
+
+  return headers
 }
 
 module.exports = ProxyAgent


### PR DESCRIPTION
Fixes #1355

types were already correct (I'm guessing this issue has been around for a little bit):
https://github.com/nodejs/undici/blob/1dc2977c94583efbecd5b6791b5a091d18a2ceeb/types/dispatcher.d.ts#L49