### PR TITLE
fix(redirect): Ignore query config after redirection

### DIFF
--- a/lib/handler/RedirectHandler.js
+++ b/lib/handler/RedirectHandler.js
@@ -109,6 +109,7 @@ class RedirectHandler {
     this.opts.path = path
     this.opts.origin = origin
     this.opts.maxRedirections = 0
+    this.opts.query = null
 
     // https://tools.ietf.org/html/rfc7231#section-6.4.4
     // In case of HTTP 303, always replace method to be either HEAD or GET

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -8,7 +8,8 @@ const {
   startRedirectingChainServers,
   startRedirectingWithoutLocationServer,
   startRedirectingWithAuthorization,
-  startRedirectingWithCookie
+  startRedirectingWithCookie,
+  startRedirectingWithQueryParams
 } = require('./utils/redirecting-servers')
 const { createReadable, createReadableStream } = require('./utils/stream')
 
@@ -298,6 +299,21 @@ for (const factory of [
     t.notOk(headers.location)
     t.same(history.map(x => x.toString()), [`http://${server}/`, `http://${server}/end`])
     t.equal(body, 'FINAL')
+  })
+
+  t.test('should ignore query after redirection', async t => {
+    t.plan(3)
+
+    const server = await startRedirectingWithQueryParams(t)
+
+    const { statusCode, headers, context: { history } } = await request(server, undefined, `http://${server}/`, {
+      maxRedirections: 10,
+      query: { param1: 'first' }
+    })
+
+    t.equal(statusCode, 200)
+    t.notOk(headers.location)
+    t.same(history.map(x => x.toString()), [`http://${server}/`, `http://${server}/?param2=second`])
   })
 
   t.test('should follow a redirect chain up to the allowed number of times', async t => {

--- a/test/utils/redirecting-servers.js
+++ b/test/utils/redirecting-servers.js
@@ -222,6 +222,23 @@ async function startRedirectingWithRelativePath (t) {
   return server
 }
 
+async function startRedirectingWithQueryParams (t) {
+  const server = await startServer(t, (req, res) => {
+    if (req.url === '/?param1=first') {
+      res.statusCode = 301
+      res.setHeader('Connection', 'close')
+      res.setHeader('Location', `http://${server}/?param2=second`)
+      res.end('REDIRECT')
+      return
+    }
+
+    res.setHeader('Connection', 'close')
+    res.end('')
+  })
+
+  return server
+}
+
 module.exports = {
   startServer,
   startRedirectingServer,
@@ -230,5 +247,6 @@ module.exports = {
   startRedirectingChainServers,
   startRedirectingWithAuthorization,
   startRedirectingWithCookie,
-  startRedirectingWithRelativePath
+  startRedirectingWithRelativePath,
+  startRedirectingWithQueryParams
 }


### PR DESCRIPTION
Ignore query option on redirection, please check https://github.com/nodejs/undici/issues/1691 for more information.
The issue can be reproduced with a simple node/express server:

```javascript
app.get('/', (req, res) => { res.send('Hello world');});

app.get('/endpoint', (req, res) => { res.redirect('/redirection?param1=first');});

app.get('/redirection', (req, res) => { res.redirect('/');});

app.listen(4000, () => {})
```

Then we can call it with undici:

```javascript
undici.request(
'http://localhost:4000/endpoint',
{
   maxRedirection: 4,
   query: { param: 'test' }
}
).then(res => console.log('Good')).catch(err => console.log(err));
```
The code snippet will produce an error as described in the issue.

Solution: Remove query from options after redirection