### PR TITLE
fix: allow optional body for mock reply

### DIFF
--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -465,7 +465,7 @@ agent.disableNetConnect()
 agent
   .get('https://example.com')
   .intercept({ method: 'GET', path: '/' })
-  .reply(200, '')
+  .reply(200)
 
 const pendingInterceptors = agent.pendingInterceptors()
 // Returns [
@@ -508,7 +508,7 @@ agent.disableNetConnect()
 agent
   .get('https://example.com')
   .intercept({ method: 'GET', path: '/' })
-  .reply(200, '')
+  .reply(200)
 
 agent.assertNoPendingInterceptors()
 // Throws an UndiciError with the following message:

--- a/lib/mock/mock-interceptor.js
+++ b/lib/mock/mock-interceptor.js
@@ -130,7 +130,7 @@ class MockInterceptor {
           throw new InvalidArgumentError('reply options callback must return an object')
         }
 
-        const { statusCode, data, responseOptions = {} } = resolvedData
+        const { statusCode, data = '', responseOptions = {} } = resolvedData
         this.validateReplyParameters(statusCode, data, responseOptions)
         // Since the values can be obtained immediately we return them
         // from this higher order function that will be resolved later.
@@ -145,10 +145,10 @@ class MockInterceptor {
     }
 
     // We can have either one or three parameters, if we get here,
-    // we should have 2-3 parameters. So we spread the arguments of
+    // we should have 1-3 parameters. So we spread the arguments of
     // this function to obtain the parameters, since replyData will always
     // just be the statusCode.
-    const [statusCode, data, responseOptions = {}] = [...arguments]
+    const [statusCode, data = '', responseOptions = {}] = [...arguments]
     this.validateReplyParameters(statusCode, data, responseOptions)
 
     // Send in-already provided data like usual

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -32,14 +32,13 @@ test('MockInterceptor - reply', t => {
   })
 
   t.test('should error if passed options invalid', t => {
-    t.plan(3)
+    t.plan(2)
 
     const mockInterceptor = new MockInterceptor({
       path: '',
       method: ''
     }, [])
     t.throws(() => mockInterceptor.reply(), new InvalidArgumentError('statusCode must be defined'))
-    t.throws(() => mockInterceptor.reply(200), new InvalidArgumentError('data must be defined'))
     t.throws(() => mockInterceptor.reply(200, '', 'hello'), new InvalidArgumentError('responseOptions must be an object'))
   })
 })
@@ -113,7 +112,7 @@ test('MockInterceptor - reply options callback', t => {
   })
 
   t.test('should error if passed options invalid', async (t) => {
-    t.plan(4)
+    t.plan(3)
 
     const baseUrl = 'http://localhost:9999'
     const mockAgent = new MockAgent()
@@ -125,13 +124,6 @@ test('MockInterceptor - reply options callback', t => {
       path: '/test',
       method: 'GET'
     }).reply(() => {})
-
-    mockPool.intercept({
-      path: '/test2',
-      method: 'GET'
-    }).reply(() => ({
-      statusCode: 200
-    }))
 
     mockPool.intercept({
       path: '/test3',
@@ -158,15 +150,6 @@ test('MockInterceptor - reply options callback', t => {
       onData: () => {},
       onComplete: () => {}
     }), new InvalidArgumentError('reply options callback must return an object'))
-
-    t.throws(() => mockPool.dispatch({
-      path: '/test2',
-      method: 'GET'
-    }, {
-      onHeaders: () => {},
-      onData: () => {},
-      onComplete: () => {}
-    }), new InvalidArgumentError('data must be defined'))
 
     t.throws(() => mockPool.dispatch({
       path: '/test3',

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -12,6 +12,7 @@ expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCall
   const mockInterceptorDefaultMethod = mockPool.intercept({ path: '' })
 
   // reply
+  expectAssignable<MockScope>(mockInterceptor.reply(200))
   expectAssignable<MockScope>(mockInterceptor.reply(200, ''))
   expectAssignable<MockScope>(mockInterceptor.reply(200, Buffer))
   expectAssignable<MockScope>(mockInterceptor.reply(200, {}))
@@ -55,7 +56,7 @@ expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCall
 
 {
   const mockPool: MockPool = new MockAgent().get('')
-  const mockScope = mockPool.intercept({ path: '', method: 'GET' }).reply(200, '')
+  const mockScope = mockPool.intercept({ path: '', method: 'GET' }).reply(200)
 
   // delay
   expectAssignable<MockScope>(mockScope.delay(1))

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -26,7 +26,7 @@ declare class MockInterceptor {
   reply<TData extends object = object>(replyOptionsCallback: MockInterceptor.MockReplyOptionsCallback<TData>): MockScope<TData>;
   reply<TData extends object = object>(
     statusCode: number,
-    data: TData | Buffer | string | MockInterceptor.MockResponseDataHandler<TData>,
+    data?: TData | Buffer | string | MockInterceptor.MockResponseDataHandler<TData>,
     responseOptions?: MockInterceptor.MockResponseOptions
   ): MockScope<TData>;
   /** Mock an undici request by throwing the defined reply error. */
@@ -84,7 +84,7 @@ declare namespace MockInterceptor {
 
   export type MockReplyOptionsCallback<TData extends object = object> = (
     opts: MockResponseCallbackOptions
-  ) => { statusCode: number, data: TData | Buffer | string, responseOptions?: MockResponseOptions }
+  ) => { statusCode: number, data?: TData | Buffer | string, responseOptions?: MockResponseOptions }
 }
 
 interface Interceptable extends Dispatcher {


### PR DESCRIPTION
Quick quality of life fix.  The `reply` method today on the mock interceptor requires both an HTTP status code and a body to send.  In a lot of cases, it's common to mock out an empty body.  Trying to make this as smooth as `nock` by defaulting the body to `''` :)