### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
+          persist-credentials: false
           ref: ${{ github.base_ref }}
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -27,6 +28,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*


### PR DESCRIPTION
See option description at https://github.com/actions/checkout#usage.
The repo does not use git in any `run` commands after checking out the repo in any of the workflow jobs.
This just removes the git credentials for security sake; should any used actions become compromised then at least they won't be exposed.
