### PR TITLE
docs: add example with `HEAD` method to garbage collection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ const headers = await fetch(url)
   .then(res => res.headers)
 ```
 
+However, if you want to get only headers, it might be better to use `HEAD` request method. Usage of this method will obviate the need for consumption or cancelling of the response body. See [MDN - HTTP - HTTP request methods - HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) for more details.
+
+```js
+const headers = await fetch(url, { method: 'HEAD' })
+  .then(res => res.headers)
+```
+
 ##### Forbidden and Safelisted Header Names
 
 * https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name


### PR DESCRIPTION
Adds example of getting headers using `HEAD` method to garbage collection section.

Closes #1505.