### PR TITLE
ci: skip automerge job if user is not dependabot

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,9 @@ jobs:
         - name: Coverage Report
           uses: codecov/codecov-action@v2
   automerge:
+    if: >
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This stops the job from running if the user is not Dependabot, saving a few seconds CI run time.