### PR TITLE
fix(fetch): hangs on a stream response with manual redirect

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1048,7 +1048,9 @@ async function httpFetch (fetchParams) {
     // and the connection uses HTTP/2, then user agents may, and are even
     // encouraged to, transmit an RST_STREAM frame.
     // See, https://github.com/whatwg/fetch/issues/1288
-    fetchParams.controller.connection.destroy()
+    if (request.redirect !== 'manual') {
+      fetchParams.controller.connection.destroy()
+    }
 
     // 2. Switch on request’s redirect mode:
     if (request.redirect === 'error') {


### PR DESCRIPTION
### 📖 What's in there?

We found out that `fetch()` hangs when consuming the stream body of a redirect, when `{ redirect: 'manual' }` is set.
Full discussion: https://github.com/nodejs/undici/discussions/1618

### 🧪 How to test?

It's covered with unit test: `npm run test:fetch`
Without the fix, you'll see a new test failing like this:
```shell
 FAIL  test/fetch/client-fetch.js
 ✖ terminated

        fetchParams.controller.controller.error(
          new TypeError('terminated', {
----------^
            cause: isErrorLike(reason) ? reason : undefined
          })

  test: redirect with stream
  stack: |
    Fetch.onAborted (lib/fetch/index.js:1913:11)
    Fetch.terminate (lib/fetch/index.js:83:10)
    Object.onError (lib/fetch/index.js:2061:36)
    Request.onError (lib/core/request.js:265:27)
    errorRequest (lib/client.js:1722:13)
    Object.abort (lib/client.js:1335:7)
    Object.destroy (lib/fetch/index.js:1571:21)
    httpFetch (lib/fetch/index.js:1066:41)
  at:
    line: 1913
    column: 11
    file: lib/fetch/index.js
    function: Fetch.onAborted
  type: TypeError
  tapCaught: unhandledRejection
```
