### PR TITLE
feat(fetch): add in native File class support

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -7,17 +7,20 @@ const { FormData } = require('./formdata')
 const { kState } = require('./symbols')
 const { webidl } = require('./webidl')
 const { DOMException, structuredClone } = require('./constants')
-const { Blob } = require('buffer')
+const { Blob, File: NativeFile } = require('buffer')
 const { kBodyUsed } = require('../core/symbols')
 const assert = require('assert')
 const { isErrored } = require('../core/util')
 const { isUint8Array, isArrayBuffer } = require('util/types')
-const { File } = require('./file')
+const { File: UndiciFile } = require('./file')
 const { StringDecoder } = require('string_decoder')
 const { parseMIMEType, serializeAMimeType } = require('./dataURL')
 
 /** @type {globalThis['ReadableStream']} */
 let ReadableStream
+
+/** @type {globalThis['File']} */
+const File = NativeFile ?? UndiciFile
 
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -329,11 +329,14 @@ function convertLineEndingsNative (s) {
 // rollup) will warn about circular dependencies. See:
 // https://github.com/nodejs/undici/issues/1629
 function isFileLike (object) {
-  return object instanceof File || (
-    object &&
-    (typeof object.stream === 'function' ||
-     typeof object.arrayBuffer === 'function') &&
-     object[Symbol.toStringTag] === 'File'
+  return (
+    (globalThis.File && object instanceof globalThis.File) ||
+    object instanceof File || (
+      object &&
+      (typeof object.stream === 'function' ||
+      typeof object.arrayBuffer === 'function') &&
+      object[Symbol.toStringTag] === 'File'
+    )
   )
 }
 

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -2,9 +2,12 @@
 
 const { isBlobLike, toUSVString, makeIterator } = require('./util')
 const { kState } = require('./symbols')
-const { File, FileLike, isFileLike } = require('./file')
+const { File: UndiciFile, FileLike, isFileLike } = require('./file')
 const { webidl } = require('./webidl')
-const { Blob } = require('buffer')
+const { Blob, File: NativeFile } = require('buffer')
+
+/** @type {globalThis['File']} */
+const File = NativeFile ?? UndiciFile
 
 // https://xhr.spec.whatwg.org/#formdata
 class FormData {

--- a/test/wpt/status/FileAPI.status.json
+++ b/test/wpt/status/FileAPI.status.json
@@ -5,13 +5,18 @@
 		]
 	},
 	"idlharness.any.js": {
-		"fail": [
+		"note": "These flaky tests only fail in < node v19; add in a way to mark them as such eventually",
+		"flaky": [
 			"Blob interface: attribute size",
 			"Blob interface: attribute type",
 			"Blob interface: operation slice(optional long long, optional long long, optional DOMString)",
 			"Blob interface: operation stream()",
 			"Blob interface: operation text()",
 			"Blob interface: operation arrayBuffer()",
+			"URL interface: operation createObjectURL((Blob or MediaSource))",
+			"URL interface: operation revokeObjectURL(DOMString)"
+		],
+		"fail": [
 			"FileList interface: existence and properties of interface object",
 			"FileList interface object length",
 			"FileList interface object name",
@@ -19,9 +24,7 @@
 			"FileList interface: existence and properties of interface prototype object's \"constructor\" property",
 			"FileList interface: existence and properties of interface prototype object's @@unscopables property",
 			"FileList interface: operation item(unsigned long)",
-			"FileList interface: attribute length",
-			"URL interface: operation createObjectURL((Blob or MediaSource))",
-			"URL interface: operation revokeObjectURL(DOMString)"
+			"FileList interface: attribute length"
 		]
 	},
 	"filereader_events.any.js": {


### PR DESCRIPTION
I added File to node core in https://github.com/nodejs/node/pull/45139

This PR prioritizes using it if it exists, and falling back to the undici implementation if it doesn't exist.

---

I tested this PR with node v18.11.0 and https://github.com/nodejs/node/commit/b18ec0433e602d17693a316ddcd60357fa1892d8

I only tested the WPTs, so node-fetch and the undici tests may still fail.