### PR TITLE
fix(File): respect typed array `byteOffset` and `byteLength`

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -278,7 +278,9 @@ function processBlobParts (parts, options) {
       if (!element.buffer) { // ArrayBuffer
         bytes.push(new Uint8Array(element))
       } else {
-        bytes.push(element.buffer)
+        bytes.push(
+          new Uint8Array(element.buffer, element.byteOffset, element.byteLength)
+        )
       }
     } else if (isBlobLike(element)) {
       // 3. If element is a Blob, append the bytes it represents

--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -120,6 +120,16 @@ test('File.prototype.text', async (t) => {
     t.equal(await file.text(), 'hello world')
     t.end()
   })
+
+  t.test('With TypedArray range', async (t) => {
+    const uint8_1 = new Uint8Array(Buffer.from('hello world'))
+    const uint8_2 = new Uint8Array(uint8_1.buffer, 1, 4)
+
+    const file = new File([uint8_2], 'hello_world.txt')
+
+    t.equal(await file.text(), 'ello')
+    t.end()
+  })
   /* eslint-enable camelcase */
 
   t.test('With ArrayBuffer', async (t) => {
@@ -135,6 +145,15 @@ test('File.prototype.text', async (t) => {
   t.test('With string', async (t) => {
     const string = 'hello world'
     const file = new File([string], 'hello_world.txt')
+
+    t.equal(await file.text(), 'hello world')
+    t.end()
+  })
+
+  t.test('With Buffer', async (t) => {
+    const buffer = Buffer.from('hello world')
+
+    const file = new File([buffer], 'hello_world.txt')
 
     t.equal(await file.text(), 'hello world')
     t.end()


### PR DESCRIPTION
`File` ignored the `byteOffset` and `byteLength` properties of typed arrays, meaning the entire backing `ArrayBuffer` was included. Notably, this caused issues when passing `Buffer`s to the `File` constructor.

```js
import { File } from "undici";

const arrayBuffer = new TextEncoder().encode("abcdef").buffer;
const array = new Uint8Array(arrayBuffer, 1, 3);
const arrayFile = new File([array], "file.txt");
console.log(await arrayFile.text()); // expected "bcd", got "abcdef"

const buffer = Buffer.from("test");
const bufferFile = new File([buffer], "file.txt");
console.log(await bufferFile.text()); // expected "test", got garbage
```