### PR TITLE
More correct filereader event firing

### DIFF
--- a/lib/fileapi/filereader.js
+++ b/lib/fileapi/filereader.js
@@ -182,11 +182,11 @@ class FileReader extends EventTarget {
   set onloadend (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].loadend) {
-        this.removeEventListener('loadend', this[kEvents].loadend)
-      }
+    if (this[kEvents].loadend) {
+      this.removeEventListener('loadend', this[kEvents].loadend)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].loadend = fn
       this.addEventListener('loadend', fn)
     } else {
@@ -203,11 +203,11 @@ class FileReader extends EventTarget {
   set onerror (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].error) {
-        this.removeEventListener('error', this[kEvents].error)
-      }
+    if (this[kEvents].error) {
+      this.removeEventListener('error', this[kEvents].error)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].error = fn
       this.addEventListener('error', fn)
     } else {
@@ -224,11 +224,11 @@ class FileReader extends EventTarget {
   set onloadstart (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].loadstart) {
-        this.removeEventListener('loadstart', this[kEvents].loadstart)
-      }
+    if (this[kEvents].loadstart) {
+      this.removeEventListener('loadstart', this[kEvents].loadstart)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].loadstart = fn
       this.addEventListener('loadstart', fn)
     } else {
@@ -245,11 +245,11 @@ class FileReader extends EventTarget {
   set onprogress (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].progress) {
-        this.removeEventListener('progress', this[kEvents].progress)
-      }
+    if (this[kEvents].progress) {
+      this.removeEventListener('progress', this[kEvents].progress)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].progress = fn
       this.addEventListener('progress', fn)
     } else {
@@ -266,11 +266,11 @@ class FileReader extends EventTarget {
   set onload (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].load) {
-        this.removeEventListener('load', this[kEvents].load)
-      }
+    if (this[kEvents].load) {
+      this.removeEventListener('load', this[kEvents].load)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].load = fn
       this.addEventListener('load', fn)
     } else {
@@ -287,11 +287,11 @@ class FileReader extends EventTarget {
   set onabort (fn) {
     webidl.brandCheck(this, FileReader)
 
-    if (typeof fn === 'function') {
-      if (this[kEvents].abort) {
-        this.removeEventListener('abort', this[kEvents].abort)
-      }
+    if (this[kEvents].abort) {
+      this.removeEventListener('abort', this[kEvents].abort)
+    }
 
+    if (typeof fn === 'function') {
       this[kEvents].abort = fn
       this.addEventListener('abort', fn)
     } else {

--- a/lib/fileapi/filereader.js
+++ b/lib/fileapi/filereader.js
@@ -183,7 +183,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].loadend) {
+        this.removeEventListener('loadend', this[kEvents].loadend)
+      }
+
       this[kEvents].loadend = fn
+      this.addEventListener('loadend', fn)
     } else {
       this[kEvents].loadend = null
     }
@@ -199,7 +204,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].error) {
+        this.removeEventListener('error', this[kEvents].error)
+      }
+
       this[kEvents].error = fn
+      this.addEventListener('error', fn)
     } else {
       this[kEvents].error = null
     }
@@ -215,7 +225,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].loadstart) {
+        this.removeEventListener('loadstart', this[kEvents].loadstart)
+      }
+
       this[kEvents].loadstart = fn
+      this.addEventListener('loadstart', fn)
     } else {
       this[kEvents].loadstart = null
     }
@@ -231,7 +246,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].progress) {
+        this.removeEventListener('progress', this[kEvents].progress)
+      }
+
       this[kEvents].progress = fn
+      this.addEventListener('progress', fn)
     } else {
       this[kEvents].progress = null
     }
@@ -247,7 +267,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].load) {
+        this.removeEventListener('load', this[kEvents].load)
+      }
+
       this[kEvents].load = fn
+      this.addEventListener('load', fn)
     } else {
       this[kEvents].load = null
     }
@@ -263,7 +288,12 @@ class FileReader extends EventTarget {
     webidl.brandCheck(this, FileReader)
 
     if (typeof fn === 'function') {
+      if (this[kEvents].abort) {
+        this.removeEventListener('abort', this[kEvents].abort)
+      }
+
       this[kEvents].abort = fn
+      this.addEventListener('abort', fn)
     } else {
       this[kEvents].abort = null
     }

--- a/lib/fileapi/util.js
+++ b/lib/fileapi/util.js
@@ -191,25 +191,19 @@ function readOperation (fr, blob, type, encodingName) {
 
 /**
  * @see https://w3c.github.io/FileAPI/#fire-a-progress-event
+ * @see https://dom.spec.whatwg.org/#concept-event-fire
  * @param {string} e The name of the event
  * @param {import('./filereader').FileReader} reader
  */
 function fireAProgressEvent (e, reader) {
+  // The progress event e does not bubble. e.bubbles must be false
+  // The progress event e is NOT cancelable. e.cancelable must be false
   const event = new ProgressEvent(e, {
     bubbles: false,
     cancelable: false
   })
 
   reader.dispatchEvent(event)
-  try {
-    // eslint-disable-next-line no-useless-call
-    reader[`on${e}`]?.call(reader, event)
-  } catch (err) {
-    // Prevent the error from being swallowed
-    queueMicrotask(() => {
-      throw err
-    })
-  }
 }
 
 /**


### PR DESCRIPTION
I discovered this while working on WebSocket support.

This replaces the previous custom `on[name]` event handlers with the correct way.