### PR TITLE
fix: import `BodyReadable` and `Dispatcher` correctly

### DIFF
--- a/test/types/readable.test-d.ts
+++ b/test/types/readable.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import BodyReadable from '../../types/readable'
+import BodyReadable = require('../../types/readable')
 import { Blob } from 'buffer'
 
 expectAssignable<BodyReadable>(new BodyReadable())

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -3,7 +3,7 @@ import { Duplex, Readable, Writable } from 'stream'
 import { EventEmitter } from 'events'
 import { IncomingHttpHeaders } from 'http'
 import { Blob } from 'buffer'
-import BodyReadable from './readable'
+import BodyReadable = require('./readable')
 import { FormData } from './formdata'
 
 type AbortSignal = unknown;

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -1,5 +1,5 @@
 import { IncomingHttpHeaders } from 'http'
-import Dispatcher from './dispatcher';
+import Dispatcher = require('./dispatcher');
 import { BodyInit, Headers } from './fetch'
 
 export {


### PR DESCRIPTION
_This PR is a continuation of the changes made in #1059._

`BodyReadable` is imported with the assumption that `allowSyntheticDefaultImports` is enabled. This is restrictive to consumers wishing to use undici's type definitions without its enablement.

The following imports have been fixed:

- `BodyReadable` in test/types/readable.test-d.ts
- `BodyReadable` in types/dispatcher.d.ts
- `Dispatcher` in types/mock-interceptor.d.ts