### PR TITLE
docs: make examples uniform

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ Help us improve the test coverage by following instructions at [nodejs/undici/#9
 Basic usage example:
 
 ```js
-import { fetch } from 'undici';
+import { fetch } from 'undici'
 
 
 const res = await fetch('https://example.com')
 const json = await res.json()
-console.log(json);
+console.log(json)
 ```
 
 You can pass an optional dispatcher to `fetch` as:
@@ -225,16 +225,16 @@ A body can be of the following types:
 In this implementation of fetch, ```request.body``` now accepts ```Async Iterables```. It is not present in the [Fetch Standard.](https://fetch.spec.whatwg.org)
 
 ```js
-import { fetch } from "undici";
+import { fetch } from "undici"
 
 const data = {
   async *[Symbol.asyncIterator]() {
-    yield "hello";
-    yield "world";
+    yield "hello"
+    yield "world"
   },
-};
+}
 
-await fetch("https://example.com", { body: data, method: 'POST' });
+await fetch("https://example.com", { body: data, method: 'POST' })
 ```
 
 #### `response.body`
@@ -242,12 +242,12 @@ await fetch("https://example.com", { body: data, method: 'POST' });
 Nodejs has two kinds of streams: [web streams](https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html), which follow the API of the WHATWG web standard found in browsers, and an older Node-specific [streams API](https://nodejs.org/api/stream.html). `response.body` returns a readable web stream. If you would prefer to work with a Node stream you can convert a web stream using `.fromWeb()`.
 
 ```js
-import { fetch } from 'undici';
-import { Readable } from 'node:stream';
+import { fetch } from 'undici'
+import { Readable } from 'node:stream'
 
 const response = await fetch('https://example.com')
-const readableWebStream = response.body;
-const readableNodeStream = Readable.fromWeb(readableWebStream);
+const readableWebStream = response.body
+const readableNodeStream = Readable.fromWeb(readableWebStream)
 ```
 
 #### Specification Compliance

--- a/README.md
+++ b/README.md
@@ -225,16 +225,16 @@ A body can be of the following types:
 In this implementation of fetch, ```request.body``` now accepts ```Async Iterables```. It is not present in the [Fetch Standard.](https://fetch.spec.whatwg.org)
 
 ```js
-import { fetch } from "undici"
+import { fetch } from 'undici'
 
 const data = {
   async *[Symbol.asyncIterator]() {
-    yield "hello"
-    yield "world"
+    yield 'hello'
+    yield 'world'
   },
 }
 
-await fetch("https://example.com", { body: data, method: 'POST' })
+await fetch('https://example.com', { body: data, method: 'POST' })
 ```
 
 #### `response.body`


### PR DESCRIPTION
The readme examples were all stylistically a little different, this PR makes them more uniform. About 1 in 4 applicable lines used semis, so I opted to remove them. One example intermixed double and single quotes, the rest were single, so I opted for that too.