### PR TITLE
websocket: add tests for opening handshake

### DIFF
--- a/test/websocket/diagnostics-channel.js
+++ b/test/websocket/diagnostics-channel.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { test } = require('tap')
+const dc = require('diagnostics_channel')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+
+test('undici:websocket:open and undici:websocket:close', (t) => {
+  t.plan(6)
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (ws) => {
+    ws.close(1000, 'goodbye')
+  })
+
+  t.teardown(server.close.bind(server))
+
+  const { port } = server.address()
+
+  dc.channel('undici:websocket:open').subscribe(({ extensions, protocol }) => {
+    t.equal(extensions, null)
+    t.equal(protocol, 'chat')
+  })
+
+  dc.channel('undici:websocket:close').subscribe(({ websocket, code, reason }) => {
+    t.type(websocket, WebSocket)
+    t.equal(code, 1000)
+    t.equal(reason, 'goodbye')
+  })
+
+  const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
+
+  ws.addEventListener('open', () => {
+    t.pass('Emitted open')
+  })
+})

--- a/test/websocket/diagnostics-channel.js
+++ b/test/websocket/diagnostics-channel.js
@@ -1,37 +1,71 @@
 'use strict'
 
-const { test } = require('tap')
+const t = require('tap')
 const dc = require('diagnostics_channel')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
 
-test('undici:websocket:open and undici:websocket:close', (t) => {
-  t.plan(6)
+t.test('diagnostics channel', { jobs: 1 }, (t) => {
+  t.plan(2)
 
-  const server = new WebSocketServer({ port: 0 })
+  t.test('undici:websocket:open', (t) => {
+    t.plan(3)
 
-  server.on('connection', (ws) => {
-    ws.close(1000, 'goodbye')
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.close(1000, 'goodbye')
+    })
+
+    const listener = ({ extensions, protocol }) => {
+      t.equal(extensions, null)
+      t.equal(protocol, 'chat')
+    }
+
+    t.teardown(() => {
+      dc.channel('undici:websocket:open').unsubscribe(listener)
+      return server.close()
+    })
+
+    const { port } = server.address()
+
+    dc.channel('undici:websocket:open').subscribe(listener)
+
+    const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
+
+    ws.addEventListener('open', () => {
+      t.pass('Emitted open')
+    })
   })
 
-  t.teardown(server.close.bind(server))
+  t.test('undici:websocket:close', (t) => {
+    t.plan(4)
 
-  const { port } = server.address()
+    const server = new WebSocketServer({ port: 0 })
 
-  dc.channel('undici:websocket:open').subscribe(({ extensions, protocol }) => {
-    t.equal(extensions, null)
-    t.equal(protocol, 'chat')
-  })
+    server.on('connection', (ws) => {
+      ws.close(1000, 'goodbye')
+    })
 
-  dc.channel('undici:websocket:close').subscribe(({ websocket, code, reason }) => {
-    t.type(websocket, WebSocket)
-    t.equal(code, 1000)
-    t.equal(reason, 'goodbye')
-  })
+    const listener = ({ websocket, code, reason }) => {
+      t.type(websocket, WebSocket)
+      t.equal(code, 1000)
+      t.equal(reason, 'goodbye')
+    }
 
-  const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
+    t.teardown(() => {
+      dc.channel('undici:websocket:close').unsubscribe(listener)
+      return server.close()
+    })
 
-  ws.addEventListener('open', () => {
-    t.pass('Emitted open')
+    const { port } = server.address()
+
+    dc.channel('undici:websocket:close').subscribe(listener)
+
+    const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
+
+    ws.addEventListener('close', () => {
+      t.pass('Emitted open')
+    })
   })
 })

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -2,7 +2,6 @@
 
 const { test } = require('tap')
 const { createServer } = require('http')
-const { once } = require('events')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
 

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const { createServer } = require('http')
+const { once } = require('events')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
 
@@ -43,4 +44,173 @@ test('Open event is emitted', (t) => {
 
   ws.onmessage = ws.onerror = t.fail
   ws.addEventListener('open', t.pass)
+})
+
+test('Multiple protocols are joined by a comma', (t) => {
+  t.plan(1)
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (ws, req) => {
+    t.equal(req.headers['sec-websocket-protocol'], 'chat, echo')
+
+    ws.close(1000)
+    server.close()
+  })
+
+  t.teardown(server.close.bind(server))
+
+  const ws = new WebSocket(`ws://localhost:${server.address().port}`, ['chat', 'echo'])
+
+  ws.addEventListener('open', () => ws.close())
+})
+
+test('Server doesn\'t send Sec-WebSocket-Protocol header when protocols are used', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.statusCode = 101
+
+    req.socket.destroy()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`, 'chat')
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+})
+
+test('Server sends invalid Upgrade header', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('Upgrade', 'NotWebSocket')
+    res.statusCode = 101
+
+    req.socket.destroy()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+})
+
+test('Server sends invalid Connection header', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('Upgrade', 'websocket')
+    res.setHeader('Connection', 'downgrade')
+    res.statusCode = 101
+
+    req.socket.destroy()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+})
+
+test('Server sends invalid Sec-WebSocket-Accept header', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.setHeader('Upgrade', 'websocket')
+    res.setHeader('Connection', 'upgrade')
+    res.setHeader('Sec-WebSocket-Accept', 'abc')
+    res.statusCode = 101
+
+    req.socket.destroy()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+})
+
+test('Server sends invalid Sec-WebSocket-Extensions header', (t) => {
+  const uid = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+  const { createHash } = require('crypto')
+
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    const key = req.headers['sec-websocket-key']
+    t.ok(key)
+
+    const accept = createHash('sha1').update(key + uid).digest('base64')
+
+    res.setHeader('Upgrade', 'websocket')
+    res.setHeader('Connection', 'upgrade')
+    res.setHeader('Sec-WebSocket-Accept', accept)
+    res.setHeader('Sec-WebSocket-Extensions', 'InvalidExtension')
+    res.statusCode = 101
+
+    res.end()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
+})
+
+test('Server sends invalid Sec-WebSocket-Extensions header', (t) => {
+  const uid = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+  const { createHash } = require('crypto')
+
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    const key = req.headers['sec-websocket-key']
+    t.ok(key)
+
+    const accept = createHash('sha1').update(key + uid).digest('base64')
+
+    res.setHeader('Upgrade', 'websocket')
+    res.setHeader('Connection', 'upgrade')
+    res.setHeader('Sec-WebSocket-Accept', accept)
+    res.setHeader('Sec-WebSocket-Protocol', 'echo') // <--
+    res.statusCode = 101
+
+    res.end()
+  }).listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`, 'chat')
+
+    ws.onopen = t.fail
+
+    ws.addEventListener('error', ({ error }) => {
+      t.ok(error)
+    })
+  })
+
+  t.teardown(server.close.bind(server))
 })


### PR DESCRIPTION
Should be close to 100% coverage for [`/lib/websocket/connection.js`](https://github.com/nodejs/undici/blob/main/lib/websocket/connection.js) barring 1 or 2 branches which aren't yet possible to reach (no websocket extension support).