### PR TITLE
Fix filereader types

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,8 +116,7 @@
     "compilerOptions": {
       "esModuleInterop": true,
       "lib": [
-        "esnext",
-        "DOM"
+        "esnext"
       ]
     }
   },

--- a/types/filereader.d.ts
+++ b/types/filereader.d.ts
@@ -4,7 +4,7 @@ import { Blob } from 'buffer'
 import { DOMException, Event, EventInit, EventTarget } from './patch'
 
 export declare class FileReader {
-  __proto__: EventTarget['prototype'] & FileReader
+  __proto__: EventTarget & FileReader
 
   constructor ()
 

--- a/types/filereader.d.ts
+++ b/types/filereader.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import { Blob } from 'buffer'
+import { DOMException, Event, EventInit, EventTarget } from './patch'
 
 export declare class FileReader extends EventTarget {
   constructor ()

--- a/types/filereader.d.ts
+++ b/types/filereader.d.ts
@@ -3,7 +3,9 @@
 import { Blob } from 'buffer'
 import { DOMException, Event, EventInit, EventTarget } from './patch'
 
-export declare class FileReader extends EventTarget {
+export declare class FileReader {
+  __proto__: EventTarget
+
   constructor ()
 
   readAsArrayBuffer (blob: Blob): void
@@ -41,7 +43,9 @@ export interface ProgressEventInit extends EventInit {
   total?: number
 }
 
-export declare class ProgressEvent extends Event {
+export declare class ProgressEvent {
+  __proto__: Event
+
   constructor (type: string, eventInitDict?: ProgressEventInit)
 
   readonly lengthComputable: boolean

--- a/types/filereader.d.ts
+++ b/types/filereader.d.ts
@@ -4,7 +4,7 @@ import { Blob } from 'buffer'
 import { DOMException, Event, EventInit, EventTarget } from './patch'
 
 export declare class FileReader {
-  __proto__: EventTarget
+  __proto__: EventTarget['prototype'] & FileReader
 
   constructor ()
 
@@ -44,7 +44,7 @@ export interface ProgressEventInit extends EventInit {
 }
 
 export declare class ProgressEvent {
-  __proto__: Event
+  __proto__: Event & ProgressEvent
 
   constructor (type: string, eventInitDict?: ProgressEventInit)
 

--- a/types/patch.d.ts
+++ b/types/patch.d.ts
@@ -6,23 +6,23 @@ export type DOMException = typeof globalThis extends { DOMException: infer T }
  ? T
  : any
 
-export type EventTarget = typeof globalThis extends { EventTarget: { prototype: infer T } }
+export type EventTarget = typeof globalThis extends { EventTarget: infer T }
   ? T
   : {
     addEventListener(
       type: string,
-      listener: EventListener | EventListenerObject,
-      options?: AddEventListenerOptions | boolean,
+      listener: any,
+      options?: any,
     ): void
     dispatchEvent(event: Event): boolean
     removeEventListener(
       type: string,
-      listener: EventListener | EventListenerObject,
-      options?: EventListenerOptions | boolean,
+      listener: any,
+      options?: any | boolean,
     ): void
   }
 
-export type Event = typeof globalThis extends { Event: { prototype: infer T } }
+export type Event = typeof globalThis extends { Event: infer T }
   ? T
   : {
     readonly bubbles: boolean

--- a/types/patch.d.ts
+++ b/types/patch.d.ts
@@ -6,13 +6,43 @@ export type DOMException = typeof globalThis extends { DOMException: infer T }
  ? T
  : any
 
-export type EventTarget = typeof globalThis extends { EventTarget: infer T }
+export type EventTarget = typeof globalThis extends { EventTarget: { prototype: infer T } }
   ? T
-  : any
+  : {
+    addEventListener(
+      type: string,
+      listener: EventListener | EventListenerObject,
+      options?: AddEventListenerOptions | boolean,
+    ): void
+    dispatchEvent(event: Event): boolean
+    removeEventListener(
+      type: string,
+      listener: EventListener | EventListenerObject,
+      options?: EventListenerOptions | boolean,
+    ): void
+  }
 
-export type Event = typeof globalThis extends { Event: infer T }
+export type Event = typeof globalThis extends { Event: { prototype: infer T } }
   ? T
-  : any
+  : {
+    readonly bubbles: boolean
+    cancelBubble: () => void
+    readonly cancelable: boolean
+    readonly composed: boolean
+    composedPath(): [EventTarget?]
+    readonly currentTarget: EventTarget | null
+    readonly defaultPrevented: boolean
+    readonly eventPhase: 0 | 2
+    readonly isTrusted: boolean
+    preventDefault(): void
+    returnValue: boolean
+    readonly srcElement: EventTarget | null
+    stopImmediatePropagation(): void
+    stopPropagation(): void
+    readonly target: EventTarget | null
+    readonly timeStamp: number
+    readonly type: string
+  }
 
 export interface EventInit {
   bubbles?: boolean

--- a/types/patch.d.ts
+++ b/types/patch.d.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+
+// See https://github.com/nodejs/undici/issues/1740
+
+export type DOMException = typeof globalThis extends { DOMException: infer T }
+ ? T
+ : any
+
+export type EventTarget = typeof globalThis extends { EventTarget: infer T }
+  ? T
+  : any
+
+export type Event = typeof globalThis extends { Event: infer T }
+  ? T
+  : any
+
+export interface EventInit {
+  bubbles?: boolean
+  cancelable?: boolean
+  composed?: boolean
+}


### PR DESCRIPTION
This has got to be the worst fix of ever, but it works. 😂 

The types technically aren't correct either, but I doubt many people are accessing FileReader's `__proto__`.

Fixes #1740 

Confirmed it fixes the issue with:
- Follow instructions from [here](https://github.com/nodejs/undici/issues/1740#issuecomment-1294740460) but install undici with `npm install "https://github.com/KhafraDev/undici.git#fix-filereader-types" --save`
- `npx tsc -p ./`