### PR TITLE
fix: allow third party AbortControllers

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -835,6 +835,10 @@ webidl.converters.RequestInfo = function (V) {
   return webidl.converters.USVString(V)
 }
 
+webidl.converters.AbortSignal = webidl.interfaceConverter(
+  AbortSignal
+)
+
 // https://fetch.spec.whatwg.org/#requestinit
 webidl.converters.RequestInit = webidl.dictionaryConverter([
   {
@@ -909,7 +913,12 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
   },
   {
     key: 'signal',
-    converter: webidl.converters.any
+    converter: webidl.nullableConverter(
+      (signal) => webidl.converters.AbortSignal(
+        signal,
+        { strict: false }
+      )
+    )
   },
   {
     key: 'window',

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -5,7 +5,8 @@
 const { test } = require('tap')
 const {
   Request,
-  Headers
+  Headers,
+  fetch
 } = require('../../')
 const { kState } = require('../../lib/fetch/symbols.js')
 const hasSignalReason = !!~process.version.localeCompare('v16.14.0', undefined, { numeric: true })
@@ -420,4 +421,16 @@ test('invalid RequestInit values', (t) => {
   /* eslint-enable no-new */
 
   t.end()
+})
+
+test('RequestInit.signal option', async (t) => {
+  t.throws(() => {
+    new Request('http://asd', {
+      signal: true
+    })
+  }, TypeError)
+
+  await t.rejects(fetch('http://asd', {
+    signal: false
+  }), TypeError)
 })

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -425,6 +425,7 @@ test('invalid RequestInit values', (t) => {
 
 test('RequestInit.signal option', async (t) => {
   t.throws(() => {
+    // eslint-disable-next-line no-new
     new Request('http://asd', {
       signal: true
     })


### PR DESCRIPTION
Complements #1608 (totally fixes #1605)

When better checks are performed in the `interfaceConverter` function, this partial revert will be more useful. From my comment in #1608: `Of course the webidl interface converter could also be improved such that when passing a strict: false option, it would check the object's Symbol.toStringTag/constructor name [instead of allowing any value].`