### PR TITLE
perf: add query parameter to benchmark

### DIFF
--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -32,6 +32,14 @@ const httpBaseOptions = {
   hostname: 'localhost',
   method: 'GET',
   path: '/',
+  query: {
+    frappucino: 'muffin',
+    goat: 'scone',
+    pond: 'moose',
+    foo: ['bar', 'baz', 'bal'],
+    bool: true,
+    numberKey: 256
+  },
   ...dest
 }
 


### PR DESCRIPTION
Referencing https://github.com/nodejs/undici/pull/1673, this pull request adds `query` as a parameter to benchmarks.