### PR TITLE
test: add rejectUnauthorized for agent1 cert

### DIFF
--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -374,7 +374,8 @@ test('Proxy via HTTPS to HTTPS endpoint', async (t) => {
       ],
       key: readFileSync(join(__dirname, 'fixtures', 'client-key-2048.pem'), 'utf8'),
       cert: readFileSync(join(__dirname, 'fixtures', 'client-crt-2048.pem'), 'utf8'),
-      servername: 'agent1'
+      servername: 'agent1',
+      rejectUnauthorized: false
     },
     requestTls: {
       ca: [
@@ -434,7 +435,8 @@ test('Proxy via HTTPS to HTTP endpoint', async (t) => {
       ],
       key: readFileSync(join(__dirname, 'fixtures', 'client-key-2048.pem'), 'utf8'),
       cert: readFileSync(join(__dirname, 'fixtures', 'client-crt-2048.pem'), 'utf8'),
-      servername: 'agent1'
+      servername: 'agent1',
+      rejectUnauthorized: false
     }
   })
 


### PR DESCRIPTION
It will fix the main CI. However, it's not the best approach.

I'll be working to adjust the certificates for `servername`. FYI: this is happening because the host order has been changed.