### PR TITLE
feat(headers): expose `headerValueNormalize`

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -497,5 +497,6 @@ webidl.converters.HeadersInit = function (V) {
 module.exports = {
   fill,
   Headers,
-  HeadersList
+  HeadersList,
+  headerValueNormalize
 }


### PR DESCRIPTION
Hello,

We want to upgrade from undici [5.5.1 to 5.6.0](https://github.com/vercel/edge-runtime/pull/14), and we were using `normalizeAndValidateHeaderValue` that is now `headerValueNormalize`, so we need it to be exported too.

