### PR TITLE
feat(File): proper webidl checks

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -1,19 +1,28 @@
 'use strict'
 
 const { Blob } = require('buffer')
+const { types } = require('util')
 const { kState } = require('./symbols')
+const { isBlobLike } = require('./util')
+const { webidl } = require('./webidl')
+const { collectASequenceOfCodePoints } = require('./dataURL')
 
 class File extends Blob {
   constructor (fileBits, fileName, options = {}) {
-    // TODO: argument idl type check
-
     // The File constructor is invoked with two or three parameters, depending
     // on whether the optional dictionary parameter is used. When the File()
     // constructor is invoked, user agents must run the following steps:
+    if (arguments.length < 2) {
+      throw new TypeError('2 arguments required')
+    }
+
+    fileBits = webidl.converters['sequence<BlobPart>'](fileBits)
+    fileName = webidl.converters.USVString(fileName)
+    options = webidl.converters.FilePropertyBag(options)
 
     // 1. Let bytes be the result of processing blob parts given fileBits and
     // options.
-    // TODO
+    // Note: Blob handles this for us
 
     // 2. Let n be the fileName argument to the constructor.
     const n = fileName
@@ -25,17 +34,14 @@ class File extends Blob {
     //    be set to the type dictionary member. If t contains any characters
     //    outside the range U+0020 to U+007E, then set t to the empty string
     //    and return from these substeps.
-    //    TODO
-    const t = options.type
-
     //    2. Convert every character in t to ASCII lowercase.
-    //    TODO
+    // Note: Blob handles both of these steps for us
 
     //    3. If the lastModified member is provided, let d be set to the
     //    lastModified dictionary member. If it is not provided, set d to the
     //    current date and time represented as the number of milliseconds since
     //    the Unix Epoch (which is the equivalent of Date.now() [ECMA-262]).
-    const d = options.lastModified ?? Date.now()
+    const d = options.lastModified
 
     // 4. Return a new File object F such that:
     // F refers to the bytes byte sequence.
@@ -43,9 +49,8 @@ class File extends Blob {
     // F.name is set to n.
     // F.type is set to t.
     // F.lastModified is set to d.
-    // TODO
 
-    super(fileBits, { type: t })
+    super(processBlobParts(fileBits, options), { type: options.type })
     this[kState] = {
       name: n,
       lastModified: d
@@ -190,4 +195,177 @@ class FileLike {
   }
 }
 
-module.exports = { File: globalThis.File ?? File, FileLike }
+webidl.converters.Blob = webidl.interfaceConverter(Blob)
+
+webidl.converters.BlobPart = function (V, opts) {
+  if (webidl.util.Type(V) === 'Object') {
+    if (isBlobLike(V)) {
+      return webidl.converters.Blob(V)
+    }
+
+    return webidl.converters.BufferSource(V, opts)
+  } else {
+    return webidl.converters.USVString(V, opts)
+  }
+}
+
+webidl.converters['sequence<BlobPart>'] = webidl.sequenceConverter(
+  webidl.converters.BlobPart
+)
+
+// https://www.w3.org/TR/FileAPI/#dfn-FilePropertyBag
+webidl.converters.FilePropertyBag = webidl.dictionaryConverter([
+  {
+    key: 'lastModified',
+    converter: webidl.converters['long long'],
+    get defaultValue () {
+      return Date.now()
+    }
+  },
+  {
+    key: 'type',
+    converter: webidl.converters.DOMString,
+    defaultValue: ''
+  },
+  {
+    key: 'endings',
+    converter: (value) => {
+      value = webidl.converters.DOMString(value)
+      value = value.toLowerCase()
+
+      if (value !== 'endings') {
+        value = 'transparent'
+      }
+
+      return value
+    },
+    defaultValue: 'transparent'
+  }
+])
+
+/**
+ * @see https://www.w3.org/TR/FileAPI/#process-blob-parts
+ * @param {(NodeJS.TypedArray|Blob|string)[]} parts
+ * @param {{ type: string, endings: string }} options
+ */
+function processBlobParts (parts, options = { type: '', endings: 'transparent' }) {
+  // 1. Let bytes be an empty sequence of bytes.
+  /** @type {NodeJS.TypedArray[]} */
+  const bytes = []
+
+  // 2. For each element in parts:
+  for (const element of parts) {
+    // 1. If element is a USVString, run the following substeps:
+    if (typeof element === 'string') {
+      // 1. Let s be element.
+      let s = element
+
+      // 2. If the endings member of options is "native", set s
+      //    to the result of converting line endings to native
+      //    of element.
+      if (options.endings === 'native') {
+        s = convertLineEndingsNative(s)
+      }
+
+      // 3. Append the result of UTF-8 encoding s to bytes.
+      bytes.push(new TextEncoder().encode(s))
+    } else if (
+      types.isAnyArrayBuffer(element) ||
+      types.isTypedArray(element)
+    ) {
+      // 2. If element is a BufferSource, get a copy of the
+      //    bytes held by the buffer source, and append those
+      //    bytes to bytes.
+      bytes.push(element.buffer)
+    } else if (isBlobLike(element)) {
+      // 3. If element is a Blob, append the bytes it represents
+      //    to bytes.
+      bytes.push(element)
+    }
+  }
+
+  // 3. Return bytes.
+  return bytes
+}
+
+/**
+ * @see https://www.w3.org/TR/FileAPI/#convert-line-endings-to-native
+ * @param {string} s
+ */
+function convertLineEndingsNative (s) {
+  // 1. Let native line ending be be the code point U+000A LF.
+  let nativeLineEnding = '\n'
+
+  // 2. If the underlying platform’s conventions are to
+  //    represent newlines as a carriage return and line feed
+  //    sequence, set native line ending to the code point
+  //    U+000D CR followed by the code point U+000A LF.
+  if (process.platform === 'win32') {
+    nativeLineEnding = '\r\n'
+  }
+
+  // 3. Set result to the empty string.
+  let result = ''
+
+  // 4. Let position be a position variable for s, initially
+  //    pointing at the start of s.
+  const position = { position: 0 }
+
+  // 5. Let token be the result of collecting a sequence of
+  //    code points that are not equal to U+000A LF or
+  //    U+000D CR from s given position.
+  const token = collectASequenceOfCodePoints(
+    (char) => char !== '\r' && char !== '\n',
+    s,
+    position
+  )
+
+  // 6. Append token to result.
+  result += token
+
+  // 7. While position is not past the end of s:
+  while (position.position < s.length - 1) {
+    // 1. If the code point at position within s equals U+000D CR:
+    if (s[position.position] === '\r') {
+      // 1. Append native line ending to result.
+      result += nativeLineEnding
+
+      // 2. Advance position by 1.
+      position.position += 1
+
+      // 3. If position is not past the end of s and the code
+      //    point at position within s equals U+000A LF advance
+      //    position by 1.
+      if (
+        position.position < s.length - 1 &&
+        s[position.position] === '\n'
+      ) {
+        position.position += 1
+      } else if (s[position.position] === '\r') {
+        // 2. Otherwise if the code point at position within s
+        //    equals U+000A LF, advance position by 1 and append
+        //    native line ending to result.
+        position.position += 1
+
+        result += nativeLineEnding
+      }
+
+      // 3. Let token be the result of collecting a sequence of
+      //    code points that are not equal to U+000A LF or
+      //    U+000D CR from s given position.
+      const token = collectASequenceOfCodePoints(
+        (char) => char !== '\r' && char !== '\n',
+        s,
+        position
+      )
+
+      // 4. Append token to result.
+      result += token
+    }
+  }
+
+  // 8. Return result.
+  return result
+}
+
+module.exports = { File, FileLike }

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -5,7 +5,6 @@ const { types } = require('util')
 const { kState } = require('./symbols')
 const { isBlobLike } = require('./util')
 const { webidl } = require('./webidl')
-const { collectASequenceOfCodePoints } = require('./dataURL')
 
 class File extends Blob {
   constructor (fileBits, fileName, options = {}) {
@@ -233,7 +232,7 @@ webidl.converters.FilePropertyBag = webidl.dictionaryConverter([
       value = webidl.converters.DOMString(value)
       value = value.toLowerCase()
 
-      if (value !== 'endings') {
+      if (value !== 'native') {
         value = 'transparent'
       }
 
@@ -248,7 +247,7 @@ webidl.converters.FilePropertyBag = webidl.dictionaryConverter([
  * @param {(NodeJS.TypedArray|Blob|string)[]} parts
  * @param {{ type: string, endings: string }} options
  */
-function processBlobParts (parts, options = { type: '', endings: 'transparent' }) {
+function processBlobParts (parts, options) {
   // 1. Let bytes be an empty sequence of bytes.
   /** @type {NodeJS.TypedArray[]} */
   const bytes = []
@@ -276,7 +275,11 @@ function processBlobParts (parts, options = { type: '', endings: 'transparent' }
       // 2. If element is a BufferSource, get a copy of the
       //    bytes held by the buffer source, and append those
       //    bytes to bytes.
-      bytes.push(element.buffer)
+      if (!element.buffer) { // ArrayBuffer
+        bytes.push(new Uint8Array(element))
+      } else {
+        bytes.push(element.buffer)
+      }
     } else if (isBlobLike(element)) {
       // 3. If element is a Blob, append the bytes it represents
       //    to bytes.
@@ -304,68 +307,7 @@ function convertLineEndingsNative (s) {
     nativeLineEnding = '\r\n'
   }
 
-  // 3. Set result to the empty string.
-  let result = ''
-
-  // 4. Let position be a position variable for s, initially
-  //    pointing at the start of s.
-  const position = { position: 0 }
-
-  // 5. Let token be the result of collecting a sequence of
-  //    code points that are not equal to U+000A LF or
-  //    U+000D CR from s given position.
-  const token = collectASequenceOfCodePoints(
-    (char) => char !== '\r' && char !== '\n',
-    s,
-    position
-  )
-
-  // 6. Append token to result.
-  result += token
-
-  // 7. While position is not past the end of s:
-  while (position.position < s.length - 1) {
-    // 1. If the code point at position within s equals U+000D CR:
-    if (s[position.position] === '\r') {
-      // 1. Append native line ending to result.
-      result += nativeLineEnding
-
-      // 2. Advance position by 1.
-      position.position += 1
-
-      // 3. If position is not past the end of s and the code
-      //    point at position within s equals U+000A LF advance
-      //    position by 1.
-      if (
-        position.position < s.length - 1 &&
-        s[position.position] === '\n'
-      ) {
-        position.position += 1
-      } else if (s[position.position] === '\r') {
-        // 2. Otherwise if the code point at position within s
-        //    equals U+000A LF, advance position by 1 and append
-        //    native line ending to result.
-        position.position += 1
-
-        result += nativeLineEnding
-      }
-
-      // 3. Let token be the result of collecting a sequence of
-      //    code points that are not equal to U+000A LF or
-      //    U+000D CR from s given position.
-      const token = collectASequenceOfCodePoints(
-        (char) => char !== '\r' && char !== '\n',
-        s,
-        position
-      )
-
-      // 4. Append token to result.
-      result += token
-    }
-  }
-
-  // 8. Return result.
-  return result
+  return s.replace(/\r?\n/g, nativeLineEnding)
 }
 
 module.exports = { File, FileLike }

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -110,10 +110,6 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, opts = {}) {
       x = Math.ceil(x)
     }
 
-    if (Object.is(-0, x)) {
-      x = 0
-    }
-
     // 3. Return x.
     return x
   }

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -1,12 +1,225 @@
 'use strict'
 
-const { toUSVString } = require('util')
+const { toUSVString, types } = require('util')
 
 const webidl = {}
 webidl.converters = {}
+webidl.util = {}
+
+// https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values
+webidl.util.Type = function (V) {
+  switch (typeof V) {
+    case 'undefined': return 'Undefined'
+    case 'boolean': return 'Boolean'
+    case 'string': return 'String'
+    case 'symbol': return 'Symbol'
+    case 'number': return 'Number'
+    case 'bigint': return 'BigInt'
+    case 'function':
+    case 'object': {
+      if (V === null) {
+        return 'Null'
+      }
+
+      return 'Object'
+    }
+  }
+}
+
+// https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
+webidl.util.ConvertToInt = function (V, bitLength, signedness, opts = {}) {
+  let upperBound
+  let lowerBound
+
+  // 1. If bitLength is 64, then:
+  if (bitLength === 64) {
+    // 1. Let upperBound be 2^53 − 1.
+    upperBound = Math.pow(2, 53) - 1
+
+    // 2. If signedness is "unsigned", then let lowerBound be 0.
+    if (signedness === 'unsigned') {
+      lowerBound = 0
+    } else {
+      // 3. Otherwise let lowerBound be −2^53 + 1.
+      lowerBound = Math.pow(-2, 53) + 1
+    }
+  } else if (signedness === 'unsigned') {
+    // 2. Otherwise, if signedness is "unsigned", then:
+
+    // 1. Let lowerBound be 0.
+    lowerBound = 0
+
+    // 2. Let upperBound be 2^bitLength − 1.
+    upperBound = Math.pow(2, bitLength) - 1
+  } else {
+    // 3. Otherwise:
+
+    // 1. Let lowerBound be -2^bitLength − 1.
+    lowerBound = Math.pow(-2, bitLength) - 1
+
+    // 2. Let upperBound be 2^bitLength − 1 − 1.
+    upperBound = Math.pow(2, bitLength - 1) - 1
+  }
+
+  // 4. Let x be ? ToNumber(V).
+  let x = Number(V)
+
+  // 5. If x is −0, then set x to +0.
+  if (Object.is(-0, x)) {
+    x = 0
+  }
+
+  // 6. If the conversion is to an IDL type associated
+  //    with the [EnforceRange] extended attribute, then:
+  if (opts.enforceRange === true) {
+    // 1. If x is NaN, +∞, or −∞, then throw a TypeError.
+    if (
+      Number.isNaN(x) ||
+      x === Number.POSITIVE_INFINITY ||
+      x === Number.NEGATIVE_INFINITY
+    ) {
+      throw new TypeError()
+    }
+
+    // 2. Set x to IntegerPart(x).
+    x = webidl.util.IntegerPart(x)
+
+    // 3. If x < lowerBound or x > upperBound, then
+    //    throw a TypeError.
+    if (x < lowerBound || x > upperBound) {
+      throw new TypeError()
+    }
+
+    // 4. Return x.
+    return x
+  }
+
+  // 7. If x is not NaN and the conversion is to an IDL
+  //    type associated with the [Clamp] extended
+  //    attribute, then:
+  if (!Number.isNaN(x) && opts.clamp === true) {
+    // 1. Set x to min(max(x, lowerBound), upperBound).
+    x = Math.min(Math.max(x, lowerBound), upperBound)
+
+    // 2. Round x to the nearest integer, choosing the
+    //    even integer if it lies halfway between two,
+    //    and choosing +0 rather than −0.
+    if (Math.floor(x) % 2 === 0) {
+      x = Math.floor(x)
+    } else {
+      x = Math.ceil(x)
+    }
+
+    if (Object.is(-0, x)) {
+      x = 0
+    }
+
+    // 3. Return x.
+    return x
+  }
+
+  // 8. If x is NaN, +0, +∞, or −∞, then return +0.
+  if (
+    Number.isNaN(x) ||
+    Object.is(0, x) ||
+    x === Number.POSITIVE_INFINITY ||
+    x === Number.NEGATIVE_INFINITY
+  ) {
+    return 0
+  }
+
+  // 9. Set x to IntegerPart(x).
+  x = webidl.util.IntegerPart(x)
+
+  // 10. Set x to x modulo 2^bitLength.
+  x = x % Math.pow(2, bitLength)
+
+  // 11. If signedness is "signed" and x ≥ 2^bitLength − 1,
+  //    then return x − 2^bitLength.
+  if (signedness === 'signed' && x >= Math.pow(2, bitLength) - 1) {
+    return x - Math.pow(2, bitLength)
+  }
+
+  // 12. Otherwise, return x.
+  return x
+}
+
+// https://webidl.spec.whatwg.org/#abstract-opdef-integerpart
+webidl.util.IntegerPart = function (n) {
+  // 1. Let r be floor(abs(n)).
+  const r = Math.floor(Math.abs(n))
+
+  // 2. If n < 0, then return -1 × r.
+  if (n < 0) {
+    return -1 * r
+  }
+
+  // 3. Otherwise, return r.
+  return r
+}
+
+webidl.sequenceConverter = function (converter) {
+  return (V) => {
+    return webidl.converters.sequence(V, converter)
+  }
+}
+
+webidl.interfaceConverter = function (i) {
+  return (V) => {
+    if (!(V instanceof i)) {
+      throw new TypeError()
+    }
+
+    return V
+  }
+}
+
+/**
+ * @param {{
+ *   key: string,
+ *   defaultValue?: any,
+ *   required?: boolean,
+ *   converter: (...args: unknown[]) => unknown
+ * }[]} converters
+ * @returns
+ */
+webidl.dictionaryConverter = function (converters) {
+  return (dictionary) => {
+    const type = webidl.util.Type(dictionary)
+    const dict = {}
+
+    if (type !== 'Null' && type !== 'Undefined' && type !== 'Object') {
+      throw new TypeError()
+    }
+
+    for (const options of converters) {
+      const { key, defaultValue, required, converter } = options
+
+      if (required === true) {
+        if (!Object.hasOwn(dictionary, key)) {
+          throw new TypeError()
+        }
+      }
+
+      let value = dictionary[key]
+
+      // only use defaultValue if it is provided,
+      // even if it's falsy
+      if (Object.hasOwn(options, 'defaultValue')) {
+        value = value ?? defaultValue
+      }
+
+      value = converter(value)
+
+      dict[key] = value
+    }
+
+    return dict
+  }
+}
 
 // https://webidl.spec.whatwg.org/#es-DOMString
-webidl.converters.DOMString = function DOMString (V, opts = {}) {
+webidl.converters.DOMString = function (V, opts = {}) {
   // 1. If V is null and the conversion is to an IDL type
   //    associated with the [LegacyNullToEmptyString]
   //    extended attribute, then return the DOMString value
@@ -30,7 +243,7 @@ webidl.converters.DOMString = function DOMString (V, opts = {}) {
 const isNotLatin1 = /[^\u0000-\u00ff]/
 
 // https://webidl.spec.whatwg.org/#es-ByteString
-webidl.converters.ByteString = function ByteString (V) {
+webidl.converters.ByteString = function (V) {
   // 1. Let x be ? ToString(V).
   // Note: DOMString converter perform ? ToString(V)
   const x = webidl.converters.DOMString(V)
@@ -50,6 +263,159 @@ webidl.converters.ByteString = function ByteString (V) {
 // https://webidl.spec.whatwg.org/#es-USVString
 // TODO: ensure that util.toUSVString follows webidl spec
 webidl.converters.USVString = toUSVString
+
+// https://webidl.spec.whatwg.org/#es-long-long
+webidl.converters['long long'] = function (V, opts) {
+  // 1. Let x be ? ConvertToInt(V, 64, "signed").
+  const x = webidl.util.ConvertToInt(V, 64, 'signed', opts)
+
+  // 2. Return the IDL long long value that represents
+  //    the same numeric value as x.
+  return x
+}
+
+// https://webidl.spec.whatwg.org/#es-sequence
+webidl.converters.sequence = function (V, converter) {
+  // 1. If Type(V) is not Object, throw a TypeError.
+  if (webidl.util.Type(V) !== 'Object') {
+    throw new TypeError()
+  }
+
+  // 2. Let method be ? GetMethod(V, @@iterator).
+  /** @type {Generator} */
+  const method = V[Symbol.iterator]?.()
+  const seq = []
+
+  // 3. If method is undefined, throw a TypeError.
+  if (
+    method === undefined ||
+    typeof method.next !== 'function'
+  ) {
+    throw new TypeError()
+  }
+
+  // https://webidl.spec.whatwg.org/#create-sequence-from-iterable
+  while (true) {
+    const { done, value } = method.next()
+
+    if (done) {
+      break
+    }
+
+    seq.push(converter(value))
+  }
+
+  return seq
+}
+
+// https://webidl.spec.whatwg.org/#idl-ArrayBuffer
+webidl.converters.ArrayBuffer = function (V, opts = {}) {
+  // 1. If Type(V) is not Object, or V does not have an
+  //    [[ArrayBufferData]] internal slot, then throw a
+  //    TypeError.
+  // see: https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-instances
+  // see: https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-instances
+  if (
+    webidl.util.Type(V) !== 'Object' ||
+    !types.isAnyArrayBuffer(V)
+  ) {
+    throw new TypeError()
+  }
+
+  // 2. If the conversion is not to an IDL type associated
+  //    with the [AllowShared] extended attribute, and
+  //    IsSharedArrayBuffer(V) is true, then throw a
+  //    TypeError.
+  if (opts.allowShared === false && types.isSharedArrayBuffer(V)) {
+    throw new TypeError()
+  }
+
+  // 3. If the conversion is not to an IDL type associated
+  //    with the [AllowResizable] extended attribute, and
+  //    IsResizableArrayBuffer(V) is true, then throw a
+  //    TypeError.
+  // Note: resizable ArrayBuffers are currently a proposal.
+
+  // 4. Return the IDL ArrayBuffer value that is a
+  //    reference to the same object as V.
+  return V
+}
+
+webidl.converters.TypedArray = function (V, T, opts = {}) {
+  // 1. Let T be the IDL type V is being converted to.
+
+  // 2. If Type(V) is not Object, or V does not have a
+  //    [[TypedArrayName]] internal slot with a value
+  //    equal to T’s name, then throw a TypeError.
+  if (
+    webidl.util.Type(V) !== 'Object' ||
+    !types.isTypedArray(V) ||
+    V.constructor.name !== T.name
+  ) {
+    throw new TypeError()
+  }
+
+  // 3. If the conversion is not to an IDL type associated
+  //    with the [AllowShared] extended attribute, and
+  //    IsSharedArrayBuffer(V.[[ViewedArrayBuffer]]) is
+  //    true, then throw a TypeError.
+  if (opts.allowShared === false && types.isSharedArrayBuffer(V.buffer)) {
+    throw new TypeError()
+  }
+
+  // 4. If the conversion is not to an IDL type associated
+  //    with the [AllowResizable] extended attribute, and
+  //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
+  //    true, then throw a TypeError.
+  // Note: resizable array buffers are currently a proposal
+
+  // 5. Return the IDL value of type T that is a reference
+  //    to the same object as V.
+  return V
+}
+
+webidl.converters.DataView = function (V, opts = {}) {
+  // 1. If Type(V) is not Object, or V does not have a
+  //    [[DataView]] internal slot, then throw a TypeError.
+  if (webidl.util.Type(V) !== 'Object' || !types.isDataView(V)) {
+    throw new TypeError()
+  }
+
+  // 2. If the conversion is not to an IDL type associated
+  //    with the [AllowShared] extended attribute, and
+  //    IsSharedArrayBuffer(V.[[ViewedArrayBuffer]]) is true,
+  //    then throw a TypeError.
+  if (opts.allowShared === false && types.isSharedArrayBuffer(V.buffer)) {
+    throw new TypeError()
+  }
+
+  // 3. If the conversion is not to an IDL type associated
+  //    with the [AllowResizable] extended attribute, and
+  //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
+  //    true, then throw a TypeError.
+  // Note: resizable ArrayBuffers are currently a proposal
+
+  // 4. Return the IDL DataView value that is a reference
+  //    to the same object as V.
+  return V
+}
+
+// https://webidl.spec.whatwg.org/#BufferSource
+webidl.converters.BufferSource = function (V, opts = {}) {
+  if (types.isAnyArrayBuffer(V)) {
+    return webidl.converters.ArrayBuffer(V, opts)
+  }
+
+  if (types.isTypedArray(V)) {
+    return webidl.converters.TypedArray(V, V.constructor)
+  }
+
+  if (types.isDataView(V)) {
+    return webidl.converters.DataView(V, opts)
+  }
+
+  throw new TypeError(`Could not convert ${V} to a BufferSource.`)
+}
 
 module.exports = {
   webidl

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run test:tap && npm run test:node-fetch && npm run test:fetch && npm run test:jest && tsd",
     "test:node-fetch": "node scripts/verifyVersion.js 16 || mocha test/node-fetch",
-    "test:fetch": "node scripts/verifyVersion.js 16 || (npm run build:node && tap test/fetch/*.js)",
+    "test:fetch": "node scripts/verifyVersion.js 16 || (npm run build:node && tap test/fetch/*.js && tap test/webidl/*.js)",
     "test:jest": "jest",
     "test:tap": "tap test/*.js test/diagnostics-channel/*.js",
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",

--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { Blob } = require('buffer')
 const { test } = require('tap')
 const { File, FileLike } = require('../../lib/fetch/file')
 
@@ -92,6 +93,79 @@ test('lastModified', (t) => {
     }).lastModified,
     1
   )
+
+  t.end()
+})
+
+test('File.prototype.text', async (t) => {
+  t.test('With Blob', async (t) => {
+    const blob1 = new Blob(['hello'])
+    const blob2 = new Blob([' '])
+    const blob3 = new Blob(['world'])
+
+    const file = new File([blob1, blob2, blob3], 'hello_world.txt')
+
+    t.equal(await file.text(), 'hello world')
+    t.end()
+  })
+
+  /* eslint-disable camelcase */
+  t.test('With TypedArray', async (t) => {
+    const uint8_1 = new Uint8Array(Buffer.from('hello'))
+    const uint8_2 = new Uint8Array(Buffer.from(' '))
+    const uint8_3 = new Uint8Array(Buffer.from('world'))
+
+    const file = new File([uint8_1, uint8_2, uint8_3], 'hello_world.txt')
+
+    t.equal(await file.text(), 'hello world')
+    t.end()
+  })
+  /* eslint-enable camelcase */
+
+  t.test('With ArrayBuffer', async (t) => {
+    const uint8 = new Uint8Array([65, 66, 67])
+    const ab = uint8.buffer
+
+    const file = new File([ab], 'file.txt')
+
+    t.equal(await file.text(), 'ABC')
+    t.end()
+  })
+
+  t.test('With string', async (t) => {
+    const string = 'hello world'
+    const file = new File([string], 'hello_world.txt')
+
+    t.equal(await file.text(), 'hello world')
+    t.end()
+  })
+
+  t.test('Mixed', async (t) => {
+    const blob = new Blob(['Hello, '])
+    const uint8 = new Uint8Array(Buffer.from('world! This'))
+    const string = ' is a test! Hope it passes!'
+
+    const file = new File([blob, uint8, string], 'mixed-messages.txt')
+
+    t.equal(
+      await file.text(),
+      'Hello, world! This is a test! Hope it passes!'
+    )
+    t.end()
+  })
+
+  t.end()
+})
+
+test('endings=native', async (t) => {
+  const file = new File(['Hello\nWorld'], 'text.txt', { endings: 'native' })
+  const text = await file.text()
+
+  if (process.platform === 'win32') {
+    t.equal(text, 'Hello\r\nWorld', 'on windows, LF is replace with CRLF')
+  } else {
+    t.equal(text, 'Hello\nWorld', `on ${process.platform} LF stays LF`)
+  }
 
   t.end()
 })

--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -59,6 +59,39 @@ test('return value of File.lastModified', (t) => {
 
 test('Symbol.toStringTag', (t) => {
   t.plan(2)
-  t.equal(new File()[Symbol.toStringTag], 'File')
+  t.equal(new File([], '')[Symbol.toStringTag], 'File')
   t.equal(new FileLike()[Symbol.toStringTag], 'File')
+})
+
+test('arguments', (t) => {
+  t.throws(() => {
+    new File() // eslint-disable-line no-new
+  }, TypeError)
+
+  t.throws(() => {
+    new File([]) // eslint-disable-line no-new
+  }, TypeError)
+
+  t.end()
+})
+
+test('lastModified', (t) => {
+  const file = new File([], '')
+  const lastModified = Date.now() - 69_000
+
+  t.notOk(file === 0)
+
+  const file1 = new File([], '', { lastModified })
+  t.equal(file1.lastModified, lastModified)
+
+  t.equal(new File([], '', { lastModified: 0 }).lastModified, 0)
+
+  t.equal(
+    new File([], '', {
+      lastModified: true
+    }).lastModified,
+    1
+  )
+
+  t.end()
 })

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { test } = require('tap')
+const { webidl } = require('../../lib/fetch/webidl')
+
+test('sequence', (t) => {
+  t.throws(() => {
+    webidl.converters.sequence(true)
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.sequence({})
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.sequence({
+      [Symbol.iterator]: 42
+    })
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.sequence({
+      [Symbol.iterator] () {
+        return {
+          next: 'never!'
+        }
+      }
+    })
+  }, TypeError)
+
+  const converter = webidl.sequenceConverter(
+    webidl.converters.DOMString
+  )
+
+  t.same(converter([1, 2, 3]), ['1', '2', '3'])
+
+  t.end()
+})

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -36,3 +36,142 @@ test('sequence', (t) => {
 
   t.end()
 })
+
+test('webidl.dictionaryConverter', (t) => {
+  t.test('arguments', (t) => {
+    const converter = webidl.dictionaryConverter([])
+
+    t.throws(() => {
+      converter(true)
+    }, TypeError)
+
+    for (const value of [{}, undefined, null]) {
+      t.doesNotThrow(() => {
+        converter(value)
+      })
+    }
+
+    t.end()
+  })
+
+  t.test('required key', (t) => {
+    const converter = webidl.dictionaryConverter([
+      {
+        converter: () => true,
+        key: 'Key',
+        required: true
+      }
+    ])
+
+    t.throws(() => {
+      converter({ wrongKey: 'key' })
+    }, TypeError)
+
+    t.doesNotThrow(() => {
+      converter({ Key: 'this key was required!' })
+    })
+
+    t.end()
+  })
+
+  t.end()
+})
+
+test('ArrayBuffer', (t) => {
+  t.throws(() => {
+    webidl.converters.ArrayBuffer(true)
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.ArrayBuffer({})
+  }, TypeError)
+
+  t.throws(() => {
+    const sab = new SharedArrayBuffer(1024)
+    webidl.converters.ArrayBuffer(sab, { allowShared: false })
+  }, TypeError)
+
+  t.doesNotThrow(() => {
+    const sab = new SharedArrayBuffer(1024)
+    webidl.converters.ArrayBuffer(sab)
+  })
+
+  t.doesNotThrow(() => {
+    const ab = new ArrayBuffer(8)
+    webidl.converters.ArrayBuffer(ab)
+  })
+
+  t.end()
+})
+
+test('TypedArray', (t) => {
+  t.throws(() => {
+    webidl.converters.TypedArray(3)
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.TypedArray({})
+  }, TypeError)
+
+  t.throws(() => {
+    const uint8 = new Uint8Array([1, 2, 3])
+    Object.defineProperty(uint8, 'buffer', {
+      get () {
+        return new SharedArrayBuffer(8)
+      }
+    })
+
+    webidl.converters.TypedArray(uint8, Uint8Array, {
+      allowShared: false
+    })
+  }, TypeError)
+
+  t.end()
+})
+
+test('DataView', (t) => {
+  t.throws(() => {
+    webidl.converters.DataView(3)
+  }, TypeError)
+
+  t.throws(() => {
+    webidl.converters.DataView({})
+  }, TypeError)
+
+  t.throws(() => {
+    const buffer = new ArrayBuffer(16)
+    const view = new DataView(buffer, 0)
+
+    Object.defineProperty(view, 'buffer', {
+      get () {
+        return new SharedArrayBuffer(8)
+      }
+    })
+
+    webidl.converters.DataView(view, {
+      allowShared: false
+    })
+  })
+
+  const buffer = new ArrayBuffer(16)
+  const view = new DataView(buffer, 0)
+
+  t.equal(webidl.converters.DataView(view), view)
+
+  t.end()
+})
+
+test('BufferSource', (t) => {
+  t.doesNotThrow(() => {
+    const buffer = new ArrayBuffer(16)
+    const view = new DataView(buffer, 0)
+
+    webidl.converters.BufferSource(view)
+  })
+
+  t.throws(() => {
+    webidl.converters.BufferSource(3)
+  }, TypeError)
+
+  t.end()
+})

--- a/test/webidl/helpers.js
+++ b/test/webidl/helpers.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { test } = require('tap')
+const { webidl } = require('../../lib/fetch/webidl')
+
+test('webidl.interfaceConverter', (t) => {
+  class A {}
+  class B {}
+
+  const converter = webidl.interfaceConverter(A)
+
+  t.throws(() => {
+    converter(new B())
+  }, TypeError)
+
+  t.doesNotThrow(() => {
+    converter(new A())
+  })
+
+  t.end()
+})

--- a/test/webidl/util.js
+++ b/test/webidl/util.js
@@ -68,6 +68,13 @@ test('ConvertToInt(V)', (t) => {
         enforceRange: true
       })
     }, TypeError)
+
+    t.equal(
+      ConvertToInt(65.5, 64, signedness, {
+        enforceRange: true
+      }),
+      65
+    )
   }
 
   for (const signedness of ['signed', 'unsigned']) {
@@ -92,6 +99,8 @@ test('ConvertToInt(V)', (t) => {
       0
     )
   }
+
+  t.equal(ConvertToInt(111, 2, 'signed'), -1)
 
   t.end()
 })

--- a/test/webidl/util.js
+++ b/test/webidl/util.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const { test } = require('tap')
+const { webidl } = require('../../lib/fetch/webidl')
+
+test('Type(V)', (t) => {
+  const Type = webidl.util.Type
+
+  t.equal(Type(undefined), 'Undefined')
+  t.equal(Type(null), 'Null')
+  t.equal(Type(true), 'Boolean')
+  t.equal(Type('string'), 'String')
+  t.equal(Type(Symbol('symbol')), 'Symbol')
+  t.equal(Type(1.23), 'Number')
+  t.equal(Type(1n), 'BigInt')
+  t.equal(Type({ a: 'b' }), 'Object')
+
+  t.end()
+})
+
+test('ConvertToInt(V)', (t) => {
+  const ConvertToInt = webidl.util.ConvertToInt
+
+  t.equal(ConvertToInt(63, 64, 'signed'), 63, 'odd int')
+  t.equal(ConvertToInt(64.49, 64, 'signed'), 64)
+  t.equal(ConvertToInt(64.51, 64, 'signed'), 64)
+
+  const max = 2 ** 53
+  t.equal(ConvertToInt(max + 1, 64, 'signed'), max, 'signed pos')
+  t.equal(ConvertToInt(-max - 1, 64, 'signed'), -max, 'signed neg')
+
+  t.equal(ConvertToInt(max + 1, 64, 'unsigned'), max + 1, 'unsigned pos')
+  t.equal(ConvertToInt(-max - 1, 64, 'unsigned'), -max - 1, 'unsigned neg')
+
+  for (const signedness of ['signed', 'unsigned']) {
+    t.equal(ConvertToInt(Infinity, 64, signedness), 0)
+    t.equal(ConvertToInt(-Infinity, 64, signedness), 0)
+    t.equal(ConvertToInt(NaN, 64, signedness), 0)
+  }
+
+  for (const signedness of ['signed', 'unsigned']) {
+    t.throws(() => {
+      ConvertToInt(NaN, 64, signedness, {
+        enforceRange: true
+      })
+    }, TypeError)
+
+    t.throws(() => {
+      ConvertToInt(Infinity, 64, signedness, {
+        enforceRange: true
+      })
+    }, TypeError)
+
+    t.throws(() => {
+      ConvertToInt(-Infinity, 64, signedness, {
+        enforceRange: true
+      })
+    }, TypeError)
+
+    t.throws(() => {
+      ConvertToInt(2 ** 53 + 1, 32, 'signed', {
+        enforceRange: true
+      })
+    }, TypeError)
+
+    t.throws(() => {
+      ConvertToInt(-(2 ** 53 + 1), 32, 'unsigned', {
+        enforceRange: true
+      })
+    }, TypeError)
+  }
+
+  for (const signedness of ['signed', 'unsigned']) {
+    t.equal(
+      ConvertToInt(63.49, 64, signedness, {
+        clamp: true
+      }),
+      64
+    )
+
+    t.equal(
+      ConvertToInt(63.51, 64, signedness, {
+        clamp: true
+      }),
+      64
+    )
+
+    t.equal(
+      ConvertToInt(-0, 64, signedness, {
+        clamp: true
+      }),
+      0
+    )
+  }
+
+  t.end()
+})

--- a/types/file.d.ts
+++ b/types/file.d.ts
@@ -1,9 +1,14 @@
 // Based on https://github.com/octet-stream/form-data/blob/2d0f0dc371517444ce1f22cdde13f51995d0953a/lib/File.ts (MIT)
 /// <reference types="node" />
 
-import { Blob, BlobOptions } from 'buffer'
+import { Blob } from 'buffer'
 
-export interface FileOptions extends BlobOptions {
+export interface BlobPropertyBag {
+  type?: string
+  endings?: 'native' | 'transparent'
+}
+
+export interface FilePropertyBag extends BlobPropertyBag {
   /**
    * The last modified date of the file as the number of milliseconds since the Unix epoch (January 1, 1970 at midnight). Files without a known last modified date return the current date.
    */
@@ -18,7 +23,7 @@ export declare class File extends Blob {
    * @param fileName The name of the file.
    * @param options An options object containing optional attributes for the file.
    */
-  constructor(fileBits: ReadonlyArray<string | NodeJS.ArrayBufferView | Blob>, fileName: string, options?: FileOptions)
+  constructor(fileBits: ReadonlyArray<string | NodeJS.ArrayBufferView | Blob>, fileName: string, options?: FilePropertyBag)
 
   /**
    * Name of the file referenced by the File object.


### PR DESCRIPTION
Makes `File` completely spec-compliant and adds in a bunch of needed webidl checks.

# File:
- Fixes 0 arguments being allowed in File constructor.
- Add webidl checks for File constructor parameters.
- Add missing steps from the spec.

# WebIdl:
- Add `sequence` converters
- Add dictionary matching & optional key assigning with default & required keys.
- Add TypedArray, (Shared)ArrayBuffer, DataView, and IDL long long converters (required by File).

p.s. most of the webidl apis were inspired by Deno because they're just done well.