### PR TITLE
fetch: remove duplicate checks

### DIFF
--- a/lib/fetch/constants.js
+++ b/lib/fetch/constants.js
@@ -55,6 +55,11 @@ const requestBodyHeader = [
   'content-type'
 ]
 
+// https://fetch.spec.whatwg.org/#enumdef-requestduplex
+const requestDuplex = [
+  'half'
+]
+
 // http://fetch.spec.whatwg.org/#forbidden-method
 const forbiddenMethods = ['CONNECT', 'TRACE', 'TRACK']
 
@@ -120,5 +125,6 @@ module.exports = {
   corsSafeListedMethods,
   nullBodyStatus,
   safeMethods,
-  badPorts
+  badPorts,
+  requestDuplex
 }

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -18,7 +18,8 @@ const {
   requestRedirect,
   requestMode,
   requestCredentials,
-  requestCache
+  requestCache,
+  requestDuplex
 } = require('./constants')
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = require('./symbols')
@@ -243,22 +244,12 @@ class Request {
     // to it.
     if (init.referrerPolicy !== undefined) {
       request.referrerPolicy = init.referrerPolicy
-      if (!referrerPolicy.includes(request.referrerPolicy)) {
-        throw new TypeError(
-          `Failed to construct 'Request': The provided value '${request.referrerPolicy}' is not a valid enum value of type ReferrerPolicy.`
-        )
-      }
     }
 
     // 16. Let mode be init["mode"] if it exists, and fallbackMode otherwise.
     let mode
     if (init.mode !== undefined) {
       mode = init.mode
-      if (!requestMode.includes(mode)) {
-        throw new TypeError(
-          `Failed to construct 'Request': The provided value '${request.mode}' is not a valid enum value of type RequestMode.`
-        )
-      }
     } else {
       mode = fallbackMode
     }
@@ -280,21 +271,11 @@ class Request {
     // to it.
     if (init.credentials !== undefined) {
       request.credentials = init.credentials
-      if (!requestCredentials.includes(request.credentials)) {
-        throw new TypeError(
-          `Failed to construct 'Request': The provided value '${request.credentials}' is not a valid enum value of type RequestCredentials.`
-        )
-      }
     }
 
     // 18. If init["cache"] exists, then set request’s cache mode to it.
     if (init.cache !== undefined) {
       request.cache = init.cache
-      if (!requestCache.includes(request.cache)) {
-        throw new TypeError(
-          `Failed to construct 'Request': The provided value '${request.cache}' is not a valid enum value of type RequestCache.`
-        )
-      }
     }
 
     // 21. If request’s cache mode is "only-if-cached" and request’s mode is
@@ -308,11 +289,6 @@ class Request {
     // 22. If init["redirect"] exists, then set request’s redirect mode to it.
     if (init.redirect !== undefined) {
       request.redirect = init.redirect
-      if (!requestRedirect.includes(request.redirect)) {
-        throw new TypeError(
-          `Failed to construct 'Request': The provided value '${request.redirect}' is not a valid enum value of type RequestRedirect.`
-        )
-      }
     }
 
     // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
@@ -914,45 +890,31 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
     key: 'referrerPolicy',
     converter: webidl.converters.DOMString,
     // https://w3c.github.io/webappsec-referrer-policy/#referrer-policy
-    allowedValues: [
-      '', 'no-referrer', 'no-referrer-when-downgrade',
-      'same-origin', 'origin', 'strict-origin',
-      'origin-when-cross-origin', 'strict-origin-when-cross-origin',
-      'unsafe-url'
-    ]
+    allowedValues: referrerPolicy
   },
   {
     key: 'mode',
     converter: webidl.converters.DOMString,
     // https://fetch.spec.whatwg.org/#concept-request-mode
-    allowedValues: [
-      'same-origin', 'cors', 'no-cors', 'navigate', 'websocket'
-    ]
+    allowedValues: requestMode
   },
   {
     key: 'credentials',
     converter: webidl.converters.DOMString,
     // https://fetch.spec.whatwg.org/#requestcredentials
-    allowedValues: [
-      'omit', 'same-origin', 'include'
-    ]
+    allowedValues: requestCredentials
   },
   {
     key: 'cache',
     converter: webidl.converters.DOMString,
     // https://fetch.spec.whatwg.org/#requestcache
-    allowedValues: [
-      'default', 'no-store', 'reload', 'no-cache', 'force-cache',
-      'only-if-cached'
-    ]
+    allowedValues: requestCache
   },
   {
     key: 'redirect',
     converter: webidl.converters.DOMString,
     // https://fetch.spec.whatwg.org/#requestredirect
-    allowedValues: [
-      'follow', 'error', 'manual'
-    ]
+    allowedValues: requestRedirect
   },
   {
     key: 'integrity',
@@ -978,7 +940,7 @@ webidl.converters.RequestInit = webidl.dictionaryConverter([
   {
     key: 'duplex',
     converter: webidl.converters.DOMString,
-    allowedValues: ['half']
+    allowedValues: requestDuplex
   }
 ])
 


### PR DESCRIPTION
- Removes checks that are already handled in webidl (the checks were added before webidl was added)
- Uses the already existing valid enum values from constants, instead of duplicating them.

Tests already exist that check that invalid values throw an error.