### PR TITLE
feat(util): use fast-querystring for building url

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -8,6 +8,7 @@ const net = require('net')
 const { InvalidArgumentError } = require('./errors')
 const { Blob } = require('buffer')
 const nodeUtil = require('util')
+const queryString = require('fast-querystring')
 
 function nop () {}
 
@@ -26,47 +27,12 @@ function isBlobLike (object) {
   )
 }
 
-function isObject (val) {
-  return val !== null && typeof val === 'object'
-}
-
-// this escapes all non-uri friendly characters
-function encode (val) {
-  return encodeURIComponent(val)
-}
-
-// based on https://github.com/axios/axios/blob/63e559fa609c40a0a460ae5d5a18c3470ffc6c9e/lib/helpers/buildURL.js (MIT license)
 function buildURL (url, queryParams) {
   if (url.includes('?') || url.includes('#')) {
     throw new Error('Query params cannot be passed when url already contains "?" or "#".')
   }
-  if (!isObject(queryParams)) {
-    throw new Error('Query params must be an object')
-  }
 
-  const parts = []
-  for (let [key, val] of Object.entries(queryParams)) {
-    if (val === null || typeof val === 'undefined') {
-      continue
-    }
-
-    if (!Array.isArray(val)) {
-      val = [val]
-    }
-
-    for (const v of val) {
-      if (isObject(v)) {
-        throw new Error('Passing object as a query param is not supported, please serialize to string up-front')
-      }
-      parts.push(encode(key) + '=' + encode(v))
-    }
-  }
-
-  const serializedParams = parts.join('&')
-
-  if (serializedParams) {
-    url += '?' + serializedParams
-  }
+  url += '?' + queryString.stringify(queryParams)
 
   return url
 }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -8,7 +8,7 @@ const net = require('net')
 const { InvalidArgumentError } = require('./errors')
 const { Blob } = require('buffer')
 const nodeUtil = require('util')
-const queryString = require('fast-querystring')
+const { stringify } = require('fast-querystring')
 
 function nop () {}
 
@@ -32,7 +32,7 @@ function buildURL (url, queryParams) {
     throw new Error('Query params cannot be passed when url already contains "?" or "#".')
   }
 
-  url += '?' + queryString.stringify(queryParams)
+  url += '?' + stringify(queryParams)
 
   return url
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     ]
   },
   "dependencies": {
-    "busboy": "^1.6.0"
+    "busboy": "^1.6.0",
+    "fast-querystring": "^1.0.0"
   }
 }

--- a/test/client.js
+++ b/test/client.js
@@ -97,6 +97,8 @@ test('basic get with query params', (t) => {
       bool: 'true',
       foo: '1',
       bar: 'bar',
+      nullVal: '',
+      undefinedVal: '',
       '%60~%3A%24%2C%2B%5B%5D%40%5E*()-': '%60~%3A%24%2C%2B%5B%5D%40%5E*()-',
       multi: ['1', '2']
     })
@@ -134,95 +136,6 @@ test('basic get with query params', (t) => {
       t.equal(statusCode, 200)
     })
     t.equal(signal.listenerCount('abort'), 1)
-  })
-})
-
-test('basic get with query params with object throws an error', (t) => {
-  t.plan(1)
-
-  const server = createServer((req, res) => {
-    t.fail()
-  })
-  t.teardown(server.close.bind(server))
-
-  const query = {
-    obj: { id: 1 }
-  }
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      keepAliveTimeout: 300e3
-    })
-    t.teardown(client.close.bind(client))
-
-    const signal = new EE()
-    client.request({
-      signal,
-      path: '/',
-      method: 'GET',
-      query
-    }, (err, data) => {
-      t.equal(err.message, 'Passing object as a query param is not supported, please serialize to string up-front')
-    })
-  })
-})
-
-test('basic get with non-object query params throws an error', (t) => {
-  t.plan(1)
-
-  const server = createServer((req, res) => {
-    t.fail()
-  })
-  t.teardown(server.close.bind(server))
-
-  const query = '{ obj: { id: 1 } }'
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      keepAliveTimeout: 300e3
-    })
-    t.teardown(client.close.bind(client))
-
-    const signal = new EE()
-    client.request({
-      signal,
-      path: '/',
-      method: 'GET',
-      query
-    }, (err, data) => {
-      t.equal(err.message, 'Query params must be an object')
-    })
-  })
-})
-
-test('basic get with query params with date throws an error', (t) => {
-  t.plan(1)
-
-  const date = new Date()
-  const server = createServer((req, res) => {
-    t.fail()
-  })
-  t.teardown(server.close.bind(server))
-
-  const query = {
-    dateObj: date
-  }
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      keepAliveTimeout: 300e3
-    })
-    t.teardown(client.close.bind(client))
-
-    const signal = new EE()
-    client.request({
-      signal,
-      path: '/',
-      method: 'GET',
-      query
-    }, (err, data) => {
-      t.equal(err.message, 'Passing object as a query param is not supported, please serialize to string up-front')
-    })
   })
 })
 

--- a/test/client.js
+++ b/test/client.js
@@ -99,6 +99,8 @@ test('basic get with query params', (t) => {
       bar: 'bar',
       nullVal: '',
       undefinedVal: '',
+      functionVal: '',
+      objectVal: '',
       '%60~%3A%24%2C%2B%5B%5D%40%5E*()-': '%60~%3A%24%2C%2B%5B%5D%40%5E*()-',
       multi: ['1', '2']
     })
@@ -114,6 +116,8 @@ test('basic get with query params', (t) => {
     bar: 'bar',
     nullVal: null,
     undefinedVal: undefined,
+    functionVal: function () {},
+    objectVal: {},
     '`~:$,+[]@^*()-': '`~:$,+[]@^*()-',
     multi: [1, 2]
   }


### PR DESCRIPTION
Solves https://github.com/nodejs/undici/issues/1672.

**Important Note**: Even though none of the benchmarks focus on query-string building (can test it with just adding `new Error('hello')` inside buildURL function), the results of the benchmarks show significant degregation in ops/sec. My educated guess would be: Due to requiring & resolving a new package, and how `cronometro` creates an isolated v8 environment every time a benchmark is run, the require is never cached, and therefore the amount of time requiring the `fast-querystring` package is also included in the benchmark and as a result creates a **false** outcome.