### PR TITLE
fix(fetch): ByteString checks & conversion in Headers

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1946,8 +1946,8 @@ async function httpNetworkFetch (
 
           const headers = new Headers()
           for (let n = 0; n < headersList.length; n += 2) {
-            const key = headersList[n + 0].toString()
-            const val = headersList[n + 1].toString()
+            const key = headersList[n + 0].toString('latin1')
+            const val = headersList[n + 1].toString('latin1')
 
             if (key.toLowerCase() === 'content-encoding') {
               codings = val.split(',').map((x) => x.trim())

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -388,8 +388,9 @@ webidl.converters.DOMString = function (V, opts = {}) {
   return String(V)
 }
 
+// Check for 0 or more characters outside of the latin1 range.
 // eslint-disable-next-line no-control-regex
-const isNotLatin1 = /[^\u0000-\u00ff]/
+const isLatin1 = /^[\u0000-\u00ff]{0,}$/
 
 // https://webidl.spec.whatwg.org/#es-ByteString
 webidl.converters.ByteString = function (V) {
@@ -399,7 +400,7 @@ webidl.converters.ByteString = function (V) {
 
   // 2. If the value of any element of x is greater than
   //    255, then throw a TypeError.
-  if (isNotLatin1.test(x)) {
+  if (!isLatin1.test(x)) {
     throw new TypeError('Argument is not a ByteString')
   }
 

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -183,3 +183,11 @@ test('BufferSource', (t) => {
 
   t.end()
 })
+
+test('ByteString', (t) => {
+  t.doesNotThrow(() => {
+    webidl.converters.ByteString('')
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1317 

Properly converts headers to Latin1. Also fixes some inconsistencies with the regex check in webidl.