### PR TITLE
fix: flaky abort test

### DIFF
--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -90,9 +90,7 @@ test('Allow the usage of custom implementation of AbortController', async (t) =>
 })
 
 test('allows aborting with custom errors', { skip: process.version.startsWith('v16.') }, async (t) => {
-  const server = createServer((req, res) => {
-    setTimeout(() => res.end(), 5000)
-  }).listen(0)
+  const server = createServer().listen(0)
 
   t.teardown(server.close.bind(server))
   await once(server, 'listening')


### PR DESCRIPTION
Refs: #1862 (the issue should stay open because most of the abort tests are flaky in some capacity)

This is a really simple fix where the server never ends the request, so the request can only be aborted.