### PR TITLE
refactor: allow server-side headers

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -303,26 +303,6 @@ function processHeader (request, key, val) {
     request.contentType = val
     request.headers += `${key}: ${val}\r\n`
   } else if (
-    key.length === 17 &&
-    key.toLowerCase() === 'transfer-encoding'
-  ) {
-    throw new InvalidArgumentError('invalid transfer-encoding header')
-  } else if (
-    key.length === 10 &&
-    key.toLowerCase() === 'connection'
-  ) {
-    throw new InvalidArgumentError('invalid connection header')
-  } else if (
-    key.length === 10 &&
-    key.toLowerCase() === 'keep-alive'
-  ) {
-    throw new InvalidArgumentError('invalid keep-alive header')
-  } else if (
-    key.length === 7 &&
-    key.toLowerCase() === 'upgrade'
-  ) {
-    throw new InvalidArgumentError('invalid upgrade header')
-  } else if (
     key.length === 6 &&
     key.toLowerCase() === 'expect'
   ) {


### PR DESCRIPTION
Hello,

At [Edge Runtime](https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/patches/undici-core-request.js#L2), we are patching the undici `Request` implementation to be more server-side friendly, allowing to pass `connection` header.

I guess `connection` and the rest of headers are forbidden to follow with `fetch` spec. Potentially there are more headers that should to be forbidden according to https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name

but since undici can be used in servers too, is it any chance to be less restrictive?

MDN is pointing something that could be key:

> Modifying such headers is forbidden because the user agent retains full control over them.

Maybe setup `user-agent: undefined` could be the way to discriminate these headers in any way?

Related:

- https://github.com/nodejs/undici/issues/1305
- https://github.com/nodejs/undici/issues/1307
- https://github.com/nodejs/undici/issues/1470