### PR TITLE
feat(Headers): spec-compliant `fill` & constructor

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -30,45 +30,30 @@ function headerValueNormalize (potentialValue) {
 }
 
 function fill (headers, object) {
-  // TODO: use idl converters once implemented
   // To fill a Headers object headers with a given object object, run these steps:
 
-  if (object[Symbol.iterator]) {
-    // 1. If object is a sequence, then for each header in object:
-    // TODO: How to check if sequence?
-    for (let header of object) {
+  // 1. If object is a sequence, then for each header in object:
+  // Note: webidl conversion to array has already been done.
+  if (Array.isArray(object)) {
+    for (const header of object) {
       // 1. If header does not contain exactly two items, then throw a TypeError.
-      if (!header[Symbol.iterator]) {
-        // TODO: Spec doesn't define what to do here?
-        throw new TypeError()
-      }
-
-      if (typeof header === 'string') {
-        // TODO: Spec doesn't define what to do here?
-        throw new TypeError()
-      }
-
-      if (!Array.isArray(header)) {
-        header = [...header]
-      }
-
       if (header.length !== 2) {
         throw new TypeError()
       }
 
-      // 2. Append header’s first item/header’s second item to headers.
+      // 2. Append (header’s first item, header’s second item) to headers.
       headers.append(header[0], header[1])
     }
-  } else if (object && typeof object === 'object') {
-    // Otherwise, object is a record, then for each key → value in object,
-    // append key/value to headers.
-    // TODO: How to check if record?
-    for (const header of Object.entries(object)) {
-      headers.append(header[0], header[1])
+  } else if (typeof object === 'object' && object !== null) {
+    // Note: null should throw
+
+    // 2. Otherwise, object is a record, then for each key → value in object,
+    //    append (key, value) to headers
+    for (const [key, value] of Object.entries(object)) {
+      headers.append(key, value)
     }
   } else {
-    // TODO: Spec doesn't define what to do here?
-    throw TypeError()
+    throw new TypeError()
   }
 }
 
@@ -173,17 +158,7 @@ class HeadersList {
 
 // https://fetch.spec.whatwg.org/#headers-class
 class Headers {
-  constructor (...args) {
-    if (
-      args[0] !== undefined &&
-      !(typeof args[0] === 'object' && args[0] != null) &&
-      !Array.isArray(args[0])
-    ) {
-      throw new TypeError(
-        "Failed to construct 'Headers': The provided value is not of type '(record<ByteString, ByteString> or sequence<sequence<ByteString>>"
-      )
-    }
-    const init = args.length >= 1 ? args[0] ?? {} : {}
+  constructor (init = undefined) {
     this[kHeadersList] = new HeadersList()
 
     // The new Headers(init) constructor steps are:
@@ -192,7 +167,10 @@ class Headers {
     this[kGuard] = 'none'
 
     // 2. If init is given, then fill this with init.
-    fill(this, init)
+    if (init !== undefined) {
+      init = webidl.converters.HeadersInit(init)
+      fill(this, init)
+    }
   }
 
   get [Symbol.toStringTag] () {
@@ -460,6 +438,18 @@ Object.defineProperties(Headers.prototype, {
   entries: kEnumerableProperty,
   forEach: kEnumerableProperty
 })
+
+webidl.converters.HeadersInit = function (V) {
+  if (webidl.util.Type(V) === 'Object') {
+    if (V[Symbol.iterator]) {
+      return webidl.converters['sequence<sequence<ByteString>>'](V)
+    }
+
+    return webidl.converters['record<ByteString, ByteString>'](V)
+  }
+
+  throw new TypeError()
+}
 
 module.exports = {
   fill,

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -154,9 +154,63 @@ webidl.util.IntegerPart = function (n) {
   return r
 }
 
+// https://webidl.spec.whatwg.org/#es-sequence
 webidl.sequenceConverter = function (converter) {
   return (V) => {
-    return webidl.converters.sequence(V, converter)
+    // 1. If Type(V) is not Object, throw a TypeError.
+    if (webidl.util.Type(V) !== 'Object') {
+      throw new TypeError()
+    }
+
+    // 2. Let method be ? GetMethod(V, @@iterator).
+    /** @type {Generator} */
+    const method = V?.[Symbol.iterator]?.()
+    const seq = []
+
+    // 3. If method is undefined, throw a TypeError.
+    if (
+      method === undefined ||
+      typeof method.next !== 'function'
+    ) {
+      throw new TypeError()
+    }
+
+    // https://webidl.spec.whatwg.org/#create-sequence-from-iterable
+    while (true) {
+      const { done, value } = method.next()
+
+      if (done) {
+        break
+      }
+
+      seq.push(converter(value))
+    }
+
+    return seq
+  }
+}
+
+webidl.recordConverter = function (keyConverter, valueConverter) {
+  return (V) => {
+    const record = {}
+    const type = webidl.util.Type(V)
+
+    if (type === 'Undefined' || type === 'Null') {
+      return record
+    }
+
+    if (type !== 'Object') {
+      throw new TypeError()
+    }
+
+    for (let [key, value] of Object.entries(V)) {
+      key = keyConverter(key)
+      value = valueConverter(value)
+
+      record[key] = value
+    }
+
+    return record
   }
 }
 
@@ -270,40 +324,6 @@ webidl.converters['long long'] = function (V, opts) {
   return x
 }
 
-// https://webidl.spec.whatwg.org/#es-sequence
-webidl.converters.sequence = function (V, converter) {
-  // 1. If Type(V) is not Object, throw a TypeError.
-  if (webidl.util.Type(V) !== 'Object') {
-    throw new TypeError()
-  }
-
-  // 2. Let method be ? GetMethod(V, @@iterator).
-  /** @type {Generator} */
-  const method = V[Symbol.iterator]?.()
-  const seq = []
-
-  // 3. If method is undefined, throw a TypeError.
-  if (
-    method === undefined ||
-    typeof method.next !== 'function'
-  ) {
-    throw new TypeError()
-  }
-
-  // https://webidl.spec.whatwg.org/#create-sequence-from-iterable
-  while (true) {
-    const { done, value } = method.next()
-
-    if (done) {
-      break
-    }
-
-    seq.push(converter(value))
-  }
-
-  return seq
-}
-
 // https://webidl.spec.whatwg.org/#idl-ArrayBuffer
 webidl.converters.ArrayBuffer = function (V, opts = {}) {
   // 1. If Type(V) is not Object, or V does not have an
@@ -412,6 +432,19 @@ webidl.converters.BufferSource = function (V, opts = {}) {
 
   throw new TypeError(`Could not convert ${V} to a BufferSource.`)
 }
+
+webidl.converters['sequence<ByteString>'] = webidl.sequenceConverter(
+  webidl.converters.ByteString
+)
+
+webidl.converters['sequence<sequence<ByteString>>'] = webidl.sequenceConverter(
+  webidl.converters['sequence<ByteString>']
+)
+
+webidl.converters['record<ByteString, ByteString>'] = webidl.recordConverter(
+  webidl.converters.ByteString,
+  webidl.converters.ByteString
+)
 
 module.exports = {
   webidl

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -5,7 +5,7 @@ const { Headers, fill } = require('../../lib/fetch/headers')
 const { kGuard } = require('../../lib/fetch/symbols')
 
 tap.test('Headers initialization', t => {
-  t.plan(7)
+  t.plan(8)
 
   t.test('allows undefined', t => {
     t.plan(1)
@@ -54,13 +54,23 @@ tap.test('Headers initialization', t => {
     /* eslint-enable no-new-wrappers */
   })
 
-  t.test('fails if function or primitive is passed', t => {
-    t.plan(4)
-    const expectedTypeError = TypeError("Failed to construct 'Headers': The provided value is not of type '(record<ByteString, ByteString> or sequence<sequence<ByteString>>")
-    t.throws(() => new Headers(Function), expectedTypeError)
-    t.throws(() => new Headers(function () {}), expectedTypeError)
+  t.test('fails if primitive is passed', t => {
+    t.plan(2)
+    const expectedTypeError = TypeError
     t.throws(() => new Headers(1), expectedTypeError)
     t.throws(() => new Headers('1'), expectedTypeError)
+  })
+
+  t.test('allows some weird stuff (because of webidl)', t => {
+    t.doesNotThrow(() => {
+      new Headers(function () {}) // eslint-disable-line no-new
+    })
+
+    t.doesNotThrow(() => {
+      new Headers(Function) // eslint-disable-line no-new
+    })
+
+    t.end()
   })
 
   t.test('allows a myriad of header values to be passed', t => {

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -4,35 +4,43 @@ const { test } = require('tap')
 const { webidl } = require('../../lib/fetch/webidl')
 
 test('sequence', (t) => {
-  t.throws(() => {
-    webidl.converters.sequence(true)
-  }, TypeError)
-
-  t.throws(() => {
-    webidl.converters.sequence({})
-  }, TypeError)
-
-  t.throws(() => {
-    webidl.converters.sequence({
-      [Symbol.iterator]: 42
-    })
-  }, TypeError)
-
-  t.throws(() => {
-    webidl.converters.sequence({
-      [Symbol.iterator] () {
-        return {
-          next: 'never!'
-        }
-      }
-    })
-  }, TypeError)
-
   const converter = webidl.sequenceConverter(
     webidl.converters.DOMString
   )
 
   t.same(converter([1, 2, 3]), ['1', '2', '3'])
+
+  t.throws(() => {
+    converter(3)
+  }, TypeError, 'disallows non-objects')
+
+  t.throws(() => {
+    converter(null)
+  }, TypeError)
+
+  t.throws(() => {
+    converter(undefined)
+  }, TypeError)
+
+  t.throws(() => {
+    converter({})
+  }, TypeError, 'no Symbol.iterator')
+
+  t.throws(() => {
+    converter({
+      [Symbol.iterator]: 42
+    })
+  }, TypeError, 'invalid Symbol.iterator')
+
+  t.throws(() => {
+    converter(webidl.converters.sequence({
+      [Symbol.iterator] () {
+        return {
+          next: 'never!'
+        }
+      }
+    }))
+  }, TypeError, 'invalid generator')
 
   t.end()
 })


### PR DESCRIPTION
- Removes `TODOs` in the `fill` method. Weird behavior can be entirely explained with one word: "webidl".
- Fixes some invalid errors being thrown when HeadersInit is a function (in webidl, functions are considered Object types).
- Adds a webidl `record<key, value>` converter.
- Combined `webidl.sequenceConverter` and `webidl.converters.sequence` as the latter has no uses without the former.

p.s. once I make a pr for `Response`/`Request` idl, I am going to make a PR to improve the error messages.

---

No major changes in this pr. All current tests pass (other than 2 which were invalid) and node-fetch tests pass.