### PR TITLE
fix(fetch): decode response body when Location is set on non-3xx response

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1958,8 +1958,12 @@ async function httpNetworkFetch (
 
           const decoders = []
 
+          const willFollow = request.redirect === 'follow' &&
+            location &&
+            redirectStatus.includes(status)
+
           // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-          if (request.method !== 'HEAD' && request.method !== 'CONNECT' && !nullBodyStatus.includes(status) && !(request.redirect === 'follow' && location)) {
+          if (request.method !== 'HEAD' && request.method !== 'CONNECT' && !nullBodyStatus.includes(status) && !willFollow) {
             for (const coding of codings) {
               if (/(x-)?gzip/.test(coding)) {
                 decoders.push(zlib.createGunzip())

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -533,6 +533,25 @@ test('do not decode redirect body', (t) => {
   })
 })
 
+test('decode non-redirect body with location header', (t) => {
+  t.plan(2)
+
+  const obj = { asd: true }
+  const server = createServer((req, res) => {
+    t.pass('response')
+    res.statusCode = 201
+    res.setHeader('location', '/resource/')
+    res.setHeader('content-encoding', 'gzip')
+    res.end(gzipSync(JSON.stringify(obj)))
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const body = await fetch(`http://localhost:${server.address().port}/resource`)
+    t.strictSame(JSON.stringify(obj), await body.text())
+  })
+})
+
 test('Receiving non-Latin1 headers', async (t) => {
   const ContentDisposition = [
     'inline; filename=rock&roll.png',


### PR DESCRIPTION
Recent changes in #1554 cause the response body to not be decoded when a `Location` header is set and the request's `redirect` option is set to `follow`.

For us this caused a few problems because we set the `Location` header on 201 responses to reference the location of the created resource. When looking at the spec, I don't think we're doing anything wrong on our end here. 

> For [201 (Created)](https://www.rfc-editor.org/rfc/rfc9110.html#status.201) responses, the Location value refers to the primary resource created by the request. For [3xx (Redirection)](https://www.rfc-editor.org/rfc/rfc9110.html#status.3xx) responses, the Location value refers to the preferred target resource for automatically redirecting the request.
>
> https://www.rfc-editor.org/rfc/rfc9110.html#name-location

I updated the code to only skip decoding when the response code matches one of the codes defined as a `redirectStatus` as that's also what decides whether or not fetch is going to follow the redirect or not.