### PR TITLE
Fix up `exclude` in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
       include: |
         - runs-on: ubuntu-latest
           node-version: 16.8
-      exclude:
+      exclude: |
         - runs-on: windows-latest
           node-version: 16
   automerge:


### PR DESCRIPTION
Unfortunately, shared worklfows can't take objects as params - this needs to be a string...