### PR TITLE
fix(test/fetch): <getter>.call will always throw

### DIFF
--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -7,10 +7,10 @@ test('args validation', (t) => {
   t.plan(14)
 
   t.throws(() => {
-    File.prototype.name.call(null)
+    File.prototype.name.toString()
   }, TypeError)
   t.throws(() => {
-    File.prototype.lastModified.call(null)
+    File.prototype.lastModified.toString()
   }, TypeError)
   t.doesNotThrow(() => {
     File.prototype[Symbol.toStringTag].charAt(0)
@@ -29,16 +29,16 @@ test('args validation', (t) => {
     FileLike.prototype.text.call(null)
   }, TypeError)
   t.throws(() => {
-    FileLike.prototype.size.call(null)
+    FileLike.prototype.size.toString()
   }, TypeError)
   t.throws(() => {
-    FileLike.prototype.type.call(null)
+    FileLike.prototype.type.toString()
   }, TypeError)
   t.throws(() => {
-    FileLike.prototype.name.call(null)
+    FileLike.prototype.name.toString()
   }, TypeError)
   t.throws(() => {
-    FileLike.prototype.lastModified.call(null)
+    FileLike.prototype.lastModified.toString()
   }, TypeError)
   t.doesNotThrow(() => {
     FileLike.prototype[Symbol.toStringTag].charAt(0)

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -98,51 +98,51 @@ test('arg validation', (t) => {
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.destination.call(null)
+    Request.prototype.destination.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.referrer.call(null)
+    Request.prototype.referrer.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.referrerPolicy.call(null)
+    Request.prototype.referrerPolicy.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.mode.call(null)
+    Request.prototype.mode.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.credentials.call(null)
+    Request.prototype.credentials.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.cache.call(null)
+    Request.prototype.cache.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.redirect.call(null)
+    Request.prototype.redirect.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.integrity.call(null)
+    Request.prototype.integrity.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.keepalive.call(null)
+    Request.prototype.keepalive.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.isReloadNavigation.call(null)
+    Request.prototype.isReloadNavigation.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.isHistoryNavigation.call(null)
+    Request.prototype.isHistoryNavigation.toString()
   }, TypeError)
 
   t.throws(() => {
-    Request.prototype.signal.call(null)
+    Request.prototype.signal.toString()
   }, TypeError)
 
   t.throws(() => {

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -50,31 +50,31 @@ test('arg validation', (t) => {
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.type.call(null)
+    Response.prototype.type.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.url.call(null)
+    Response.prototype.url.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.redirected.call(null)
+    Response.prototype.redirected.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.status.call(null)
+    Response.prototype.status.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.ok.call(null)
+    Response.prototype.ok.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.statusText.call(null)
+    Response.prototype.statusText.toString()
   }, TypeError)
 
   t.throws(() => {
-    Response.prototype.headers.call(null)
+    Response.prototype.headers.toString()
   }, TypeError)
 
   t.throws(() => {


### PR DESCRIPTION
The tests would always pass regardless of if the assumption (accessing prototype methods/getters without a valid `this` value will throw) was correct.

For example,
`File.prototype.name` is a string, so `.call(...)` is not a function. It will always throw a TypeError, even if the brand check was removed.