### PR TITLE
fix(fetch): connection is cancelled when redirecting

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -781,8 +781,11 @@ async function mainFetch (fetchParams, recursive = false) {
 // https://fetch.spec.whatwg.org/#concept-scheme-fetch
 // given a fetch params fetchParams
 async function schemeFetch (fetchParams) {
+  // Note: since the connection is destroyed on redirect, which sets fetchParams to a
+  // cancelled state, we do not want this condition to trigger *unless* there have been
+  // no redirects. See https://github.com/nodejs/undici/issues/1776
   // 1. If fetchParams is canceled, then return the appropriate network error for fetchParams.
-  if (isCancelled(fetchParams)) {
+  if (isCancelled(fetchParams) && fetchParams.request.redirectCount === 0) {
     return makeAppropriateNetworkError(fetchParams)
   }
 

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -436,7 +436,7 @@ function makeAppropriateNetworkError (fetchParams) {
   // otherwise return a network error.
   return isAborted(fetchParams)
     ? makeNetworkError(new DOMException('The operation was aborted.', 'AbortError'))
-    : makeNetworkError(fetchParams.controller.terminated.reason)
+    : makeNetworkError('Request was cancelled.')
 }
 
 // https://whatpr.org/fetch/1392.html#initialize-a-response

--- a/test/fetch/redirect.js
+++ b/test/fetch/redirect.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { test } = require('tap')
+const { createServer } = require('http')
+const { once } = require('events')
+const { fetch } = require('../..')
+
+// https://github.com/nodejs/undici/issues/1776
+test('Redirecting with a body does not cancel the current request - #1776', async (t) => {
+  const server = createServer((req, res) => {
+    if (req.url === '/redirect') {
+      res.statusCode = 301
+      res.setHeader('location', '/redirect/')
+      res.write('<a href="/redirect/">Moved Permanently</a>')
+      setTimeout(() => res.end(), 500)
+      return
+    }
+
+    res.write(req.url)
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const resp = await fetch(`http://localhost:${server.address().port}/redirect`)
+  t.equal(await resp.text(), '/redirect/')
+  t.ok(resp.redirected)
+})


### PR DESCRIPTION
Fixes #1776 

https://github.com/nodejs/undici/blob/bb84264639df423fd66dc8b5e03773002c71ddaa/lib/fetch/index.js#L1071-L1073

Since the connection is destroyed on redirect, fetchParams was being marked as cancelled incorrectly due to a check added in https://github.com/nodejs/undici/commit/6883ba5e6ab27eec82dc55eda20438ca50f8e383.

This also fixes an issue where `fetchParams.controller.terminated.reason` doesn't exist, and would throw a TypeError.