### PR TITLE
feat: add support for dependabot 🥳

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,13 @@
 version: 2
 updates:
-  # Fetch and update latest `npm` packages
-  - package-ecosystem: npm
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
-      time: "00:00"
-    reviewers:
-      - ronag
-      - mcollina
-    assignees:
-      - ronag
-      - mcollina
-    commit-message:
-      prefix: fix
-      prefix-development: chore
-      include: scope
-  # Fetch and update latest `github-actions` pkgs
-  - package-ecosystem: github-actions
+      interval: "monthly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
-      time: "00:00"
-    reviewers:
-      - ronag
-      - mcollina
-    assignees:
-      - ronag
-      - mcollina
-    commit-message:
-      prefix: fix
-      prefix-development: chore
-      include: scope
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Fetch and update latest `npm` packages
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+    reviewers:
+      - ronag
+      - mcollina
+    assignees:
+      - ronag
+      - mcollina
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+  # Fetch and update latest `github-actions` pkgs
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+    reviewers:
+      - ronag
+      - mcollina
+    assignees:
+      - ronag
+      - mcollina
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,3 +17,13 @@ jobs:
       post-test-steps: |
         - name: Coverage Report
           uses: codecov/codecov-action@v2
+  automerge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] Enables support for `dependabot` so that all the package dependencies are kept up-to-date with `npm` so as to mitigate any vulnerabilities in older versions of packages.