### PR TITLE
fix(cookie): add docs & expose in node v16

### DIFF
--- a/docs/api/Cookies.md
+++ b/docs/api/Cookies.md
@@ -1,0 +1,101 @@
+# Cookie Handling
+
+## `Cookie` interface
+
+* **name** `string`
+* **value** `string`
+* **expires** `Date|number` (optional)
+* **maxAge** `number` (optional)
+* **domain** `string` (optional)
+* **path** `string` (optional)
+* **secure** `boolean` (optional)
+* **httpOnly** `boolean` (optional)
+* **sameSite** `'String'|'Lax'|'None'` (optional)
+* **unparsed** `string[]` (optional) Left over attributes that weren't parsed.
+
+## `deleteCookie(headers, name[, attributes])`
+
+Sets the expiry time of the cookie to the unix epoch, causing browsers to delete it when received.
+
+```js
+import { deleteCookie, Headers } from 'undici'
+
+const headers = new Headers()
+deleteCookie(headers, 'name')
+
+console.log(headers.get('set-cookie')) // name=; Expires=Thu, 01 Jan 1970 00:00:00 GMT
+```
+
+Arguments:
+
+* **headers** `Headers`
+* **name** `string`
+* **attributes** `{ path?: string, domain?: string }` (optional)
+
+Returns: `void`
+
+## `getCookies(headers)`
+
+Parses the `Cookie` header and returns a list of attributes and values.
+
+```js
+import { getCookies, Headers } from 'undici'
+
+const headers = new Headers({
+  cookie: 'get=cookies; and=attributes'
+})
+
+console.log(getCookies(headers)) // { get: 'cookies', and: 'attributes' }
+```
+
+Arguments:
+
+* **headers** `Headers`
+
+Returns: `Record<string, string>`
+
+## `getSetCookies(headers)`
+
+Parses all `Set-Cookie` headers.
+
+```js
+import { getSetCookies, Headers } from 'undici'
+
+const headers = new Headers({ 'set-cookie': 'undici=getSetCookies; Secure' })
+
+console.log(getSetCookies(headers))
+// [
+//   {
+//     name: 'undici',
+//     value: 'getSetCookies',
+//     secure: true
+//   }
+// ]
+
+```
+
+Arguments:
+
+* **headers** `Headers`
+
+Returns: `Cookie[]`
+
+## `setCookie(headers, cookie)`
+
+Appends a cookie to the `Set-Cookie` header.
+
+```js
+import { setCookie, Headers } from 'undici'
+
+const headers = new Headers()
+setCookie(headers, { name: 'undici', value: 'setCookie' })
+
+console.log(headers.get('Set-Cookie')) // undici=setCookie
+```
+
+Arguments:
+
+* **headers** `Headers`
+* **cookie** `Cookie`
+
+Returns: `void`

--- a/docsify/sidebar.md
+++ b/docsify/sidebar.md
@@ -11,6 +11,7 @@
   * [Connector](/docs/api/Connector.md "Custom connector")
   * [Errors](/docs/api/Errors.md "Undici API - Errors")
   * [Fetch](/docs/api/Fetch.md "Undici API - Fetch")
+  * [Cookies](/docs/api/Cookies.md "Undici API - Cookies")
   * [MockClient](/docs/api/MockClient.md "Undici API - MockClient")
   * [MockPool](/docs/api/MockPool.md "Undici API - MockPool")
   * [MockAgent](/docs/api/MockAgent.md "Undici API - MockAgent")

--- a/index.js
+++ b/index.js
@@ -119,17 +119,19 @@ if (nodeMajor > 16 || (nodeMajor === 16 && nodeMinor >= 8)) {
   module.exports.getGlobalOrigin = getGlobalOrigin
 }
 
-if (nodeMajor >= 18) {
-  const { WebSocket } = require('./lib/websocket/websocket')
-
-  module.exports.WebSocket = WebSocket
-
+if (nodeMajor >= 16) {
   const { deleteCookie, getCookies, getSetCookies, setCookie } = require('./lib/cookies')
 
   module.exports.deleteCookie = deleteCookie
   module.exports.getCookies = getCookies
   module.exports.getSetCookies = getSetCookies
   module.exports.setCookie = setCookie
+}
+
+if (nodeMajor >= 18) {
+  const { WebSocket } = require('./lib/websocket/websocket')
+
+  module.exports.WebSocket = WebSocket
 }
 
 module.exports.request = makeDispatcher(api.request)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
     "test": "npm run test:tap && npm run test:node-fetch && npm run test:fetch && npm run test:cookies && npm run test:wpt && npm run test:websocket && npm run test:jest && tsd",
-    "test:cookies": "node scripts/verifyVersion 18 || tap test/cookie/*.js",
+    "test:cookies": "node scripts/verifyVersion 16 || tap test/cookie/*.js",
     "test:node-fetch": "node scripts/verifyVersion.js 16 || mocha test/node-fetch",
     "test:fetch": "node scripts/verifyVersion.js 16 || (npm run build:node && tap test/fetch/*.js && tap test/webidl/*.js)",
     "test:jest": "node scripts/verifyVersion.js 14 || jest",


### PR DESCRIPTION
Since the cookie handling uses some stuff from the fetch spec, it can only be exposed in node v16+.