### PR TITLE
feat(fetch): add `Request{Init}.duplex` and add WPTs

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -472,7 +472,13 @@ class Request {
     // 38. If inputOrInitBody is non-null and inputOrInitBody’s source is
     // null, then:
     if (inputOrInitBody != null && inputOrInitBody.source == null) {
-      // 1. If this’s request’s mode is neither "same-origin" nor "cors",
+      // 1. If initBody is non-null and init["duplex"] does not exist,
+      //    then throw a TypeError.
+      if (initBody != null && init.duplex == null) {
+        throw new TypeError(`RequestInit: duplex option is required when sending a body.`)
+      }
+
+      // 2. If this’s request’s mode is neither "same-origin" nor "cors",
       // then throw a TypeError.
       if (request.mode !== 'same-origin' && request.mode !== 'cors') {
         throw new TypeError(
@@ -480,7 +486,7 @@ class Request {
         )
       }
 
-      // 2. Set this’s request’s use-CORS-preflight flag.
+      // 3. Set this’s request’s use-CORS-preflight flag.
       request.useCORSPreflightFlag = true
     }
 
@@ -821,7 +827,17 @@ Object.defineProperties(Request.prototype, {
   headers: kEnumerableProperty,
   redirect: kEnumerableProperty,
   clone: kEnumerableProperty,
-  signal: kEnumerableProperty
+  signal: kEnumerableProperty,
+  duplex: {
+    ...kEnumerableProperty,
+    get () {
+      // The duplex getter steps are to return "half".
+      return 'half'
+    },
+    set () {
+
+    }
+  }
 })
 
 webidl.converters.Request = webidl.interfaceConverter(
@@ -929,6 +945,12 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
   {
     key: 'window',
     converter: webidl.converters.any
+  },
+  {
+    key: 'duplex',
+    converter: webidl.converters.DOMString,
+    allowedValues: ['half'],
+    defaultValue: 'half'
   }
 ])
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -475,7 +475,7 @@ class Request {
       // 1. If initBody is non-null and init["duplex"] does not exist,
       //    then throw a TypeError.
       if (initBody != null && init.duplex == null) {
-        throw new TypeError(`RequestInit: duplex option is required when sending a body.`)
+        throw new TypeError('RequestInit: duplex option is required when sending a body.')
       }
 
       // 2. If this’s request’s mode is neither "same-origin" nor "cors",
@@ -950,6 +950,9 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
     key: 'duplex',
     converter: webidl.converters.DOMString,
     allowedValues: ['half'],
+    // TODO(@KhafraDev): this behavior is incorrect, but
+    // without it, a WPT throws with an uncaught exception,
+    // causing the entire WPT runner to crash.
     defaultValue: 'half'
   }
 ])

--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -4,7 +4,6 @@ const { test } = require('tap')
 const { fetch } = require('../..')
 const { createServer } = require('http')
 const { once } = require('events')
-const { ReadableStream } = require('stream/web')
 const { DOMException } = require('../../lib/fetch/constants')
 
 const { AbortController: NPMAbortController } = require('abort-controller')
@@ -58,53 +57,6 @@ test('parallel fetch with the same AbortController works as expected', async (t)
 
   t.ok(rejected.every(rej => rej.reason?.code === DOMException.ABORT_ERR))
   t.same(resolved[0].value, body)
-
-  t.end()
-})
-
-// https://github.com/web-platform-tests/wpt/blob/fd8aeb1bb2eb33bc43f8a5bbc682b0cff6075dfe/fetch/api/abort/general.any.js#L474-L507
-test('Readable stream synchronously cancels with AbortError if aborted before reading', async (t) => {
-  const server = createServer((req, res) => {
-    res.write('')
-    res.end()
-  }).listen(0)
-
-  t.teardown(server.close.bind(server))
-  await once(server, 'listening')
-
-  const controller = new AbortController()
-  const signal = controller.signal
-  controller.abort()
-
-  let cancelReason
-
-  const body = new ReadableStream({
-    pull (controller) {
-      controller.enqueue(new Uint8Array([42]))
-    },
-    cancel (reason) {
-      cancelReason = reason
-    }
-  })
-
-  const fetchPromise = fetch(`http://localhost:${server.address().port}`, {
-    body,
-    signal,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'text/plain'
-    }
-  })
-
-  t.ok(cancelReason, 'Cancel called sync')
-  t.equal(cancelReason.constructor, DOMException)
-  t.equal(cancelReason.name, 'AbortError')
-
-  await t.rejects(fetchPromise, { name: 'AbortError' })
-
-  const fetchErr = await fetchPromise.catch(e => e)
-
-  t.equal(cancelReason, fetchErr, 'Fetch rejects with same error instance')
 
   t.end()
 })

--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -1,7 +1,7 @@
 import { URL } from 'url'
 import { Blob } from 'buffer'
 import { ReadableStream } from 'stream/web'
-import { expectType, expectError } from 'tsd'
+import { expectType, expectError, expectAssignable, expectNotAssignable } from 'tsd'
 import {
   Agent,
   BodyInit,
@@ -10,7 +10,6 @@ import {
   Headers,
   HeadersInit,
   SpecIterableIterator,
-  SpecIterator,
   Request,
   RequestCache,
   RequestCredentials,
@@ -166,3 +165,7 @@ expectType<Promise<FormData>>(response.formData())
 expectType<Promise<unknown>>(response.json())
 expectType<Promise<string>>(response.text())
 expectType<Response>(response.clone())
+
+expectType<Request>(new Request('https://example.com', { body: 'Hello, world', duplex: 'half' }))
+expectAssignable<RequestInit>({ duplex: 'half' })
+expectNotAssignable<RequestInit>({ duplex: 'not valid' })

--- a/test/wpt/runner/runner/util.mjs
+++ b/test/wpt/runner/runner/util.mjs
@@ -38,8 +38,9 @@ export function parseMeta (fileContents) {
     }
 
     switch (groups.type) {
+      case 'title':
       case 'timeout': {
-        meta.timeout = groups.match
+        meta[groups.type] = groups.match
         break
       }
       case 'global': {

--- a/test/wpt/runner/runner/worker.mjs
+++ b/test/wpt/runner/runner/worker.mjs
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import { runInThisContext } from 'node:vm'
 import { parentPort, workerData } from 'node:worker_threads'
+import { readFileSync } from 'node:fs'
 import {
   setGlobalOrigin,
   Response,
@@ -65,7 +66,8 @@ runInThisContext(`
   globalThis.location = new URL('${url}')
 `)
 
-await import('../resources/testharness.cjs')
+const harness = readFileSync(join(basePath, '../runner/resources/testharness.cjs'), 'utf-8')
+runInThisContext(harness)
 
 // add_*_callback comes from testharness
 // stolen from node's wpt test runner

--- a/test/wpt/status/fetch.status.json
+++ b/test/wpt/status/fetch.status.json
@@ -1,7 +1,19 @@
 {
-	"fail": [
-		"Stream errors once aborted. Underlying connection closed.",
-		"Underlying connection is closed when aborting after receiving response - no-cors",
-		"Already aborted signal rejects immediately"
-	]
+	"request-init-stream.any.js": {
+		"fail": [
+			"It is error to omit .duplex when the body is a ReadableStream."
+		]
+	},
+	"general.any.js": {
+		"fail": [
+			"Stream errors once aborted. Underlying connection closed.",
+			"Underlying connection is closed when aborting after receiving response - no-cors",
+			"Already aborted signal rejects immediately"
+		]
+	},
+	"request-disturbed.any.js": {
+		"fail": [
+			"Input request used for creating new request became disturbed even if body is not used"
+		]
+	}
 }

--- a/test/wpt/tests/fetch/api/request/forbidden-method.any.js
+++ b/test/wpt/tests/fetch/api/request/forbidden-method.any.js
@@ -1,0 +1,13 @@
+// META: global=window,worker
+
+// https://fetch.spec.whatwg.org/#forbidden-method
+for (const method of [
+    'CONNECT', 'TRACE', 'TRACK',
+    'connect', 'trace', 'track'
+  ]) {
+  test(function() {
+    assert_throws_js(TypeError,
+      function() { new Request('./', {method: method}); }
+    );
+  }, 'Request() with a forbidden method ' + method + ' must throw.');
+}

--- a/test/wpt/tests/fetch/api/request/request-bad-port.any.js
+++ b/test/wpt/tests/fetch/api/request/request-bad-port.any.js
@@ -1,0 +1,92 @@
+// META: global=window,worker
+
+// list of bad ports according to
+// https://fetch.spec.whatwg.org/#port-blocking
+var BLOCKED_PORTS_LIST = [
+    1,    // tcpmux
+    7,    // echo
+    9,    // discard
+    11,   // systat
+    13,   // daytime
+    15,   // netstat
+    17,   // qotd
+    19,   // chargen
+    20,   // ftp-data
+    21,   // ftp
+    22,   // ssh
+    23,   // telnet
+    25,   // smtp
+    37,   // time
+    42,   // name
+    43,   // nicname
+    53,   // domain
+    69,   // tftp
+    77,   // priv-rjs
+    79,   // finger
+    87,   // ttylink
+    95,   // supdup
+    101,  // hostriame
+    102,  // iso-tsap
+    103,  // gppitnp
+    104,  // acr-nema
+    109,  // pop2
+    110,  // pop3
+    111,  // sunrpc
+    113,  // auth
+    115,  // sftp
+    117,  // uucp-path
+    119,  // nntp
+    123,  // ntp
+    135,  // loc-srv / epmap
+    137,  // netbios-ns
+    139,  // netbios-ssn
+    143,  // imap2
+    161,  // snmp
+    179,  // bgp
+    389,  // ldap
+    427,  // afp (alternate)
+    465,  // smtp (alternate)
+    512,  // print / exec
+    513,  // login
+    514,  // shell
+    515,  // printer
+    526,  // tempo
+    530,  // courier
+    531,  // chat
+    532,  // netnews
+    540,  // uucp
+    548,  // afp
+    554,  // rtsp
+    556,  // remotefs
+    563,  // nntp+ssl
+    587,  // smtp (outgoing)
+    601,  // syslog-conn
+    636,  // ldap+ssl
+    989,  // ftps-data
+    990,  // ftps
+    993,  // ldap+ssl
+    995,  // pop3+ssl
+    1719, // h323gatestat
+    1720, // h323hostcall
+    1723, // pptp
+    2049, // nfs
+    3659, // apple-sasl
+    4045, // lockd
+    5060, // sip
+    5061, // sips
+    6000, // x11
+    6566, // sane-port
+    6665, // irc (alternate)
+    6666, // irc (alternate)
+    6667, // irc (default)
+    6668, // irc (alternate)
+    6669, // irc (alternate)
+    6697, // irc+tls
+    10080, // amanda
+];
+
+BLOCKED_PORTS_LIST.map(function(a){
+    promise_test(function(t){
+        return promise_rejects_js(t, TypeError, fetch("http://example.com:" + a))
+    }, 'Request on bad port ' + a + ' should throw TypeError.');
+});

--- a/test/wpt/tests/fetch/api/request/request-disturbed.any.js
+++ b/test/wpt/tests/fetch/api/request/request-disturbed.any.js
@@ -1,0 +1,109 @@
+// META: global=window,worker
+// META: title=Request disturbed
+// META: script=../resources/utils.js
+
+var initValuesDict = {"method" : "POST",
+                      "body" : "Request's body"
+};
+
+var noBodyConsumed = new Request("");
+var bodyConsumed = new Request("", initValuesDict);
+
+test(() => {
+  assert_equals(noBodyConsumed.body, null, "body's default value is null");
+  assert_false(noBodyConsumed.bodyUsed , "bodyUsed is false when request is not disturbed");
+  assert_not_equals(bodyConsumed.body, null, "non-null body");
+  assert_true(bodyConsumed.body instanceof ReadableStream, "non-null body type");
+  assert_false(noBodyConsumed.bodyUsed, "bodyUsed is false when request is not disturbed");
+}, "Request's body: initial state");
+
+noBodyConsumed.blob();
+bodyConsumed.blob();
+
+test(function() {
+  assert_false(noBodyConsumed.bodyUsed , "bodyUsed is false when request is not disturbed");
+  try {
+    noBodyConsumed.clone();
+  } catch (e) {
+    assert_unreached("Can use request not disturbed for creating or cloning request");
+  }
+}, "Request without body cannot be disturbed");
+
+test(function() {
+  assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
+  assert_throws_js(TypeError, function() { bodyConsumed.clone(); });
+}, "Check cloning a disturbed request");
+
+test(function() {
+  assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
+  assert_throws_js(TypeError, function() { new Request(bodyConsumed); });
+}, "Check creating a new request from a disturbed request");
+
+promise_test(function() {
+  assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
+  const originalBody = bodyConsumed.body;
+  const bodyReplaced = new Request(bodyConsumed, { body: "Replaced body" });
+  assert_not_equals(bodyReplaced.body, originalBody, "new request's body is new");
+  assert_false(bodyReplaced.bodyUsed, "bodyUsed is false when request is not disturbed");
+  return bodyReplaced.text().then(text => {
+    assert_equals(text, "Replaced body");
+  });
+}, "Check creating a new request with a new body from a disturbed request");
+
+promise_test(function() {
+  var bodyRequest = new Request("", initValuesDict);
+  const originalBody = bodyRequest.body;
+  assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");
+  var requestFromRequest = new Request(bodyRequest);
+  assert_true(bodyRequest.bodyUsed , "bodyUsed is true when request is disturbed");
+  assert_equals(bodyRequest.body, originalBody, "body should not change");
+  assert_not_equals(originalBody, undefined, "body should not be undefined");
+  assert_not_equals(originalBody, null, "body should not be null");
+  assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
+  return requestFromRequest.text().then(text => {
+    assert_equals(text, "Request's body");
+  });
+}, "Input request used for creating new request became disturbed");
+
+promise_test(() => {
+  const bodyRequest = new Request("", initValuesDict);
+  const originalBody = bodyRequest.body;
+  assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");
+  const requestFromRequest = new Request(bodyRequest, { body : "init body" });
+  assert_true(bodyRequest.bodyUsed , "bodyUsed is true when request is disturbed");
+  assert_equals(bodyRequest.body, originalBody, "body should not change");
+  assert_not_equals(originalBody, undefined, "body should not be undefined");
+  assert_not_equals(originalBody, null, "body should not be null");
+  assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
+
+  return requestFromRequest.text().then(text => {
+    assert_equals(text, "init body");
+  });
+}, "Input request used for creating new request became disturbed even if body is not used");
+
+promise_test(function(test) {
+  assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
+  return promise_rejects_js(test, TypeError, bodyConsumed.blob());
+}, "Check consuming a disturbed request");
+
+test(function() {
+  var req = new Request(URL, {method: 'POST', body: 'hello'});
+  assert_false(req.bodyUsed,
+                'Request should not be flagged as used if it has not been ' +
+                'consumed.');
+  assert_throws_js(TypeError,
+    function() { new Request(req, {method: 'GET'}); },
+    'A get request may not have body.');
+
+  assert_false(req.bodyUsed, 'After the GET case');
+
+  assert_throws_js(TypeError,
+    function() { new Request(req, {method: 'CONNECT'}); },
+    'Request() with a forbidden method must throw.');
+
+  assert_false(req.bodyUsed, 'After the forbidden method case');
+
+  var req2 = new Request(req);
+  assert_true(req.bodyUsed,
+              'Request should be flagged as used if it has been consumed.');
+}, 'Request construction failure should not set "bodyUsed"');

--- a/test/wpt/tests/fetch/api/request/request-error.any.js
+++ b/test/wpt/tests/fetch/api/request/request-error.any.js
@@ -1,0 +1,56 @@
+// META: global=window,worker
+// META: title=Request error
+// META: script=request-error.js
+
+// badRequestArgTests is from response-error.js
+for (const { args, testName } of badRequestArgTests) {
+  test(() => {
+    assert_throws_js(
+      TypeError,
+      () => new Request(...args),
+      "Expect TypeError exception"
+    );
+  }, testName);
+}
+
+test(function() {
+  assert_throws_js(
+      TypeError,
+      () => Request("about:blank"),
+      "Calling Request constructor without 'new' must throw"
+    );
+});
+
+test(function() {
+  var initialHeaders = new Headers([["Content-Type", "potato"]]);
+  var initialRequest = new Request("", {"headers" : initialHeaders});
+  var request = new Request(initialRequest);
+  assert_equals(request.headers.get("Content-Type"), "potato");
+}, "Request should get its content-type from the init request");
+
+test(function() {
+  var initialHeaders = new Headers([["Content-Type", "potato"]]);
+  var initialRequest = new Request("", {"headers" : initialHeaders});
+  var headers = new Headers([]);
+  var request = new Request(initialRequest, {"headers" : headers});
+  assert_false(request.headers.has("Content-Type"));
+}, "Request should not get its content-type from the init request if init headers are provided");
+
+test(function() {
+  var initialHeaders = new Headers([["Content-Type-Extra", "potato"]]);
+  var initialRequest = new Request("", {"headers" : initialHeaders, "body" : "this is my plate", "method" : "POST"});
+  var request = new Request(initialRequest);
+  assert_equals(request.headers.get("Content-Type"), "text/plain;charset=UTF-8");
+}, "Request should get its content-type from the body if none is provided");
+
+test(function() {
+  var initialHeaders = new Headers([["Content-Type", "potato"]]);
+  var initialRequest = new Request("", {"headers" : initialHeaders, "body" : "this is my plate", "method" : "POST"});
+  var request = new Request(initialRequest);
+  assert_equals(request.headers.get("Content-Type"), "potato");
+}, "Request should get its content-type from init headers if one is provided");
+
+test(function() {
+  var options = {"cache": "only-if-cached", "mode": "same-origin"};
+  new Request("test", options);
+}, "Request with cache mode: only-if-cached and fetch mode: same-origin");

--- a/test/wpt/tests/fetch/api/request/request-init-002.any.js
+++ b/test/wpt/tests/fetch/api/request/request-init-002.any.js
@@ -1,0 +1,60 @@
+// META: global=window,worker
+// META: title=Request init: headers and body
+
+test(function() {
+  var headerDict = {"name1": "value1",
+                    "name2": "value2",
+                    "name3": "value3"
+                    };
+  var headers = new Headers(headerDict);
+  var request = new Request("", { "headers" : headers })
+  for (var name in headerDict) {
+    assert_equals(request.headers.get(name), headerDict[name],
+      "request's headers has " + name + " : " + headerDict[name]);
+  }
+}, "Initialize Request with headers values");
+
+function makeRequestInit(body, method) {
+  return {"method": method, "body": body};
+}
+
+function checkRequestInit(body, bodyType, expectedTextBody) {
+  promise_test(function(test) {
+    var request = new Request("", makeRequestInit(body, "POST"));
+    if (body) {
+      assert_throws_js(TypeError, function() { new Request("", makeRequestInit(body, "GET")); });
+      assert_throws_js(TypeError, function() { new Request("", makeRequestInit(body, "HEAD")); });
+    } else {
+      new Request("", makeRequestInit(body, "GET")); // should not throw
+    }
+    var reqHeaders = request.headers;
+    var mime = reqHeaders.get("Content-Type");
+    assert_true(!body || (mime && mime.search(bodyType) > -1), "Content-Type header should be \"" + bodyType + "\", not \"" + mime + "\"");
+    return request.text().then(function(bodyAsText) {
+      //not equals: cannot guess formData exact value
+      assert_true( bodyAsText.search(expectedTextBody) > -1, "Retrieve and verify request body");
+    });
+  }, `Initialize Request's body with "${body}", ${bodyType}`);
+}
+
+var blob = new Blob(["This is a blob"], {type: "application/octet-binary"});
+var formaData = new FormData();
+formaData.append("name", "value");
+var usvString = "This is a USVString"
+
+checkRequestInit(undefined, undefined, "");
+checkRequestInit(null, null, "");
+checkRequestInit(blob, "application/octet-binary", "This is a blob");
+checkRequestInit(formaData, "multipart/form-data", "name=\"name\"\r\n\r\nvalue");
+checkRequestInit(usvString, "text/plain;charset=UTF-8", "This is a USVString");
+checkRequestInit({toString: () => "hi!"}, "text/plain;charset=UTF-8", "hi!");
+
+// Ensure test does not time out in case of missing URLSearchParams support.
+if (self.URLSearchParams) {
+  var urlSearchParams = new URLSearchParams("name=value");
+  checkRequestInit(urlSearchParams, "application/x-www-form-urlencoded;charset=UTF-8", "name=value");
+} else {
+  promise_test(function(test) {
+    return Promise.reject("URLSearchParams not supported");
+  }, "Initialize Request's body with application/x-www-form-urlencoded;charset=UTF-8");
+}

--- a/test/wpt/tests/fetch/api/request/request-init-contenttype.any.js
+++ b/test/wpt/tests/fetch/api/request/request-init-contenttype.any.js
@@ -1,0 +1,141 @@
+function requestFromBody(body) {
+  return new Request(
+    "https://example.com",
+    {
+      method: "POST",
+      body,
+      duplex: "half",
+    },
+  );
+}
+
+test(() => {
+  const request = requestFromBody(undefined);
+  assert_equals(request.headers.get("Content-Type"), null);
+}, "Default Content-Type for Request with empty body");
+
+test(() => {
+  const blob = new Blob([]);
+  const request = requestFromBody(blob);
+  assert_equals(request.headers.get("Content-Type"), null);
+}, "Default Content-Type for Request with Blob body (no type set)");
+
+test(() => {
+  const blob = new Blob([], { type: "" });
+  const request = requestFromBody(blob);
+  assert_equals(request.headers.get("Content-Type"), null);
+}, "Default Content-Type for Request with Blob body (empty type)");
+
+test(() => {
+  const blob = new Blob([], { type: "a/b; c=d" });
+  const request = requestFromBody(blob);
+  assert_equals(request.headers.get("Content-Type"), "a/b; c=d");
+}, "Default Content-Type for Request with Blob body (set type)");
+
+test(() => {
+  const buffer = new Uint8Array();
+  const request = requestFromBody(buffer);
+  assert_equals(request.headers.get("Content-Type"), null);
+}, "Default Content-Type for Request with buffer source body");
+
+promise_test(async () => {
+  const formData = new FormData();
+  formData.append("a", "b");
+  const request = requestFromBody(formData);
+  const boundary = (await request.text()).split("\r\n")[0].slice(2);
+  assert_equals(
+    request.headers.get("Content-Type"),
+    `multipart/form-data; boundary=${boundary}`,
+  );
+}, "Default Content-Type for Request with FormData body");
+
+test(() => {
+  const usp = new URLSearchParams();
+  const request = requestFromBody(usp);
+  assert_equals(
+    request.headers.get("Content-Type"),
+    "application/x-www-form-urlencoded;charset=UTF-8",
+  );
+}, "Default Content-Type for Request with URLSearchParams body");
+
+test(() => {
+  const request = requestFromBody("");
+  assert_equals(
+    request.headers.get("Content-Type"),
+    "text/plain;charset=UTF-8",
+  );
+}, "Default Content-Type for Request with string body");
+
+test(() => {
+  const stream = new ReadableStream();
+  const request = requestFromBody(stream);
+  assert_equals(request.headers.get("Content-Type"), null);
+}, "Default Content-Type for Request with ReadableStream body");
+
+// -----------------------------------------------------------------------------
+
+const OVERRIDE_MIME = "test/only; mime=type";
+
+function requestFromBodyWithOverrideMime(body) {
+  return new Request(
+    "https://example.com",
+    {
+      method: "POST",
+      body,
+      headers: { "Content-Type": OVERRIDE_MIME },
+      duplex: "half",
+    },
+  );
+}
+
+test(() => {
+  const request = requestFromBodyWithOverrideMime(undefined);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with empty body");
+
+test(() => {
+  const blob = new Blob([]);
+  const request = requestFromBodyWithOverrideMime(blob);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with Blob body (no type set)");
+
+test(() => {
+  const blob = new Blob([], { type: "" });
+  const request = requestFromBodyWithOverrideMime(blob);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with Blob body (empty type)");
+
+test(() => {
+  const blob = new Blob([], { type: "a/b; c=d" });
+  const request = requestFromBodyWithOverrideMime(blob);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with Blob body (set type)");
+
+test(() => {
+  const buffer = new Uint8Array();
+  const request = requestFromBodyWithOverrideMime(buffer);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with buffer source body");
+
+test(() => {
+  const formData = new FormData();
+  const request = requestFromBodyWithOverrideMime(formData);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with FormData body");
+
+test(() => {
+  const usp = new URLSearchParams();
+  const request = requestFromBodyWithOverrideMime(usp);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with URLSearchParams body");
+
+test(() => {
+  const request = requestFromBodyWithOverrideMime("");
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with string body");
+
+test(() => {
+  const stream = new ReadableStream();
+  const request = requestFromBodyWithOverrideMime(stream);
+  assert_equals(request.headers.get("Content-Type"), OVERRIDE_MIME);
+}, "Can override Content-Type for Request with ReadableStream body");

--- a/test/wpt/tests/fetch/api/request/request-init-stream.any.js
+++ b/test/wpt/tests/fetch/api/request/request-init-stream.any.js
@@ -1,0 +1,147 @@
+// META: global=window,worker
+
+"use strict";
+
+const duplex = "half";
+const method = "POST";
+
+test(() => {
+  const body = new ReadableStream();
+  const request = new Request("...", { method, body, duplex });
+  assert_equals(request.body, body);
+}, "Constructing a Request with a stream holds the original object.");
+
+test((t) => {
+  const body = new ReadableStream();
+  body.getReader();
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "Constructing a Request with a stream on which getReader() is called");
+
+test((t) => {
+  const body = new ReadableStream();
+  body.getReader().read();
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "Constructing a Request with a stream on which read() is called");
+
+promise_test(async (t) => {
+  const body = new ReadableStream({ pull: c => c.enqueue(new Uint8Array()) });
+  const reader = body.getReader();
+  await reader.read();
+  reader.releaseLock();
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "Constructing a Request with a stream on which read() and releaseLock() are called");
+
+test((t) => {
+  const request = new Request("...", { method: "POST", body: "..." });
+  request.body.getReader();
+  assert_throws_js(TypeError, () => new Request(request));
+  // This doesn't throw.
+  new Request(request, { body: "..." });
+}, "Constructing a Request with a Request on which body.getReader() is called");
+
+test((t) => {
+  const request = new Request("...", { method: "POST", body: "..." });
+  request.body.getReader().read();
+  assert_throws_js(TypeError, () => new Request(request));
+  // This doesn't throw.
+  new Request(request, { body: "..." });
+}, "Constructing a Request with a Request on which body.getReader().read() is called");
+
+promise_test(async (t) => {
+  const request = new Request("...", { method: "POST", body: "..." });
+  const reader = request.body.getReader();
+  await reader.read();
+  reader.releaseLock();
+  assert_throws_js(TypeError, () => new Request(request));
+  // This doesn't throw.
+  new Request(request, { body: "..." });
+}, "Constructing a Request with a Request on which read() and releaseLock() are called");
+
+test((t) => {
+  new Request("...", { method, body: null });
+}, "It is OK to omit .duplex when the body is null.");
+
+test((t) => {
+  new Request("...", { method, body: "..." });
+}, "It is OK to omit .duplex when the body is a string.");
+
+test((t) => {
+  new Request("...", { method, body: new Uint8Array(3) });
+}, "It is OK to omit .duplex when the body is a Uint8Array.");
+
+test((t) => {
+  new Request("...", { method, body: new Blob([]) });
+}, "It is OK to omit .duplex when the body is a Blob.");
+
+test((t) => {
+  const body = new ReadableStream();
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body }));
+}, "It is error to omit .duplex when the body is a ReadableStream.");
+
+test((t) => {
+  new Request("...", { method, body: null, duplex: "half" });
+}, "It is OK to set .duplex = 'half' when the body is null.");
+
+test((t) => {
+  new Request("...", { method, body: "...", duplex: "half" });
+}, "It is OK to set .duplex = 'half' when the body is a string.");
+
+test((t) => {
+  new Request("...", { method, body: new Uint8Array(3), duplex: "half" });
+}, "It is OK to set .duplex = 'half' when the body is a Uint8Array.");
+
+test((t) => {
+  new Request("...", { method, body: new Blob([]), duplex: "half" });
+}, "It is OK to set .duplex = 'half' when the body is a Blob.");
+
+test((t) => {
+  const body = new ReadableStream();
+  new Request("...", { method, body, duplex: "half" });
+}, "It is OK to set .duplex = 'half' when the body is a ReadableStream.");
+
+test((t) => {
+  const body = null;
+  const duplex = "full";
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "It is error to set .duplex = 'full' when the body is null.");
+
+test((t) => {
+  const body = "...";
+  const duplex = "full";
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "It is error to set .duplex = 'full' when the body is a string.");
+
+test((t) => {
+  const body = new Uint8Array(3);
+  const duplex = "full";
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "It is error to set .duplex = 'full' when the body is a Uint8Array.");
+
+test((t) => {
+  const body = new Blob([]);
+  const duplex = "full";
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "It is error to set .duplex = 'full' when the body is a Blob.");
+
+test((t) => {
+  const body = new ReadableStream();
+  const duplex = "full";
+  assert_throws_js(TypeError,
+                   () => new Request("...", { method, body, duplex }));
+}, "It is error to set .duplex = 'full' when the body is a ReadableStream.");
+
+test((t) => {
+  const body = new ReadableStream();
+  const duplex = "half";
+  const req1 = new Request("...", { method, body, duplex });
+  const req2 = new Request(req1);
+}, "It is OK to omit duplex when init.body is not given and input.body is given.");
+

--- a/test/wpt/tests/fetch/api/request/request-keepalive.any.js
+++ b/test/wpt/tests/fetch/api/request/request-keepalive.any.js
@@ -1,0 +1,17 @@
+// META: global=window,worker
+// META: title=Request keepalive
+// META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
+
+test(() => {
+  assert_false(new Request('/').keepalive, 'default');
+  assert_true(new Request('/', {keepalive: true}).keepalive, 'true');
+  assert_false(new Request('/', {keepalive: false}).keepalive, 'false');
+  assert_true(new Request('/', {keepalive: 1}).keepalive, 'truish');
+  assert_false(new Request('/', {keepalive: 0}).keepalive, 'falsy');
+}, 'keepalive flag');
+
+test(() => {
+  const init = {method: 'POST', keepalive: true, body: new ReadableStream()};
+  assert_throws_js(TypeError, () => {new Request('/', init)});
+}, 'keepalive flag with stream body');

--- a/test/wpt/tests/fetch/api/request/request-structure.any.js
+++ b/test/wpt/tests/fetch/api/request/request-structure.any.js
@@ -1,0 +1,133 @@
+// META: global=window,worker
+// META: title=Request structure
+
+var request = new Request("");
+var methods = ["clone",
+                //Request implements Body
+                "arrayBuffer",
+                "blob",
+                "formData",
+                "json",
+                "text"
+              ];
+var attributes = ["method",
+                  "url",
+                  "headers",
+                  "destination",
+                  "referrer",
+                  "referrerPolicy",
+                  "mode",
+                  "credentials",
+                  "cache",
+                  "redirect",
+                  "integrity",
+                  "isReloadNavigation",
+                  "isHistoryNavigation",
+                  "duplex",
+                  //Request implements Body
+                  "bodyUsed"
+                  ];
+
+function isReadOnly(request, attributeToCheck) {
+  var defaultValue = undefined;
+  var newValue = undefined;
+  switch (attributeToCheck) {
+    case "method":
+      defaultValue = "GET";
+      newValue = "POST";
+      break;
+
+    case "url":
+      //default value is base url
+      //i.e http://example.com/fetch/api/request-structure.html
+      newValue = "http://url.test";
+      break;
+
+    case "headers":
+      request.headers = new Headers ({"name":"value"});
+      assert_false(request.headers.has("name"), "Headers attribute is read only");
+      return;
+
+    case "destination":
+      defaultValue = "";
+      newValue = "worker";
+      break;
+
+    case "referrer":
+      defaultValue = "about:client";
+      newValue = "http://url.test";
+      break;
+
+    case "referrerPolicy":
+      defaultValue = "";
+      newValue = "unsafe-url";
+      break;
+
+    case "mode":
+      defaultValue = "cors";
+      newValue = "navigate";
+      break;
+
+    case "credentials":
+      defaultValue = "same-origin";
+      newValue = "cors";
+      break;
+
+    case "cache":
+      defaultValue = "default";
+      newValue = "reload";
+      break;
+
+    case "redirect":
+      defaultValue = "follow";
+      newValue = "manual";
+      break;
+
+    case "integrity":
+      newValue = "CannotWriteIntegrity";
+      break;
+
+    case "bodyUsed":
+      defaultValue = false;
+      newValue = true;
+      break;
+
+    case "isReloadNavigation":
+      defaultValue = false;
+      newValue = true;
+      break;
+
+    case "isHistoryNavigation":
+      defaultValue = false;
+      newValue = true;
+      break;
+
+    case "duplex":
+      defaultValue = "half";
+      newValue = "full";
+      break;
+
+    default:
+      return;
+  }
+
+  request[attributeToCheck] = newValue;
+  if (defaultValue === undefined)
+    assert_not_equals(request[attributeToCheck], newValue, "Attribute " + attributeToCheck + " is read only");
+  else
+    assert_equals(request[attributeToCheck], defaultValue,
+      "Attribute " + attributeToCheck + " is read only. Default value is " + defaultValue);
+}
+
+for (var idx in methods) {
+  test(function() {
+    assert_true(methods[idx] in request, "request has " + methods[idx] + " method");
+  }, "Request has " + methods[idx] + " method");
+}
+
+for (var idx in attributes) {
+  test(function() {
+    assert_true(attributes[idx] in request, "request has " + attributes[idx] + " attribute");
+    isReadOnly(request, attributes[idx]);
+  }, "Check " + attributes[idx] + " attribute");
+}

--- a/test/wpt/tests/fetch/api/resources/utils.js
+++ b/test/wpt/tests/fetch/api/resources/utils.js
@@ -1,0 +1,103 @@
+var RESOURCES_DIR = "../resources/";
+
+function dirname(path) {
+    return path.replace(/\/[^\/]*$/, '/')
+}
+
+function checkRequest(request, ExpectedValuesDict) {
+  for (var attribute in ExpectedValuesDict) {
+    switch(attribute) {
+      case "headers":
+        for (var key in ExpectedValuesDict["headers"].keys()) {
+          assert_equals(request["headers"].get(key), ExpectedValuesDict["headers"].get(key),
+            "Check headers attribute has " + key + ":" + ExpectedValuesDict["headers"].get(key));
+        }
+        break;
+
+      case "body":
+        //for checking body's content, a dedicated asyncronous/promise test should be used
+        assert_true(request["headers"].has("Content-Type") , "Check request has body using Content-Type header")
+        break;
+
+      case "method":
+      case "referrer":
+      case "referrerPolicy":
+      case "credentials":
+      case "cache":
+      case "redirect":
+      case "integrity":
+      case "url":
+      case "destination":
+        assert_equals(request[attribute], ExpectedValuesDict[attribute], "Check " + attribute + " attribute")
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+function stringToArray(str) {
+  var array = new Uint8Array(str.length);
+  for (var i=0, strLen = str.length; i < strLen; i++)
+    array[i] = str.charCodeAt(i);
+  return array;
+}
+
+function encode_utf8(str)
+{
+    if (self.TextEncoder)
+        return (new TextEncoder).encode(str);
+    return stringToArray(unescape(encodeURIComponent(str)));
+}
+
+function validateBufferFromString(buffer, expectedValue, message)
+{
+  return assert_array_equals(new Uint8Array(buffer !== undefined ? buffer : []), stringToArray(expectedValue), message);
+}
+
+function validateStreamFromString(reader, expectedValue, retrievedArrayBuffer) {
+  return reader.read().then(function(data) {
+    if (!data.done) {
+      assert_true(data.value instanceof Uint8Array, "Fetch ReadableStream chunks should be Uint8Array");
+      var newBuffer;
+      if (retrievedArrayBuffer) {
+        newBuffer =  new Uint8Array(data.value.length + retrievedArrayBuffer.length);
+        newBuffer.set(retrievedArrayBuffer, 0);
+        newBuffer.set(data.value, retrievedArrayBuffer.length);
+      } else {
+        newBuffer = data.value;
+      }
+      return validateStreamFromString(reader, expectedValue, newBuffer);
+    }
+    validateBufferFromString(retrievedArrayBuffer, expectedValue, "Retrieve and verify stream");
+  });
+}
+
+function validateStreamFromPartialString(reader, expectedValue, retrievedArrayBuffer) {
+  return reader.read().then(function(data) {
+    if (!data.done) {
+      assert_true(data.value instanceof Uint8Array, "Fetch ReadableStream chunks should be Uint8Array");
+      var newBuffer;
+      if (retrievedArrayBuffer) {
+        newBuffer =  new Uint8Array(data.value.length + retrievedArrayBuffer.length);
+        newBuffer.set(retrievedArrayBuffer, 0);
+        newBuffer.set(data.value, retrievedArrayBuffer.length);
+      } else {
+        newBuffer = data.value;
+      }
+      return validateStreamFromPartialString(reader, expectedValue, newBuffer);
+    }
+
+    var string = new TextDecoder("utf-8").decode(retrievedArrayBuffer);
+    return assert_true(string.search(expectedValue) != -1, "Retrieve and verify stream");
+  });
+}
+
+// From streams tests
+function delay(milliseconds)
+{
+  return new Promise(function(resolve) {
+    step_timeout(resolve, milliseconds);
+  });
+}

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -114,6 +114,7 @@ export interface RequestInit {
   referrerPolicy?: ReferrerPolicy
   window?: null
   dispatcher?: Dispatcher
+  duplex?: RequestDuplex
 }
 
 export type ReferrerPolicy =
@@ -131,6 +132,8 @@ export type RequestMode = 'cors' | 'navigate' | 'no-cors' | 'same-origin'
 
 export type RequestRedirect = 'error' | 'follow' | 'manual'
 
+export type RequestDuplex = 'half'
+
 export declare class Request implements BodyMixin {
   constructor (input: RequestInfo, init?: RequestInit)
 
@@ -147,6 +150,7 @@ export declare class Request implements BodyMixin {
 
   readonly keepalive: boolean
   readonly signal: AbortSignal
+  readonly duplex: RequestDuplex
 
   readonly body: ReadableStream | null
   readonly bodyUsed: boolean


### PR DESCRIPTION
- Adds [`Request.duplex`](https://github.com/whatwg/fetch/commit/1fbc40c1df1a353ce1a49de8e4b2c753563e265d) and [`RequestInit.duplex`](https://github.com/whatwg/fetch/commit/edf07e58abdf6fbef0e1b0c3a6788dbfe93e14ad)
- Handles `title` attributes in META tags.
- Better expected fails - only fails tests in a file with the test name now. Can also be adjusted to allow skipping entire files, etc. in the future (similar to node core).
- Most importantly, fixes an issue with using a dynamic import that would cause multiple `test(...)` functions to fail due to the internal state being set. I could not tell you why this happened.

Both tests that were added to the expected fails could likely be fixed, but I haven't looked into it.