### PR TITLE
fix: get `set-cookie` header with `credentials: include`

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -654,7 +654,7 @@ async function mainFetch (fetchParams, recursive = false) {
     // Set response to the following filtered response with response as its
     // internal response, depending on request’s response tainting:
     if (request.responseTainting === 'basic') {
-      response = filterResponse(response, 'basic')
+      response = filterResponse(response, 'basic', request.credentials)
     } else if (request.responseTainting === 'cors') {
       response = filterResponse(response, 'cors')
     } else if (request.responseTainting === 'opaque') {

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -407,7 +407,7 @@ function makeFilteredHeadersList (headersList, filter) {
 }
 
 // https://fetch.spec.whatwg.org/#concept-filtered-response
-function filterResponse (response, type) {
+function filterResponse (response, type, credentials) {
   // Set response to the following filtered response with response as its
   // internal response, depending on request’s response tainting:
   if (type === 'basic') {
@@ -419,7 +419,7 @@ function filterResponse (response, type) {
       type: 'basic',
       headersList: makeFilteredHeadersList(
         response.headersList,
-        (name) => !forbiddenResponseHeaderNames.includes(name.toLowerCase())
+        (name) => credentials === 'include' || !forbiddenResponseHeaderNames.includes(name.toLowerCase())
       )
     })
   } else if (type === 'cors') {

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -403,3 +403,21 @@ test('custom agent node fetch', (t) => {
     t.strictSame(obj, await body.json())
   })
 })
+
+test('get set-cookie with credentials: include (#1262)', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('set-cookie', 'hello=world')
+    res.end('Hello World!')
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const { headers } = await fetch(`http://localhost:${server.address().port}`, {
+      credentials: 'include'
+    })
+
+    t.equal(headers.get('set-cookie'), 'hello=world')
+  })
+})


### PR DESCRIPTION
Fixes #1262 

When `credentials` is equal to `include`, the `set-cookie` header(s) should not be stripped.