### PR TITLE
fix(tests): broken `node-fetch` tests

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -9,7 +9,7 @@ const { kBodyUsed } = require('../core/symbols')
 const assert = require('assert')
 const { NotSupportedError } = require('../core/errors')
 const { isErrored } = require('../core/util')
-const { isUint8Array } = require('util/types')
+const { isUint8Array, isArrayBuffer } = require('util/types')
 
 let ReadableStream
 
@@ -61,7 +61,7 @@ function extractBody (object, keepalive = false) {
 
     // Set Content-Type to `application/x-www-form-urlencoded;charset=UTF-8`.
     contentType = 'application/x-www-form-urlencoded;charset=UTF-8'
-  } else if (object instanceof ArrayBuffer || ArrayBuffer.isView(object)) {
+  } else if (isArrayBuffer(object) || ArrayBuffer.isView(object)) {
     // BufferSource
 
     if (object instanceof DataView) {


### PR DESCRIPTION
With 48c03b62fa9c7e69444fba4a936a7a5e5c88e144, a test from the `node-fetch` suite has started to fail.

```mjs
import vm from 'vm'
import { types } from 'util'

const {
  Uint8Array: VMUint8Array
} = vm.runInNewContext('this')

const ab = new VMUint8Array([0, 1, 2]).buffer

ab instanceof ArrayBuffer // false
types.isArrayBuffer(ab) // true
```

https://github.com/nodejs/undici/blob/966a54ff80993573d1baab5999ce258ccc0e7ec9/test/node-fetch/main.js#L36-L38
https://github.com/nodejs/undici/blob/966a54ff80993573d1baab5999ce258ccc0e7ec9/test/node-fetch/main.js#L1004

Not entirely sure how the ci passed 🤷, the precommit hook caught it for me. I assume this is a *really* niche case that possibly shouldn't work, but I think that can be left up to another time...