### PR TITLE
fix: don't include websockets in node bundle

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -56,7 +56,7 @@ const { Readable, pipeline } = require('stream')
 const { isErrored, isReadable } = require('../core/util')
 const { dataURLProcessor, serializeAMimeType } = require('./dataURL')
 const { TransformStream } = require('stream/web')
-const { getGlobalDispatcher } = require('../../index')
+const { getGlobalDispatcher } = require('../global')
 const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('http')
 


### PR DESCRIPTION
The WebSockets implementation is included in the bundle for Node.js even though it isn't used, the [esbuld bundle analyser](https://esbuild.github.io/analyze/) explains why it's included:
```
lib/websocket/websocket.js
This file is included in the bundle because:

Entry point index-fetch.js contains:
require("./lib/fetch");

Required file lib/fetch/index.js contains:
require("../../index");

Required file index.js contains:
require("./lib/websocket/websocket");

So required file lib/websocket/websocket.js is included in the bundle.
```

Ref https://github.com/nodejs/undici/pull/1868#issuecomment-1397711309