### PR TITLE
fix(fetch): do not assign default value to `RequestInit.method`

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -95,7 +95,7 @@ class Fetch extends EE {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
-async function fetch (input, init = undefined) {
+async function fetch (input, init = {}) {
   if (arguments.length < 1) {
     throw new TypeError(
       `Failed to execute 'fetch' on 'Window': 1 argument required, but only ${arguments.length} present.`

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -843,8 +843,7 @@ webidl.converters.AbortSignal = webidl.interfaceConverter(
 webidl.converters.RequestInit = webidl.dictionaryConverter([
   {
     key: 'method',
-    converter: webidl.converters.ByteString,
-    defaultValue: 'GET'
+    converter: webidl.converters.ByteString
   },
   {
     key: 'headers',


### PR DESCRIPTION
Fixes #1527 

---

The fetch docs confused me; for the `method` getter steps, GET is the default value. It should have been unset if the value was not provided in the constructor, though.

See:
1. https://fetch.spec.whatwg.org/#ref-for-dom-requestinit-method
2. https://fetch.spec.whatwg.org/#concept-request-method