### PR TITLE
fix(docs): `MockPoolInterceptOptions.method` is optional

### DIFF
--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -54,7 +54,7 @@ Returns: `MockInterceptor` corresponding to the input options.
 ### Parameter: `MockPoolInterceptOptions`
 
 * **path** `string | RegExp | (path: string) => boolean` - a matcher for the HTTP request path.
-* **method** `string | RegExp | (method: string) => boolean` - a matcher for the HTTP request method.
+* **method** `string | RegExp | (method: string) => boolean` - (optional) - a matcher for the HTTP request method. Defaults to `GET`.
 * **body** `string | RegExp | (body: string) => boolean` - (optional) - a matcher for the HTTP request body.
 * **headers** `Record<string, string | RegExp | (body: string) => boolean`> - (optional) - a matcher for the HTTP request headers. To be intercepted, a request must match all defined headers. Extra headers not defined here may (or may not) be included in the request and do not affect the interception in any way.
 * **query** `Record<string, any> | null` - (optional) - a matcher for the HTTP request query string params.


### PR DESCRIPTION
Fixes #1642 