### PR TITLE
feat: add ship.js for release & changelog generation

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -1,0 +1,29 @@
+name: Ship js trigger
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
+    steps:
+      - name: Checkout code 🛎
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup node environment 📦
+        uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org
+          check-latest: true
+
+      - name: Trigger a release 🥳
+        run: npx shipjs trigger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_INCOMING_HOOK: ${{ secrets.SLACK_INCOMING_HOOK }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # undici
 
-[![Node CI](https://github.com/nodejs/undici/actions/workflows/nodejs.yml/badge.svg)](https://github.com/nodejs/undici/actions/workflows/nodejs.yml) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![npm version](https://badge.fury.io/js/undici.svg)](https://badge.fury.io/js/undici) [![codecov](https://codecov.io/gh/nodejs/undici/branch/main/graph/badge.svg?token=yZL6LtXkOA)](https://codecov.io/gh/nodejs/undici)
+[![Node CI](https://github.com/nodejs/undici/actions/workflows/nodejs.yml/badge.svg)](https://github.com/nodejs/undici/actions/workflows/nodejs.yml) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/) [![npm version](https://badge.fury.io/js/undici.svg)](https://badge.fury.io/js/undici) [![codecov](https://codecov.io/gh/nodejs/undici/branch/main/graph/badge.svg?token=yZL6LtXkOA)](https://codecov.io/gh/nodejs/undici) [![Ship js trigger](https://github.com/nodejs/undici/actions/workflows/shipjs-trigger.yml/badge.svg)](https://github.com/nodejs/undici/actions/workflows/shipjs-trigger.yml)
 
 An HTTP/1.1 client, written from scratch for Node.js.
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
     "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js; CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
     "serve:website": "docsify serve .",
     "prepare": "husky install",
-    "fuzz": "jsfuzz test/fuzzing/fuzz.js corpus"
+    "fuzz": "jsfuzz test/fuzzing/fuzz.js corpus",
+    "release": "shipjs prepare",
+    "release:dry": "shipjs prepare --dry-run",
+    "release:auto": "shipjs prepare --yes"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "^9.1.2",
@@ -87,6 +90,7 @@
     "proxyquire": "^2.1.3",
     "semver": "^7.3.5",
     "sinon": "^13.0.2",
+    "shipjs": "^0.24.4",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.1.0",

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  buildCommand: () => "npm run build:node",
-};
+  buildCommand: () => 'npm run build:node'
+}

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  buildCommand: () => "npm run build:node",
+};


### PR DESCRIPTION
- [x] Since we follow the conventional commit workflow(s) in this repository, it'd be a nice feature of performing the publishing of packages, generation of changelog & releases in an automated fashion. For reference – https://github.com/geospoc/v-mapbox/actions/workflows/shipjs-trigger.yml?query=is%3Asuccess++
- [x] [Ship.js](https://github.com/algolia/shipjs) allows us to perform automated releases without any manual intervention, for checking out a potential release, `npm run release:dry`, for fully automated release, `npm run release:auto`, for default way ship.js works, `npm run release`. This will generate an automated PR like this – https://github.com/geospoc/v-mapbox/pull/903 which has to be squashed and merged which in turn will trigger the `shipjs-trigger.yml` workflow like this – https://github.com/geospoc/v-mapbox/runs/6095348980?check_suite_focus=true ; This will potentially help @mcollina in generating automated [CHANGELOG.md](https://github.com/geospoc/v-mapbox/blob/main/CHANGELOG.md) & auto–generate the [release](https://github.com/nodejs/undici/releases) notes!