### PR TITLE
fix(Request): URLSearchParams body w/ Headers obj

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -467,8 +467,8 @@ class Request {
       // not contain `Content-Type`, then append `Content-Type`/Content-Type to
       // this’s headers.
       if (contentType && !this[kHeaders].has('content-type')) {
-        this[kHeaders].append('content-type', contentType)
-        this[kState].headersList.append('content-type', contentType)
+        this[kHeaders].set('content-type', contentType)
+        this[kState].headersList.set('content-type', contentType)
       }
     }
 

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -7,6 +7,7 @@ const {
   Request
 } = require('../../')
 const { kState } = require('../../lib/fetch/symbols.js')
+const { URLSearchParams } = require('url')
 
 test('arg validation', (t) => {
   // constructor
@@ -259,6 +260,27 @@ test('pre aborted signal cloned', t => {
   const req = new Request('http://asd', { signal: ac.signal }).clone()
   t.equal(req.signal.aborted, true)
   t.end()
+})
+
+test('URLSearchParams body with Headers object - issue #1407', async (t) => {
+  const body = new URLSearchParams({
+    abc: 123
+  })
+
+  const request = new Request(
+    'http://localhost',
+    {
+      method: 'POST',
+      body,
+      headers: {
+        Authorization: 'test'
+      }
+    }
+  )
+
+  t.equal(request.headers.get('content-type'), 'application/x-www-form-urlencoded;charset=UTF-8')
+  t.equal(request.headers.get('authorization'), 'test')
+  t.equal(await request.text(), 'abc=123')
 })
 
 test('post aborted signal cloned', t => {


### PR DESCRIPTION
Fixes #1407

Although the spec says to "append" the header, setting it should make no difference as the check beforehand ensures that no 'content-type' header exists.

p.s.: I have no idea how the header was being duplicated 😕 