### PR TITLE
fix: remove unnecessary toLowerCase

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -129,8 +129,6 @@ class HeadersList {
 
   // https://fetch.spec.whatwg.org/#concept-header-list-get
   get (name) {
-    name = name.toLowerCase()
-
     // 1. If list does not contain name, then return null.
     if (!this.contains(name)) {
       return null
@@ -139,7 +137,7 @@ class HeadersList {
     // 2. Return the values of all headers in list whose name
     //    is a byte-case-insensitive match for name,
     //    separated from each other by 0x2C 0x20, in order.
-    return this[kHeadersMap].get(name) ?? null
+    return this[kHeadersMap].get(name.toLowerCase()) ?? null
   }
 
   has (name) {


### PR DESCRIPTION
Line 135: `this.contains(name)` already runs `name.toLowerCase()` there is no need to run it twice.