### PR TITLE
feat: add parameter to ProxyAgent options, which is type of authentication

### DIFF
--- a/docs/api/ProxyAgent.md
+++ b/docs/api/ProxyAgent.md
@@ -17,6 +17,8 @@ Returns: `ProxyAgent`
 Extends: [`AgentOptions`](Agent.md#parameter-agentoptions)
 
 * **uri** `string` (required) - It can be passed either by a string or a object containing `uri` as string.
+* **token** `string` (optional) - It can be passed by a string of token for authentication.
+* **auth** `string` (**deprecated**) - Use token.
 
 Examples:
 
@@ -71,6 +73,26 @@ console.log('response received', statusCode) // response received 200
 
 for await (const data of body) {
   console.log('data', data.toString('utf8')) // data foo
+}
+```
+
+#### Example - Basic Proxy Request with authentication
+
+```js
+import { setGlobalDispatcher, request, ProxyAgent } from 'undici';
+
+const proxyAgent = new ProxyAgent({
+  uri: 'my.proxy.server',
+  token 'Bearer xxxx'
+});
+setGlobalDispatcher(proxyAgent);
+
+const { statusCode, body } = await request('http://localhost:3000/foo');
+
+console.log('response received', statusCode); // response received 200
+
+for await (const data of body) {
+  console.log('data', data.toString('utf8')); // data foo
 }
 ```
 

--- a/docs/api/ProxyAgent.md
+++ b/docs/api/ProxyAgent.md
@@ -83,7 +83,7 @@ import { setGlobalDispatcher, request, ProxyAgent } from 'undici';
 
 const proxyAgent = new ProxyAgent({
   uri: 'my.proxy.server',
-  token 'Bearer xxxx'
+  token: 'Bearer xxxx'
 });
 setGlobalDispatcher(proxyAgent);
 

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -55,12 +55,10 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = {}
 
-    // deprecated
+    // @deprecated in favour of opts.token
     if (opts.auth) {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
-    }
-
-    if (opts.token) {
+    } else if (opts.token) {
       this[kProxyHeaders]['proxy-authorization'] = opts.token
     }
 

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -55,8 +55,10 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = {}
 
-    // @deprecated in favour of opts.token
-    if (opts.auth) {
+    if (opts.auth && opts.token) {
+      throw new InvalidArgumentError('opts.auth cannot be used in combination with opts.token')
+    } else if (opts.auth) {
+      /* @deprecated in favour of opts.token */
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
     } else if (opts.token) {
       this[kProxyHeaders]['proxy-authorization'] = opts.token

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -55,8 +55,13 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = {}
 
+    // deprecated
     if (opts.auth) {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
+    }
+
+    if (opts.token) {
+      this[kProxyHeaders]['proxy-authorization'] = opts.token
     }
 
     const resolvedUrl = new URL(opts.uri)

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -18,6 +18,17 @@ test('should throw error when no uri is provided', (t) => {
   t.throws(() => new ProxyAgent({}), InvalidArgumentError)
 })
 
+test('using auth in combination with token should throw', (t) => {
+  t.plan(1)
+  t.throws(() => new ProxyAgent({
+    auth: 'foo',
+    token: 'Bearer bar',
+    uri: 'http://example.com'
+  }),
+  InvalidArgumentError
+  )
+})
+
 test('should accept string and object as options', (t) => {
   t.plan(2)
   t.doesNotThrow(() => new ProxyAgent('http://example.com'))

--- a/test/types/proxy-agent.test-d.ts
+++ b/test/types/proxy-agent.test-d.ts
@@ -9,6 +9,7 @@ expectAssignable<ProxyAgent>(
     connections: 1,
     uri: '',
     auth: '',
+    token: '',
     maxRedirections: 1,
     factory: (_origin: URL, opts: Object) => new Agent(opts),
     requestTls: {

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -15,6 +15,7 @@ declare namespace ProxyAgent {
   export interface Options extends Agent.Options {
     uri: string;
     auth?: string;
+    token?: string;
     requestTls?: TlsOptions & { servername?: string };
     proxyTls?: TlsOptions & { servername?: string };
   }

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -14,6 +14,9 @@ declare class ProxyAgent extends Dispatcher {
 declare namespace ProxyAgent {
   export interface Options extends Agent.Options {
     uri: string;
+    /**
+     * @deprecated use opts.token
+     */
     auth?: string;
     token?: string;
     requestTls?: TlsOptions & { servername?: string };


### PR DESCRIPTION
Implements: add parameter to ProxyAgent options

Benefits: ProxyAgent can use a variety of authentication types.

Also see: About this issue https://github.com/nodejs/undici/issues/1704