### PR TITLE
fix(FormData): spec compliance

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -199,7 +199,7 @@ webidl.converters.Blob = webidl.interfaceConverter(Blob)
 webidl.converters.BlobPart = function (V, opts) {
   if (webidl.util.Type(V) === 'Object') {
     if (isBlobLike(V)) {
-      return webidl.converters.Blob(V)
+      return webidl.converters.Blob(V, { strict: false })
     }
 
     return webidl.converters.BufferSource(V, opts)

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -3,43 +3,47 @@
 const { isBlobLike, isFileLike, toUSVString, makeIterator } = require('./util')
 const { kState } = require('./symbols')
 const { File, FileLike } = require('./file')
+const { webidl } = require('./webidl')
 const { Blob } = require('buffer')
 
+// https://xhr.spec.whatwg.org/#formdata
 class FormData {
   static name = 'FormData'
 
-  constructor (...args) {
-    if (args.length > 0 && !(args[0]?.constructor?.name === 'HTMLFormElement')) {
-      throw new TypeError(
-        "Failed to construct 'FormData': parameter 1 is not of type 'HTMLFormElement'"
-      )
+  constructor (form) {
+    if (arguments.length > 0 && form != null) {
+      throw new TypeError()
     }
 
     this[kState] = []
   }
 
-  append (...args) {
+  append (name, value, filename = undefined) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 2) {
+    if (arguments.length < 2) {
       throw new TypeError(
-        `Failed to execute 'append' on 'FormData': 2 arguments required, but only ${args.length} present.`
+        `Failed to execute 'append' on 'FormData': 2 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    if (args.length === 3 && !isBlobLike(args[1])) {
+    if (arguments.length === 3 && !isBlobLike(value)) {
       throw new TypeError(
         "Failed to execute 'append' on 'FormData': parameter 2 is not of type 'Blob'"
       )
     }
 
-    const name = toUSVString(args[0])
-    const filename = args.length === 3 ? toUSVString(args[2]) : undefined
-
     // 1. Let value be value if given; otherwise blobValue.
-    const value = isBlobLike(args[1]) ? args[1] : toUSVString(args[1])
+
+    name = webidl.converters.USVString(name)
+    value = isBlobLike(value) || isFileLike(value)
+      ? webidl.converters.Blob(value, { strict: false })
+      : webidl.converters.USVString(value)
+    filename = arguments.length === 3
+      ? webidl.converters.USVString(filename)
+      : undefined
 
     // 2. Let entry be the result of creating an entry with
     // name, value, and filename if given.
@@ -49,18 +53,18 @@ class FormData {
     this[kState].push(entry)
   }
 
-  delete (...args) {
+  delete (name) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to execute 'delete' on 'FormData': 1 arguments required, but only ${args.length} present.`
+        `Failed to execute 'delete' on 'FormData': 1 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    const name = toUSVString(args[0])
+    name = webidl.converters.USVString(name)
 
     // The delete(name) method steps are to remove all entries whose name
     // is name from this’s entry list.
@@ -74,18 +78,18 @@ class FormData {
     this[kState] = next
   }
 
-  get (...args) {
+  get (name) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to execute 'get' on 'FormData': 1 arguments required, but only ${args.length} present.`
+        `Failed to execute 'get' on 'FormData': 1 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    const name = toUSVString(args[0])
+    name = webidl.converters.USVString(name)
 
     // 1. If there is no entry whose name is name in this’s entry list,
     // then return null.
@@ -99,18 +103,18 @@ class FormData {
     return this[kState][idx].value
   }
 
-  getAll (...args) {
+  getAll (name) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to execute 'getAll' on 'FormData': 1 arguments required, but only ${args.length} present.`
+        `Failed to execute 'getAll' on 'FormData': 1 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    const name = toUSVString(args[0])
+    name = webidl.converters.USVString(name)
 
     // 1. If there is no entry whose name is name in this’s entry list,
     // then return the empty list.
@@ -121,48 +125,53 @@ class FormData {
       .map((entry) => entry.value)
   }
 
-  has (...args) {
+  has (name) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to execute 'has' on 'FormData': 1 arguments required, but only ${args.length} present.`
+        `Failed to execute 'has' on 'FormData': 1 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    const name = toUSVString(args[0])
+    name = webidl.converters.USVString(name)
 
     // The has(name) method steps are to return true if there is an entry
     // whose name is name in this’s entry list; otherwise false.
     return this[kState].findIndex((entry) => entry.name === name) !== -1
   }
 
-  set (...args) {
+  set (name, value, filename = undefined) {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
     }
 
-    if (args.length < 2) {
+    if (arguments.length < 2) {
       throw new TypeError(
-        `Failed to execute 'set' on 'FormData': 2 arguments required, but only ${args.length} present.`
+        `Failed to execute 'set' on 'FormData': 2 arguments required, but only ${arguments.length} present.`
       )
     }
 
-    if (args.length === 3 && !isBlobLike(args[1])) {
+    if (arguments.length === 3 && !isBlobLike(value)) {
       throw new TypeError(
         "Failed to execute 'set' on 'FormData': parameter 2 is not of type 'Blob'"
       )
     }
-    const name = toUSVString(args[0])
-    const filename = args.length === 3 ? toUSVString(args[2]) : undefined
 
     // The set(name, value) and set(name, blobValue, filename) method steps
     // are:
 
     // 1. Let value be value if given; otherwise blobValue.
-    const value = isBlobLike(args[1]) ? args[1] : toUSVString(args[1])
+
+    name = webidl.converters.USVString(name)
+    value = isBlobLike(value) || isFileLike(value)
+      ? webidl.converters.Blob(value, { strict: false })
+      : webidl.converters.USVString(value)
+    filename = arguments.length === 3
+      ? toUSVString(filename)
+      : undefined
 
     // 2. Let entry be the result of creating an entry with name, value, and
     // filename if given.
@@ -249,45 +258,46 @@ class FormData {
 
 FormData.prototype[Symbol.iterator] = FormData.prototype.entries
 
+/**
+ * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry
+ * @param {string} name
+ * @param {string|Blob} value
+ * @param {?string} filename
+ * @returns
+ */
 function makeEntry (name, value, filename) {
-  // To create an entry for name, value, and optionally a filename, run these
-  // steps:
+  // 1. Set name to the result of converting name into a scalar value string.
+  // "To convert a string into a scalar value string, replace any surrogates
+  //  with U+FFFD."
+  // see: https://nodejs.org/dist/latest-v18.x/docs/api/buffer.html#buftostringencoding-start-end
+  name = Buffer.from(name).toString('utf8')
 
-  // 1. Let entry be a new entry.
-  const entry = {
-    name: null,
-    value: null
+  // 2. If value is a string, then set value to the result of converting
+  //    value into a scalar value string.
+  if (typeof value === 'string') {
+    value = Buffer.from(value).toString('utf8')
+  } else {
+    // 3. Otherwise:
+
+    // 1. If value is not a File object, then set value to a new File object,
+    //    representing the same bytes, whose name attribute value is "blob"
+    if (!isFileLike(value)) {
+      value = value instanceof Blob
+        ? new File([value], 'blob', { type: value.type })
+        : new FileLike(value, 'blob', { type: value.type })
+    }
+
+    // 2. If filename is given, then set value to a new File object,
+    //    representing the same bytes, whose name attribute is filename.
+    if (filename !== undefined) {
+      value = value instanceof File
+        ? new File([value], filename, { type: value.type })
+        : new FileLike(value, filename, { type: value.type })
+    }
   }
 
-  // 2. Set entry’s name to name.
-  entry.name = name
-
-  // 3. If value is a Blob object and not a File object, then set value to a new File
-  // object, representing the same bytes, whose name attribute value is "blob".
-  if (isBlobLike(value) && !isFileLike(value)) {
-    value = value instanceof Blob
-      ? new File([value], 'blob', value)
-      : new FileLike(value, 'blob', value)
-  }
-
-  // 4. If value is (now) a File object and filename is given, then set value to a
-  // new File object, representing the same bytes, whose name attribute value is
-  // filename.
-  // TODO: This is a bit weird... What if passed value is a File?
-  // Do we just override the name attribute? Since it says "if value is (now)"
-  // does that mean that this lives inside the previous condition? In which case
-  // creating one more File instance doesn't make much sense....
-  if (isFileLike(value) && filename != null) {
-    value = value instanceof File
-      ? new File([value], filename, value)
-      : new FileLike(value, filename, value)
-  }
-
-  // 5. Set entry’s value to value.
-  entry.value = value
-
-  // 6. Return entry.
-  return entry
+  // 4. Return an entry whose name is name and whose value is value.
+  return { name, value }
 }
 
 function * makeIterable (entries, type) {

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -38,7 +38,7 @@ class FormData {
     // 1. Let value be value if given; otherwise blobValue.
 
     name = webidl.converters.USVString(name)
-    value = isBlobLike(value) || isFileLike(value)
+    value = isBlobLike(value)
       ? webidl.converters.Blob(value, { strict: false })
       : webidl.converters.USVString(value)
     filename = arguments.length === 3
@@ -166,7 +166,7 @@ class FormData {
     // 1. Let value be value if given; otherwise blobValue.
 
     name = webidl.converters.USVString(name)
-    value = isBlobLike(value) || isFileLike(value)
+    value = isBlobLike(value)
       ? webidl.converters.Blob(value, { strict: false })
       : webidl.converters.USVString(value)
     filename = arguments.length === 3

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -161,8 +161,8 @@ webidl.sequenceConverter = function (converter) {
 }
 
 webidl.interfaceConverter = function (i) {
-  return (V) => {
-    if (!(V instanceof i)) {
+  return (V, opts = {}) => {
+    if (opts.strict !== false && !(V instanceof i)) {
       throw new TypeError()
     }
 

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -284,3 +284,15 @@ test('formData.constructor.name', (t) => {
   t.equal(form.constructor.name, 'FormData')
   t.end()
 })
+
+test('arguments', (t) => {
+  t.equal(FormData.constructor.length, 1)
+  t.equal(FormData.prototype.append.length, 2)
+  t.equal(FormData.prototype.delete.length, 1)
+  t.equal(FormData.prototype.get.length, 1)
+  t.equal(FormData.prototype.getAll.length, 1)
+  t.equal(FormData.prototype.has.length, 1)
+  t.equal(FormData.prototype.set.length, 2)
+
+  t.end()
+})


### PR DESCRIPTION
- Fixes argument length being incorrect (very minor)
- Updates `makeEntry` since the spec was updated apparently.

Surprisingly the `FormData` class was almost entirely correct and even did most of the webidl conversions.