### PR TITLE
perf: replace querystring with fast-querystring

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -8,7 +8,7 @@ const net = require('net')
 const { InvalidArgumentError } = require('./errors')
 const { Blob } = require('buffer')
 const nodeUtil = require('util')
-const { stringify } = require('querystring')
+const stringify = require('fast-querystring/lib/stringify')
 
 function nop () {}
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     ]
   },
   "dependencies": {
-    "busboy": "^1.6.0"
+    "busboy": "^1.6.0",
+    "fast-querystring": "^1.0.0"
   }
 }


### PR DESCRIPTION
I wanted to see the performance difference between legacy and fast-querystring benchmarks in undici.