### PR TITLE
fix(types): make `RequestInit` properties assignable

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -29,6 +29,9 @@ const responseInit: ResponseInit = { status: 200, statusText: 'OK' }
 const requestInit2: RequestInit = {
   dispatcher: new Agent()
 }
+const requestInit3: RequestInit = {}
+// Test assignment. See https://github.com/whatwg/fetch/issues/1445
+requestInit3.credentials = 'include'
 
 declare const request: Request
 declare const headers: Headers

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -101,19 +101,19 @@ type RequestDestination =
   | 'xslt'
 
 export interface RequestInit {
-  readonly method?: string
-  readonly keepalive?: boolean
-  readonly headers?: HeadersInit
-  readonly body?: BodyInit
-  readonly redirect?: RequestRedirect
-  readonly integrity?: string
-  readonly signal?: AbortSignal
-  readonly credentials?: RequestCredentials
-  readonly mode?: RequestMode
-  readonly referrer?: string
-  readonly referrerPolicy?: ReferrerPolicy
-  readonly window?: null
-  readonly dispatcher?: Dispatcher
+  method?: string
+  keepalive?: boolean
+  headers?: HeadersInit
+  body?: BodyInit
+  redirect?: RequestRedirect
+  integrity?: string
+  signal?: AbortSignal
+  credentials?: RequestCredentials
+  mode?: RequestMode
+  referrer?: string
+  referrerPolicy?: ReferrerPolicy
+  window?: null
+  dispatcher?: Dispatcher
 }
 
 export type ReferrerPolicy =


### PR DESCRIPTION
Fixes #1445