### PR TITLE
fix: `DiagnosticsChannel` namespace not exported

### DIFF
--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -3,6 +3,8 @@ import { URL } from "url";
 import { connector } from "./connector";
 import { HttpMethod } from "./dispatcher";
 
+export = DiagnosticsChannel;
+
 declare namespace DiagnosticsChannel {
   interface Request {
     origin?: string | URL;

--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -3,9 +3,7 @@ import { URL } from "url";
 import { connector } from "./connector";
 import { HttpMethod } from "./dispatcher";
 
-export = DiagnosticsChannel;
-
-declare namespace DiagnosticsChannel {
+export declare namespace DiagnosticsChannel {
   interface Request {
     origin?: string | URL;
     completed: boolean;


### PR DESCRIPTION
## Rationale

One can already subscribe to `diagnostics_channel` messages, but because the types of said messages aren't exported, they are awkward to deal with.

I'm assuming that the missing export declaration is an oversight, as multiple interfaces inside `DiagnosticsChannel` are already exported.

## Changes

* Add export declaration for `DiagnosticsChannel` namespace

### Bug Fixes

N/A

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
