### PR TITLE
fix(fetch): replace `instanceof FormData` check

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -71,7 +71,7 @@ function extractBody (object, keepalive = false) {
 
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object)
-  } else if (object instanceof FormData || util.isFormDataLike(object)) {
+  } else if (util.isFormDataLike(object)) {
     const boundary = '----formdata-undici-' + Math.random()
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -6,6 +6,8 @@ const { File, FileLike } = require('./file')
 const { Blob } = require('buffer')
 
 class FormData {
+  static name = 'FormData'
+
   constructor (...args) {
     if (args.length > 0 && !(args[0]?.constructor?.name === 'HTMLFormElement')) {
       throw new TypeError(

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -216,3 +216,9 @@ test('formData toStringTag', (t) => {
   t.equal(FormData.prototype[Symbol.toStringTag], 'FormData')
   t.end()
 })
+
+test('formData.constructor.name', (t) => {
+  const form = new FormData()
+  t.equal(form.constructor.name, 'FormData')
+  t.end()
+})


### PR DESCRIPTION
See https://github.com/nodejs/undici/pull/1451#issuecomment-1131619657

I've tested this using `esbuild` with `--minify` and `util.isFormData` still works on a minified `FormData` class