### PR TITLE
fix(proxy-agent): include host port in the path

### DIFF
--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -14,6 +14,10 @@ const kRequestTls = Symbol('request tls settings')
 const kProxyTls = Symbol('proxy tls settings')
 const kConnectEndpoint = Symbol('connect endpoint function')
 
+function defaultProtocolPort (protocol) {
+  return protocol === 'https:' ? 443 : 80
+}
+
 class ProxyAgent extends DispatcherBase {
   constructor (opts) {
     super(opts)
@@ -42,11 +46,15 @@ class ProxyAgent extends DispatcherBase {
     this[kAgent] = new Agent({
       ...opts,
       connect: async (opts, callback) => {
+        let requestedHost = opts.host
+        if (!opts.port) {
+          requestedHost += `:${defaultProtocolPort(opts.protocol)}`
+        }
         try {
           const { socket, statusCode } = await this[kClient].connect({
             origin,
             port,
-            path: opts.host,
+            path: requestedHost,
             signal: opts.signal,
             headers: {
               ...this[kProxyHeaders],


### PR DESCRIPTION
fixes: #1496 

I've tried to include a test, but this happens when the requested URL doesn't contain the port. Usually, external requests, so adding that might lead our tests to flaky in some moment.