### PR TITLE
fix: do not use the logicial assignment operator

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -302,7 +302,9 @@ class Headers {
   }
 
   get [kHeadersSortedMap] () {
-    this[kHeadersList][kHeadersSortedMap] ??= new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1))
+    if (this[kHeadersList][kHeadersSortedMap] === undefined) {
+      this[kHeadersList][kHeadersSortedMap] = new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1))
+    }
     return this[kHeadersList][kHeadersSortedMap]
   }
 

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -302,7 +302,7 @@ class Headers {
   }
 
   get [kHeadersSortedMap] () {
-    if (this[kHeadersList][kHeadersSortedMap] == undefined) {
+    if (!this[kHeadersList][kHeadersSortedMap]) {
       this[kHeadersList][kHeadersSortedMap] = new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1))
     }
     return this[kHeadersList][kHeadersSortedMap]

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -302,7 +302,7 @@ class Headers {
   }
 
   get [kHeadersSortedMap] () {
-    if (this[kHeadersList][kHeadersSortedMap] === undefined) {
+    if (this[kHeadersList][kHeadersSortedMap] == undefined) {
       this[kHeadersList][kHeadersSortedMap] = new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1))
     }
     return this[kHeadersList][kHeadersSortedMap]


### PR DESCRIPTION
Alternative solution for https://github.com/nodejs/undici/pull/1398

See https://github.com/nodejs/undici/pull/1318

> The package.json of this project lists ["node": ">=12.18" in the engines](https://github.com/nodejs/undici/blob/8b1dcd44755d7c9bfba06066518f4c01629ad1c0/package.json#L96-L98).
>
> [Logical Assignment is only supported since Node.js 15.14](https://node.green/#ES2021-features-Logical-Assignment).
>
> To me, it seems like this usage here got added unexpectedly.
>
> We would love to prevent such things in the future by setting up a GitHub action that runs eslint with the following rule: https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/no-unsupported-features/es-syntax.md
>
> Would that be something you are interested in?