### PR TITLE
fix: Remove unnecessary mismatched trailers check

### DIFF
--- a/docs/api/Errors.md
+++ b/docs/api/Errors.md
@@ -19,7 +19,6 @@ import { errors } from 'undici'
 | `RequestContentLengthMismatchError`  | `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` | request body does not match content-length header  |
 | `ResponseContentLengthMismatchError` | `UND_ERR_RES_CONTENT_LENGTH_MISMATCH` | response body does not match content-length header |
 | `InformationalError`                 | `UND_ERR_INFO`                        | expected error with reason                         |
-| `TrailerMismatchError`               | `UND_ERR_TRAILER_MISMATCH`            | trailers did not match specification               |
 
 ### `SocketError`
 

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -116,16 +116,6 @@ class ResponseContentLengthMismatchError extends UndiciError {
   }
 }
 
-class TrailerMismatchError extends UndiciError {
-  constructor (message) {
-    super(message)
-    Error.captureStackTrace(this, TrailerMismatchError)
-    this.name = 'TrailerMismatchError'
-    this.message = message || 'Trailers does not match trailer header'
-    this.code = 'UND_ERR_TRAILER_MISMATCH'
-  }
-}
-
 class ClientDestroyedError extends UndiciError {
   constructor (message) {
     super(message)
@@ -196,7 +186,6 @@ module.exports = {
   BodyTimeoutError,
   RequestContentLengthMismatchError,
   ConnectTimeoutError,
-  TrailerMismatchError,
   InvalidArgumentError,
   InvalidReturnValueError,
   RequestAbortedError,

--- a/test/errors.js
+++ b/test/errors.js
@@ -22,7 +22,6 @@ const scenarios = [
   createScenario(errors.RequestAbortedError, 'Request aborted', 'AbortError', 'UND_ERR_ABORTED'),
   createScenario(errors.InformationalError, 'Request information', 'InformationalError', 'UND_ERR_INFO'),
   createScenario(errors.RequestContentLengthMismatchError, 'Request body length does not match content-length header', 'RequestContentLengthMismatchError', 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'),
-  createScenario(errors.TrailerMismatchError, 'Trailers does not match trailer header', 'TrailerMismatchError', 'UND_ERR_TRAILER_MISMATCH'),
   createScenario(errors.ClientDestroyedError, 'The client is destroyed', 'ClientDestroyedError', 'UND_ERR_DESTROYED'),
   createScenario(errors.ClientClosedError, 'The client is closed', 'ClientClosedError', 'UND_ERR_CLOSED'),
   createScenario(errors.SocketError, 'Socket error', 'SocketError', 'UND_ERR_SOCKET'),

--- a/test/trailers.js
+++ b/test/trailers.js
@@ -3,36 +3,32 @@
 const { test } = require('tap')
 const { Client } = require('..')
 const { createServer } = require('http')
-const errors = require('../lib/core/errors')
 
-test('response trailers missing', (t) => {
-  t.plan(2)
+test('response trailers missing is OK', (t) => {
+  t.plan(1)
 
   const server = createServer((req, res) => {
     res.writeHead(200, {
       Trailer: 'content-length'
     })
-    res.end()
+    res.end('response')
   })
   t.teardown(server.close.bind(server))
-  server.listen(0, () => {
+  server.listen(0, async () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({
+    const { body } = await client.request({
       path: '/',
       method: 'GET',
       body: 'asd'
-    }, (err, data) => {
-      t.error(err)
-      data.body.on('error', (err) => {
-        t.type(err, errors.TrailerMismatchError)
-      })
     })
+
+    t.equal(await body.text(), 'response')
   })
 })
 
-test('response trailers missing w trailers', (t) => {
+test('response trailers missing w trailers is OK', (t) => {
   t.plan(2)
 
   const server = createServer((req, res) => {
@@ -42,22 +38,20 @@ test('response trailers missing w trailers', (t) => {
     res.addTrailers({
       asd: 'foo'
     })
-    res.end()
+    res.end('response')
   })
   t.teardown(server.close.bind(server))
-  server.listen(0, () => {
+  server.listen(0, async () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     t.teardown(client.destroy.bind(client))
 
-    client.request({
+    const { body, trailers } = await client.request({
       path: '/',
       method: 'GET',
       body: 'asd'
-    }, (err, data) => {
-      t.error(err)
-      data.body.on('error', (err) => {
-        t.type(err, errors.TrailerMismatchError)
-      })
     })
+
+    t.equal(await body.text(), 'response')
+    t.same(trailers, { asd: 'foo' })
   })
 })


### PR DESCRIPTION
Fixes #1418.

As in that issue, I don't think there's any reason for this, and it doesn't match other implementations, so this removes the error and check entirely, and flips the error tests to check it works correctly.