### PR TITLE
fix: make mock headers case-insensitive

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -38,7 +38,7 @@ function lowerCaseEntries (headers) {
 function getHeaderByName (headers, key) {
   if (Array.isArray(headers)) {
     for (let i = 0; i < headers.length; i += 2) {
-      if (headers[i] === key) {
+      if (headers[i].toLocaleLowerCase() === key.toLocaleLowerCase()) {
         return headers[i + 1]
       }
     }
@@ -47,7 +47,7 @@ function getHeaderByName (headers, key) {
   } else if (typeof headers.get === 'function') {
     return headers.get(key)
   } else {
-    return headers[key]
+    return lowerCaseEntries(headers)[key.toLocaleLowerCase()]
   }
 }
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2469,6 +2469,7 @@ test('MockAgent - headers in mock dispatcher intercept should be case-insensitiv
   const { fetch } = require('..')
 
   const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
   setGlobalDispatcher(mockAgent)
   t.teardown(mockAgent.close.bind(mockAgent))
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2463,3 +2463,33 @@ test('MockAgent - using fetch yields a headers object in the reply callback', { 
 
   t.end()
 })
+
+// https://github.com/nodejs/undici/issues/1579
+test('MockAgent - headers in mock dispatcher intercept should be case-insensitive', { skip: nodeMajor < 16 }, async (t) => {
+  const { fetch } = require('..')
+
+  const mockAgent = new MockAgent()
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+
+  const mockPool = mockAgent.get('https://example.com')
+
+  mockPool
+    .intercept({
+      path: '/',
+      headers: {
+        authorization: 'Bearer 12345',
+        'USER-agent': 'undici'
+      }
+    })
+    .reply(200)
+
+  await fetch('https://example.com', {
+    headers: {
+      Authorization: 'Bearer 12345',
+      'user-AGENT': 'undici'
+    }
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1579

This PR makes headers in mock dispatcher case-insensitive. Let me know if I'm going in the wrong direction.