### PR TITLE
fix(fetch): match spec text

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -433,7 +433,7 @@ class Request {
       // 3, If Content-Type is non-null and this’s headers’s header list does
       // not contain `Content-Type`, then append `Content-Type`/Content-Type to
       // this’s headers.
-      if (contentType && !this[kHeaders].has('content-type')) {
+      if (contentType && !this[kHeaders][kHeadersList].contains('content-type')) {
         this[kHeaders].append('content-type', contentType)
       }
     }


### PR DESCRIPTION
Uses headersList where the spec says to do "... [if] this’s headers’s header list does not contain..."