### PR TITLE
fix(WPTs): flaky abort test

### DIFF
--- a/test/wpt/runner/runner/runner.mjs
+++ b/test/wpt/runner/runner/runner.mjs
@@ -112,6 +112,12 @@ export class WPTRunner extends EventEmitter {
       })
 
       activeWorkers.add(worker)
+      const timeout = setTimeout(
+        () => {
+          console.warn('Test timed out:', test)
+        },
+        meta.timeout === 'long' ? 60_000 : 10_000
+      )
 
       worker.on('message', (message) => {
         if (message.type === 'result') {
@@ -123,6 +129,7 @@ export class WPTRunner extends EventEmitter {
 
       worker.once('exit', () => {
         activeWorkers.delete(worker)
+        clearTimeout(timeout)
 
         if (activeWorkers.size === 0) {
           this.handleRunnerCompletion()

--- a/test/wpt/server/server.mjs
+++ b/test/wpt/server/server.mjs
@@ -115,18 +115,19 @@ const server = createServer(async (req, res) => {
       while (true) {
         if (!res.write('.')) {
           break
-        } else if (abortKey && stash.take(abortKey, fullUrl.pathname)) {
+        } else if (abortKey && stash.take(abortKey)) {
           break
         }
 
-        await sleep(10)
+        await sleep(100)
       }
 
       if (stateKey) {
         stash.put(stateKey, 'closed', fullUrl.pathname)
       }
 
-      return res.end()
+      res.end()
+      return
     }
     case '/fetch/api/resources/stash-take.py': {
       // https://github.com/web-platform-tests/wpt/blob/6ae3f702a332e8399fab778c831db6b7dca3f1c6/fetch/api/resources/stash-take.py

--- a/test/wpt/status/fetch.status.json
+++ b/test/wpt/status/fetch.status.json
@@ -1,6 +1,6 @@
 {
 	"general.any.js": {
-		"fail": [
+		"flaky": [
 			"Already aborted signal rejects immediately",
 			"Underlying connection is closed when aborting after receiving response - no-cors",
 			"Stream errors once aborted. Underlying connection closed."


### PR DESCRIPTION
Fixes #1834 

Merry Christmas! 🎅

The flaky WPT on Windows should now be fixed. I detailed the cause/fix for this in the issue above. Testing locally (on windows), this fixed the issue for me.

Also, tests which timeout in the future will now be logged. Should help discover any issues in the runner.