### PR TITLE
fetch: prefer global over lazy loading

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -16,8 +16,7 @@ const { File } = require('./file')
 const { StringDecoder } = require('string_decoder')
 const { parseMIMEType, serializeAMimeType } = require('./dataURL')
 
-/** @type {globalThis['ReadableStream']} */
-let ReadableStream
+let ReadableStream = globalThis.ReadableStream
 
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -61,8 +61,7 @@ const { webidl } = require('./webidl')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
-/** @type {globalThis['ReadableStream']} */
-let ReadableStream
+let ReadableStream = globalThis.ReadableStream
 
 const nodeVersion = process.versions.node.split('.')
 const nodeMajor = Number(nodeVersion[0])

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -29,7 +29,7 @@ const { URLSerializer } = require('./dataURL')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 
-let TransformStream
+let TransformStream = globalThis.TransformStream
 
 const kInit = Symbol('init')
 


### PR DESCRIPTION
ReadableStream and TransformStream were added as globals in v18, this PR uses them if available, and falls back to lazy loading them. This pattern is already used elsewhere in the code:

https://github.com/nodejs/undici/blob/232905f476913da9c73df03bac41a0a96d48b128/lib/fetch/util.js#L853