### PR TITLE
docs: Add documentation for reply accepting a function as the data parameter

### DIFF
--- a/docs/best-practices/mocking-request.md
+++ b/docs/best-practices/mocking-request.md
@@ -103,7 +103,7 @@ const badRequest = await bankTransfer('1234567890', '100')
 
 ## Reply with data based on request
 
-If the mocked response needs to be dinamically derived from the reuqest parametes, you can provide a function instead of an object to `reply`
+If the mocked response needs to be dynamically derived from the request parameters, you can provide a function instead of an object to `reply`
 
 ```js
 mockPool.intercept({

--- a/docs/best-practices/mocking-request.md
+++ b/docs/best-practices/mocking-request.md
@@ -101,4 +101,36 @@ const badRequest = await bankTransfer('1234567890', '100')
 // subsequent request to origin http://localhost:3000 was not allowed (net.connect disabled)
 ```
 
+## Reply with data based on request
 
+If the mocked response needs to be dinamically derived from the reuqest parametes, you can provide a function instead of an object to `reply`
+
+```js
+mockPool.intercept({
+  path: '/bank-transfer',
+  method: 'POST',
+  headers: {
+    'X-TOKEN-SECRET': 'SuperSecretToken',
+  },
+  body: JSON.stringify({
+    recepient: '1234567890',
+    amount: '100'
+  })
+}).reply(200, (opts) => {
+  // do something with opts
+
+  return { message: 'transaction processed' }
+})
+```
+
+in this case opts will be
+
+```
+{
+  method: 'POST',
+  headers: { 'X-TOKEN-SECRET': 'SuperSecretToken' },
+  body: '{"recepient":"1234567890","amount":"100"}',
+  origin: 'http://localhost:3000',
+  path: '/bank-transfer'
+}
+```


### PR DESCRIPTION
Following up from this discussion https://github.com/nodejs/undici/discussions/1185 I thought there was a missing bit in the doc around the fact that the `reply` `data` parameter can be a function that will have the mocked request options as input .