### PR TITLE
perf: simplify isValidHeaderName

### DIFF
--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -146,13 +146,7 @@ function isValidHeaderName (potentialValue) {
     return false
   }
 
-  for (const char of potentialValue) {
-    if (!isValidHTTPToken(char)) {
-      return false
-    }
-  }
-
-  return true
+  return isValidHTTPToken(potentialValue)
 }
 
 /**


### PR DESCRIPTION
`isValidHTTPToken` already checks character by character. There is no need for the additional for loop.