### PR TITLE
fix(Headers): forEach

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -354,26 +354,24 @@ class Headers {
     return makeHeadersIterator(this[kHeadersSortedMap])
   }
 
-  forEach (...args) {
+  /**
+   * @param {(value: string, key: string, self: Headers) => void} callbackFn
+   * @param {unknown} thisArg
+   */
+  forEach (callbackFn, thisArg = globalThis) {
     if (!(this instanceof Headers)) {
       throw new TypeError('Illegal invocation')
     }
-    if (args.length < 1) {
-      throw new TypeError(
-        `Failed to execute 'forEach' on 'Headers': 1 argument required, but only ${args.length} present.`
-      )
-    }
-    if (typeof args[0] !== 'function') {
+
+    if (typeof callbackFn !== 'function') {
       throw new TypeError(
         "Failed to execute 'forEach' on 'Headers': parameter 1 is not of type 'Function'."
       )
     }
-    const callback = args[0]
-    const thisArg = args[1]
 
-    this[kHeadersSortedMap].forEach((value, index) => {
-      callback.apply(thisArg, [value, index, this])
-    })
+    for (const [key, value] of this) {
+      callbackFn.apply(thisArg, [value, key, this])
+    }
   }
 
   [Symbol.for('nodejs.util.inspect.custom')] () {

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -289,6 +289,41 @@ tap.test('Headers set', t => {
   })
 })
 
+tap.test('Headers forEach', t => {
+  const headers = new Headers([['a', 'b'], ['c', 'd']])
+
+  t.test('standard', t => {
+    t.equal(typeof headers.forEach, 'function')
+
+    headers.forEach((value, key, headerInstance) => {
+      t.ok(value === 'b' || value === 'd')
+      t.ok(key === 'a' || key === 'c')
+      t.equal(headers, headerInstance)
+    })
+
+    t.end()
+  })
+
+  t.test('when no thisArg is set, it is globalThis', (t) => {
+    headers.forEach(function () {
+      t.equal(this, globalThis)
+    })
+
+    t.end()
+  })
+
+  t.test('with thisArg', t => {
+    const thisArg = { a: Math.random() }
+    headers.forEach(function () {
+      t.equal(this, thisArg)
+    }, thisArg)
+
+    t.end()
+  })
+
+  t.end()
+})
+
 tap.test('Headers as Iterable', t => {
   t.plan(8)
 


### PR DESCRIPTION
`Headers.forEach` had a bunch of things wrong with it:
- Parameter order was named weird (where `key` was named as `index` in the code).
- `thisArg` was not set to `globalThis` by default.
- `Headers.prototype.forEach.length` was returning 0, instead of 1 (this is another issue I was going to make a PR for eventually).

I have 2 more PRs planned for Headers fixes, so I'm wondering if you would prefer combining those 2 changes into a single PR, or if you would prefer 2 separate PRs?