### PR TITLE
feat(fetch): better errors messages for body-mixin methods

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -230,9 +230,9 @@ function safelyExtractBody (object, keepalive = false) {
   if (object instanceof ReadableStream) {
     // Assert: object is neither disturbed nor locked.
     // istanbul ignore next
-    assert(!util.isDisturbed(object), 'disturbed')
+    assert(!util.isDisturbed(object), 'The body has already been consumed.')
     // istanbul ignore next
-    assert(!object.locked, 'locked')
+    assert(!object.locked, 'The stream is locked.')
   }
 
   // 2. Return the results of extracting object.
@@ -266,11 +266,11 @@ async function * consumeBody (body) {
       const stream = body.stream
 
       if (util.isDisturbed(stream)) {
-        throw new TypeError('disturbed')
+        throw new TypeError('The body has already been consumed.')
       }
 
       if (stream.locked) {
-        throw new TypeError('locked')
+        throw new TypeError('The stream is locked.')
       }
 
       // Compat.

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -250,7 +250,7 @@ test('locked blob body', (t) => {
     const res = await fetch(`http://localhost:${server.address().port}`)
     const reader = res.body.getReader()
     res.blob().catch(err => {
-      t.equal(err.message, 'locked')
+      t.equal(err.message, 'The stream is locked.')
       reader.cancel()
     })
   })
@@ -270,7 +270,7 @@ test('disturbed blob body', (t) => {
       t.pass(2)
     })
     res.blob().catch(err => {
-      t.equal(err.message, 'disturbed')
+      t.equal(err.message, 'The body has already been consumed.')
     })
   })
 })


### PR DESCRIPTION
Fixes #1653

The error messages are closer to chrome/firefox now. I don't think they need to be super descriptive.
![image](https://user-images.githubusercontent.com/42794878/190682512-0488b211-e0c9-4472-900c-c9910db8cbd3.png)
![image](https://user-images.githubusercontent.com/42794878/190682592-f59ea605-7996-46cc-ae04-77d962267582.png)

edit: I considered adding the error header (ie. `Response.text`) but it would be relatively annoying to add the message to `.json()` as it just calls `.text()`, or the message would be completely wrong.