### PR TITLE
fix(fetch): allow third-party `FormData`/`Blob` bodies

### DIFF
--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -519,7 +519,7 @@ webidl.converters.XMLHttpRequestBodyInit = function (V) {
   }
 
   if (isBlobLike(V)) {
-    return webidl.converters.Blob(V)
+    return webidl.converters.Blob(V, { strict: false })
   }
 
   if (
@@ -530,8 +530,8 @@ webidl.converters.XMLHttpRequestBodyInit = function (V) {
     return webidl.converters.BufferSource(V)
   }
 
-  if (V instanceof FormData) {
-    return webidl.converters.FormData(V)
+  if (util.isFormDataLike(V)) {
+    return webidl.converters.FormData(V, { strict: false })
   }
 
   if (V instanceof URLSearchParams) {

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -5,6 +5,10 @@ const {
   Response
 } = require('../../')
 const { ReadableStream } = require('stream/web')
+const {
+  Blob: ThirdPartyBlob,
+  FormData: ThirdPartyFormData
+} = require('formdata-node')
 
 test('arg validation', async (t) => {
   // constructor
@@ -229,4 +233,18 @@ test('constructing a Response with a ReadableStream body', async (t) => {
   })
 
   t.end()
+})
+
+test('constructing Response with third party Blob body', async (t) => {
+  const blob = new ThirdPartyBlob(['text'])
+  const res = new Response(blob)
+  t.equal(await res.text(), 'text')
+})
+test('constructing Response with third party FormData body', async (t) => {
+  const form = new ThirdPartyFormData()
+  form.set('key', 'value')
+  const res = new Response(form)
+  const contentType = res.headers.get('content-type').split('=')
+  t.equal(contentType[0], 'multipart/form-data; boundary')
+  t.ok((await res.text()).startsWith(`--${contentType[1]}`))
 })


### PR DESCRIPTION
`webidl.converters.XMLHttpRequestBodyInit` rejected third-party `FormData`/`Blob`s, meaning they were passed through `webidl.converters.DOMString`. This meant `Request`/`Response`s constructed with third-party `FormData`/`Blob` bodies ended up with a plain-text `[object FormData]`/`[object Blob]` body.

Undici has code for extracting a body from [third-party `Blob`s](https://github.com/nodejs/undici/blob/0862fba5406ff7d45e3b80cd0aaea952098b5a6c/lib/fetch/body.js#L121) and [`FormData`s](https://github.com/nodejs/undici/blob/0862fba5406ff7d45e3b80cd0aaea952098b5a6c/lib/fetch/body.js#L70). This was just being called after [Web IDL](https://github.com/nodejs/undici/blob/0862fba5406ff7d45e3b80cd0aaea952098b5a6c/lib/fetch/request.js#L52-L53) [conversion](https://github.com/nodejs/undici/blob/0862fba5406ff7d45e3b80cd0aaea952098b5a6c/lib/fetch/response.js#L140).

```js
import { Request as UndiciRequest, Response as UndiciResponse, FormData as UndiciFormData } from "undici";
import { FormData as AlternativeFormData } from "@web-std/form-data";

let req = new UndiciRequest("http://a", { method: "POST", body: new UndiciFormData() });
console.log(req.headers.get("Content-Type")); // multipart/form-data; boundary=...
req = new UndiciRequest("http://a", { method: "POST", body: new FormData() }); // From Node
console.log(req.headers.get("Content-Type")); // text/plain;charset=UTF-8
req = new UndiciRequest("http://a", { method: "POST", body: new AlternativeFormData() });
console.log(req.headers.get("Content-Type")); // text/plain;charset=UTF-8

let res = new UndiciResponse(new UndiciFormData());
console.log(res.headers.get("Content-Type")); // multipart/form-data; boundary=...
res = new UndiciResponse(new FormData()); // From Node
console.log(res.headers.get("Content-Type")); // text/plain;charset=UTF-8
res = new UndiciResponse(new AlternativeFormData());
console.log(res.headers.get("Content-Type")); // text/plain;charset=UTF-8
```