### PR TITLE
websocket: add tests for constructor, close, and send

### DIFF
--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -80,11 +80,7 @@ class WebSocket extends EventTarget {
     // 5. If protocols is a string, set protocols to a sequence consisting
     //    of just that string.
     if (typeof protocols === 'string') {
-      if (protocols.length === 0) {
-        protocols = []
-      } else {
-        protocols = [protocols]
-      }
+      protocols = [protocols]
     }
 
     // 6. If any of the values in protocols occur more than once or otherwise

--- a/test/websocket/close.js
+++ b/test/websocket/close.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const { test } = require('tap')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+
+test('Close', (t) => {
+  t.plan(5)
+
+  t.test('Close with code', (t) => {
+    t.plan(1)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.on('close', (code) => {
+        t.equal(code, 1000)
+      })
+    })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    ws.addEventListener('open', () => ws.close(1000))
+  })
+
+  t.test('Close with code and reason', (t) => {
+    t.plan(2)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.on('close', (code, reason) => {
+        t.equal(code, 1000)
+        t.same(reason, Buffer.from('Goodbye'))
+      })
+    })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    ws.addEventListener('open', () => ws.close(1000, 'Goodbye'))
+  })
+
+  t.test('Close with invalid code', (t) => {
+    t.plan(2)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    ws.addEventListener('open', () => {
+      t.throws(
+        () => ws.close(2999),
+        {
+          name: 'InvalidAccessError',
+          constructor: DOMException
+        }
+      )
+
+      t.throws(
+        () => ws.close(5000),
+        {
+          name: 'InvalidAccessError',
+          constructor: DOMException
+        }
+      )
+
+      ws.close()
+    })
+  })
+
+  t.test('Close with invalid reason', (t) => {
+    t.plan(1)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    t.teardown(server.close.bind(server))
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.addEventListener('open', () => {
+      t.throws(
+        () => ws.close(1000, 'a'.repeat(124)),
+        {
+          name: 'SyntaxError',
+          constructor: DOMException
+        }
+      )
+
+      ws.close(1000)
+    })
+  })
+
+  t.test('Close with no code or reason', (t) => {
+    t.plan(2)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.on('close', (code, reason) => {
+        t.equal(code, 1005)
+        t.same(reason, Buffer.alloc(0))
+      })
+    })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    ws.addEventListener('open', () => ws.close())
+  })
+})

--- a/test/websocket/constructor.js
+++ b/test/websocket/constructor.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const { test } = require('tap')
+const { WebSocket } = require('../..')
+
+test('Constructor', (t) => {
+  t.throws(
+    () => new WebSocket('abc'),
+    {
+      name: 'SyntaxError',
+      constructor: DOMException
+    }
+  )
+
+  t.throws(
+    () => new WebSocket('https://www.google.com'),
+    {
+      name: 'SyntaxError',
+      constructor: DOMException
+    }
+  )
+
+  t.throws(
+    () => new WebSocket('wss://echo.websocket.events/#a'),
+    {
+      name: 'SyntaxError',
+      constructor: DOMException
+    }
+  )
+
+  t.throws(
+    () => new WebSocket('wss://echo.websocket.events', ''),
+    {
+      name: 'SyntaxError',
+      constructor: DOMException
+    }
+  )
+
+  t.throws(
+    () => new WebSocket('wss://echo.websocket.events', ['chat', 'chat']),
+    {
+      name: 'SyntaxError',
+      constructor: DOMException
+    }
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Should cover most branches in the constructor, WebSocket.send, and WebSocket.close.

Fixes 1 small bug when setting protocols to an empty string.