### PR TITLE
chore: revert #1349

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no-install lint-staged
+npm run lint
+npm run test

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  '*.{js,ts}': 'npm run lint && npm test'
-}


### PR DESCRIPTION
There was nothing wrong with the original pre-commit hook. The only thing #1349 does is introduce an extra dependency that needs to be downloaded (which could be compromised down the road).