### PR TITLE
fix(fetch): Explicitly check for FormData type

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -71,7 +71,7 @@ function extractBody (object, keepalive = false) {
 
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object)
-  } else if (util.isFormDataLike(object)) {
+  } else if (object instanceof FormData || util.isFormDataLike(object)) {
     const boundary = '----formdata-undici-' + Math.random()
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 


### PR DESCRIPTION
On one hand, the current implementation of the core `isFormDataLike` helper is:

https://github.com/nodejs/undici/blob/2ea8f0375dfa83e71d14e68fd90af51af2b868a4/lib/core/util.js#L328

On the other hand, the Fetch code has an actual [`FormData` implementation](https://github.com/nodejs/undici/blob/2ea8f0375dfa83e71d14e68fd90af51af2b868a4/lib/fetch/formdata.js).

The latter's `constructor.name` is `'FormData'`, so the combination of the two does work. So far, so good.

Now, I'm using esbuild to bundle undici into my app. Because of some naming conflict, it renames the class to `FormData3`. And then, all hell breaks loose.

To avoid that issue, this PR makes the Fetch part explicitly check the type of the given object.

It'd probably be better to update the core helper instead. I'd originally started to do that. Unfortunately, it introduced a circular dependency. It seemed solvable, but I didn't want to start moving things around just yet.