### PR TITLE
feat(Headers): implement `Headers Iterator`

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -77,6 +77,22 @@ function fill (headers, object) {
   }
 }
 
+function makeHeadersIterator (iterator) {
+  const i = {
+    next: () => {
+      // TODO(@KhafraDev): brand check
+      return iterator.next()
+    },
+    [Symbol.iterator]: () => {
+      // TODO(@KhafraDev): brand check
+      return makeHeadersIterator(iterator)
+    },
+    [Symbol.toStringTag]: 'Headers Iterator'
+  }
+
+  return Object.setPrototypeOf({}, i)
+}
+
 class HeadersList {
   constructor (init) {
     if (init instanceof HeadersList) {
@@ -311,7 +327,7 @@ class Headers {
       throw new TypeError('Illegal invocation')
     }
 
-    return this[kHeadersSortedMap].keys()
+    return makeHeadersIterator(this[kHeadersSortedMap].keys())
   }
 
   values () {
@@ -319,7 +335,7 @@ class Headers {
       throw new TypeError('Illegal invocation')
     }
 
-    return this[kHeadersSortedMap].values()
+    return makeHeadersIterator(this[kHeadersSortedMap].values())
   }
 
   entries () {
@@ -327,7 +343,7 @@ class Headers {
       throw new TypeError('Illegal invocation')
     }
 
-    return this[kHeadersSortedMap].entries()
+    return makeHeadersIterator(this[kHeadersSortedMap].entries())
   }
 
   [Symbol.iterator] () {
@@ -335,7 +351,7 @@ class Headers {
       throw new TypeError('Illegal invocation')
     }
 
-    return this[kHeadersSortedMap]
+    return makeHeadersIterator(this[kHeadersSortedMap])
   }
 
   forEach (...args) {

--- a/test/fetch/headers-iterator.js
+++ b/test/fetch/headers-iterator.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { test } = require('tap')
+const { Headers } = require('../..')
+
+test('Implements "Headers Iterator" properly', (t) => {
+  t.test('all iterators implement Headers Iterator', (t) => {
+    const headers = new Headers([['a', 'b'], ['c', 'd']])
+
+    for (const iterable of ['keys', 'values', 'entries', Symbol.iterator]) {
+      const gen = headers[iterable]()
+
+      t.ok(gen.constructor === Object)
+      t.ok(gen.prototype === undefined)
+      // eslint-disable-next-line no-proto
+      t.equal(gen.__proto__[Symbol.toStringTag], 'Headers Iterator')
+      // https://github.com/node-fetch/node-fetch/issues/1119#issuecomment-100222049
+      t.notOk(gen instanceof function * () {}.constructor)
+      // eslint-disable-next-line no-proto
+      t.ok(gen.__proto__.next.__proto__ === Function.prototype)
+    }
+
+    t.end()
+  })
+
+  t.test('Headers Iterator symbols are properly set', (t) => {
+    const headers = new Headers([['a', 'b'], ['c', 'd']])
+    const gen = headers.entries()
+
+    t.equal(typeof gen[Symbol.toStringTag], 'string')
+    t.equal(typeof gen[Symbol.iterator], 'function')
+    t.end()
+  })
+
+  t.test('Headers Iterator does not inherit Generator prototype methods', (t) => {
+    const headers = new Headers([['a', 'b'], ['c', 'd']])
+    const gen = headers.entries()
+
+    t.equal(gen.return, undefined)
+    t.equal(gen.throw, undefined)
+    t.equal(typeof gen.next, 'function')
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -9,6 +9,8 @@ import {
   FormData,
   Headers,
   HeadersInit,
+  HeadersIterableIterator,
+  HeadersIterator,
   Request,
   RequestCache,
   RequestCredentials,
@@ -115,9 +117,9 @@ expectType<void>(headers.delete('key'))
 expectType<string | null>(headers.get('key'))
 expectType<boolean>(headers.has('key'))
 expectType<void>(headers.set('key', 'value'))
-expectType<IterableIterator<string>>(headers.keys())
-expectType<IterableIterator<string>>(headers.values())
-expectType<IterableIterator<[string, string]>>(headers.entries())
+expectType<HeadersIterableIterator<string>>(headers.keys())
+expectType<HeadersIterableIterator<string>>(headers.values())
+expectType<HeadersIterableIterator<[string, string]>>(headers.entries())
 
 expectType<RequestCache>(request.cache)
 expectType<RequestCredentials>(request.credentials)

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -38,9 +38,21 @@ export interface BodyMixin {
   readonly text: () => Promise<string>
 }
 
+export interface HeadersIterator<T, TReturn = any, TNext = undefined> {
+  next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+}
+
+export interface HeadersIterableIterator<T> extends HeadersIterator<T> {
+  [Symbol.iterator](): HeadersIterableIterator<T>;
+}
+
+export interface HeadersIterable<T> {
+  [Symbol.iterator](): HeadersIterator<T>;
+}
+
 export type HeadersInit = string[][] | Record<string, string | ReadonlyArray<string>> | Headers
 
-export declare class Headers implements Iterable<[string, string]> {
+export declare class Headers implements HeadersIterable<[string, string]> {
   constructor (init?: HeadersInit)
   readonly append: (name: string, value: string) => void
   readonly delete: (name: string) => void
@@ -52,10 +64,10 @@ export declare class Headers implements Iterable<[string, string]> {
     thisArg?: unknown
   ) => void
 
-  readonly keys: () => IterableIterator<string>
-  readonly values: () => IterableIterator<string>
-  readonly entries: () => IterableIterator<[string, string]>
-  readonly [Symbol.iterator]: () => Iterator<[string, string]>
+  readonly keys: () => HeadersIterableIterator<string>
+  readonly values: () => HeadersIterableIterator<string>
+  readonly entries: () => HeadersIterableIterator<[string, string]>
+  readonly [Symbol.iterator]: () => HeadersIterator<[string, string]>
 }
 
 export type RequestCache =


### PR DESCRIPTION
See:
- https://github.com/node-fetch/node-fetch/issues/1119#issuecomment-100222049
- https://bugs.chromium.org/p/chromium/issues/detail?id=793204

This implements `Headers Iterator` which is a generator-like... thing... that only has a ` .next()` method. Chrome doesn't implement this entirely correct so I recommend using Firefox to see the correct behavior.

Notes:
- Typescript's Header types are incorrect! You can't use `.return()` or `.throw()` on a Headers iterator (.keys(), .entries(), .values(), Symbol.iterator()).
- Deno does implement this correctly.
- The [`Headers`](https://fetch.spec.whatwg.org/#headers-class) standard doesn't mention Headers Iterator at all so I made this implementation through ✨ trial and error ✨.