### PR TITLE
Exclude windows node 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,6 +20,9 @@ jobs:
       include: |
         - runs-on: ubuntu-latest
           node-version: 16.8
+      exclude:
+        - runs-on: windows-latest
+          node-version: 16
   automerge:
     if: >
         github.event_name == 'pull_request' &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undici",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "An HTTP/1.1 client, written from scratch for Node.js",
   "homepage": "https://undici.nodejs.org",
   "bugs": {


### PR DESCRIPTION
Our CI has been failing consistently on Windows and Node v16.
I'm removing that environment from CI.