### PR TITLE
fix(Headers): do not brand-check toString & Symbol.toStringTag

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -185,19 +185,7 @@ class Headers {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof Headers)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return this.constructor.name
-  }
-
-  toString () {
-    if (!(this instanceof Headers)) {
-      throw new TypeError('Illegal invocation')
-    }
-
-    return Object.prototype.toString.call(this)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-append

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -518,12 +518,12 @@ tap.test('arg validation', (t) => {
   }, TypeError)
 
   // get [Symbol.toStringTag]
-  t.throws(() => {
+  t.doesNotThrow(() => {
     Object.prototype.toString.call(Headers.prototype)
   }, TypeError)
 
   // toString
-  t.throws(() => {
+  t.doesNotThrow(() => {
     Headers.prototype.toString.call(null)
   }, TypeError)
 
@@ -606,7 +606,15 @@ tap.test('function signature verification', (t) => {
 
   t.test('function equality', (t) => {
     t.equal(Headers.prototype.entries, Headers.prototype[Symbol.iterator])
-    // TODO(@KhafraDev): ensure Headers.prototype.toString === Object.prototype.toString
+    t.equal(Headers.prototype.toString, Object.prototype.toString)
+
+    t.end()
+  })
+
+  tap.test('toString and Symbol.toStringTag', (t) => {
+    t.equal(Object.prototype.toString.call(Headers.prototype), '[object Headers]')
+    t.equal(Headers.prototype[Symbol.toStringTag], 'Headers')
+    t.equal(Headers.prototype.toString.call(null), '[object Null]')
 
     t.end()
   })

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -520,12 +520,12 @@ tap.test('arg validation', (t) => {
   // get [Symbol.toStringTag]
   t.doesNotThrow(() => {
     Object.prototype.toString.call(Headers.prototype)
-  }, TypeError)
+  })
 
   // toString
   t.doesNotThrow(() => {
     Headers.prototype.toString.call(null)
-  }, TypeError)
+  })
 
   // append
   t.throws(() => {

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -611,7 +611,7 @@ tap.test('function signature verification', (t) => {
     t.end()
   })
 
-  tap.test('toString and Symbol.toStringTag', (t) => {
+  t.test('toString and Symbol.toStringTag', (t) => {
     t.equal(Object.prototype.toString.call(Headers.prototype), '[object Headers]')
     t.equal(Headers.prototype[Symbol.toStringTag], 'Headers')
     t.equal(Headers.prototype.toString.call(null), '[object Null]')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42794878/167648966-1798360e-5736-44f6-8edd-e6f0787ae768.png)

Fixes 2 bugs:
1. `Headers.toString` should be inherited from Object's prototype.
2. The `Symbol.toStringTag` getter should not be brand checked.