### PR TITLE
fix: mock node fetch with `options.body` fn

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1911,7 +1911,7 @@ async function httpNetworkFetch (
         path: url.pathname + url.search,
         origin: url.origin,
         method: request.method,
-        body: fetchParams.controller.dispatcher.isActive ? request.body && request.body.source : body,
+        body: fetchParams.controller.dispatcher.isMockActive ? request.body && request.body.source : body,
         headers: [...request.headersList].flat(),
         maxRedirections: 0,
         bodyTimeout: 300_000,

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -51,7 +51,6 @@ const EE = require('events')
 const { Readable, pipeline } = require('stream')
 const { isErrored, isReadable } = require('../core/util')
 const { dataURLProcessor } = require('./dataURL')
-const { kIsMockActive } = require('../mock/mock-symbols')
 const { TransformStream } = require('stream/web')
 
 /** @type {import('buffer').resolveObjectURL} */
@@ -1912,7 +1911,7 @@ async function httpNetworkFetch (
         path: url.pathname + url.search,
         origin: url.origin,
         method: request.method,
-        body: fetchParams.controller.dispatcher[kIsMockActive] ? request.body && request.body.source : body,
+        body: fetchParams.controller.dispatcher.isActive ? request.body && request.body.source : body,
         headers: [...request.headersList].flat(),
         maxRedirections: 0,
         bodyTimeout: 300_000,

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -96,6 +96,12 @@ class MockAgent extends Dispatcher {
     this[kNetConnect] = false
   }
 
+  // This is required to bypass issues caused by using global symbols - see:
+  // https://github.com/nodejs/undici/issues/1447
+  get isActive () {
+    return this[kIsMockActive]
+  }
+
   [kMockAgentSet] (origin, dispatcher) {
     this[kClients].set(origin, new FakeWeakRef(dispatcher))
   }

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -98,7 +98,7 @@ class MockAgent extends Dispatcher {
 
   // This is required to bypass issues caused by using global symbols - see:
   // https://github.com/nodejs/undici/issues/1447
-  get isActive () {
+  get isMockActive () {
     return this[kIsMockActive]
   }
 

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -301,7 +301,7 @@ function buildMockDispatch () {
   const originalDispatch = this[kOriginalDispatch]
 
   return function dispatch (opts, handler) {
-    if (agent.isActive) {
+    if (agent.isMockActive) {
       try {
         mockDispatch.call(this, opts, handler)
       } catch (error) {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -6,7 +6,6 @@ const {
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
-  kIsMockActive,
   kGetNetConnect
 } = require('./mock-symbols')
 
@@ -302,7 +301,7 @@ function buildMockDispatch () {
   const originalDispatch = this[kOriginalDispatch]
 
   return function dispatch (opts, handler) {
-    if (agent[kIsMockActive]) {
+    if (agent.isActive) {
       try {
         mockDispatch.call(this, opts, handler)
       } catch (error) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run test:tap && npm run test:node-fetch && npm run test:fetch && npm run test:jest && tsd",
     "test:node-fetch": "node scripts/verifyVersion.js 16 || mocha test/node-fetch",
-    "test:fetch": "node scripts/verifyVersion.js 16 || npm run build:node && tap test/fetch/*.js",
+    "test:fetch": "node scripts/verifyVersion.js 16 || (npm run build:node && tap test/fetch/*.js)",
     "test:jest": "jest",
     "test:tap": "tap test/*.js test/diagnostics-channel/*.js",
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run test:tap && npm run test:node-fetch && npm run test:fetch && npm run test:jest && tsd",
     "test:node-fetch": "node scripts/verifyVersion.js 16 || mocha test/node-fetch",
-    "test:fetch": "node scripts/verifyVersion.js 16 || tap test/fetch/*.js",
+    "test:fetch": "node scripts/verifyVersion.js 16 || npm run build:node && tap test/fetch/*.js",
     "test:jest": "jest",
     "test:tap": "tap test/*.js test/diagnostics-channel/*.js",
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",

--- a/test/fetch/issue-1447.js
+++ b/test/fetch/issue-1447.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test } = require('tap')
+
+const undici = require('../..')
+const { fetch: theoreticalGlobalFetch } = require('../../undici-fetch')
+
+test('Mocking works with both fetches', async (t) => {
+  const mockAgent = new undici.MockAgent()
+  const body = JSON.stringify({ foo: 'bar' })
+
+  mockAgent.disableNetConnect()
+  undici.setGlobalDispatcher(mockAgent)
+  const pool = mockAgent.get('https://example.com')
+
+  pool.intercept({
+    path: '/path',
+    method: 'POST',
+    body (bodyString) {
+      t.equal(bodyString, body)
+      return true
+    }
+  }).reply(200, { ok: 1 }).times(2)
+
+  const url = new URL('https://example.com/path').href
+
+  // undici fetch from node_modules
+  await undici.fetch(url, {
+    method: 'POST',
+    body
+  })
+
+  // the global fetch bundled with esbuild
+  await theoreticalGlobalFetch(url, {
+    method: 'POST',
+    body
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1447 

No tests but I could theoretically add them in (by calling `npm run node:build` and then using that file, but seems pretty hacky).

Verify the fix works:

test.mjs:
```js
import * as undici from './index.js' // 5.2.0
import { fetch } from './undici-fetch.js'

const mockAgent = new undici.MockAgent()
mockAgent.disableNetConnect()
undici.setGlobalDispatcher(mockAgent)
const pool = mockAgent.get('https://example.com')

pool.intercept({
  path: '/path',
  method: 'POST',
  body (body) {
    console.log(body)
    return true
  }
}).reply(200, { ok: 1 }).times(2)

const url = new URL('https://example.com/path').href

// undici fetch v5.2.0 from node_modules
await undici.fetch(url, {
  method: 'POST',
  body: JSON.stringify({ foo: 'bar' })
})

// undici fetch v5.2.0 from node 18.2.0 global
await fetch(url, {
  method: 'POST',
  body: JSON.stringify({ foo: 'bar' })
})
```

```
npm run build:node && node test.mjs
```

Output:
```
{"foo":"bar"}
{"foo":"bar"}
{"foo":"bar"}
```
The issue of the function being called 3 times is not an issue with this fix (see comment in the issue)

Everything is done in the repo's root directory.