### PR TITLE
wpt: fail runner if expected failures don't fail

### DIFF
--- a/test/wpt/status/FileAPI.status.json
+++ b/test/wpt/status/FileAPI.status.json
@@ -6,8 +6,6 @@
 	},
 	"idlharness.any.js": {
 		"fail": [
-			"URL interface: operation revokeObjectURL(DOMString)",
-			"URL interface: operation createObjectURL((Blob or MediaSource))",
 			"Blob interface: attribute size",
 			"Blob interface: attribute type",
 			"Blob interface: operation slice(optional long long, optional long long, optional DOMString)",
@@ -21,7 +19,9 @@
 			"FileList interface: existence and properties of interface prototype object's \"constructor\" property",
 			"FileList interface: existence and properties of interface prototype object's @@unscopables property",
 			"FileList interface: operation item(unsigned long)",
-			"FileList interface: attribute length"
+			"FileList interface: attribute length",
+			"URL interface: operation createObjectURL((Blob or MediaSource))",
+			"URL interface: operation revokeObjectURL(DOMString)"
 		]
 	},
 	"filereader_events.any.js": {

--- a/test/wpt/status/fetch.status.json
+++ b/test/wpt/status/fetch.status.json
@@ -1,9 +1,9 @@
 {
 	"general.any.js": {
 		"fail": [
-			"Stream errors once aborted. Underlying connection closed.",
+			"Already aborted signal rejects immediately",
 			"Underlying connection is closed when aborting after receiving response - no-cors",
-			"Already aborted signal rejects immediately"
+			"Stream errors once aborted. Underlying connection closed."
 		]
 	},
 	"request-disturbed.any.js": {


### PR DESCRIPTION
The runner will now fail if a test that is marked as an expected failure doesn't fail.

The way I did this is either ingenious or horrible, depending on how you look at it. It maps tests that failed to an object and then compares that object to a slightly modified version of the status file (without including other flags or flaky tests).

`assert` gives a very nice error message with exactly which test(s) did not fail (ie. tests that were not in both objects)

I should also add that the order in which tests fail in is entirely deterministic such that the order in which tests fail in will never differ. The failures are mapped by the name of the file itself, similarly to the status files.