### PR TITLE
fix(types): import `URL`

### DIFF
--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -1,4 +1,5 @@
 import { Socket } from "net";
+import { URL } from "url";
 import { connector } from "./connector";
 import { HttpMethod } from "./dispatcher";
 


### PR DESCRIPTION
For various reasons, we are stuck on a slightly older `@types/node` which [doesn't have the global `URL` declaration](https://www.runpkg.com/?@types/node@16.11.21/url.d.ts). Importing it explicitly fixes that, without any negative side-effects