### PR TITLE
fix: circular dependencies in fetch

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -312,6 +312,9 @@ function convertLineEndingsNative (s) {
   return s.replace(/\r?\n/g, nativeLineEnding)
 }
 
+// If this function is moved to ./util.js, some tools (such as
+// rollup) will warn about circular dependencies. See:
+// https://github.com/nodejs/undici/issues/1629
 function isFileLike (object) {
   return object instanceof File || (
     object &&

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -312,4 +312,13 @@ function convertLineEndingsNative (s) {
   return s.replace(/\r?\n/g, nativeLineEnding)
 }
 
-module.exports = { File, FileLike }
+function isFileLike (object) {
+  return object instanceof File || (
+    object &&
+    (typeof object.stream === 'function' ||
+     typeof object.arrayBuffer === 'function') &&
+     object[Symbol.toStringTag] === 'File'
+  )
+}
+
+module.exports = { File, FileLike, isFileLike }

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { isBlobLike, isFileLike, toUSVString, makeIterator } = require('./util')
+const { isBlobLike, toUSVString, makeIterator } = require('./util')
 const { kState } = require('./symbols')
-const { File, FileLike } = require('./file')
+const { File, FileLike, isFileLike } = require('./file')
 const { webidl } = require('./webidl')
 const { Blob } = require('buffer')
 

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -6,8 +6,6 @@ const { isBlobLike, toUSVString, ReadableStreamFrom } = require('../core/util')
 const assert = require('assert')
 const { isUint8Array } = require('util/types')
 
-let File
-
 // https://nodejs.org/api/crypto.html#determining-if-crypto-support-is-unavailable
 /** @type {import('crypto')|undefined} */
 let crypto
@@ -79,18 +77,6 @@ function requestBadPort (request) {
 
   // 3. Return allowed.
   return 'allowed'
-}
-
-function isFileLike (object) {
-  if (!File) {
-    File = require('./file').File
-  }
-  return object instanceof File || (
-    object &&
-    (typeof object.stream === 'function' ||
-     typeof object.arrayBuffer === 'function') &&
-    /^(File)$/.test(object[Symbol.toStringTag])
-  )
 }
 
 function isErrorLike (object) {
@@ -631,7 +617,6 @@ module.exports = {
   responseURL,
   responseLocationURL,
   isBlobLike,
-  isFileLike,
   isValidReasonPhrase,
   sameOrigin,
   normalizeMethod,


### PR DESCRIPTION
Fixes #1629 

Not the greatest solution & no tests. This might not even be a problem - undici correctly lazily loads `File` in fetch's utils already, and pnpm only gives a *warning*. However it was easy enough to make a PR and see.