### PR TITLE
docs: Fix DiagnosticsChannel sidebar link

### DIFF
--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -15,7 +15,7 @@
   * [MockAgent](/docs/api/MockAgent.md "Undici API - MockAgent")
   * [MockErrors](/docs/api/MockErrors.md "Undici API - MockErrors")
   * [API Lifecycle](/docs/api/api-lifecycle.md "Undici API - Lifecycle")
-  * [Diagnosthic Channel Support](/docs/api/DiagnosticChannel.md "Diagnostic Channel Support")
+  * [Diagnostics Channel Support](/docs/api/DiagnosticsChannel.md "Diagnostics Channel Support")
 * Best Practices
   * [Proxy](/docs/best-practices/proxy.md "Connecting through a proxy")
   * [Client Certificate](/docs/best-practices/client-certificate.md "Connect using a client certificate")


### PR DESCRIPTION
Currently the sidebar link 404s because of the typo: https://undici.nodejs.org/#/docs/api/DiagnosticChannel