### PR TITLE
fix(websocket): run parser in loop, instead of recursively

### DIFF
--- a/lib/websocket/receiver.js
+++ b/lib/websocket/receiver.js
@@ -48,201 +48,204 @@ class ByteParser extends Writable {
    * or not enough bytes are buffered to parse.
    */
   run (callback) {
-    if (this.#state === parserStates.INFO) {
-      // If there aren't enough bytes to parse the payload length, etc.
-      if (this.#byteOffset < 2) {
-        return callback()
-      }
+    while (true) {
+      if (this.#state === parserStates.INFO) {
+        // If there aren't enough bytes to parse the payload length, etc.
+        if (this.#byteOffset < 2) {
+          return callback()
+        }
 
-      const buffer = this.consume(2)
+        const buffer = this.consume(2)
 
-      this.#info.fin = (buffer[0] & 0x80) !== 0
-      this.#info.opcode = buffer[0] & 0x0F
+        this.#info.fin = (buffer[0] & 0x80) !== 0
+        this.#info.opcode = buffer[0] & 0x0F
 
-      // If we receive a fragmented message, we use the type of the first
-      // frame to parse the full message as binary/text, when it's terminated
-      this.#info.originalOpcode ??= this.#info.opcode
+        // If we receive a fragmented message, we use the type of the first
+        // frame to parse the full message as binary/text, when it's terminated
+        this.#info.originalOpcode ??= this.#info.opcode
 
-      this.#info.fragmented = !this.#info.fin && this.#info.opcode !== opcodes.CONTINUATION
+        this.#info.fragmented = !this.#info.fin && this.#info.opcode !== opcodes.CONTINUATION
 
-      if (this.#info.fragmented && this.#info.opcode !== opcodes.BINARY && this.#info.opcode !== opcodes.TEXT) {
-        // Only text and binary frames can be fragmented
-        failWebsocketConnection(this.ws, 'Invalid frame type was fragmented.')
-        return
-      }
-
-      const payloadLength = buffer[1] & 0x7F
-
-      if (payloadLength <= 125) {
-        this.#info.payloadLength = payloadLength
-        this.#state = parserStates.READ_DATA
-      } else if (payloadLength === 126) {
-        this.#state = parserStates.PAYLOADLENGTH_16
-      } else if (payloadLength === 127) {
-        this.#state = parserStates.PAYLOADLENGTH_64
-      }
-
-      if (this.#info.fragmented && payloadLength > 125) {
-        // A fragmented frame can't be fragmented itself
-        failWebsocketConnection(this.ws, 'Fragmented frame exceeded 125 bytes.')
-        return
-      } else if (
-        (this.#info.opcode === opcodes.PING ||
-          this.#info.opcode === opcodes.PONG ||
-          this.#info.opcode === opcodes.CLOSE) &&
-        payloadLength > 125
-      ) {
-        // Control frames can have a payload length of 125 bytes MAX
-        failWebsocketConnection(this.ws, 'Payload length for control frame exceeded 125 bytes.')
-        return
-      } else if (this.#info.opcode === opcodes.CLOSE) {
-        if (payloadLength === 1) {
-          failWebsocketConnection(this.ws, 'Received close frame with a 1-byte body.')
+        if (this.#info.fragmented && this.#info.opcode !== opcodes.BINARY && this.#info.opcode !== opcodes.TEXT) {
+          // Only text and binary frames can be fragmented
+          failWebsocketConnection(this.ws, 'Invalid frame type was fragmented.')
           return
         }
 
-        const body = this.consume(payloadLength)
+        const payloadLength = buffer[1] & 0x7F
 
-        this.#info.closeInfo = this.parseCloseBody(false, body)
-
-        if (!this.ws[kSentClose]) {
-          // If an endpoint receives a Close frame and did not previously send a
-          // Close frame, the endpoint MUST send a Close frame in response.  (When
-          // sending a Close frame in response, the endpoint typically echos the
-          // status code it received.)
-          const body = Buffer.allocUnsafe(2)
-          body.writeUInt16BE(this.#info.closeInfo.code, 0)
-          const closeFrame = new WebsocketFrameSend(body)
-
-          this.ws[kResponse].socket.write(
-            closeFrame.createFrame(opcodes.CLOSE),
-            (err) => {
-              if (!err) {
-                this.ws[kSentClose] = true
-              }
-            }
-          )
+        if (payloadLength <= 125) {
+          this.#info.payloadLength = payloadLength
+          this.#state = parserStates.READ_DATA
+        } else if (payloadLength === 126) {
+          this.#state = parserStates.PAYLOADLENGTH_16
+        } else if (payloadLength === 127) {
+          this.#state = parserStates.PAYLOADLENGTH_64
         }
 
-        // Upon either sending or receiving a Close control frame, it is said
-        // that _The WebSocket Closing Handshake is Started_ and that the
-        // WebSocket connection is in the CLOSING state.
-        this.ws[kReadyState] = states.CLOSING
-        this.ws[kReceivedClose] = true
+        if (this.#info.fragmented && payloadLength > 125) {
+          // A fragmented frame can't be fragmented itself
+          failWebsocketConnection(this.ws, 'Fragmented frame exceeded 125 bytes.')
+          return
+        } else if (
+          (this.#info.opcode === opcodes.PING ||
+            this.#info.opcode === opcodes.PONG ||
+            this.#info.opcode === opcodes.CLOSE) &&
+          payloadLength > 125
+        ) {
+          // Control frames can have a payload length of 125 bytes MAX
+          failWebsocketConnection(this.ws, 'Payload length for control frame exceeded 125 bytes.')
+          return
+        } else if (this.#info.opcode === opcodes.CLOSE) {
+          if (payloadLength === 1) {
+            failWebsocketConnection(this.ws, 'Received close frame with a 1-byte body.')
+            return
+          }
 
-        this.end()
+          const body = this.consume(payloadLength)
 
-        return
-      } else if (this.#info.opcode === opcodes.PING) {
-        // Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in
-        // response, unless it already received a Close frame.
-        // A Pong frame sent in response to a Ping frame must have identical
-        // "Application data"
+          this.#info.closeInfo = this.parseCloseBody(false, body)
 
-        const body = this.consume(payloadLength)
+          if (!this.ws[kSentClose]) {
+            // If an endpoint receives a Close frame and did not previously send a
+            // Close frame, the endpoint MUST send a Close frame in response.  (When
+            // sending a Close frame in response, the endpoint typically echos the
+            // status code it received.)
+            const body = Buffer.allocUnsafe(2)
+            body.writeUInt16BE(this.#info.closeInfo.code, 0)
+            const closeFrame = new WebsocketFrameSend(body)
 
-        if (!this.ws[kReceivedClose]) {
-          const frame = new WebsocketFrameSend(body)
+            this.ws[kResponse].socket.write(
+              closeFrame.createFrame(opcodes.CLOSE),
+              (err) => {
+                if (!err) {
+                  this.ws[kSentClose] = true
+                }
+              }
+            )
+          }
 
-          this.ws[kResponse].socket.write(frame.createFrame(opcodes.PONG))
+          // Upon either sending or receiving a Close control frame, it is said
+          // that _The WebSocket Closing Handshake is Started_ and that the
+          // WebSocket connection is in the CLOSING state.
+          this.ws[kReadyState] = states.CLOSING
+          this.ws[kReceivedClose] = true
 
-          if (channels.ping.hasSubscribers) {
-            channels.ping.publish({
+          this.end()
+
+          return
+        } else if (this.#info.opcode === opcodes.PING) {
+          // Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in
+          // response, unless it already received a Close frame.
+          // A Pong frame sent in response to a Ping frame must have identical
+          // "Application data"
+
+          const body = this.consume(payloadLength)
+
+          if (!this.ws[kReceivedClose]) {
+            const frame = new WebsocketFrameSend(body)
+
+            this.ws[kResponse].socket.write(frame.createFrame(opcodes.PONG))
+
+            if (channels.ping.hasSubscribers) {
+              channels.ping.publish({
+                payload: body
+              })
+            }
+          }
+
+          this.#state = parserStates.INFO
+
+          if (this.#byteOffset > 0) {
+            continue
+          } else {
+            callback()
+            return
+          }
+        } else if (this.#info.opcode === opcodes.PONG) {
+          // A Pong frame MAY be sent unsolicited.  This serves as a
+          // unidirectional heartbeat.  A response to an unsolicited Pong frame is
+          // not expected.
+
+          const body = this.consume(payloadLength)
+
+          if (channels.pong.hasSubscribers) {
+            channels.pong.publish({
               payload: body
             })
           }
+
+          if (this.#byteOffset > 0) {
+            continue
+          } else {
+            callback()
+            return
+          }
+        }
+      } else if (this.#state === parserStates.PAYLOADLENGTH_16) {
+        if (this.#byteOffset < 2) {
+          return callback()
         }
 
-        this.#state = parserStates.INFO
+        const buffer = this.consume(2)
 
-        if (this.#byteOffset > 0) {
-          return this.run(callback)
-        } else {
-          callback()
+        this.#info.payloadLength = buffer.readUInt16BE(0)
+        this.#state = parserStates.READ_DATA
+      } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
+        if (this.#byteOffset < 8) {
+          return callback()
+        }
+
+        const buffer = this.consume(8)
+        const upper = buffer.readUInt32BE(0)
+
+        // 2^31 is the maxinimum bytes an arraybuffer can contain
+        // on 32-bit systems. Although, on 64-bit systems, this is
+        // 2^53-1 bytes.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length
+        // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/common/globals.h;drc=1946212ac0100668f14eb9e2843bdd846e510a1e;bpv=1;bpt=1;l=1275
+        // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/objects/js-array-buffer.h;l=34;drc=1946212ac0100668f14eb9e2843bdd846e510a1e
+        if (upper > 2 ** 31 - 1) {
+          failWebsocketConnection(this.ws, 'Received payload length > 2^31 bytes.')
           return
         }
-      } else if (this.#info.opcode === opcodes.PONG) {
-        // A Pong frame MAY be sent unsolicited.  This serves as a
-        // unidirectional heartbeat.  A response to an unsolicited Pong frame is
-        // not expected.
 
-        const body = this.consume(payloadLength)
+        const lower = buffer.readUInt32BE(4)
 
-        if (channels.pong.hasSubscribers) {
-          channels.pong.publish({
-            payload: body
-          })
+        this.#info.payloadLength = (upper << 8) + lower
+        this.#state = parserStates.READ_DATA
+      } else if (this.#state === parserStates.READ_DATA) {
+        if (this.#byteOffset < this.#info.payloadLength) {
+          // If there is still more data in this chunk that needs to be read
+          return callback()
+        } else if (this.#byteOffset >= this.#info.payloadLength) {
+          // If the server sent multiple frames in a single chunk
+
+          const body = this.consume(this.#info.payloadLength)
+
+          this.#fragments.push(body)
+
+          // If the frame is unfragmented, or a fragmented frame was terminated,
+          // a message was received
+          if (!this.#info.fragmented || (this.#info.fin && this.#info.opcode === opcodes.CONTINUATION)) {
+            const fullMessage = Buffer.concat(this.#fragments)
+
+            websocketMessageReceived(this.ws, this.#info.originalOpcode, fullMessage)
+
+            this.#info = {}
+            this.#fragments.length = 0
+          }
+
+          this.#state = parserStates.INFO
         }
-
-        if (this.#byteOffset > 0) {
-          return this.run(callback)
-        } else {
-          callback()
-          return
-        }
-      }
-    } else if (this.#state === parserStates.PAYLOADLENGTH_16) {
-      if (this.#byteOffset < 2) {
-        return callback()
       }
 
-      const buffer = this.consume(2)
-
-      this.#info.payloadLength = buffer.readUInt16BE(0)
-      this.#state = parserStates.READ_DATA
-    } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
-      if (this.#byteOffset < 8) {
-        return callback()
+      if (this.#byteOffset > 0) {
+        continue
+      } else {
+        callback()
+        break
       }
-
-      const buffer = this.consume(8)
-      const upper = buffer.readUInt32BE(0)
-
-      // 2^31 is the maxinimum bytes an arraybuffer can contain
-      // on 32-bit systems. Although, on 64-bit systems, this is
-      // 2^53-1 bytes.
-      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_array_length
-      // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/common/globals.h;drc=1946212ac0100668f14eb9e2843bdd846e510a1e;bpv=1;bpt=1;l=1275
-      // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/objects/js-array-buffer.h;l=34;drc=1946212ac0100668f14eb9e2843bdd846e510a1e
-      if (upper > 2 ** 31 - 1) {
-        failWebsocketConnection(this.ws, 'Received payload length > 2^31 bytes.')
-        return
-      }
-
-      const lower = buffer.readUInt32BE(4)
-
-      this.#info.payloadLength = (upper << 8) + lower
-      this.#state = parserStates.READ_DATA
-    } else if (this.#state === parserStates.READ_DATA) {
-      if (this.#byteOffset < this.#info.payloadLength) {
-        // If there is still more data in this chunk that needs to be read
-        return callback()
-      } else if (this.#byteOffset >= this.#info.payloadLength) {
-        // If the server sent multiple frames in a single chunk
-
-        const body = this.consume(this.#info.payloadLength)
-
-        this.#fragments.push(body)
-
-        // If the frame is unfragmented, or a fragmented frame was terminated,
-        // a message was received
-        if (!this.#info.fragmented || (this.#info.fin && this.#info.opcode === opcodes.CONTINUATION)) {
-          const fullMessage = Buffer.concat(this.#fragments)
-
-          websocketMessageReceived(this.ws, this.#info.originalOpcode, fullMessage)
-
-          this.#info = {}
-          this.#fragments.length = 0
-        }
-
-        this.#state = parserStates.INFO
-      }
-    }
-
-    if (this.#byteOffset > 0) {
-      return this.run(callback)
-    } else {
-      callback()
     }
   }
 


### PR DESCRIPTION
Refs: #1811

Unsure if I can add a test case, but I've confirmed that this patch fixes the following repro:

```mjs
import assert from 'assert'
import { WebSocketServer } from 'ws'
import { WebSocket } from './index.js'

const helloFrame = Buffer.from([0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f])

// largest body size that is divisible by the frame length
const buffer = Buffer.allocUnsafe(2 ** 31 - 2).fill(helloFrame)

const server = new WebSocketServer({ port: 0 })

server.on('connection', (ws) => {
  ws._socket.write(buffer)
})

const ws = new WebSocket(`ws://localhost:${server.address().port}`)

ws.addEventListener('message', ({ data }) => {
  assert.equal(data, 'Hello')
})
```

Before, a RangeError would be thrown; now, it succeeds. The problem is that the test takes forever to complete because it's parsing about 306,783,378 frames. I have no idea what the v8 limit is for how many times a function can recurse, or if it's dependent upon hardware/specs.