### PR TITLE
fix(fetch): remove brand checks from Symbol.toStringTag

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -69,10 +69,6 @@ class File extends Blob {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof File)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return this.constructor.name
   }
 }
@@ -190,10 +186,6 @@ class FileLike {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof FileLike)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return 'File'
   }
 }

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -182,10 +182,6 @@ class FormData {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof FormData)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return this.constructor.name
   }
 
@@ -269,4 +265,4 @@ function makeEntry (name, value, filename) {
   return entry
 }
 
-module.exports = { FormData: globalThis.FormData ?? FormData }
+module.exports = { FormData }

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -516,10 +516,6 @@ class Request {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof Request)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return this.constructor.name
   }
 

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -178,10 +178,6 @@ class Response {
   }
 
   get [Symbol.toStringTag] () {
-    if (!(this instanceof Response)) {
-      throw new TypeError('Illegal invocation')
-    }
-
     return this.constructor.name
   }
 

--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { File, FileLike } = require('../../lib/fetch/file')
 
 test('args validation', (t) => {
-  t.plan(12)
+  t.plan(14)
 
   t.throws(() => {
     File.prototype.name.call(null)
@@ -12,8 +12,8 @@ test('args validation', (t) => {
   t.throws(() => {
     File.prototype.lastModified.call(null)
   }, TypeError)
-  t.throws(() => {
-    File.prototype[Symbol.toStringTag].call(null)
+  t.doesNotThrow(() => {
+    File.prototype[Symbol.toStringTag].charAt(0)
   }, TypeError)
 
   t.throws(() => {
@@ -40,9 +40,12 @@ test('args validation', (t) => {
   t.throws(() => {
     FileLike.prototype.lastModified.call(null)
   }, TypeError)
-  t.throws(() => {
-    FileLike.prototype[Symbol.toStringTag].call(null)
+  t.doesNotThrow(() => {
+    FileLike.prototype[Symbol.toStringTag].charAt(0)
   }, TypeError)
+
+  t.equal(File.prototype[Symbol.toStringTag], 'File')
+  t.equal(FileLike.prototype[Symbol.toStringTag], 'File')
 })
 
 test('return value of File.lastModified', (t) => {

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -73,6 +73,11 @@ test('arg validation', (t) => {
     Reflect.apply(FormData.prototype[Symbol.iterator], null)
   }, TypeError)
 
+  // toStringTag
+  t.doesNotThrow(() => {
+    FormData.prototype[Symbol.toStringTag].charAt(0)
+  })
+
   t.end()
 })
 
@@ -208,5 +213,6 @@ test('formData.values', (t) => {
 test('formData toStringTag', (t) => {
   const form = new FormData()
   t.equal(form[Symbol.toStringTag], 'FormData')
+  t.equal(FormData.prototype[Symbol.toStringTag], 'FormData')
   t.end()
 })

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -149,6 +149,10 @@ test('arg validation', (t) => {
     Request.prototype.clone.call(null)
   }, TypeError)
 
+  t.doesNotThrow(() => {
+    Request.prototype[Symbol.toStringTag].charAt(0)
+  })
+
   t.end()
 })
 
@@ -325,5 +329,13 @@ test('Passing headers in init', (t) => {
     t.end()
   })
 
+  t.end()
+})
+
+test('Symbol.toStringTag', (t) => {
+  const req = new Request('http://localhost')
+
+  t.equal(req[Symbol.toStringTag], 'Request')
+  t.equal(Request.prototype[Symbol.toStringTag], 'Request')
   t.end()
 })

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -45,8 +45,8 @@ test('arg validation', (t) => {
     }, TypeError)
   }
 
-  t.throws(() => {
-    Response.prototype[Symbol.toStringTag].call(null)
+  t.doesNotThrow(() => {
+    Response.prototype[Symbol.toStringTag].charAt(0)
   }, TypeError)
 
   t.throws(() => {
@@ -92,5 +92,13 @@ test('response clone', (t) => {
   t.equal(response1.body, response1.clone().body)
   t.equal(response2.body, response2.clone().body)
   t.equal(response2.body, null)
+  t.end()
+})
+
+test('Symbol.toStringTag', (t) => {
+  const resp = new Response()
+
+  t.equal(resp[Symbol.toStringTag], 'Response')
+  t.equal(Response.prototype[Symbol.toStringTag], 'Response')
   t.end()
 })


### PR DESCRIPTION
Continuation of #1430

I also removed the FormData export resolving to globalthis.FormData by default as it made testing the fixes impossible.