### PR TITLE
Add test for mock agent with fetch in jest

### DIFF
--- a/test/jest/mock-agent.test.js
+++ b/test/jest/mock-agent.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { request, setGlobalDispatcher, MockAgent } = require('../..')
+const { request, setGlobalDispatcher, MockAgent, fetch } = require('../..')
 const { getResponse } = require('../../lib/mock/mock-utils')
 
 /* global describe, it, expect */
@@ -42,5 +42,21 @@ describe('MockAgent', () => {
 
     const jsonResponse = JSON.parse(await getResponse(body))
     expect(jsonResponse).toEqual({ foo: 'bar' })
+  })
+
+  it('should work in jest with fetch', async () => {
+    expect.assertions(1)
+
+    mockAgent = new MockAgent()
+    setGlobalDispatcher(mockAgent)
+
+    let failed = false
+    try {
+      await fetch('http://localhost:9999')
+    } catch (e) {
+      if (e.cause?.code === 'UND_MOCK_ERR_MOCK_NOT_MATCHED') failed = true
+    }
+
+    expect(failed).toBe(true)
   })
 })


### PR DESCRIPTION
(I'm also sorry for using jest)

MockAgent or setGlobalDispatcher seem to be bypassed when used with Node 18 native fetch or with fetch imported from undici, but only when running in Jest.

I added a simple test, but I'm not familiar with undici internals, any suggestions where I can look?