### PR TITLE
fix(fetch): allow custom implementation of AbortSignal

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -835,10 +835,6 @@ webidl.converters.RequestInfo = function (V) {
   return webidl.converters.USVString(V)
 }
 
-webidl.converters.AbortSignal = webidl.interfaceConverter(
-  AbortSignal
-)
-
 // https://fetch.spec.whatwg.org/#requestinit
 webidl.converters.RequestInit = webidl.dictionaryConverter([
   {
@@ -913,9 +909,7 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
   },
   {
     key: 'signal',
-    converter: webidl.nullableConverter(
-      webidl.converters.AbortSignal
-    )
+    converter: webidl.converters.any
   },
   {
     key: 'window',


### PR DESCRIPTION
The PR closes #1605.

A test case is added to ensure it is the `DOMException` being thrown, not `TypeError`.

cc @mcollina @KhafraDev 