### PR TITLE
feat(Request): webidl checks

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -8,7 +8,6 @@ const util = require('../core/util')
 const {
   isValidHTTPToken,
   sameOrigin,
-  toUSVString,
   normalizeMethod
 } = require('./util')
 const {
@@ -22,6 +21,7 @@ const {
 } = require('./constants')
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = require('./symbols')
+const { webidl } = require('./webidl')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 
@@ -36,27 +36,19 @@ const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
 // https://fetch.spec.whatwg.org/#request-class
 class Request {
   // https://fetch.spec.whatwg.org/#dom-request
-  constructor (...args) {
-    if (args[0] === kInit) {
+  constructor (input, init = {}) {
+    if (input === kInit) {
       return
     }
 
-    if (args.length < 1) {
+    if (arguments.length < 1) {
       throw new TypeError(
-        `Failed to construct 'Request': 1 argument required, but only ${args.length} present.`
+        `Failed to construct 'Request': 1 argument required, but only ${arguments.length} present.`
       )
     }
-    if (
-      args.length >= 1 &&
-      typeof args[1] !== 'object' &&
-      args[1] !== undefined
-    ) {
-      throw new TypeError(
-        "Failed to construct 'Request': cannot convert to dictionary."
-      )
-    }
-    const input = args[0] instanceof Request ? args[0] : toUSVString(args[0])
-    const init = args.length >= 1 ? args[1] ?? {} : {}
+
+    input = webidl.converters.RequestInfo(input)
+    init = webidl.converters.RequestInit(init)
 
     // TODO
     this[kRealm] = { settingsObject: {} }
@@ -822,5 +814,111 @@ Object.defineProperties(Request.prototype, {
   clone: kEnumerableProperty,
   signal: kEnumerableProperty
 })
+
+webidl.converters.Request = webidl.interfaceConverter(
+  Request
+)
+
+// https://fetch.spec.whatwg.org/#requestinfo
+webidl.converters.RequestInfo = function (V) {
+  if (typeof V === 'string') {
+    return webidl.converters.USVString(V)
+  }
+
+  if (V instanceof Request) {
+    return webidl.converters.Request(V)
+  }
+
+  return webidl.converters.USVString(V)
+}
+
+webidl.converters.AbortSignal = webidl.interfaceConverter(
+  AbortSignal
+)
+
+// https://fetch.spec.whatwg.org/#requestinit
+webidl.converters.RequestInit = webidl.dictionaryConverter([
+  {
+    key: 'method',
+    converter: webidl.converters.ByteString,
+    defaultValue: 'GET'
+  },
+  {
+    key: 'headers',
+    converter: webidl.converters.HeadersInit
+  },
+  {
+    key: 'body',
+    converter: webidl.nullableConverter(
+      webidl.converters.BodyInit
+    )
+  },
+  {
+    key: 'referrer',
+    converter: webidl.converters.USVString
+  },
+  {
+    key: 'referrerPolicy',
+    converter: webidl.converters.DOMString,
+    // https://w3c.github.io/webappsec-referrer-policy/#referrer-policy
+    allowedValues: [
+      '', 'no-referrer', 'no-referrer-when-downgrade',
+      'same-origin', 'origin', 'strict-origin',
+      'origin-when-cross-origin', 'strict-origin-when-cross-origin',
+      'unsafe-url'
+    ]
+  },
+  {
+    key: 'mode',
+    converter: webidl.converters.DOMString,
+    // https://fetch.spec.whatwg.org/#concept-request-mode
+    allowedValues: [
+      'same-origin', 'cors', 'no-cors', 'navigate', 'websocket'
+    ]
+  },
+  {
+    key: 'credentials',
+    converter: webidl.converters.DOMString,
+    // https://fetch.spec.whatwg.org/#requestcredentials
+    allowedValues: [
+      'omit', 'same-origin', 'include'
+    ]
+  },
+  {
+    key: 'cache',
+    converter: webidl.converters.DOMString,
+    // https://fetch.spec.whatwg.org/#requestcache
+    allowedValues: [
+      'default', 'no-store', 'reload', 'no-cache', 'force-cache',
+      'only-if-cached'
+    ]
+  },
+  {
+    key: 'redirect',
+    converter: webidl.converters.DOMString,
+    // https://fetch.spec.whatwg.org/#requestredirect
+    allowedValues: [
+      'follow', 'error', 'manual'
+    ]
+  },
+  {
+    key: 'integrity',
+    converter: webidl.converters.DOMString
+  },
+  {
+    key: 'keepalive',
+    converter: webidl.converters.boolean
+  },
+  {
+    key: 'signal',
+    converter: webidl.nullableConverter(
+      webidl.converters.AbortSignal
+    )
+  },
+  {
+    key: 'window',
+    converter: webidl.converters.any
+  }
+])
 
 module.exports = { Request, makeRequest }

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -530,7 +530,7 @@ webidl.converters.XMLHttpRequestBodyInit = function (V) {
     return webidl.converters.URLSearchParams(V)
   }
 
-  throw new TypeError()
+  return webidl.converters.DOMString(V)
 }
 
 // https://fetch.spec.whatwg.org/#bodyinit

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -229,7 +229,8 @@ webidl.interfaceConverter = function (i) {
  *   key: string,
  *   defaultValue?: any,
  *   required?: boolean,
- *   converter: (...args: unknown[]) => unknown
+ *   converter: (...args: unknown[]) => unknown,
+ *   allowedValues?: any[]
  * }[]} converters
  * @returns
  */
@@ -265,11 +266,29 @@ webidl.dictionaryConverter = function (converters) {
       // and do not assign the key a value.
       if (required || hasDefault || value !== undefined) {
         value = converter(value)
+
+        if (
+          options.allowedValues &&
+          !options.allowedValues.includes(value)
+        ) {
+          throw new TypeError()
+        }
+
         dict[key] = value
       }
     }
 
     return dict
+  }
+}
+
+webidl.nullableConverter = function (converter) {
+  return (V) => {
+    if (V === null) {
+      return V
+    }
+
+    return converter(V)
   }
 }
 
@@ -318,6 +337,21 @@ webidl.converters.ByteString = function (V) {
 // https://webidl.spec.whatwg.org/#es-USVString
 // TODO: ensure that util.toUSVString follows webidl spec
 webidl.converters.USVString = toUSVString
+
+// https://webidl.spec.whatwg.org/#es-boolean
+webidl.converters.boolean = function (V) {
+  // 1. Let x be the result of computing ToBoolean(V).
+  const x = Boolean(V)
+
+  // 2. Return the IDL boolean value that is the one that represents
+  //    the same truth value as the ECMAScript Boolean value x.
+  return x
+}
+
+// https://webidl.spec.whatwg.org/#es-any
+webidl.converters.any = function (V) {
+  return V
+}
 
 // https://webidl.spec.whatwg.org/#es-long-long
 webidl.converters['long long'] = function (V, opts) {

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -258,7 +258,7 @@ test('undefined integrity', t => {
 
 test('null integrity', t => {
   const req = new Request('http://asd', { integrity: null })
-  t.equal(req.integrity, '')
+  t.equal(req.integrity, 'null')
   t.end()
 })
 
@@ -366,5 +366,43 @@ test('Symbol.toStringTag', (t) => {
 
   t.equal(req[Symbol.toStringTag], 'Request')
   t.equal(Request.prototype[Symbol.toStringTag], 'Request')
+  t.end()
+})
+
+test('invalid RequestInit values', (t) => {
+  /* eslint-disable no-new */
+  t.throws(() => {
+    new Request('http://l', { mode: 'CoRs' })
+  }, TypeError, 'not exact case = error')
+
+  t.throws(() => {
+    new Request('http://l', { mode: 'random' })
+  }, TypeError)
+
+  t.throws(() => {
+    new Request('http://l', { credentials: 'OMIt' })
+  }, TypeError, 'not exact case = error')
+
+  t.throws(() => {
+    new Request('http://l', { credentials: 'random' })
+  }, TypeError)
+
+  t.throws(() => {
+    new Request('http://l', { cache: 'DeFaULt' })
+  }, TypeError, 'not exact case = error')
+
+  t.throws(() => {
+    new Request('http://l', { cache: 'random' })
+  }, TypeError)
+
+  t.throws(() => {
+    new Request('http://l', { redirect: 'FOllOW' })
+  }, TypeError, 'not exact case = error')
+
+  t.throws(() => {
+    new Request('http://l', { redirect: 'random' })
+  }, TypeError)
+  /* eslint-enable no-new */
+
   t.end()
 })

--- a/test/node-fetch/request.js
+++ b/test/node-fetch/request.js
@@ -1,7 +1,6 @@
 const stream = require('stream')
 const http = require('http')
 
-const AbortController = require('abort-controller')
 const chai = require('chai')
 const { Blob } = require('buffer')
 


### PR DESCRIPTION
- Remove `abort-controller` npm package support in `fetch`. I could add it back, but unlike `fetch-blob`, doesn't necessarily offer anything over node's built-in AbortController.
- Add in `webidl.converters.any` (just a noop)
- Add in `webidl.converters.boolean` (required for RequestInit.keepalive)
- Add in `webidl.nullableConverter` which allows null as a value in converters.
- Add in `allowedValues` in `webidl.dictionaryConverter` which allows specifying a list of values an input must be (this is needed for webidl enums)
- `webidl.converters.XMLHttpRequestBodyInit` now defaults to using the DOMString converter. Fixed a bug in the node-fetch suite when passing an object as RequestInit's body.
- Add in webidl converters for `Request`.