### PR TITLE
fix: Convert logical nullish assignment for backward compatibility

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -402,7 +402,7 @@ class Headers {
   }
 
   get [kHeadersSortedMap] () {
-    this[kHeadersList][kHeadersSortedMap] ??= new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1))
+    this[kHeadersList][kHeadersSortedMap] ?? (this[kHeadersList][kHeadersSortedMap] = new Map([...this[kHeadersList]].sort((a, b) => a[0] < b[0] ? -1 : 1)))
     return this[kHeadersList][kHeadersSortedMap]
   }
 


### PR DESCRIPTION
### Motivation
Backward compatibility
`??=` is only supported from `ecmaVersion: 2021`

### Solution
Converted logical nullish assignment `x ??= y` to `x ?? (x = y)`
(Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment)

### Related Issue
Closes #1479