### PR TITLE
ci(lint-pr): reduce permissions to minimum

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+  statuses: write
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: 'Lint PR'
+name: 'Lint PR Title'
 
 on:
   pull_request_target:


### PR DESCRIPTION
As discussed in https://github.com/nodejs/undici/pull/1356#discussion_r856063520, the use of `pull_request_target` here opens up a potential security hole.

Declaring the minimum [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) for this workflow to run, following principle of least privilege, negates this. See [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/) regarding permissions.