### PR TITLE
feat(Response): webidl checks

### DIFF
--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -539,6 +539,12 @@ webidl.converters.BodyInit = function (V) {
     return webidl.converters.ReadableStream(V)
   }
 
+  // Note: the spec doesn't include async iterables,
+  // this is an undici extension.
+  if (V?.[Symbol.asyncIterator]) {
+    return V
+  }
+
   return webidl.converters.XMLHttpRequestBodyInit(V)
 }
 

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -5,14 +5,26 @@ const { AbortError } = require('../core/errors')
 const { extractBody, cloneBody, mixinBody } = require('./body')
 const util = require('../core/util')
 const { kEnumerableProperty } = util
-const { responseURL, isValidReasonPhrase, toUSVString, isCancelled, isAborted, serializeJavascriptValueToJSONString } = require('./util')
+const {
+  responseURL,
+  isValidReasonPhrase,
+  isCancelled,
+  isAborted,
+  isBlobLike,
+  serializeJavascriptValueToJSONString
+} = require('./util')
 const {
   redirectStatus,
   nullBodyStatus
 } = require('./constants')
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
+const { webidl } = require('./webidl')
+const { FormData } = require('./formdata')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
+const { types } = require('util')
+
+const ReadableStream = globalThis.ReadableStream || require('stream/web').ReadableStream
 
 // https://fetch.spec.whatwg.org/#response-class
 class Response {
@@ -41,17 +53,8 @@ class Response {
       )
     }
 
-    if (init === null || typeof init !== 'object') {
-      throw new TypeError(
-        `Failed to execute 'json' on 'Response': init must be a RequestInit, found ${typeof init}.`
-      )
-    }
-
-    init = {
-      status: 200,
-      statusText: '',
-      headers: new HeadersList(),
-      ...init
+    if (init !== null) {
+      init = webidl.converters.ResponseInit(init)
     }
 
     // 1. Let bytes the result of running serialize a JavaScript value to JSON bytes on data.
@@ -78,17 +81,17 @@ class Response {
   }
 
   // Creates a redirect Response that redirects to url with status status.
-  static redirect (...args) {
+  static redirect (url, status = 302) {
     const relevantRealm = { settingsObject: {} }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to execute 'redirect' on 'Response': 1 argument required, but only ${args.length} present.`
+        `Failed to execute 'redirect' on 'Response': 1 argument required, but only ${arguments.length} present.`
       )
     }
 
-    const status = args.length >= 2 ? args[1] : 302
-    const url = toUSVString(args[0])
+    url = webidl.converters.USVString(url)
+    status = webidl.converters['unsigned short'](status)
 
     // 1. Let parsedURL be the result of parsing url with current settings
     // object’s API base URL.
@@ -130,19 +133,12 @@ class Response {
   }
 
   // https://fetch.spec.whatwg.org/#dom-response
-  constructor (...args) {
-    if (
-      args.length >= 1 &&
-      typeof args[1] !== 'object' &&
-      args[1] !== undefined
-    ) {
-      throw new TypeError(
-        "Failed to construct 'Request': cannot convert to dictionary."
-      )
+  constructor (body = null, init = {}) {
+    if (body !== null) {
+      body = webidl.converters.BodyInit(body)
     }
 
-    const body = args.length >= 1 ? args[0] : null
-    const init = args.length >= 2 ? args[1] ?? {} : {}
+    init = webidl.converters.ResponseInit(init)
 
     // TODO
     this[kRealm] = { settingsObject: {} }
@@ -287,6 +283,7 @@ class Response {
     return clonedResponseObject
   }
 }
+
 mixinBody(Response)
 
 Object.defineProperties(Response.prototype, {
@@ -448,7 +445,7 @@ function makeAppropriateNetworkError (fetchParams) {
 function initializeResponse (response, init, body) {
   // 1. If init["status"] is not in the range 200 to 599, inclusive, then
   //    throw a RangeError.
-  if (init.status != null && (init.status < 200 || init.status > 599)) {
+  if (init.status !== null && (init.status < 200 || init.status > 599)) {
     throw new RangeError('init["status"] must be in the range of 200 to 599, inclusive.')
   }
 
@@ -494,6 +491,73 @@ function initializeResponse (response, init, body) {
     }
   }
 }
+
+webidl.converters.ReadableStream = webidl.interfaceConverter(
+  ReadableStream
+)
+
+webidl.converters.FormData = webidl.interfaceConverter(
+  FormData
+)
+
+webidl.converters.URLSearchParams = webidl.interfaceConverter(
+  URLSearchParams
+)
+
+// https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit
+webidl.converters.XMLHttpRequestBodyInit = function (V) {
+  if (typeof V === 'string') {
+    return webidl.converters.USVString(V)
+  }
+
+  if (isBlobLike(V)) {
+    return webidl.converters.Blob(V)
+  }
+
+  if (
+    types.isAnyArrayBuffer(V) ||
+    types.isTypedArray(V) ||
+    types.isDataView(V)
+  ) {
+    return webidl.converters.BufferSource(V)
+  }
+
+  if (V instanceof FormData) {
+    return webidl.converters.FormData(V)
+  }
+
+  if (V instanceof URLSearchParams) {
+    return webidl.converters.URLSearchParams(V)
+  }
+
+  throw new TypeError()
+}
+
+// https://fetch.spec.whatwg.org/#bodyinit
+webidl.converters.BodyInit = function (V) {
+  if (V instanceof ReadableStream) {
+    return webidl.converters.ReadableStream(V)
+  }
+
+  return webidl.converters.XMLHttpRequestBodyInit(V)
+}
+
+webidl.converters.ResponseInit = webidl.dictionaryConverter([
+  {
+    key: 'status',
+    converter: webidl.converters['unsigned short'],
+    defaultValue: 200
+  },
+  {
+    key: 'statusText',
+    converter: webidl.converters.ByteString,
+    defaultValue: ''
+  },
+  {
+    key: 'headers',
+    converter: webidl.converters.HeadersInit
+  }
+])
 
 module.exports = {
   makeNetworkError,

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -252,16 +252,21 @@ webidl.dictionaryConverter = function (converters) {
       }
 
       let value = dictionary[key]
+      const hasDefault = Object.hasOwn(options, 'defaultValue')
 
-      // only use defaultValue if it is provided,
-      // even if it's falsy
-      if (Object.hasOwn(options, 'defaultValue')) {
+      // Only use defaultValue if value is undefined and
+      // a defaultValue options was provided.
+      if (hasDefault && value !== null) {
         value = value ?? defaultValue
       }
 
-      value = converter(value)
-
-      dict[key] = value
+      // A key can be optional and have no default value.
+      // When this happens, do not perform a conversion,
+      // and do not assign the key a value.
+      if (required || hasDefault || value !== undefined) {
+        value = converter(value)
+        dict[key] = value
+      }
     }
 
     return dict
@@ -320,6 +325,16 @@ webidl.converters['long long'] = function (V, opts) {
   const x = webidl.util.ConvertToInt(V, 64, 'signed', opts)
 
   // 2. Return the IDL long long value that represents
+  //    the same numeric value as x.
+  return x
+}
+
+// https://webidl.spec.whatwg.org/#es-unsigned-short
+webidl.converters['unsigned short'] = function (V) {
+  // 1. Let x be ? ConvertToInt(V, 16, "unsigned").
+  const x = webidl.util.ConvertToInt(V, 16, 'unsigned')
+
+  // 2. Return the IDL unsigned short value that represents
   //    the same numeric value as x.
   return x
 }

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -124,3 +124,17 @@ test('Symbol.toStringTag', (t) => {
   t.equal(Response.prototype[Symbol.toStringTag], 'Response')
   t.end()
 })
+
+test('async iterable body', async (t) => {
+  const asyncIterable = {
+    async * [Symbol.asyncIterator] () {
+      yield 'a'
+      yield 'b'
+      yield 'c'
+    }
+  }
+
+  const response = new Response(asyncIterable)
+  t.equal(await response.text(), 'abc')
+  t.end()
+})

--- a/test/node-fetch/response.js
+++ b/test/node-fetch/response.js
@@ -1,6 +1,7 @@
 /* eslint no-unused-expressions: "off" */
 
 const chai = require('chai')
+const stream = require('stream')
 const { Response } = require('../../lib/fetch/response.js')
 const TestServer = require('./utils/server.js')
 const { Blob } = require('buffer')
@@ -65,12 +66,12 @@ describe('Response', () => {
     // }
   })
 
-  // it('should support empty options', () => {
-  //   const res = new Response(stream.Readable.from('a=1'))
-  //   return res.text().then(result => {
-  //     expect(result).to.equal('a=1')
-  //   })
-  // })
+  it('should support empty options', () => {
+    const res = new Response(stream.Readable.from('a=1'))
+    return res.text().then(result => {
+      expect(result).to.equal('a=1')
+    })
+  })
 
   it('should support parsing headers', () => {
     const res = new Response(null, {
@@ -112,7 +113,7 @@ describe('Response', () => {
   }
 
   it('should support clone() method', () => {
-    const body = 'a=1'
+    const body = stream.Readable.from('a=1')
     const res = new Response(body, {
       headers: {
         a: '1'
@@ -136,13 +137,13 @@ describe('Response', () => {
     })
   })
 
-  // it('should support stream as body', () => {
-  //   const body = stream.Readable.from('a=1')
-  //   const res = new Response(body)
-  //   return res.text().then(result => {
-  //     expect(result).to.equal('a=1')
-  //   })
-  // })
+  it('should support stream as body', () => {
+    const body = stream.Readable.from('a=1')
+    const res = new Response(body)
+    return res.text().then(result => {
+      expect(result).to.equal('a=1')
+    })
+  })
 
   it('should support string as body', () => {
     const res = new Response('a=1')

--- a/test/node-fetch/response.js
+++ b/test/node-fetch/response.js
@@ -1,7 +1,6 @@
 /* eslint no-unused-expressions: "off" */
 
 const chai = require('chai')
-const stream = require('stream')
 const { Response } = require('../../lib/fetch/response.js')
 const TestServer = require('./utils/server.js')
 const { Blob } = require('buffer')
@@ -66,12 +65,12 @@ describe('Response', () => {
     // }
   })
 
-  it('should support empty options', () => {
-    const res = new Response(stream.Readable.from('a=1'))
-    return res.text().then(result => {
-      expect(result).to.equal('a=1')
-    })
-  })
+  // it('should support empty options', () => {
+  //   const res = new Response(stream.Readable.from('a=1'))
+  //   return res.text().then(result => {
+  //     expect(result).to.equal('a=1')
+  //   })
+  // })
 
   it('should support parsing headers', () => {
     const res = new Response(null, {
@@ -113,7 +112,7 @@ describe('Response', () => {
   }
 
   it('should support clone() method', () => {
-    const body = stream.Readable.from('a=1')
+    const body = 'a=1'
     const res = new Response(body, {
       headers: {
         a: '1'
@@ -137,13 +136,13 @@ describe('Response', () => {
     })
   })
 
-  it('should support stream as body', () => {
-    const body = stream.Readable.from('a=1')
-    const res = new Response(body)
-    return res.text().then(result => {
-      expect(result).to.equal('a=1')
-    })
-  })
+  // it('should support stream as body', () => {
+  //   const body = stream.Readable.from('a=1')
+  //   const res = new Response(body)
+  //   return res.text().then(result => {
+  //     expect(result).to.equal('a=1')
+  //   })
+  // })
 
   it('should support string as body', () => {
     const res = new Response('a=1')

--- a/test/webidl/helpers.js
+++ b/test/webidl/helpers.js
@@ -19,3 +19,57 @@ test('webidl.interfaceConverter', (t) => {
 
   t.end()
 })
+
+test('webidl.dictionaryConverter', (t) => {
+  t.test('extraneous keys are provided', (t) => {
+    const converter = webidl.dictionaryConverter([
+      {
+        key: 'key',
+        converter: webidl.converters.USVString,
+        defaultValue: 420,
+        required: true
+      }
+    ])
+
+    t.same(
+      converter({
+        a: 'b',
+        key: 'string',
+        c: 'd',
+        get value () {
+          return 6
+        }
+      }),
+      { key: 'string' }
+    )
+
+    t.end()
+  })
+
+  t.test('defaultValue with key = null', (t) => {
+    const converter = webidl.dictionaryConverter([
+      {
+        key: 'key',
+        converter: webidl.converters['unsigned short'],
+        defaultValue: 200
+      }
+    ])
+
+    t.same(converter({ key: null }), { key: 0 })
+    t.end()
+  })
+
+  t.test('no defaultValue and optional', (t) => {
+    const converter = webidl.dictionaryConverter([
+      {
+        key: 'key',
+        converter: webidl.converters.ByteString
+      }
+    ])
+
+    t.same(converter({ a: 'b', c: 'd' }), {})
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
- Adds idl checks to `Response`
- Adds `unsigned short` idl conversion (required by Response).
- Fixes 2 bugs in `webidl.dictionaryConverter` (tests added for these)

All tests pass.