### PR TITLE
fix: connect option types

### DIFF
--- a/docs/api/Connector.md
+++ b/docs/api/Connector.md
@@ -24,8 +24,10 @@ Once you call `buildConnector`, it will return a connector function, which takes
 * **hostname** `string` (required)
 * **host** `string` (optional)
 * **protocol** `string` (required)
-* **port** `number` (required)
+* **port** `string` (required)
 * **servername** `string` (optional)
+* **localAddress** `string | null` (optional) Local address the socket should connect from.
+* **httpSocket** `Socket` (optional) Establish secure connection on a given socket rather than creating a new socket. It can only be sent on TLS update.
 
 ### Basic example
 

--- a/test/types/connector.test-d.ts
+++ b/test/types/connector.test-d.ts
@@ -1,6 +1,7 @@
 import {expectAssignable} from 'tsd'
 import { Client, buildConnector } from '../..'
 import {ConnectionOptions, TLSSocket} from 'tls'
+import {Socket} from 'net'
 import {IpcNetConnectOpts, NetConnectOpts, TcpNetConnectOpts} from "net";
 
 const connector = buildConnector({ rejectUnauthorized: false })
@@ -24,4 +25,12 @@ expectAssignable<Client>(new Client('', {
 expectAssignable<buildConnector.BuildOptions>({
   checkServerIdentity: () => undefined, // Test if ConnectionOptions is assignable
   localPort: 1234, // Test if TcpNetConnectOpts is assignable
+});
+
+expectAssignable<buildConnector.Options>({
+  protocol: "http",
+  hostname: "example.com",
+  port: "",
+  localAddress: "127.0.0.1",
+  httpSocket: new Socket(),
 });

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -16,8 +16,10 @@ declare namespace buildConnector {
     hostname: string
     host?: string
     protocol: string
-    port: number
+    port: string
     servername?: string
+    localAddress?: string | null
+    httpSocket?: Socket
   }
 
   export type Callback = (...args: CallbackArgs) => void


### PR DESCRIPTION
This PR fixes `buildConnector.Options` issues:

* The `port` property passed from `URL.port` is a string.
* Missing `localAddress` and `httpSocket`.