### PR TITLE
chore(performance#38): Performance improvements

### DIFF
--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -264,9 +264,7 @@ function parseMIMEType (input) {
     /** @type {Map<string, string>} */
     parameters: new Map(),
     // https://mimesniff.spec.whatwg.org/#mime-type-essence
-    get essence () {
-      return `${this.type}/${this.subtype}`
-    }
+    essence: `${type}/${subtype}`
   }
 
   // 11. While position is not past the end of input:
@@ -362,7 +360,7 @@ function parseMIMEType (input) {
     if (
       parameterName.length !== 0 &&
       HTTP_TOKEN_CODEPOINTS.test(parameterName) &&
-      !HTTP_QUOTED_STRING_TOKENS.test(parameterValue) &&  // eslint-disable-line
+      !HTTP_QUOTED_STRING_TOKENS.test(parameterValue) &&
       !mimeType.parameters.has(parameterName)
     ) {
       mimeType.parameters.set(parameterName, parameterValue)

--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -5,6 +5,12 @@ const { isValidHTTPToken, isomorphicDecode } = require('./util')
 
 const encoder = new TextEncoder()
 
+// Regex
+const HTTP_TOKEN_CODEPOINTS = /^[!#$%&'*+-.^_|~A-z0-9]+$/
+const HTTP_WHITESPACE_REGEX = /(\u000A|\u000D|\u0009|\u0020)/ // eslint-disable-line
+// https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
+const HTTP_QUOTED_STRING_TOKENS = /^(\u0009|\x{0020}-\x{007E}|\x{0080}-\x{00FF})+$/ // eslint-disable-line
+
 // https://fetch.spec.whatwg.org/#data-url-processor
 /** @param {URL} dataURL */
 function dataURLProcessor (dataURL) {
@@ -217,7 +223,7 @@ function parseMIMEType (input) {
   // 4. If type is the empty string or does not solely
   // contain HTTP token code points, then return failure.
   // https://mimesniff.spec.whatwg.org/#http-token-code-point
-  if (type.length === 0 || !/^[!#$%&'*+-.^_|~A-z0-9]+$/.test(type)) {
+  if (type.length === 0 || !HTTP_TOKEN_CODEPOINTS.test(type)) {
     return 'failure'
   }
 
@@ -244,7 +250,7 @@ function parseMIMEType (input) {
 
   // 9. If subtype is the empty string or does not solely
   // contain HTTP token code points, then return failure.
-  if (subtype.length === 0 || !/^[!#$%&'*+-.^_|~A-z0-9]+$/.test(subtype)) {
+  if (subtype.length === 0 || !HTTP_TOKEN_CODEPOINTS.test(subtype)) {
     return 'failure'
   }
 
@@ -272,7 +278,7 @@ function parseMIMEType (input) {
     // whitespace from input given position.
     collectASequenceOfCodePoints(
       // https://fetch.spec.whatwg.org/#http-whitespace
-      (char) => /(\u000A|\u000D|\u0009|\u0020)/.test(char), // eslint-disable-line
+      char => HTTP_WHITESPACE_REGEX.test(char),
       input,
       position
     )
@@ -355,9 +361,8 @@ function parseMIMEType (input) {
     // then set mimeType’s parameters[parameterName] to parameterValue.
     if (
       parameterName.length !== 0 &&
-      /^[!#$%&'*+-.^_|~A-z0-9]+$/.test(parameterName) &&
-      // https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
-      !/^(\u0009|\x{0020}-\x{007E}|\x{0080}-\x{00FF})+$/.test(parameterValue) &&  // eslint-disable-line
+      HTTP_TOKEN_CODEPOINTS.test(parameterName) &&
+      !HTTP_QUOTED_STRING_TOKENS.test(parameterValue) &&  // eslint-disable-line
       !mimeType.parameters.has(parameterName)
     ) {
       mimeType.parameters.set(parameterName, parameterValue)


### PR DESCRIPTION
While working on [Performance#38](https://github.com/nodejs/performance/issues/38), I decided to use it as starting point Undici for experimenting with possible performance improvements, as Undici has a greatly clean implementation of the WHATWG for parsing a MIMEType.

While experimenting I was able to notice substantial performance improvements while changing smaller pieces, while trying to respect them as much as possible the spec.

Was able to obtain a substantial ~48% improvement compared to the current implementation.

The PR as always is just a suggestion as pointed out in the performance thread, in Undici this is not one of the biggest worries as it is used only while parsing `data:` strings 🙂

Feel free to close it if there's no value added.

## Benchmarks:
### Machine
```
Hardware Overview:
	Model Name: MacBook Pro
	Model Identifier: MacBookPro18,1
	Chip: Apple M1 Pro
	Total Number of Cores: 10 (8 performance and 2 efficiencies)
	Memory: 16 GB
	System Firmware Version: 8419.60.44
	OS Loader Version: 7459.141.1
```

### Results
**Code**
```js
const str = 'application/json; charset=utf-8'

suite
  .add('util#MIMEType', function () {
    new util.MIMEType(str)
  })
  .add('undici#parseMIMEType', function () {
    parseMIMEType(str)
  })
  .add('undici#parseMIMEType(original)', function () {
    parseMIMETypeOriginal(str)
  })
  .add('fast-content-type-parse#parse', function () {
    fastContentType.parse(str)
  })
  .add('fast-content-type-parse#safeParse', function () {
    fastContentType.safeParse(str)
  })
  .on('cycle', function (event) {
    console.log(String(event.target))
  })
  .on('complete', function () {
    console.log('Fastest is ' + this.filter('fastest').map('name'))
  })
  .run({ async: true })
```

```
util#MIMEType x 1,330,919 ops/sec ±0.36% (92 runs sampled)
undici#parseMIMEType x 2,366,624 ops/sec ±0.22% (98 runs sampled)
undici#parseMIMEType(original) x 1,588,546 ops/sec ±0.67% (98 runs sampled)
```