### PR TITLE
fix(fetch): set Symbol.toStringTag properly on classes

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -98,10 +98,6 @@ class File extends Blob {
 
     return this[kState].type
   }
-
-  get [Symbol.toStringTag] () {
-    return this.constructor.name
-  }
 }
 
 class FileLike {
@@ -222,6 +218,10 @@ class FileLike {
 }
 
 Object.defineProperties(File.prototype, {
+  [Symbol.toStringTag]: {
+    value: 'File',
+    configurable: true
+  },
   name: kEnumerableProperty,
   lastModified: kEnumerableProperty
 })

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -8,8 +8,6 @@ const { Blob } = require('buffer')
 
 // https://xhr.spec.whatwg.org/#formdata
 class FormData {
-  static name = 'FormData'
-
   constructor (form) {
     if (form !== undefined) {
       webidl.errors.conversionFailed({

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -196,10 +196,6 @@ class FormData {
     }
   }
 
-  get [Symbol.toStringTag] () {
-    return this.constructor.name
-  }
-
   entries () {
     if (!(this instanceof FormData)) {
       throw new TypeError('Illegal invocation')
@@ -264,6 +260,13 @@ class FormData {
 }
 
 FormData.prototype[Symbol.iterator] = FormData.prototype.entries
+
+Object.defineProperties(FormData.prototype, {
+  [Symbol.toStringTag]: {
+    value: 'FormData',
+    configurable: true
+  }
+})
 
 /**
  * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -171,10 +171,6 @@ class Headers {
     }
   }
 
-  get [Symbol.toStringTag] () {
-    return this.constructor.name
-  }
-
   // https://fetch.spec.whatwg.org/#dom-headers-append
   append (name, value) {
     if (!(this instanceof Headers)) {
@@ -481,7 +477,11 @@ Object.defineProperties(Headers.prototype, {
   values: kEnumerableProperty,
   entries: kEnumerableProperty,
   forEach: kEnumerableProperty,
-  [Symbol.iterator]: { enumerable: false }
+  [Symbol.iterator]: { enumerable: false },
+  [Symbol.toStringTag]: {
+    value: 'Headers',
+    configurable: true
+  }
 })
 
 webidl.converters.HeadersInit = function (V) {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -522,10 +522,6 @@ class Request {
     this[kState].body = finalBody
   }
 
-  get [Symbol.toStringTag] () {
-    return this.constructor.name
-  }
-
   // Returns request’s HTTP method, which is "GET" by default.
   get method () {
     if (!(this instanceof Request)) {
@@ -866,7 +862,11 @@ Object.defineProperties(Request.prototype, {
   attribute: kEnumerableProperty,
   referrerPolicy: kEnumerableProperty,
   referrer: kEnumerableProperty,
-  mode: kEnumerableProperty
+  mode: kEnumerableProperty,
+  [Symbol.toStringTag]: {
+    value: 'Request',
+    configurable: true
+  }
 })
 
 webidl.converters.Request = webidl.interfaceConverter(

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -169,10 +169,6 @@ class Response {
     initializeResponse(this, init, bodyWithType)
   }
 
-  get [Symbol.toStringTag] () {
-    return this.constructor.name
-  }
-
   // Returns response’s type, e.g., "cors".
   get type () {
     if (!(this instanceof Response)) {
@@ -314,7 +310,11 @@ Object.defineProperties(Response.prototype, {
   headers: kEnumerableProperty,
   clone: kEnumerableProperty,
   body: kEnumerableProperty,
-  bodyUsed: kEnumerableProperty
+  bodyUsed: kEnumerableProperty,
+  [Symbol.toStringTag]: {
+    value: 'Response',
+    configurable: true
+  }
 })
 
 Object.defineProperties(Response, {

--- a/test/fetch/general.js
+++ b/test/fetch/general.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('tap')
+const {
+  File,
+  FormData,
+  Headers,
+  Request,
+  Response
+} = require('../../index')
+
+test('Symbol.toStringTag descriptor', (t) => {
+  for (const cls of [
+    File,
+    FormData,
+    Headers,
+    Request,
+    Response
+  ]) {
+    const desc = Object.getOwnPropertyDescriptor(cls.prototype, Symbol.toStringTag)
+    t.same(desc, {
+      value: cls.name,
+      writable: false,
+      enumerable: false,
+      configurable: true
+    })
+  }
+
+  t.end()
+})


### PR DESCRIPTION
See: https://webidl.spec.whatwg.org/#ecmascript-binding

"If an object has a [class string](https://webidl.spec.whatwg.org/#dfn-class-string) classString, then the object must, at the time it is created, have a property whose name is the [@@toStringTag](https://tc39.es/ecma262/#sec-well-known-symbols) symbol with PropertyDescriptor{[[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true, [[Value]]: classString}."

---

Also removes a hack that was added in d023b2d8