### PR TITLE
Fix array headers

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -244,7 +244,11 @@ function parseHeaders (headers, obj = {}) {
     const key = headers[i].toString().toLowerCase()
     let val = obj[key]
     if (!val) {
-      obj[key] = headers[i + 1].toString()
+      if (Array.isArray(headers[i + 1])) {
+        obj[key] = headers[i + 1]
+      } else {
+        obj[key] = headers[i + 1].toString()
+      }
     } else {
       if (!Array.isArray(val)) {
         val = [val]

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2495,7 +2495,7 @@ test('MockAgent - headers in mock dispatcher intercept should be case-insensitiv
   t.end()
 })
 
-test('MockAgent - headers should be array of strings', { skip: nodeMajor < 16 }, async (t) => {
+test('MockAgent - headers should be array of strings', async (t) => {
   const mockAgent = new MockAgent()
   mockAgent.disableNetConnect()
   setGlobalDispatcher(mockAgent)

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2494,3 +2494,30 @@ test('MockAgent - headers in mock dispatcher intercept should be case-insensitiv
 
   t.end()
 })
+
+test('MockAgent - headers should be array of strings', { skip: nodeMajor < 16 }, async (t) => {
+  const mockAgent = new MockAgent()
+  mockAgent.disableNetConnect()
+  setGlobalDispatcher(mockAgent)
+
+  const mockPool = mockAgent.get('http://localhost:3000')
+
+  mockPool.intercept({
+    path: '/foo',
+    method: 'GET'
+  }).reply(200, 'foo', {
+    headers: {
+      'set-cookie': [
+        'foo=bar',
+        'bar=baz',
+        'baz=qux'
+      ]
+    }
+  })
+
+  const { headers } = await request('http://localhost:3000/foo', {
+    method: 'GET'
+  })
+
+  t.equal(headers['set-cookie'].length, 3)
+})

--- a/test/util.js
+++ b/test/util.js
@@ -83,11 +83,12 @@ test('validateHandler', (t) => {
 })
 
 test('parseHeaders', (t) => {
-  t.plan(4)
+  t.plan(5)
   t.same(util.parseHeaders(['key', 'value']), { key: 'value' })
   t.same(util.parseHeaders([Buffer.from('key'), Buffer.from('value')]), { key: 'value' })
   t.same(util.parseHeaders(['Key', 'Value']), { key: 'Value' })
   t.same(util.parseHeaders(['Key', 'value', 'key', 'Value']), { key: ['value', 'Value'] })
+  t.same(util.parseHeaders(['key', ['value1', 'value2', 'value3']]), { key: ['value1', 'value2', 'value3'] })
 })
 
 test('parseRawHeaders', (t) => {


### PR DESCRIPTION
This PR fixes #1532.

The `parseHeaders` method doesn't handle the possibility of the array as the value in the headers. So I've added 1 check to prevent array serialization. I've added 2 tests for that.

The response now is:

```js
{
  statusCode: 200,
  headers: {
    'set-cookie': ['a=b', 'c=d', 'd=e'];
  }
}
```
