### PR TITLE
fetch: implement isomorphic decoding

### DIFF
--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const { atob } = require('buffer')
-const { isValidHTTPToken } = require('./util')
+const { isValidHTTPToken, isomorphicDecode } = require('./util')
 
 const encoder = new TextEncoder()
 
@@ -54,7 +54,6 @@ function dataURLProcessor (dataURL) {
   const encodedBody = input.slice(mimeTypeLength + 1)
 
   // 10. Let body be the percent-decoding of encodedBody.
-  /** @type {Uint8Array|string} */
   let body = stringPercentDecode(encodedBody)
 
   // 11. If mimeType ends with U+003B (;), followed by
@@ -62,7 +61,8 @@ function dataURLProcessor (dataURL) {
   // case-insensitive match for "base64", then:
   if (/;(\u0020){0,}base64$/i.test(mimeType)) {
     // 1. Let stringBody be the isomorphic decode of body.
-    const stringBody = decodeURIComponent(new TextDecoder('utf-8').decode(body))
+    const stringBody = isomorphicDecode(body)
+
     // 2. Set body to the forgiving-base64 decode of
     // stringBody.
     body = forgivingBase64(stringBody)

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -857,6 +857,23 @@ function isReadableStreamLike (stream) {
 }
 
 /**
+ * @see https://infra.spec.whatwg.org/#isomorphic-decode
+ * @param {number[]|Uint8Array} input
+ */
+function isomorphicDecode (input) {
+  // 1. To isomorphic decode a byte sequence input, return a string whose code point
+  //    length is equal to input’s length and whose code points have the same values
+  //    as the values of input’s bytes, in the same order.
+  let output = ''
+
+  for (let i = 0; i < input.length; i++) {
+    output += String.fromCharCode(input[i])
+  }
+
+  return output
+}
+
+/**
  * @param {ReadableStreamController<Uint8Array>} controller
  */
 function readableStreamClose (controller) {
@@ -929,5 +946,6 @@ module.exports = {
   bytesMatch,
   isReadableStreamLike,
   readableStreamClose,
-  isomorphicEncode
+  isomorphicEncode,
+  isomorphicDecode
 }


### PR DESCRIPTION
No new failing or passing tests but this way avoids TextDecoder and removes a useless decodeURIComponent so it's probably considerably faster.