### PR TITLE
test: remove erroneous tap test only filter

### DIFF
--- a/test/http-100.js
+++ b/test/http-100.js
@@ -108,7 +108,7 @@ test('error 101 upgrade', (t) => {
   })
 })
 
-test('1xx response without timeouts', { only: true }, t => {
+test('1xx response without timeouts', t => {
   t.plan(2)
 
   const server = createServer((req, res) => {


### PR DESCRIPTION
Removes an erroneous `only` filter from a test in `http-100.js`

Refs: https://github.com/nodejs/undici/pull/716