### PR TITLE
fix(MockInterceptor): callback options.headers w/ fetch

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -51,15 +51,20 @@ function getHeaderByName (headers, key) {
   }
 }
 
+/** @param {string[]} headers */
+function buildHeadersFromArray (headers) { // fetch HeadersList
+  const clone = headers.slice()
+  const entries = []
+  for (let index = 0; index < clone.length; index += 2) {
+    entries.push([clone[index], clone[index + 1]])
+  }
+  return Object.fromEntries(entries)
+}
+
 function matchHeaders (mockDispatch, headers) {
   if (typeof mockDispatch.headers === 'function') {
     if (Array.isArray(headers)) { // fetch HeadersList
-      const clone = headers.slice()
-      const entries = []
-      for (let index = 0; index < clone.length; index += 2) {
-        entries.push([clone[index], clone[index + 1]])
-      }
-      headers = Object.fromEntries(entries)
+      headers = buildHeadersFromArray(headers)
     }
     return mockDispatch.headers(headers ? lowerCaseEntries(headers) : {})
   }
@@ -284,7 +289,13 @@ function mockDispatch (opts, handler) {
   }
 
   function handleReply (mockDispatches) {
-    const responseData = getResponseData(typeof data === 'function' ? data(opts) : data)
+    // fetch's HeadersList is a 1D string array
+    const optsHeaders = Array.isArray(opts.headers)
+      ? buildHeadersFromArray(opts.headers)
+      : opts.headers
+    const responseData = getResponseData(
+      typeof data === 'function' ? data({ ...opts, headers: optsHeaders }) : data
+    )
     const responseHeaders = generateKeyValues(headers)
     const responseTrailers = generateKeyValues(trailers)
 

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -36,6 +36,10 @@ expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCall
   expectAssignable<MockScope>(mockInterceptor.reply(() => ({ statusCode: 200, data: { foo: 'bar' }, responseOptions: {
     trailers: { foo: 'bar' }
   }})))
+  mockInterceptor.reply((options) => {
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions['headers']>(options.headers);
+    return { statusCode: 200, data: { foo: 'bar' } }
+  })
 
   // replyWithError
   class CustomError extends Error {

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -74,7 +74,7 @@ declare namespace MockInterceptor {
     origin: string;
     method: string;
     body?: BodyInit | Dispatcher.DispatchOptions['body'];
-    headers: Headers;
+    headers: Headers | Record<string, string>;
     maxRedirections: number;
   }
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/undici/issues/1556

1D headers array comes from https://github.com/nodejs/undici/blob/23f80fb1067ec9844ae3ac2827893980c5c1b839/lib/fetch/index.js#L1918