### PR TITLE
perf: reduce number of native calls from fetch.body

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -151,22 +151,18 @@ function extractBody (object, keepalive = false) {
         if (typeof value === 'string') {
           bodyLength +=
             prefixLength +
-            Buffer.byteLength(`; name="${escape(normalizeLinefeeds(name))}"`) +
-            Buffer.byteLength(`\r\n\r\n${normalizeLinefeeds(value)}\r\n`)
+            Buffer.byteLength(`; name="${escape(normalizeLinefeeds(name))}"\r\n\r\n${normalizeLinefeeds(value)}\r\n`)
         } else {
           bodyLength +=
             prefixLength +
-            Buffer.byteLength(`; name="${escape(normalizeLinefeeds(name))}"`) +
-            (value.name ? Buffer.byteLength(`; filename="${escape(value.name)}"`) : 0) +
+            Buffer.byteLength(`; name="${escape(normalizeLinefeeds(name))}"` + (value.name ? `; filename="${escape(value.name)}"` : '')) +
             2 + // \r\n
             `Content-Type: ${
               value.type || 'application/octet-stream'
             }\r\n\r\n`.length
 
-          // value is a Blob or File
-          bodyLength += value.size
-
-          bodyLength += 2 // \r\n
+          // value is a Blob or File, and \r\n
+          bodyLength += value.size + 2
         }
       }
 
@@ -394,7 +390,7 @@ function bodyMixinMethods (instance) {
           const { filename, encoding, mimeType } = info
           const chunks = []
 
-          if (encoding.toLowerCase() === 'base64') {
+          if (encoding === 'base64' || encoding.toLowerCase() === 'base64') {
             let base64chunk = ''
 
             value.on('data', (chunk) => {


### PR DESCRIPTION
This pull request includes 2 changes around improving the performance:

1. Each `Buffer.byteLength` makes a C++ call. If we concat them and then calculate pass it to ByteLength, it is faster.

2. `toLowerCase()` is a slow method. That's why I divided the if statement into 2 parts.