### PR TITLE
feat: remove headers filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ const headers = await fetch(url)
 * https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name
 * https://fetch.spec.whatwg.org/#forbidden-header-name
 * https://fetch.spec.whatwg.org/#forbidden-response-header-name
+* https://github.com/wintercg/fetch/issues/6
 
 The [Fetch Standard](https://fetch.spec.whatwg.org) requires implementations to exclude certain headers from requests and responses. Undici does not filter out these headers.
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ const headers = await fetch(url)
 * https://fetch.spec.whatwg.org/#forbidden-response-header-name
 * https://github.com/wintercg/fetch/issues/6
 
-The [Fetch Standard](https://fetch.spec.whatwg.org) requires implementations to exclude certain headers from requests and responses. Undici does not filter out these headers.
+The [Fetch Standard](https://fetch.spec.whatwg.org) requires implementations to exclude certain headers from requests and responses. In browser environments, some headers are forbidden so the user agent remains in full control over them. In Undici, these constraints are removed to give more control to the user.
 
 ### `undici.upgrade([url, options]): Promise`
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ const headers = await fetch(url)
   .then(res => res.headers)
 ```
 
+##### Forbidden and Safelisted Header Names
+
+* https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name
+* https://fetch.spec.whatwg.org/#forbidden-header-name
+* https://fetch.spec.whatwg.org/#forbidden-response-header-name
+
+The [Fetch Standard](https://fetch.spec.whatwg.org) requires implementations to exclude certain headers from requests and responses. Undici does not filter out these headers.
+
 ### `undici.upgrade([url, options]): Promise`
 
 Upgrade to a different protocol. See [MDN - HTTP - Protocol upgrade mechanism](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) for more details.

--- a/lib/fetch/constants.js
+++ b/lib/fetch/constants.js
@@ -1,28 +1,5 @@
 'use strict'
 
-const forbiddenHeaderNames = [
-  'accept-charset',
-  'accept-encoding',
-  'access-control-request-headers',
-  'access-control-request-method',
-  'connection',
-  'content-length',
-  'cookie',
-  'cookie2',
-  'date',
-  'dnt',
-  'expect',
-  'host',
-  'keep-alive',
-  'origin',
-  'referer',
-  'te',
-  'trailer',
-  'transfer-encoding',
-  'upgrade',
-  'via'
-]
-
 const corsSafeListedMethods = ['GET', 'HEAD', 'POST']
 
 const nullBodyStatus = [101, 204, 205, 304]
@@ -58,9 +35,6 @@ const requestCache = [
   'only-if-cached'
 ]
 
-// https://fetch.spec.whatwg.org/#forbidden-response-header-name
-const forbiddenResponseHeaderNames = ['set-cookie', 'set-cookie2']
-
 const requestBodyHeader = [
   'content-encoding',
   'content-language',
@@ -86,12 +60,8 @@ const subresource = [
   ''
 ]
 
-const corsSafeListedResponseHeaderNames = [] // TODO
-
 module.exports = {
   subresource,
-  forbiddenResponseHeaderNames,
-  corsSafeListedResponseHeaderNames,
   forbiddenMethods,
   requestBodyHeader,
   referrerPolicy,
@@ -99,7 +69,6 @@ module.exports = {
   requestMode,
   requestCredentials,
   requestCache,
-  forbiddenHeaderNames,
   redirectStatus,
   corsSafeListedMethods,
   nullBodyStatus,

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -6,10 +6,6 @@ const { validateHeaderName, validateHeaderValue } = require('http')
 const { kHeadersList } = require('../core/symbols')
 const { kGuard } = require('./symbols')
 const { kEnumerableProperty } = require('../core/util')
-const {
-  forbiddenHeaderNames,
-  forbiddenResponseHeaderNames
-} = require('./constants')
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
@@ -211,21 +207,14 @@ class Headers {
       )
     }
 
-    const normalizedName = normalizeAndValidateHeaderName(String(name))
-
+    // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (
-      this[kGuard] === 'request' &&
-      forbiddenHeaderNames.includes(normalizedName)
-    ) {
+    } else if (this[kGuard] === 'request') {
       return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (
-      this[kGuard] === 'response' &&
-      forbiddenResponseHeaderNames.includes(normalizedName)
-    ) {
+    } else if (this[kGuard] === 'response') {
       return
     }
 
@@ -244,21 +233,14 @@ class Headers {
       )
     }
 
-    const normalizedName = normalizeAndValidateHeaderName(String(name))
-
+    // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (
-      this[kGuard] === 'request' &&
-      forbiddenHeaderNames.includes(normalizedName)
-    ) {
+    } else if (this[kGuard] === 'request') {
       return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (
-      this[kGuard] === 'response' &&
-      forbiddenResponseHeaderNames.includes(normalizedName)
-    ) {
+    } else if (this[kGuard] === 'response') {
       return
     }
 
@@ -307,19 +289,14 @@ class Headers {
       )
     }
 
+    // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (
-      this[kGuard] === 'request' &&
-      forbiddenHeaderNames.includes(String(name).toLocaleLowerCase())
-    ) {
+    } else if (this[kGuard] === 'request') {
       return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (
-      this[kGuard] === 'response' &&
-      forbiddenResponseHeaderNames.includes(String(name).toLocaleLowerCase())
-    ) {
+    } else if (this[kGuard] === 'response') {
       return
     }
 

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -111,6 +111,11 @@ class HeadersList {
     }
   }
 
+  clear () {
+    this[kHeadersMap].clear()
+    this[kHeadersSortedMap] = null
+  }
+
   append (name, value) {
     this[kHeadersSortedMap] = null
 
@@ -210,12 +215,8 @@ class Headers {
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (this[kGuard] === 'request') {
-      return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (this[kGuard] === 'response') {
-      return
     }
 
     return this[kHeadersList].append(String(name), String(value))
@@ -236,12 +237,8 @@ class Headers {
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (this[kGuard] === 'request') {
-      return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (this[kGuard] === 'response') {
-      return
     }
 
     return this[kHeadersList].delete(String(name))
@@ -292,12 +289,8 @@ class Headers {
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
-    } else if (this[kGuard] === 'request') {
-      return
     } else if (this[kGuard] === 'request-no-cors') {
       // TODO
-    } else if (this[kGuard] === 'response') {
-      return
     }
 
     return this[kHeadersList].set(String(name), String(value))

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -383,10 +383,10 @@ class Request {
     // 30. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is request’s header list and guard is
     // "request".
-    this[kHeaders] = new Headers(request.headersList)
+    this[kHeaders] = new Headers()
+    this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kGuard] = 'request'
     this[kHeaders][kRealm] = this[kRealm]
-    this[kState].headersList = this[kHeaders][kHeadersList]
 
     // 31. If this’s request’s mode is "no-cors", then:
     if (mode === 'no-cors') {
@@ -414,8 +414,7 @@ class Request {
       }
 
       // 3. Empty this’s headers’s header list.
-      this[kHeaders] = new Headers()
-      this[kState].headersList = this[kHeaders][kHeadersList]
+      this[kHeaders][kHeadersList].clear()
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -383,10 +383,10 @@ class Request {
     // 30. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is request’s header list and guard is
     // "request".
-    this[kHeaders] = new Headers()
+    this[kHeaders] = new Headers(request.headersList)
     this[kHeaders][kGuard] = 'request'
-    this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kRealm] = this[kRealm]
+    this[kState].headersList = this[kHeaders][kHeadersList]
 
     // 31. If this’s request’s mode is "no-cors", then:
     if (mode === 'no-cors') {
@@ -406,7 +406,7 @@ class Request {
     if (Object.keys(init).length !== 0) {
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
-      let headers = new Headers(this.headers)
+      let headers = new Headers(this[kHeaders])
 
       // 2. If init["headers"] exists, then set headers to init["headers"].
       if (init.headers !== undefined) {
@@ -414,18 +414,18 @@ class Request {
       }
 
       // 3. Empty this’s headers’s header list.
-      this[kState].headersList = new HeadersList()
-      this[kHeaders][kHeadersList] = this[kState].headersList
+      this[kHeaders] = new Headers()
+      this[kState].headersList = this[kHeaders][kHeadersList]
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers.constructor.name === 'Headers') {
-        for (const [key, val] of headers[kHeadersList] || headers) {
-          this[kState].headersList.append(key, val)
+        for (const [key, val] of headers) {
+          this[kHeaders].append(key, val)
         }
       } else {
         // 5. Otherwise, fill this’s headers with headers.
-        fillHeaders(this[kState].headersList, headers)
+        fillHeaders(this[kHeaders], headers)
       }
     }
 
@@ -461,7 +461,7 @@ class Request {
       // not contain `Content-Type`, then append `Content-Type`/Content-Type to
       // this’s headers.
       if (contentType && !this[kHeaders].has('content-type')) {
-        this[kState].headersList.append('content-type', contentType)
+        this[kHeaders].append('content-type', contentType)
       }
     }
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -421,7 +421,7 @@ class Request {
       // list, append header’s name/header’s value to this’s headers.
       if (headers.constructor.name === 'Headers') {
         for (const [key, val] of headers[kHeadersList] || headers) {
-          this[kHeaders].append(key, val)
+          this[kState].headersList.append(key, val)
         }
       } else {
         // 5. Otherwise, fill this’s headers with headers.
@@ -461,7 +461,7 @@ class Request {
       // not contain `Content-Type`, then append `Content-Type`/Content-Type to
       // this’s headers.
       if (contentType && !this[kHeaders].has('content-type')) {
-        this[kHeaders].append('content-type', contentType)
+        this[kState].headersList.append('content-type', contentType)
       }
     }
 

--- a/test/fetch/cookies.js
+++ b/test/fetch/cookies.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { once } = require('events')
+const { createServer } = require('http')
+const { test } = require('tap')
+const { fetch, Headers } = require('../..')
+
+test('Can receive set-cookie headers from a server using fetch - issue #1262', async (t) => {
+  const server = createServer((req, res) => {
+    res.setHeader('set-cookie', 'name=value; Domain=example.com')
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const response = await fetch(`http://localhost:${server.address().port}`)
+
+  t.equal(response.headers.get('set-cookie'), 'name=value; Domain=example.com')
+
+  const response2 = await fetch(`http://localhost:${server.address().port}`, {
+    credentials: 'include'
+  })
+
+  t.equal(response2.headers.get('set-cookie'), 'name=value; Domain=example.com')
+
+  t.end()
+})
+
+test('Can send cookies to a server with fetch - issue #1463', async (t) => {
+  const server = createServer((req, res) => {
+    t.equal(req.headers.cookie, 'value')
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const headersInit = [
+    new Headers([['cookie', 'value']]),
+    { cookie: 'value' },
+    [['cookie', 'value']]
+  ]
+
+  for (const headers of headersInit) {
+    await fetch(`http://localhost:${server.address().port}`, { headers })
+  }
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1463 
Fixes #1262 

@ronag's checklist [here](https://github.com/nodejs/undici/issues/1262#issuecomment-1132013882) should be completed:

1. "A WinterCG issue" - https://github.com/wintercg/fetch/issues/6
2. "It's clear in the code that all related logic is outside of spec and a reference motivating it." - Areas of the code where the spec mentioned "filtered" or "safelisted" headers has been commented.
3. "Clearly added to the README."
4. "Investigate what exactly deno, node-fetch and cloudflare does so that we don't introduce another variant with slight differences." - 

- Cloudflare has a [`Headers.prototype.getAll`](https://developers.cloudflare.com/workers/runtime-apis/headers#differences) method (deprecated & removed from the spec) that only works with `set-cookie` headers.
- Deno [doesn't do this filtering at all](https://deno.land/manual/runtime/web_platform_apis#spec-deviations) (confirmed on my end, a Deno maintainer also mentions this in the wintercg issue).
- node-fetch has a [`Headers.prototype.raw`](https://github.com/node-fetch/node-fetch#extract-set-cookie-header) method that returns the raw headers.

Clearly, following Deno is the best idea and closest to the spec itself. We aren't adding anything in, but simply removing constraints that don't apply to a server environment.