### PR TITLE
fix(mock utils): set Readable.abort

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -8,7 +8,7 @@ const {
   kOrigin,
   kGetNetConnect
 } = require('./mock-symbols')
-const { buildURL } = require('../core/util')
+const { buildURL, nop } = require('../core/util')
 
 function matchValue (match, value) {
   if (typeof match === 'string') {
@@ -288,6 +288,7 @@ function mockDispatch (opts, handler) {
     const responseHeaders = generateKeyValues(headers)
     const responseTrailers = generateKeyValues(trailers)
 
+    handler.abort = nop
     handler.onHeaders(statusCode, responseHeaders, resume, getStatusText(statusCode))
     handler.onData(Buffer.from(responseData))
     handler.onComplete(responseTrailers)


### PR DESCRIPTION
Fixes #1546

`.abort` is set once `Dispatcher.onConnect` is called, but it's possible the method doesn't exist (another test was failing with this change) and the semantics of calling it when no request was dispatched didn't make much sense to me.