### PR TITLE
fix: wpts on node v18.13.0+

### DIFF
--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -259,7 +259,7 @@ function makeEntry (name, value, filename) {
         lastModified: value.lastModified
       }
 
-      value = value instanceof File
+      value = (NativeFile && value instanceof NativeFile) || value instanceof UndiciFile
         ? new File([value], filename, options)
         : new FileLike(value, filename, options)
     }

--- a/test/wpt/runner/runner/worker.mjs
+++ b/test/wpt/runner/runner/worker.mjs
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { runInThisContext } from 'node:vm'
 import { parentPort, workerData } from 'node:worker_threads'
 import { readFileSync } from 'node:fs'
+import buffer from 'node:buffer'
 import {
   setGlobalOrigin,
   Response,
@@ -34,7 +35,7 @@ Object.defineProperties(globalThis, {
   },
   File: {
     ...globalPropertyDescriptors,
-    value: File
+    value: buffer.File ?? File
   },
   FormData: {
     ...globalPropertyDescriptors,

--- a/test/wpt/status/FileAPI.status.json
+++ b/test/wpt/status/FileAPI.status.json
@@ -1,6 +1,6 @@
 {
 	"File-constructor.any.js": {
-		"fail": [
+		"flaky": [
 			"Using type in File constructor: nonparsable"
 		]
 	},


### PR DESCRIPTION
Refs: https://github.com/nodejs/undici/pull/1858#issuecomment-1385018002

The actual issue is that node v18.13.0 introduces buffer.File and undici's File isn't an instanceof the native File implementation. Really easy fix at least!