### PR TITLE
fix: x-www-form-urlencoded parser keep the BOM

### DIFF
--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -202,6 +202,42 @@ test('urlencoded formData', (t) => {
   })
 })
 
+test('text with BOM', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('content-type', 'application/x-www-form-urlencoded')
+    res.end('\uFEFFtest=\uFEFF')
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    fetch(`http://localhost:${server.address().port}`)
+      .then(res => res.text())
+      .then(text => {
+        t.equal(text, 'test=\uFEFF')
+      })
+  })
+})
+
+test('formData with BOM', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('content-type', 'application/x-www-form-urlencoded')
+    res.end('\uFEFFtest=\uFEFF')
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    fetch(`http://localhost:${server.address().port}`)
+      .then(res => res.formData())
+      .then(formData => {
+        t.equal(formData.get('\uFEFFtest'), '\uFEFF')
+      })
+  })
+})
+
 test('locked blob body', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
According to [WHATWG spec](https://fetch.spec.whatwg.org/#body-mixin:~:text=Otherwise%2C%20if%20mimeType%E2%80%99s%20essence%20is%20%22application/x%2Dwww%2Dform%2Durlencoded%22%2C%20then%3A), if mimeType is "application/x-www-form-urlencoded", `.formData()` will parse the body with [application/x-www-form-urlencoded parser](https://url.spec.whatwg.org/#concept-urlencoded-parser). It uses [UTF-8 decode without BOM](https://encoding.spec.whatwg.org/#utf-8-decode-without-bom) which preserves the BOM.
In contrast, `.text()` will use [UTF-8 decode](https://fetch.spec.whatwg.org/#body-mixin:~:text=Return%20the%20result%20of%20running%20UTF%2D8%20decode%20on%20bytes.) , which removes the BOM.

Currently Node.js fails this test case from WPT.
https://github.com/web-platform-tests/wpt/blob/fd64a55ccd24da176a82c1d9cc4e777f1832ab30/url/urlencoded-parser.any.js#L3