### PR TITLE
feat: add in Header WPTs

### DIFF
--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -250,30 +250,64 @@ webidl.sequenceConverter = function (converter) {
   }
 }
 
+// https://webidl.spec.whatwg.org/#es-to-record
 webidl.recordConverter = function (keyConverter, valueConverter) {
-  return (V) => {
-    const record = {}
-    const type = webidl.util.Type(V)
-
-    if (type === 'Undefined' || type === 'Null') {
-      return record
-    }
-
-    if (type !== 'Object') {
+  return (O) => {
+    // 1. If Type(O) is not Object, throw a TypeError.
+    if (webidl.util.Type(O) !== 'Object') {
       webidl.errors.exception({
         header: 'Record',
-        message: `Expected ${V} to be an Object type.`
+        message: `Value of type ${webidl.util.Type(O)} is not an Object.`
       })
     }
 
-    for (let [key, value] of Object.entries(V)) {
-      key = keyConverter(key)
-      value = valueConverter(value)
+    // 2. Let result be a new empty instance of record<K, V>.
+    const result = {}
 
-      record[key] = value
+    if (!types.isProxy(O)) {
+      // Object.keys only returns enumerable properties
+      const keys = Object.keys(O)
+
+      for (const key of keys) {
+        // 1. Let typedKey be key converted to an IDL value of type K.
+        const typedKey = keyConverter(key)
+
+        // 2. Let value be ? Get(O, key).
+        // 3. Let typedValue be value converted to an IDL value of type V.
+        const typedValue = valueConverter(O[key])
+
+        // 4. Set result[typedKey] to typedValue.
+        result[typedKey] = typedValue
+      }
+
+      // 5. Return result.
+      return result
     }
 
-    return record
+    // 3. Let keys be ? O.[[OwnPropertyKeys]]().
+    const keys = Reflect.ownKeys(O)
+
+    // 4. For each key of keys.
+    for (const key of keys) {
+      // 1. Let desc be ? O.[[GetOwnProperty]](key).
+      const desc = Reflect.getOwnPropertyDescriptor(O, key)
+
+      // 2. If desc is not undefined and desc.[[Enumerable]] is true:
+      if (desc?.enumerable) {
+        // 1. Let typedKey be key converted to an IDL value of type K.
+        const typedKey = keyConverter(key)
+
+        // 2. Let value be ? Get(O, key).
+        // 3. Let typedValue be value converted to an IDL value of type V.
+        const typedValue = valueConverter(O[key])
+
+        // 4. Set result[typedKey] to typedValue.
+        result[typedKey] = typedValue
+      }
+    }
+
+    // 5. Return result.
+    return result
   }
 }
 
@@ -401,7 +435,7 @@ webidl.converters.ByteString = function (V) {
 
     if (charCode > 255) {
       throw new TypeError(
-        'Cannot convert argument to a ByteString because the character at' +
+        'Cannot convert argument to a ByteString because the character at ' +
         `index ${index} has a value of ${charCode} which is greater than 255.`
       )
     }

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -194,7 +194,7 @@ test('ByteString', (t) => {
     const char = String.fromCharCode(256)
     webidl.converters.ByteString(`invalid${char}char`)
   }, {
-    message: 'Cannot convert argument to a ByteString because the character at' +
+    message: 'Cannot convert argument to a ByteString because the character at ' +
              'index 7 has a value of 256 which is greater than 255.'
   })
 

--- a/test/wpt/tests/fetch/api/body/formdata.any.js
+++ b/test/wpt/tests/fetch/api/body/formdata.any.js
@@ -1,0 +1,14 @@
+promise_test(async t => {
+  const res = new Response(new FormData());
+  const fd = await res.formData();
+  assert_true(fd instanceof FormData);
+}, 'Consume empty response.formData() as FormData');
+
+promise_test(async t => {
+  const req = new Request('about:blank', {
+    method: 'POST',
+    body: new FormData()
+  });
+  const fd = await req.formData();
+  assert_true(fd instanceof FormData);
+}, 'Consume empty request.formData() as FormData');

--- a/test/wpt/tests/fetch/api/headers/headers-basic.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-basic.any.js
@@ -1,0 +1,220 @@
+// META: title=Headers structure
+// META: global=window,worker
+
+"use strict";
+
+test(function() {
+  new Headers();
+}, "Create headers from no parameter");
+
+test(function() {
+  new Headers(undefined);
+}, "Create headers from undefined parameter");
+
+test(function() {
+  new Headers({});
+}, "Create headers from empty object");
+
+var parameters = [null, 1];
+parameters.forEach(function(parameter) {
+  test(function() {
+    assert_throws_js(TypeError, function() { new Headers(parameter) });
+  }, "Create headers with " + parameter + " should throw");
+});
+
+var headerDict = {"name1": "value1",
+                  "name2": "value2",
+                  "name3": "value3",
+                  "name4": null,
+                  "name5": undefined,
+                  "name6": 1,
+                  "Content-Type": "value4"
+};
+
+var headerSeq = [];
+for (var name in headerDict)
+  headerSeq.push([name, headerDict[name]]);
+
+test(function() {
+  var headers = new Headers(headerSeq);
+  for (name in headerDict) {
+    assert_equals(headers.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+  }
+  assert_equals(headers.get("length"), null, "init should be treated as a sequence, not as a dictionary");
+}, "Create headers with sequence");
+
+test(function() {
+  var headers = new Headers(headerDict);
+  for (name in headerDict) {
+    assert_equals(headers.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+  }
+}, "Create headers with record");
+
+test(function() {
+  var headers = new Headers(headerDict);
+  var headers2 = new Headers(headers);
+  for (name in headerDict) {
+    assert_equals(headers2.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+  }
+}, "Create headers with existing headers");
+
+test(function() {
+  var headers = new Headers()
+  headers[Symbol.iterator] = function *() {
+    yield ["test", "test"]
+  }
+  var headers2 = new Headers(headers)
+  assert_equals(headers2.get("test"), "test")
+}, "Create headers with existing headers with custom iterator");
+
+test(function() {
+  var headers = new Headers();
+  for (name in headerDict) {
+    headers.append(name, headerDict[name]);
+    assert_equals(headers.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+  }
+}, "Check append method");
+
+test(function() {
+  var headers = new Headers();
+  for (name in headerDict) {
+    headers.set(name, headerDict[name]);
+    assert_equals(headers.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+  }
+}, "Check set method");
+
+test(function() {
+  var headers = new Headers(headerDict);
+  for (name in headerDict)
+    assert_true(headers.has(name),"headers has name " + name);
+
+  assert_false(headers.has("nameNotInHeaders"),"headers do not have header: nameNotInHeaders");
+}, "Check has method");
+
+test(function() {
+  var headers = new Headers(headerDict);
+  for (name in headerDict) {
+    assert_true(headers.has(name),"headers have a header: " + name);
+    headers.delete(name)
+    assert_true(!headers.has(name),"headers do not have anymore a header: " + name);
+  }
+}, "Check delete method");
+
+test(function() {
+  var headers = new Headers(headerDict);
+  for (name in headerDict)
+    assert_equals(headers.get(name), String(headerDict[name]),
+      "name: " + name + " has value: " + headerDict[name]);
+
+  assert_equals(headers.get("nameNotInHeaders"), null, "header: nameNotInHeaders has no value");
+}, "Check get method");
+
+var headerEntriesDict = {"name1": "value1",
+                          "Name2": "value2",
+                          "name": "value3",
+                          "content-Type": "value4",
+                          "Content-Typ": "value5",
+                          "Content-Types": "value6"
+};
+var sortedHeaderDict = {};
+var headerValues = [];
+var sortedHeaderKeys = Object.keys(headerEntriesDict).map(function(value) {
+  sortedHeaderDict[value.toLowerCase()] = headerEntriesDict[value];
+  headerValues.push(headerEntriesDict[value]);
+  return value.toLowerCase();
+}).sort();
+
+var iteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+function checkIteratorProperties(iterator) {
+  var prototype = Object.getPrototypeOf(iterator);
+  assert_equals(Object.getPrototypeOf(prototype), iteratorPrototype);
+
+  var descriptor = Object.getOwnPropertyDescriptor(prototype, "next");
+  assert_true(descriptor.configurable, "configurable");
+  assert_true(descriptor.enumerable, "enumerable");
+  assert_true(descriptor.writable, "writable");
+}
+
+test(function() {
+  var headers = new Headers(headerEntriesDict);
+  var actual = headers.keys();
+  checkIteratorProperties(actual);
+
+  sortedHeaderKeys.forEach(function(key) {
+      const entry = actual.next();
+      assert_false(entry.done);
+      assert_equals(entry.value, key);
+  });
+  assert_true(actual.next().done);
+  assert_true(actual.next().done);
+
+  for (const key of headers.keys())
+      assert_true(sortedHeaderKeys.indexOf(key) != -1);
+}, "Check keys method");
+
+test(function() {
+  var headers = new Headers(headerEntriesDict);
+  var actual = headers.values();
+  checkIteratorProperties(actual);
+
+  sortedHeaderKeys.forEach(function(key) {
+      const entry = actual.next();
+      assert_false(entry.done);
+      assert_equals(entry.value, sortedHeaderDict[key]);
+  });
+  assert_true(actual.next().done);
+  assert_true(actual.next().done);
+
+  for (const value of headers.values())
+      assert_true(headerValues.indexOf(value) != -1);
+}, "Check values method");
+
+test(function() {
+  var headers = new Headers(headerEntriesDict);
+  var actual = headers.entries();
+  checkIteratorProperties(actual);
+
+  sortedHeaderKeys.forEach(function(key) {
+      const entry = actual.next();
+      assert_false(entry.done);
+      assert_equals(entry.value[0], key);
+      assert_equals(entry.value[1], sortedHeaderDict[key]);
+  });
+  assert_true(actual.next().done);
+  assert_true(actual.next().done);
+
+  for (const entry of headers.entries())
+      assert_equals(entry[1], sortedHeaderDict[entry[0]]);
+}, "Check entries method");
+
+test(function() {
+  var headers = new Headers(headerEntriesDict);
+  var actual = headers[Symbol.iterator]();
+
+  sortedHeaderKeys.forEach(function(key) {
+      const entry = actual.next();
+      assert_false(entry.done);
+      assert_equals(entry.value[0], key);
+      assert_equals(entry.value[1], sortedHeaderDict[key]);
+  });
+  assert_true(actual.next().done);
+  assert_true(actual.next().done);
+}, "Check Symbol.iterator method");
+
+test(function() {
+  var headers = new Headers(headerEntriesDict);
+  var reference = sortedHeaderKeys[Symbol.iterator]();
+  headers.forEach(function(value, key, container) {
+      assert_equals(headers, container);
+      const entry = reference.next();
+      assert_false(entry.done);
+      assert_equals(key, entry.value);
+      assert_equals(value, sortedHeaderDict[entry.value]);
+  });
+  assert_true(reference.next().done);
+}, "Check forEach method");

--- a/test/wpt/tests/fetch/api/headers/headers-casing.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-casing.any.js
@@ -1,0 +1,54 @@
+// META: title=Headers case management
+// META: global=window,worker
+
+"use strict";
+
+var headerDictCase = {"UPPERCASE": "value1",
+                      "lowercase": "value2",
+                      "mixedCase": "value3",
+                      "Content-TYPE": "value4"
+                      };
+
+function checkHeadersCase(originalName, headersToCheck, expectedDict) {
+  var lowCaseName = originalName.toLowerCase();
+  var upCaseName = originalName.toUpperCase();
+  var expectedValue = expectedDict[originalName];
+  assert_equals(headersToCheck.get(originalName), expectedValue,
+      "name: " + originalName + " has value: " + expectedValue);
+  assert_equals(headersToCheck.get(lowCaseName), expectedValue,
+      "name: " + lowCaseName + " has value: " + expectedValue);
+  assert_equals(headersToCheck.get(upCaseName), expectedValue,
+      "name: " + upCaseName + " has value: " + expectedValue);
+}
+
+test(function() {
+  var headers = new Headers(headerDictCase);
+  for (const name in headerDictCase)
+    checkHeadersCase(name, headers, headerDictCase)
+}, "Create headers, names use characters with different case");
+
+test(function() {
+  var headers = new Headers();
+  for (const name in headerDictCase) {
+    headers.append(name, headerDictCase[name]);
+    checkHeadersCase(name, headers, headerDictCase);
+  }
+}, "Check append method, names use characters with different case");
+
+test(function() {
+  var headers = new Headers();
+  for (const name in headerDictCase) {
+    headers.set(name, headerDictCase[name]);
+    checkHeadersCase(name, headers, headerDictCase);
+  }
+}, "Check set method, names use characters with different case");
+
+test(function() {
+  var headers = new Headers();
+  for (const name in headerDictCase)
+    headers.set(name, headerDictCase[name]);
+  for (const name in headerDictCase)
+    headers.delete(name.toLowerCase());
+  for (const name in headerDictCase)
+    assert_false(headers.has(name), "header " + name + " should have been deleted");
+}, "Check delete method, names use characters with different case");

--- a/test/wpt/tests/fetch/api/headers/headers-combine.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-combine.any.js
@@ -1,0 +1,66 @@
+// META: title=Headers have combined (and sorted) values
+// META: global=window,worker
+
+"use strict";
+
+var headerSeqCombine = [["single", "singleValue"],
+                        ["double", "doubleValue1"],
+                        ["double", "doubleValue2"],
+                        ["triple", "tripleValue1"],
+                        ["triple", "tripleValue2"],
+                        ["triple", "tripleValue3"]
+];
+var expectedDict = {"single": "singleValue",
+                    "double": "doubleValue1, doubleValue2",
+                    "triple": "tripleValue1, tripleValue2, tripleValue3"
+};
+
+test(function() {
+  var headers = new Headers(headerSeqCombine);
+  for (const name in expectedDict)
+    assert_equals(headers.get(name), expectedDict[name]);
+}, "Create headers using same name for different values");
+
+test(function() {
+  var headers = new Headers(headerSeqCombine);
+  for (const name in expectedDict) {
+    assert_true(headers.has(name), "name: " + name + " has value(s)");
+    headers.delete(name);
+    assert_false(headers.has(name), "name: " + name + " has no value(s) anymore");
+  }
+}, "Check delete and has methods when using same name for different values");
+
+test(function() {
+  var headers = new Headers(headerSeqCombine);
+  for (const name in expectedDict) {
+    headers.set(name,"newSingleValue");
+    assert_equals(headers.get(name), "newSingleValue", "name: " + name + " has value: newSingleValue");
+  }
+}, "Check set methods when called with already used name");
+
+test(function() {
+  var headers = new Headers(headerSeqCombine);
+  for (const name in expectedDict) {
+    var value = headers.get(name);
+    headers.append(name,"newSingleValue");
+    assert_equals(headers.get(name), (value + ", " + "newSingleValue"));
+  }
+}, "Check append methods when called with already used name");
+
+test(() => {
+  const headers = new Headers([["1", "a"],["1", "b"]]);
+  for(let header of headers) {
+    assert_array_equals(header, ["1", "a, b"]);
+  }
+}, "Iterate combined values");
+
+test(() => {
+  const headers = new Headers([["2", "a"], ["1", "b"], ["2", "b"]]),
+        expected = [["1", "b"], ["2", "a, b"]];
+  let i = 0;
+  for(let header of headers) {
+    assert_array_equals(header, expected[i]);
+    i++;
+  }
+  assert_equals(i, 2);
+}, "Iterate combined values in sorted order")

--- a/test/wpt/tests/fetch/api/headers/headers-errors.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-errors.any.js
@@ -1,0 +1,96 @@
+// META: title=Headers errors
+// META: global=window,worker
+
+"use strict";
+
+test(function() {
+  assert_throws_js(TypeError, function() { new Headers([["name"]]); });
+}, "Create headers giving an array having one string as init argument");
+
+test(function() {
+  assert_throws_js(TypeError, function() { new Headers([["invalid", "invalidValue1", "invalidValue2"]]); });
+}, "Create headers giving an array having three strings as init argument");
+
+test(function() {
+  assert_throws_js(TypeError, function() { new Headers([["invalidĀ", "Value1"]]); });
+}, "Create headers giving bad header name as init argument");
+
+test(function() {
+  assert_throws_js(TypeError, function() { new Headers([["name", "invalidValueĀ"]]); });
+}, "Create headers giving bad header value as init argument");
+
+var badNames = ["invalidĀ", {}];
+var badValues = ["invalidĀ"];
+
+badNames.forEach(function(name) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.get(name); });
+  }, "Check headers get with an invalid name " + name);
+});
+
+badNames.forEach(function(name) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.delete(name); });
+  }, "Check headers delete with an invalid name " + name);
+});
+
+badNames.forEach(function(name) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.has(name); });
+  }, "Check headers has with an invalid name " + name);
+});
+
+badNames.forEach(function(name) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.set(name, "Value1"); });
+  }, "Check headers set with an invalid name " + name);
+});
+
+badValues.forEach(function(value) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.set("name", value); });
+  }, "Check headers set with an invalid value " + value);
+});
+
+badNames.forEach(function(name) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.append("invalidĀ", "Value1"); });
+  }, "Check headers append with an invalid name " + name);
+});
+
+badValues.forEach(function(value) {
+  test(function() {
+    var headers = new Headers();
+    assert_throws_js(TypeError, function() { headers.append("name", value); });
+  }, "Check headers append with an invalid value " + value);
+});
+
+test(function() {
+  var headers = new Headers([["name", "value"]]);
+  assert_throws_js(TypeError, function() { headers.forEach(); });
+  assert_throws_js(TypeError, function() { headers.forEach(undefined); });
+  assert_throws_js(TypeError, function() { headers.forEach(1); });
+}, "Headers forEach throws if argument is not callable");
+
+test(function() {
+  var headers = new Headers([["name1", "value1"], ["name2", "value2"], ["name3", "value3"]]);
+  var counter = 0;
+  try {
+      headers.forEach(function(value, name) {
+          counter++;
+          if (name == "name2")
+                throw "error";
+      });
+  } catch (e) {
+      assert_equals(counter, 2);
+      assert_equals(e, "error");
+      return;
+  }
+  assert_unreached();
+}, "Headers forEach loop should stop if callback is throwing exception");

--- a/test/wpt/tests/fetch/api/headers/headers-normalize.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-normalize.any.js
@@ -1,0 +1,56 @@
+// META: title=Headers normalize values
+// META: global=window,worker
+
+"use strict";
+
+const expectations = {
+  "name1": [" space ", "space"],
+  "name2": ["\ttab\t", "tab"],
+  "name3": [" spaceAndTab\t", "spaceAndTab"],
+  "name4": ["\r\n newLine", "newLine"], //obs-fold cases
+  "name5": ["newLine\r\n ", "newLine"],
+  "name6": ["\r\n\tnewLine", "newLine"],
+  "name7": ["\t\f\tnewLine\n", "\f\tnewLine"],
+  "name8": ["newLine\xa0", "newLine\xa0"], // \xa0 == non breaking space
+};
+
+test(function () {
+  const headerDict = Object.fromEntries(
+    Object.entries(expectations).map(([name, [actual]]) => [name, actual]),
+  );
+  var headers = new Headers(headerDict);
+  for (const name in expectations) {
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has normalized value: " + expected,
+    );
+  }
+}, "Create headers with not normalized values");
+
+test(function () {
+  var headers = new Headers();
+  for (const name in expectations) {
+    headers.append(name, expectations[name][0]);
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has value: " + expected,
+    );
+  }
+}, "Check append method with not normalized values");
+
+test(function () {
+  var headers = new Headers();
+  for (const name in expectations) {
+    headers.set(name, expectations[name][0]);
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has value: " + expected,
+    );
+  }
+}, "Check set method with not normalized values");

--- a/test/wpt/tests/fetch/api/headers/headers-record.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-record.any.js
@@ -1,0 +1,357 @@
+// META: global=window,worker
+
+"use strict";
+
+var log = [];
+function clearLog() {
+  log = [];
+}
+function addLogEntry(name, args) {
+  log.push([ name, ...args ]);
+}
+
+var loggingHandler = {
+};
+
+setup(function() {
+  for (let prop of Object.getOwnPropertyNames(Reflect)) {
+    loggingHandler[prop] = function(...args) {
+      addLogEntry(prop, args);
+      return Reflect[prop](...args);
+    }
+  }
+});
+
+test(function() {
+  var h = new Headers();
+  assert_equals([...h].length, 0);
+}, "Passing nothing to Headers constructor");
+
+test(function() {
+  var h = new Headers(undefined);
+  assert_equals([...h].length, 0);
+}, "Passing undefined to Headers constructor");
+
+test(function() {
+  assert_throws_js(TypeError, function() {
+    var h = new Headers(null);
+  });
+}, "Passing null to Headers constructor");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = { a: "b" };
+  var proxy = new Proxy(record, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 4);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+
+  // Check the results.
+  assert_equals([...h].length, 1);
+  assert_array_equals([...h.keys()], ["a"]);
+  assert_true(h.has("a"));
+  assert_equals(h.get("a"), "b");
+}, "Basic operation with one property");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var recordProto = { c: "d" };
+  var record = Object.create(recordProto, { a: { value: "b", enumerable: true } });
+  var proxy = new Proxy(record, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 4);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+
+  // Check the results.
+  assert_equals([...h].length, 1);
+  assert_array_equals([...h.keys()], ["a"]);
+  assert_true(h.has("a"));
+  assert_equals(h.get("a"), "b");
+}, "Basic operation with one property and a proto");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = { a: "b", c: "d" };
+  var proxy = new Proxy(record, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 6);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[4], ["getOwnPropertyDescriptor", record, "c"]);
+  // Then the second [[Get]] from step 5.2.
+  assert_array_equals(log[5], ["get", record, "c", proxy]);
+
+  // Check the results.
+  assert_equals([...h].length, 2);
+  assert_array_equals([...h.keys()], ["a", "c"]);
+  assert_true(h.has("a"));
+  assert_equals(h.get("a"), "b");
+  assert_true(h.has("c"));
+  assert_equals(h.get("c"), "d");
+}, "Correct operation ordering with two properties");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = { a: "b", "\uFFFF": "d" };
+  var proxy = new Proxy(record, loggingHandler);
+  assert_throws_js(TypeError, function() {
+    var h = new Headers(proxy);
+  });
+
+  assert_equals(log.length, 5);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[4], ["getOwnPropertyDescriptor", record, "\uFFFF"]);
+  // The second [[Get]] never happens, because we convert the invalid name to a
+  // ByteString first and throw.
+}, "Correct operation ordering with two properties one of which has an invalid name");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = { a: "\uFFFF", c: "d" }
+  var proxy = new Proxy(record, loggingHandler);
+  assert_throws_js(TypeError, function() {
+    var h = new Headers(proxy);
+  });
+
+  assert_equals(log.length, 4);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+  // Nothing else after this, because converting the result of that [[Get]] to a
+  // ByteString throws.
+}, "Correct operation ordering with two properties one of which has an invalid value");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = {};
+  Object.defineProperty(record, "a", { value: "b", enumerable: false });
+  Object.defineProperty(record, "c", { value: "d", enumerable: true });
+  Object.defineProperty(record, "e", { value: "f", enumerable: false });
+  var proxy = new Proxy(record, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 6);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // No [[Get]] because not enumerable
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[3], ["getOwnPropertyDescriptor", record, "c"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[4], ["get", record, "c", proxy]);
+  // Then the third [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[5], ["getOwnPropertyDescriptor", record, "e"]);
+  // No [[Get]] because not enumerable
+
+  // Check the results.
+  assert_equals([...h].length, 1);
+  assert_array_equals([...h.keys()], ["c"]);
+  assert_true(h.has("c"));
+  assert_equals(h.get("c"), "d");
+}, "Correct operation ordering with non-enumerable properties");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = {a: "b", c: "d", e: "f"};
+  var lyingHandler = {
+    getOwnPropertyDescriptor: function(target, name) {
+      if (name == "a" || name == "e") {
+        return undefined;
+      }
+      return Reflect.getOwnPropertyDescriptor(target, name);
+    }
+  };
+  var lyingProxy = new Proxy(record, lyingHandler);
+  var proxy = new Proxy(lyingProxy, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 6);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", lyingProxy, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", lyingProxy]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", lyingProxy, "a"]);
+  // No [[Get]] because no descriptor
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[3], ["getOwnPropertyDescriptor", lyingProxy, "c"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[4], ["get", lyingProxy, "c", proxy]);
+  // Then the third [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[5], ["getOwnPropertyDescriptor", lyingProxy, "e"]);
+  // No [[Get]] because no descriptor
+
+  // Check the results.
+  assert_equals([...h].length, 1);
+  assert_array_equals([...h.keys()], ["c"]);
+  assert_true(h.has("c"));
+  assert_equals(h.get("c"), "d");
+}, "Correct operation ordering with undefined descriptors");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = {a: "b", c: "d"};
+  var lyingHandler = {
+    ownKeys: function() {
+      return [ "a", "c", "a", "c" ];
+    },
+  };
+  var lyingProxy = new Proxy(record, lyingHandler);
+  var proxy = new Proxy(lyingProxy, loggingHandler);
+
+  // Returning duplicate keys from ownKeys() throws a TypeError.
+  assert_throws_js(TypeError,
+                   function() { var h = new Headers(proxy); });
+
+  assert_equals(log.length, 2);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", lyingProxy, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", lyingProxy]);
+}, "Correct operation ordering with repeated keys");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = {
+    a: "b",
+    [Symbol.toStringTag]: {
+      // Make sure the ToString conversion of the value happens
+      // after the ToString conversion of the key.
+      toString: function () { addLogEntry("toString", [this]); return "nope"; }
+    },
+    c: "d" };
+  var proxy = new Proxy(record, loggingHandler);
+  assert_throws_js(TypeError,
+                   function() { var h = new Headers(proxy); });
+
+  assert_equals(log.length, 7);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[4], ["getOwnPropertyDescriptor", record, "c"]);
+  // Then the second [[Get]] from step 5.2.
+  assert_array_equals(log[5], ["get", record, "c", proxy]);
+  // Then the third [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[6], ["getOwnPropertyDescriptor", record,
+                               Symbol.toStringTag]);
+  // Then we throw an exception converting the Symbol to a string, before we do
+  // the third [[Get]].
+}, "Basic operation with Symbol keys");
+
+test(function() {
+  this.add_cleanup(clearLog);
+  var record = {
+    a: {
+      toString: function() { addLogEntry("toString", [this]); return "b"; }
+    },
+    [Symbol.toStringTag]: {
+      toString: function () { addLogEntry("toString", [this]); return "nope"; }
+    },
+    c: {
+      toString: function() { addLogEntry("toString", [this]); return "d"; }
+    }
+  };
+  // Now make that Symbol-named property not enumerable.
+  Object.defineProperty(record, Symbol.toStringTag, { enumerable: false });
+  assert_array_equals(Reflect.ownKeys(record),
+                      ["a", "c", Symbol.toStringTag]);
+
+  var proxy = new Proxy(record, loggingHandler);
+  var h = new Headers(proxy);
+
+  assert_equals(log.length, 9);
+  // The first thing is the [[Get]] of Symbol.iterator to figure out whether
+  // we're a sequence, during overload resolution.
+  assert_array_equals(log[0], ["get", record, Symbol.iterator, proxy]);
+  // Then we have the [[OwnPropertyKeys]] from
+  // https://webidl.spec.whatwg.org/#es-to-record step 4.
+  assert_array_equals(log[1], ["ownKeys", record]);
+  // Then the [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[2], ["getOwnPropertyDescriptor", record, "a"]);
+  // Then the [[Get]] from step 5.2.
+  assert_array_equals(log[3], ["get", record, "a", proxy]);
+  // Then the ToString on the value.
+  assert_array_equals(log[4], ["toString", record.a]);
+  // Then the second [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[5], ["getOwnPropertyDescriptor", record, "c"]);
+  // Then the second [[Get]] from step 5.2.
+  assert_array_equals(log[6], ["get", record, "c", proxy]);
+  // Then the ToString on the value.
+  assert_array_equals(log[7], ["toString", record.c]);
+  // Then the third [[GetOwnProperty]] from step 5.1.
+  assert_array_equals(log[8], ["getOwnPropertyDescriptor", record,
+                               Symbol.toStringTag]);
+  // No [[Get]] because not enumerable.
+
+  // Check the results.
+  assert_equals([...h].length, 2);
+  assert_array_equals([...h.keys()], ["a", "c"]);
+  assert_true(h.has("a"));
+  assert_equals(h.get("a"), "b");
+  assert_true(h.has("c"));
+  assert_equals(h.get("c"), "d");
+}, "Operation with non-enumerable Symbol keys");

--- a/test/wpt/tests/fetch/api/headers/headers-structure.any.js
+++ b/test/wpt/tests/fetch/api/headers/headers-structure.any.js
@@ -1,0 +1,20 @@
+// META: title=Headers basic
+// META: global=window,worker
+
+"use strict";
+
+var headers = new Headers();
+var methods = ["append",
+                "delete",
+                "get",
+                "has",
+                "set",
+                //Headers is iterable
+                "entries",
+                "keys",
+                "values"
+                ];
+for (var idx in methods)
+  test(function() {
+    assert_true(methods[idx] in headers, "headers has " + methods[idx] + " method");
+  }, "Headers has " + methods[idx] + " method");


### PR DESCRIPTION
- Updates `webidl.recordConverter` to match the spec (handle proxies).
- Add a space between "at" and "index" in an error message.

Excludes 3 test files:
- COR checks (undici doesn't filter headers)
- One that requires XMLHttpRequest
- One mentioned in #1680 

598 to 660 tests total