### PR TITLE
fix: don't enqueue bytes if the request was aborted

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1867,7 +1867,9 @@ async function httpNetworkFetch (
 
       // 7. Enqueue a Uint8Array wrapping an ArrayBuffer containing bytes
       // into stream.
-      fetchParams.controller.controller.enqueue(new Uint8Array(bytes))
+      if (!isAborted(fetchParams)) {
+        fetchParams.controller.controller.enqueue(new Uint8Array(bytes))
+      }
 
       // 8. If stream is errored, then terminate the ongoing fetch.
       if (isErrored(stream)) {

--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const { test } = require('tap')
+const { fetch } = require('../..')
+const { createServer } = require('http')
+const { once } = require('events')
+
+/* global AbortController */
+
+test('parallel fetch with the same AbortController works as expected', async (t) => {
+  const body = {
+    fixes: 1389,
+    bug: 'Ensure request is not aborted before enqueueing bytes into stream.'
+  }
+
+  const server = createServer((req, res) => {
+    res.statusCode = 200
+    res.end(JSON.stringify(body))
+  })
+
+  t.teardown(server.close.bind(server))
+
+  const abortController = new AbortController()
+
+  async function makeRequest () {
+    const result = await fetch(`http://localhost:${server.address().port}`, {
+      signal: abortController.signal
+    }).then(response => response.json())
+
+    abortController.abort()
+    return result
+  }
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const requests = Array.from({ length: 10 }, makeRequest)
+  const result = await Promise.allSettled(requests)
+
+  // since the requests are running parallel, any of them could resolve first.
+  // therefore we cannot rely on the order of the requests sent.
+  const { resolved, rejected } = result.reduce((a, b) => {
+    if (b.status === 'rejected') {
+      a.rejected.push(b)
+    } else {
+      a.resolved.push(b)
+    }
+
+    return a
+  }, { resolved: [], rejected: [] })
+
+  t.equal(rejected.length, 9) // out of 10 requests, only 1 should succeed
+  t.equal(resolved.length, 1)
+
+  t.ok(rejected.every(rej => rej.reason?.code === 'ABORT_ERR'))
+  t.same(resolved[0].value, body)
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1389

The output is now similar to Firefox:
![image](https://user-images.githubusercontent.com/42794878/166116921-2779d385-59b4-4c52-a7ab-1db2034ebb3b.png)
![image](https://user-images.githubusercontent.com/42794878/166116927-74ff25a0-641e-41d9-9e99-d2bd7f49c571.png)
