### PR TITLE
fix(fetch): remove terminated event listener on redirect

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -73,6 +73,11 @@ class Fetch extends EE {
     this.connection = null
     this.dump = false
     this.state = 'ongoing'
+    // 2 terminated listeners get added per request,
+    // but only 1 gets removed. If there are 20 redirects,
+    // 21 listeners will be added.
+    // See https://github.com/nodejs/undici/issues/1711
+    this.setMaxListeners(21)
   }
 
   terminate (reason) {
@@ -1068,13 +1073,6 @@ async function httpFetch (fetchParams) {
       // See https://github.com/nodejs/undici/issues/1193.
       response = actualResponse
     } else if (request.redirect === 'follow') {
-      /** @type {Fetch} */
-      const controller = fetchParams.controller
-
-      if (controller.listenerCount('terminated') > 0) {
-        controller.removeAllListeners('terminated')
-      }
-
       // Set response to the result of running HTTP-redirect fetch given
       // fetchParams and response.
       response = await httpRedirectFetch(fetchParams, response)

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -77,6 +77,7 @@ class Fetch extends EE {
     // but only 1 gets removed. If there are 20 redirects,
     // 21 listeners will be added.
     // See https://github.com/nodejs/undici/issues/1711
+    // TODO (fix): Find and fix root cause for leaked listener.
     this.setMaxListeners(21)
   }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1068,6 +1068,13 @@ async function httpFetch (fetchParams) {
       // See https://github.com/nodejs/undici/issues/1193.
       response = actualResponse
     } else if (request.redirect === 'follow') {
+      /** @type {Fetch} */
+      const controller = fetchParams.controller
+
+      if (controller.listenerCount('terminated') > 0) {
+        controller.removeAllListeners('terminated')
+      }
+
       // Set response to the result of running HTTP-redirect fetch given
       // fetchParams and response.
       response = await httpRedirectFetch(fetchParams, response)


### PR DESCRIPTION
Disclaimer: this is a pretty terrible solution, but I couldn't find another way of fixing this.

Fixes #1711 

- The listener gets added here
https://github.com/nodejs/undici/blob/7102eb0b7f544cee7669aaf06eb94f38b22aba86/lib/fetch/index.js#L1813
- This is where it should be removed (& onError). If we remove it here it doesn't work, my best guess is that it gets gc'ed? I can't move `onAborted` outside of this scope as it relies on `response`, and if we use a closure (etc.) the same problem would happen.
https://github.com/nodejs/undici/blob/7102eb0b7f544cee7669aaf06eb94f38b22aba86/lib/fetch/index.js#L2028

If you have any idea of how to fix this, please let me know. I spent maybe 45 minutes trying anything I could think of.

Also not sure how I would add tests for this.