### PR TITLE
docs: change master to main for links in the nodejs org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,4 +3,4 @@
 Undici is committed to upholding the Node.js Code of Conduct.
 
 The Node.js Code of Conduct document can be found at
-https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
+https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,4 +132,4 @@ By making a contribution to this project, I certify that:
 The [Node.js Moderation Policy] applies to this project.
 
 [Node.js Moderation Policy]:
-https://github.com/nodejs/admin/blob/master/Moderation-Policy.md
+https://github.com/nodejs/admin/blob/main/Moderation-Policy.md


### PR DESCRIPTION
The name of the default branch of the admin repo has been changed from master to main.

Signed-off-by: Darshan Sen <raisinten@gmail.com>