### PR TITLE
feat: implement (basic) webidl & headers comments

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -2,37 +2,35 @@
 
 'use strict'
 
-const { validateHeaderName, validateHeaderValue } = require('http')
 const { kHeadersList } = require('../core/symbols')
 const { kGuard } = require('./symbols')
 const { kEnumerableProperty } = require('../core/util')
-const { makeIterator } = require('./util')
+const {
+  makeIterator,
+  isValidHeaderName,
+  isValidHeaderValue
+} = require('./util')
+const { webidl } = require('./webidl')
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
 
-function normalizeAndValidateHeaderName (name) {
-  if (name === undefined) {
-    throw new TypeError(`Header name ${name}`)
-  }
-  const normalizedHeaderName = name.toLocaleLowerCase()
-  validateHeaderName(normalizedHeaderName)
-  return normalizedHeaderName
-}
-
-function normalizeAndValidateHeaderValue (name, value) {
-  if (value === undefined) {
-    throw new TypeError(value, name)
-  }
-  const normalizedHeaderValue = `${value}`.replace(
-    /^[\n\t\r\x20]+|[\n\t\r\x20]+$/g,
+/**
+ * @see https://fetch.spec.whatwg.org/#concept-header-value-normalize
+ * @param {string} potentialValue
+ */
+function headerValueNormalize (potentialValue) {
+  //  To normalize a byte sequence potentialValue, remove
+  //  any leading and trailing HTTP whitespace bytes from
+  //  potentialValue.
+  return potentialValue.replace(
+    /^[\r\n\t ]+|[\r\n\t ]+$/g,
     ''
   )
-  validateHeaderValue(name, normalizedHeaderValue)
-  return normalizedHeaderValue
 }
 
 function fill (headers, object) {
+  // TODO: use idl converters once implemented
   // To fill a Headers object headers with a given object object, run these steps:
 
   if (object[Symbol.iterator]) {
@@ -85,48 +83,75 @@ class HeadersList {
     }
   }
 
+  // https://fetch.spec.whatwg.org/#header-list-contains
+  contains (name) {
+    // A header list list contains a header name name if list
+    // contains a header whose name is a byte-case-insensitive
+    // match for name.
+    name = name.toLowerCase()
+
+    return this[kHeadersMap].has(name)
+  }
+
   clear () {
     this[kHeadersMap].clear()
     this[kHeadersSortedMap] = null
   }
 
+  // https://fetch.spec.whatwg.org/#concept-header-list-append
   append (name, value) {
     this[kHeadersSortedMap] = null
 
-    const normalizedName = normalizeAndValidateHeaderName(name)
-    const normalizedValue = normalizeAndValidateHeaderValue(name, value)
+    // 1. If list contains name, then set name to the first such
+    //    header’s name.
+    name = name.toLowerCase()
+    const exists = this[kHeadersMap].get(name)
 
-    const exists = this[kHeadersMap].get(normalizedName)
-
+    // 2. Append (name, value) to list.
     if (exists) {
-      this[kHeadersMap].set(normalizedName, `${exists}, ${normalizedValue}`)
+      this[kHeadersMap].set(name, `${exists}, ${value}`)
     } else {
-      this[kHeadersMap].set(normalizedName, `${normalizedValue}`)
+      this[kHeadersMap].set(name, `${value}`)
     }
   }
 
+  // https://fetch.spec.whatwg.org/#concept-header-list-set
   set (name, value) {
     this[kHeadersSortedMap] = null
 
-    const normalizedName = normalizeAndValidateHeaderName(name)
-    return this[kHeadersMap].set(normalizedName, value)
+    // 1. If list contains name, then set the value of
+    //    the first such header to value and remove the
+    //    others.
+    // 2. Otherwise, append header (name, value) to list.
+    return this[kHeadersMap].set(name, value)
   }
 
+  // https://fetch.spec.whatwg.org/#concept-header-list-delete
   delete (name) {
     this[kHeadersSortedMap] = null
 
-    const normalizedName = normalizeAndValidateHeaderName(name)
-    return this[kHeadersMap].delete(normalizedName)
+    name = name.toLowerCase()
+    return this[kHeadersMap].delete(name)
   }
 
+  // https://fetch.spec.whatwg.org/#concept-header-list-get
   get (name) {
-    const normalizedName = normalizeAndValidateHeaderName(name)
-    return this[kHeadersMap].get(normalizedName) ?? null
+    name = name.toLowerCase()
+
+    // 1. If list does not contain name, then return null.
+    if (!this.contains(name)) {
+      return null
+    }
+
+    // 2. Return the values of all headers in list whose name
+    //    is a byte-case-insensitive match for name,
+    //    separated from each other by 0x2C 0x20, in order.
+    return this[kHeadersMap].get(name) ?? null
   }
 
   has (name) {
-    const normalizedName = normalizeAndValidateHeaderName(name)
-    return this[kHeadersMap].has(normalizedName)
+    name = name.toLowerCase()
+    return this[kHeadersMap].has(name)
   }
 
   keys () {
@@ -186,14 +211,36 @@ class Headers {
       )
     }
 
+    name = webidl.converters.ByteString(name)
+    value = webidl.converters.ByteString(value)
+
+    // 1. Normalize value.
+    value = headerValueNormalize(value)
+
+    // 2. If name is not a header name or value is not a
+    //    header value, then throw a TypeError.
+    if (!isValidHeaderName(name) || !isValidHeaderValue(value)) {
+      throw new TypeError()
+    }
+
+    // 3. If headers’s guard is "immutable", then throw a TypeError.
+    // 4. Otherwise, if headers’s guard is "request" and name is a
+    //    forbidden header name, return.
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
     } else if (this[kGuard] === 'request-no-cors') {
+      // 5. Otherwise, if headers’s guard is "request-no-cors":
       // TODO
     }
 
-    return this[kHeadersList].append(String(name), String(value))
+    // 6. Otherwise, if headers’s guard is "response" and name is a
+    //    forbidden response-header name, return.
+
+    // 7. Append (name, value) to headers’s header list.
+    // 8. If headers’s guard is "request-no-cors", then remove
+    //    privileged no-CORS request headers from headers
+    return this[kHeadersList].append(name, value)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-delete
@@ -208,6 +255,22 @@ class Headers {
       )
     }
 
+    name = webidl.converters.ByteString(name)
+
+    // 1. If name is not a header name, then throw a TypeError.
+    if (!isValidHeaderName(name)) {
+      throw new TypeError()
+    }
+
+    // 2. If this’s guard is "immutable", then throw a TypeError.
+    // 3. Otherwise, if this’s guard is "request" and name is a
+    //    forbidden header name, return.
+    // 4. Otherwise, if this’s guard is "request-no-cors", name
+    //    is not a no-CORS-safelisted request-header name, and
+    //    name is not a privileged no-CORS request-header name,
+    //    return.
+    // 5. Otherwise, if this’s guard is "response" and name is
+    //    a forbidden response-header name, return.
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
@@ -215,7 +278,16 @@ class Headers {
       // TODO
     }
 
-    return this[kHeadersList].delete(String(name))
+    // 6. If this’s header list does not contain name, then
+    //    return.
+    if (!this[kHeadersList].contains(name)) {
+      return
+    }
+
+    // 7. Delete name from this’s header list.
+    // 8. If this’s guard is "request-no-cors", then remove
+    //    privileged no-CORS request headers from this.
+    return this[kHeadersList].delete(name)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-get
@@ -230,7 +302,16 @@ class Headers {
       )
     }
 
-    return this[kHeadersList].get(String(name))
+    name = webidl.converters.ByteString(name)
+
+    // 1. If name is not a header name, then throw a TypeError.
+    if (!isValidHeaderName(name)) {
+      throw new TypeError()
+    }
+
+    // 2. Return the result of getting name from this’s header
+    //    list.
+    return this[kHeadersList].get(name)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-has
@@ -245,7 +326,16 @@ class Headers {
       )
     }
 
-    return this[kHeadersList].has(String(name))
+    name = webidl.converters.ByteString(name)
+
+    // 1. If name is not a header name, then throw a TypeError.
+    if (!isValidHeaderName(name)) {
+      throw new TypeError()
+    }
+
+    // 2. Return true if this’s header list contains name;
+    //    otherwise false.
+    return this[kHeadersList].contains(name)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-set
@@ -260,6 +350,26 @@ class Headers {
       )
     }
 
+    name = webidl.converters.ByteString(name)
+    value = webidl.converters.ByteString(value)
+
+    // 1. Normalize value.
+    value = headerValueNormalize(value)
+
+    // 2. If name is not a header name or value is not a
+    //    header value, then throw a TypeError.
+    if (!isValidHeaderName(name) || !isValidHeaderValue(value)) {
+      throw new TypeError()
+    }
+
+    // 3. If this’s guard is "immutable", then throw a TypeError.
+    // 4. Otherwise, if this’s guard is "request" and name is a
+    //    forbidden header name, return.
+    // 5. Otherwise, if this’s guard is "request-no-cors" and
+    //    name/value is not a no-CORS-safelisted request-header,
+    //    return.
+    // 6. Otherwise, if this’s guard is "response" and name is a
+    //    forbidden response-header name, return.
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
       throw new TypeError('immutable')
@@ -267,7 +377,10 @@ class Headers {
       // TODO
     }
 
-    return this[kHeadersList].set(String(name), String(value))
+    // 7. Set (name, value) in this’s header list.
+    // 8. If this’s guard is "request-no-cors", then remove
+    //    privileged no-CORS request headers from this
+    return this[kHeadersList].set(name, value)
   }
 
   get [kHeadersSortedMap] () {
@@ -351,7 +464,5 @@ Object.defineProperties(Headers.prototype, {
 module.exports = {
   fill,
   Headers,
-  HeadersList,
-  normalizeAndValidateHeaderName,
-  normalizeAndValidateHeaderValue
+  HeadersList
 }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -145,6 +145,49 @@ function isValidHTTPToken (characters) {
   return true
 }
 
+// https://fetch.spec.whatwg.org/#header-name
+// https://github.com/chromium/chromium/blob/b3d37e6f94f87d59e44662d6078f6a12de845d17/net/http/http_util.cc#L342
+function isValidHeaderName (potentialValue) {
+  if (potentialValue.length === 0) {
+    return false
+  }
+
+  for (const char of potentialValue) {
+    if (!isValidHTTPToken(char)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * @see https://fetch.spec.whatwg.org/#header-value
+ * @param {string} potentialValue
+ */
+function isValidHeaderValue (potentialValue) {
+  // - Has no leading or trailing HTTP tab or space bytes.
+  // - Contains no 0x00 (NUL) or HTTP newline bytes.
+  if (
+    potentialValue.startsWith('\t') ||
+    potentialValue.startsWith(' ') ||
+    potentialValue.endsWith('\t') ||
+    potentialValue.endsWith(' ')
+  ) {
+    return false
+  }
+
+  if (
+    potentialValue.includes('\0') ||
+    potentialValue.includes('\r') ||
+    potentialValue.includes('\n')
+  ) {
+    return false
+  }
+
+  return true
+}
+
 // https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect
 function setRequestReferrerPolicyOnRedirect (request, actualResponse) {
   //  Given a request request and a response actualResponse, this algorithm
@@ -418,5 +461,7 @@ module.exports = {
   sameOrigin,
   normalizeMethod,
   serializeJavascriptValueToJSONString,
-  makeIterator
+  makeIterator,
+  isValidHeaderName,
+  isValidHeaderValue
 }

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -1,0 +1,54 @@
+const { toUSVString } = require('util')
+
+const webidl = {}
+webidl.converters = {}
+
+// https://webidl.spec.whatwg.org/#es-DOMString
+webidl.converters.DOMString = function DOMString (V, opts = {}) {
+  // 1. If V is null and the conversion is to an IDL type
+  //    associated with the [LegacyNullToEmptyString]
+  //    extended attribute, then return the DOMString value
+  //    that represents the empty string.
+  if (V === null && opts.legacyNullToEmptyString) {
+    return ''
+  }
+
+  // 2. Let x be ? ToString(V).
+  if (typeof V === 'symbol') {
+    throw new TypeError('Could not convert argument of type symbol to string.')
+  }
+
+  // 3. Return the IDL DOMString value that represents the
+  //    same sequence of code units as the one the
+  //    ECMAScript String value x represents.
+  return String(V)
+}
+
+// eslint-disable-next-line no-control-regex
+const isNotLatin1 = /[^\u0000-\u00ff]/
+
+// https://webidl.spec.whatwg.org/#es-ByteString
+webidl.converters.ByteString = function ByteString (V) {
+  // 1. Let x be ? ToString(V).
+  // Note: DOMString converter perform ? ToString(V)
+  const x = webidl.converters.DOMString(V)
+
+  // 2. If the value of any element of x is greater than
+  //    255, then throw a TypeError.
+  if (isNotLatin1.test(x)) {
+    throw new TypeError('Argument is not a ByteString')
+  }
+
+  // 3. Return an IDL ByteString value whose length is the
+  //    length of x, and where the value of each element is
+  //    the value of the corresponding element of x.
+  return x
+}
+
+// https://webidl.spec.whatwg.org/#es-USVString
+// TODO: ensure that util.toUSVString follows webidl spec
+webidl.converters.USVString = toUSVString
+
+module.exports = {
+  webidl
+}

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -1,12 +1,7 @@
 'use strict'
 
 const tap = require('tap')
-const {
-  Headers,
-  normalizeAndValidateHeaderName,
-  normalizeAndValidateHeaderValue,
-  fill
-} = require('../../lib/fetch/headers')
+const { Headers, fill } = require('../../lib/fetch/headers')
 const { kGuard } = require('../../lib/fetch/symbols')
 
 tap.test('Headers initialization', t => {
@@ -69,7 +64,7 @@ tap.test('Headers initialization', t => {
   })
 
   t.test('allows a myriad of header values to be passed', t => {
-    t.plan(5)
+    t.plan(4)
 
     // Headers constructor uses Headers.append
 
@@ -80,9 +75,6 @@ tap.test('Headers initialization', t => {
     t.doesNotThrow(() => new Headers([
       ['key', null]
     ]), 'allows null values')
-    t.doesNotThrow(() => new Headers([
-      ['key', Symbol('undici-fetch')]
-    ]), 'allows Symbol values')
     t.throws(() => new Headers([
       ['key']
     ]), 'throws when 2 arguments are not passed')
@@ -263,14 +255,13 @@ tap.test('Headers set', t => {
   })
 
   t.test('allows setting a myriad of values', t => {
-    t.plan(5)
+    t.plan(4)
     const headers = new Headers()
 
     t.doesNotThrow(() => headers.set('a', ['b', 'c']), 'sets array values properly')
     t.doesNotThrow(() => headers.set('b', null), 'allows setting null values')
     t.throws(() => headers.set('c'), 'throws when 2 arguments are not passed')
     t.doesNotThrow(() => headers.set('c', 'd', 'e'), 'ignores extra arguments')
-    t.doesNotThrow(() => headers.set('f', Symbol('g'), 'allows Symbol value'))
   })
 
   t.test('throws on invalid entry', t => {
@@ -488,16 +479,6 @@ tap.test('Headers as Iterable', t => {
 })
 
 tap.test('arg validation', (t) => {
-  // normalizeAndValidateHeaderName
-  t.throws(() => {
-    normalizeAndValidateHeaderName()
-  }, TypeError)
-
-  // normalizeAndValidateHeaderValue
-  t.throws(() => {
-    normalizeAndValidateHeaderValue()
-  }, TypeError)
-
   // fill
   t.throws(() => {
     fill({}, 0)

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -636,3 +636,35 @@ tap.test('request-no-cors guard', (t) => {
   t.doesNotThrow(() => { headers.delete('key') })
   t.end()
 })
+
+tap.test('invalid headers', (t) => {
+  for (const byte of ['\r', '\n', '\t', ' ', String.fromCharCode(128), '']) {
+    t.throws(() => {
+      new Headers().set(byte, 'test')
+    }, TypeError, 'invalid header name')
+  }
+
+  for (const byte of [
+    '\0',
+    '\r',
+    '\n'
+  ]) {
+    t.throws(() => {
+      new Headers().set('a', `a${byte}b`)
+    }, TypeError, 'not allowed at all in header value')
+  }
+
+  t.doesNotThrow(() => {
+    new Headers().set('a', '\r')
+  })
+
+  t.doesNotThrow(() => {
+    new Headers().set('a', '\n')
+  })
+
+  t.throws(() => {
+    new Headers().set('a', Symbol('symbol'))
+  }, TypeError, 'symbols should throw')
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #933 

WebIdl is pretty cool and it's used rather heavily in the fetch spec. Implementing a subset of it (that we need) will make everything much easier once it's finished. I can explain how it'll help if you want, just don't want to write out an essay if you don't care lol

I only did the `Headers` class as a PoC and in the process discovered a *load* of bugs and decided just to add the spec comments since I was already adding a ton to it and fixing stuff anyways 😄.

p.s.: it's very clear that `HeadersList` was not supposed to be Map-like structure, as each key can be duplicated and the actual appending doesn't occur until you use `.get(...)`. Not a big deal, just something I noticed when working on it.