### PR TITLE
perf: allow keep alive for HEAD requests

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -144,7 +144,7 @@ class Request {
 
     this.blocking = blocking == null ? false : blocking
 
-    this.reset = reset == null ? false : reset
+    this.reset = reset == null ? null : reset
 
     this.host = null
 

--- a/test/client-head-reset-override.js
+++ b/test/client-head-reset-override.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { createServer } = require('http')
+const { test } = require('tap')
+const { Client } = require('..')
+
+test('override HEAD reset', (t) => {
+  const expected = 'testing123'
+  const server = createServer((req, res) => {
+    if (req.method === 'GET') {
+      res.write(expected)
+    }
+    res.end()
+  })
+  t.teardown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.close.bind(client))
+
+    let done
+    client.on('disconnect', () => {
+      if (!done) {
+        t.fail()
+      }
+    })
+
+    client.request({
+      path: '/',
+      method: 'HEAD',
+      reset: false
+    }, (err, res) => {
+      t.error(err)
+      res.body.resume()
+    })
+
+    client.request({
+      path: '/',
+      method: 'HEAD',
+      reset: false
+    }, (err, res) => {
+      t.error(err)
+      res.body.resume()
+    })
+
+    client.request({
+      path: '/',
+      method: 'GET',
+      reset: false
+    }, (err, res) => {
+      t.error(err)
+      let str = ''
+      res.body.on('data', (data) => {
+        str += data
+      }).on('end', () => {
+        t.same(str, expected)
+        done = true
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
One of the performance bottlenecks we have is that we don't allow keep-alive for HEAD requests due to common server-side  implementation problems where we can't reliably detect if the server is properly ending the HEAD request. However, in the cases where we know the target server it would be nice to be able to explicitly allow this.