### PR TITLE
feat: make File's `type` more strict

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -5,6 +5,7 @@ const { types } = require('util')
 const { kState } = require('./symbols')
 const { isBlobLike } = require('./util')
 const { webidl } = require('./webidl')
+const { parseMIMEType, serializeAMimeType } = require('./dataURL')
 
 class File extends Blob {
   constructor (fileBits, fileName, options = {}) {
@@ -34,13 +35,29 @@ class File extends Blob {
     //    outside the range U+0020 to U+007E, then set t to the empty string
     //    and return from these substeps.
     //    2. Convert every character in t to ASCII lowercase.
-    // Note: Blob handles both of these steps for us
+    let t = options.type
+    let d
 
-    //    3. If the lastModified member is provided, let d be set to the
-    //    lastModified dictionary member. If it is not provided, set d to the
-    //    current date and time represented as the number of milliseconds since
-    //    the Unix Epoch (which is the equivalent of Date.now() [ECMA-262]).
-    const d = options.lastModified
+    // eslint-disable-next-line no-labels
+    substep: {
+      if (t) {
+        t = parseMIMEType(t)
+
+        if (t === 'failure') {
+          t = ''
+          // eslint-disable-next-line no-labels
+          break substep
+        }
+
+        t = serializeAMimeType(t).toLowerCase()
+      }
+
+      //    3. If the lastModified member is provided, let d be set to the
+      //    lastModified dictionary member. If it is not provided, set d to the
+      //    current date and time represented as the number of milliseconds since
+      //    the Unix Epoch (which is the equivalent of Date.now() [ECMA-262]).
+      d = options.lastModified
+    }
 
     // 4. Return a new File object F such that:
     // F refers to the bytes byte sequence.
@@ -49,10 +66,11 @@ class File extends Blob {
     // F.type is set to t.
     // F.lastModified is set to d.
 
-    super(processBlobParts(fileBits, options), { type: options.type })
+    super(processBlobParts(fileBits, options), { type: t })
     this[kState] = {
       name: n,
-      lastModified: d
+      lastModified: d,
+      type: t
     }
   }
 
@@ -70,6 +88,14 @@ class File extends Blob {
     }
 
     return this[kState].lastModified
+  }
+
+  get type () {
+    if (!(this instanceof File)) {
+      throw new TypeError('Illegal invocation')
+    }
+
+    return this[kState].type
   }
 
   get [Symbol.toStringTag] () {

--- a/test/wpt/status/FileAPI.status.json
+++ b/test/wpt/status/FileAPI.status.json
@@ -1,1 +1,7 @@
-{}
+{
+	"File-constructor.any.js": {
+		"fail": [
+			"Using type in File constructor: nonparsable"
+		]
+	}
+}


### PR DESCRIPTION
This might be a bad change because, although the spec says to make `type` a "parseable MIME type", browsers have seemingly ignored this for years (see: https://github.com/nodejs/node/issues/45008#issuecomment-1279557343).

Not only this, it
1. causes more tests to fail (as Blob's attribute is still 'compliant' with browsers I guess?)
2. requires us to implement our own `type` getter, rather than using Blob's.
3. causes a FileAPI test to fail. I don't think it was meant to pass, as it is literally named "nonparseable" though.

With this change, if you remove the Blob tests from the parsing.any.js test, ~400 more tests succeed. This is because the `File` and `Blob` tests are grouped together and failing an assert causes the File test not to run. 😞 