### PR TITLE
fix: ensure Blob and File `type` are included in FormData

### DIFF
--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -243,8 +243,8 @@ function makeEntry (name, value, filename) {
   // object, representing the same bytes, whose name attribute value is "blob".
   if (isBlobLike(value) && !isFileLike(value)) {
     value = value instanceof Blob
-      ? new File([value], 'blob')
-      : new FileLike(value, 'blob')
+      ? new File([value], 'blob', value)
+      : new FileLike(value, 'blob', value)
   }
 
   // 4. If value is (now) a File object and filename is given, then set value to a
@@ -256,8 +256,8 @@ function makeEntry (name, value, filename) {
   // creating one more File instance doesn't make much sense....
   if (isFileLike(value) && filename != null) {
     value = value instanceof File
-      ? new File([value], filename)
-      : new FileLike(value, filename)
+      ? new File([value], filename, value)
+      : new FileLike(value, filename, value)
   }
 
   // 5. Set entry’s value to value.

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -83,13 +83,14 @@ test('arg validation', (t) => {
 
 test('append file', (t) => {
   const form = new FormData()
-  form.set('asd', new File([], 'asd1'), 'asd2')
+  form.set('asd', new File([], 'asd1', { type: 'text/plain' }), 'asd2')
   form.append('asd2', new File([], 'asd1'), 'asd2')
 
   t.equal(form.has('asd'), true)
   t.equal(form.has('asd2'), true)
   t.equal(form.get('asd').name, 'asd2')
   t.equal(form.get('asd2').name, 'asd2')
+  t.equal(form.get('asd').type, 'text/plain')
   form.delete('asd')
   t.equal(form.get('asd'), null)
   t.equal(form.has('asd2'), true)
@@ -100,9 +101,10 @@ test('append file', (t) => {
 
 test('append blob', async (t) => {
   const form = new FormData()
-  form.set('asd', new Blob(['asd1']))
+  form.set('asd', new Blob(['asd1'], { type: 'text/plain' }))
 
   t.equal(form.has('asd'), true)
+  t.equal(form.get('asd').type, 'text/plain')
   t.equal(await form.get('asd').text(), 'asd1')
   form.delete('asd')
   t.equal(form.get('asd'), null)
@@ -112,9 +114,10 @@ test('append blob', async (t) => {
 
 test('append third-party blob', async (t) => {
   const form = new FormData()
-  form.set('asd', new ThirdPartyBlob(['asd1']))
+  form.set('asd', new ThirdPartyBlob(['asd1'], { type: 'text/plain' }))
 
   t.equal(form.has('asd'), true)
+  t.equal(form.get('asd').type, 'text/plain')
   t.equal(await form.get('asd').text(), 'asd1')
   form.delete('asd')
   t.equal(form.get('asd'), null)


### PR DESCRIPTION
When appending a Blob-like or File-like object to FormData,
the item is wrapped in a `File` object. But this was causing
any options, such as `type` to be hidden in the wrapped type
and not exposed at the top level.

This fix copies the approach used in `formdata-polyfill` and
so also `node-fetch` where the wrapped object is also passed
as the `options` argument when creating a new `File` object.

Fixes https://github.com/cloudflare/wrangler2/issues/1085