### PR TITLE
fix(fetch): use AbortError DOMException

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -1,13 +1,5 @@
 'use strict'
 
-class AbortError extends Error {
-  constructor () {
-    super('The operation was aborted')
-    this.code = 'ABORT_ERR'
-    this.name = 'AbortError'
-  }
-}
-
 class UndiciError extends Error {
   constructor (message) {
     super(message)
@@ -191,7 +183,6 @@ class HTTPParserError extends Error {
 }
 
 module.exports = {
-  AbortError,
   HTTPParserError,
   UndiciError,
   HeadersTimeoutError,

--- a/lib/fetch/constants.js
+++ b/lib/fetch/constants.js
@@ -62,19 +62,12 @@ const subresource = [
 
 /** @type {globalThis['DOMException']} */
 const DOMException = globalThis.DOMException ?? (() => {
-  /*! node-domexception. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
-
   // DOMException was only made a global in Node v17.0.0,
   // but fetch supports >= v16.5.
   try {
-    const { MessageChannel } = require('worker_threads')
-    const port = new MessageChannel().port1
-    const ab = new ArrayBuffer()
-    port.postMessage(ab, [ab, ab])
+    atob('~')
   } catch (err) {
-    if (err.constructor.name === 'DOMException') {
-      return err.constructor
-    }
+    return Object.getPrototypeOf(err).constructor
   }
 })()
 

--- a/lib/fetch/constants.js
+++ b/lib/fetch/constants.js
@@ -60,7 +60,26 @@ const subresource = [
   ''
 ]
 
+/** @type {globalThis['DOMException']} */
+const DOMException = globalThis.DOMException ?? (() => {
+  /*! node-domexception. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
+
+  // DOMException was only made a global in Node v17.0.0,
+  // but fetch supports >= v16.5.
+  try {
+    const { MessageChannel } = require('worker_threads')
+    const port = new MessageChannel().port1
+    const ab = new ArrayBuffer()
+    port.postMessage(ab, [ab, ab])
+  } catch (err) {
+    if (err.constructor.name === 'DOMException') {
+      return err.constructor
+    }
+  }
+})()
+
 module.exports = {
+  DOMException,
   subresource,
   forbiddenMethods,
   requestBodyHeader,

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -36,7 +36,6 @@ const {
   isAborted
 } = require('./util')
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
-const { AbortError } = require('../core/errors')
 const assert = require('assert')
 const { safelyExtractBody, extractBody } = require('./body')
 const {
@@ -44,7 +43,8 @@ const {
   nullBodyStatus,
   safeMethods,
   requestBodyHeader,
-  subresource
+  subresource,
+  DOMException
 } = require('./constants')
 const { kHeadersList } = require('../core/symbols')
 const EE = require('events')
@@ -82,7 +82,7 @@ class Fetch extends EE {
       return
     }
 
-    const reason = new AbortError()
+    const reason = new DOMException('The operation was aborted.', 'AbortError')
 
     this.state = 'aborted'
     this.connection?.destroy(reason)
@@ -295,7 +295,7 @@ function markResourceTiming () {
 // https://fetch.spec.whatwg.org/#abort-fetch
 function abortFetch (p, request, responseObject) {
   // 1. Let error be an "AbortError" DOMException.
-  const error = new AbortError()
+  const error = new DOMException('The operation was aborted.', 'AbortError')
 
   // 2. Reject promise with error.
   p.reject(error)
@@ -1555,7 +1555,7 @@ async function httpNetworkFetch (
     destroy (err) {
       if (!this.destroyed) {
         this.destroyed = true
-        this.abort?.(err ?? new AbortError())
+        this.abort?.(err ?? new DOMException('The operation was aborted.', 'AbortError'))
       }
     }
   }
@@ -1885,7 +1885,9 @@ async function httpNetworkFetch (
 
       // 2. If stream is readable, error stream with an "AbortError" DOMException.
       if (isReadable(stream)) {
-        fetchParams.controller.controller.error(new AbortError())
+        fetchParams.controller.controller.error(
+          new DOMException('The operation was aborted.', 'AbortError')
+        )
       }
     } else {
       // 3. Otherwise, if stream is readable, error stream with a TypeError.
@@ -1926,7 +1928,7 @@ async function httpNetworkFetch (
           const { connection } = fetchParams.controller
 
           if (connection.destroyed) {
-            abort(new AbortError())
+            abort(new DOMException('The operation was aborted.', 'AbortError'))
           } else {
             fetchParams.controller.on('terminated', abort)
             this.abort = connection.abort = abort

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { Headers, HeadersList, fill } = require('./headers')
-const { AbortError } = require('../core/errors')
 const { extractBody, cloneBody, mixinBody } = require('./body')
 const util = require('../core/util')
 const { kEnumerableProperty } = util
@@ -15,7 +14,8 @@ const {
 } = require('./util')
 const {
   redirectStatus,
-  nullBodyStatus
+  nullBodyStatus,
+  DOMException
 } = require('./constants')
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
 const { webidl } = require('./webidl')
@@ -440,7 +440,7 @@ function makeAppropriateNetworkError (fetchParams) {
   // 2. Return an aborted network error if fetchParams is aborted;
   // otherwise return a network error.
   return isAborted(fetchParams)
-    ? makeNetworkError(new AbortError())
+    ? makeNetworkError(new DOMException('The operation was aborted.', 'AbortError'))
     : makeNetworkError(fetchParams.controller.terminated.reason)
 }
 

--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -4,6 +4,8 @@ const { test } = require('tap')
 const { fetch } = require('../..')
 const { createServer } = require('http')
 const { once } = require('events')
+const { ReadableStream } = require('stream/web')
+const { DOMException } = require('../../lib/fetch/constants')
 
 /* global AbortController */
 
@@ -52,8 +54,55 @@ test('parallel fetch with the same AbortController works as expected', async (t)
   t.equal(rejected.length, 9) // out of 10 requests, only 1 should succeed
   t.equal(resolved.length, 1)
 
-  t.ok(rejected.every(rej => rej.reason?.code === 'ABORT_ERR'))
+  t.ok(rejected.every(rej => rej.reason?.code === DOMException.ABORT_ERR))
   t.same(resolved[0].value, body)
+
+  t.end()
+})
+
+// https://github.com/web-platform-tests/wpt/blob/fd8aeb1bb2eb33bc43f8a5bbc682b0cff6075dfe/fetch/api/abort/general.any.js#L474-L507
+test('Readable stream synchronously cancels with AbortError if aborted before reading', async (t) => {
+  const server = createServer((req, res) => {
+    res.write('')
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const controller = new AbortController()
+  const signal = controller.signal
+  controller.abort()
+
+  let cancelReason
+
+  const body = new ReadableStream({
+    pull (controller) {
+      controller.enqueue(new Uint8Array([42]))
+    },
+    cancel (reason) {
+      cancelReason = reason
+    }
+  })
+
+  const fetchPromise = fetch(`http://localhost:${server.address().port}`, {
+    body,
+    signal,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/plain'
+    }
+  })
+
+  t.ok(cancelReason, 'Cancel called sync')
+  t.equal(cancelReason.constructor, DOMException)
+  t.equal(cancelReason.name, 'AbortError')
+
+  await t.rejects(fetchPromise, { name: 'AbortError' })
+
+  const fetchErr = await fetchPromise.catch(e => e)
+
+  t.equal(cancelReason, fetchErr, 'Fetch rejects with same error instance')
 
   t.end()
 })


### PR DESCRIPTION
This commit uses the proper error when a request is aborted. A WPT actually checks for this behavior.

![image](https://user-images.githubusercontent.com/42794878/175205621-19010db2-a164-4d4d-856b-7ae3bbb0b3c7.png)

---

Honestly I didn't know if I should have put DOMException in constants or in util. I can change it if it matters or there's a preference.