### PR TITLE
fix: require toUSVString from fetch utils

### DIFF
--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { toUSVString, types } = require('util')
+const { toUSVString } = require('./util')
+const { types } = require('util')
 
 const webidl = {}
 webidl.converters = {}


### PR DESCRIPTION
Since `util.toUSVString` doesn't exist at node12, in this way the fallback implementation will be used.