### PR TITLE
feat(fetch): remove unnecessary checks

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -95,24 +95,12 @@ class Fetch extends EE {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
-async function fetch (...args) {
-  if (args.length < 1) {
+async function fetch (input, init = undefined) {
+  if (arguments.length < 1) {
     throw new TypeError(
-      `Failed to execute 'fetch' on 'Window': 1 argument required, but only ${args.length} present.`
+      `Failed to execute 'fetch' on 'Window': 1 argument required, but only ${arguments.length} present.`
     )
   }
-  if (
-    args.length >= 1 &&
-    typeof args[1] !== 'object' &&
-    args[1] !== undefined
-  ) {
-    throw new TypeError(
-      "Failed to execute 'fetch' on 'Window': cannot convert to dictionary."
-    )
-  }
-
-  const resource = args[0]
-  const init = args.length >= 1 ? args[1] ?? {} : {}
 
   // 1. Let p be a new promise.
   const p = createDeferredPromise()
@@ -120,7 +108,14 @@ async function fetch (...args) {
   // 2. Let requestObject be the result of invoking the initial value of
   // Request as constructor with input and init as arguments. If this throws
   // an exception, reject p with it and return p.
-  const requestObject = new Request(resource, init)
+  let requestObject
+
+  try {
+    requestObject = new Request(input, init)
+  } catch (e) {
+    p.reject(e)
+    return p.promise
+  }
 
   // 3. Let request be requestObject’s request.
   const request = requestObject[kState]


### PR DESCRIPTION
Webidl conversions/checks are done in the Request constructor, so the checks in the fetch function were unnecessary.