### PR TITLE
fix: use `unknown` statusText by default in mocks

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -209,8 +209,7 @@ function getStatusText (statusCode) {
     case 508: return 'Loop Detected'
     case 510: return 'Not Extended'
     case 511: return 'Network Authentication Required'
-    default:
-      throw new ReferenceError(`Unknown status code "${statusCode}"!`)
+    default: return 'unknown'
   }
 }
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2421,14 +2421,13 @@ test('MockAgent - using fetch yields correct statusText', { skip: nodeMajor < 16
   t.equal(statusText, 'OK')
 
   mockPool.intercept({
-    path: '/badStatusText',
+    path: '/unknownStatusText',
     method: 'GET'
   }).reply(420, 'Everyday')
 
-  await t.rejects(
-    fetch('http://localhost:3000/badStatusText'),
-    TypeError
-  )
+  const unknownStatusCodeRes = await fetch('http://localhost:3000/unknownStatusText')
+  t.equal(unknownStatusCodeRes.status, 420)
+  t.equal(unknownStatusCodeRes.statusText, 'unknown')
 
   t.end()
 })

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -125,7 +125,7 @@ test('getStatusText', (t) => {
     t.ok(getStatusText(statusCode))
   }
 
-  t.throws(() => getStatusText(420), ReferenceError)
+  t.equal(getStatusText(420), 'unknown')
 
   t.end()
 })


### PR DESCRIPTION
When encountering an unknown status code, an error should not be thrown. This behavior now matches fetch's behavior (tested with undici & node-fetch, unsure about browsers but I doubt it is different).