### PR TITLE
perf(util): improve isFormDataLike checks

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -354,8 +354,23 @@ function ReadableStreamFrom (iterable) {
   )
 }
 
+// The chunk should be a FormData instance and contains
+// all the required methods.
 function isFormDataLike (chunk) {
-  return chunk && chunk.constructor && chunk.constructor.name === 'FormData'
+  return (chunk &&
+    chunk.constructor && chunk.constructor.name === 'FormData' &&
+    typeof chunk === 'object' &&
+      (typeof chunk.append === 'function' &&
+        typeof chunk.delete === 'function' &&
+        typeof chunk.get === 'function' &&
+        typeof chunk.getAll === 'function' &&
+        typeof chunk.has === 'function' &&
+        typeof chunk.set === 'function' &&
+        typeof chunk.entries === 'function' &&
+        typeof chunk.keys === 'function' &&
+        typeof chunk.values === 'function' &&
+        typeof chunk.forEach === 'function')
+  )
 }
 
 const kEnumerableProperty = Object.create(null)

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "cronometro": "^1.0.5",
     "delay": "^5.0.0",
     "docsify-cli": "^4.4.3",
+    "form-data": "^4.0.0",
     "formdata-node": "^4.3.1",
     "https-pem": "^3.0.0",
     "husky": "^8.0.1",

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const { FormData, File, Response } = require('../../')
 const { Blob: ThirdPartyBlob } = require('formdata-node')
 const { Blob } = require('buffer')
+const { isFormDataLike } = require('../../lib/core/util')
 
 test('arg validation', (t) => {
   const form = new FormData()
@@ -283,6 +284,78 @@ test('formData.constructor.name', (t) => {
   const form = new FormData()
   t.equal(form.constructor.name, 'FormData')
   t.end()
+})
+
+test('formData should be an instance of FormData', (t) => {
+  t.plan(3)
+
+  t.test('Invalid class FormData', (t) => {
+    class FormData {
+      constructor () {
+        this.data = []
+      }
+
+      append (key, value) {
+        this.data.push([key, value])
+      }
+
+      get (key) {
+        return this.data.find(([k]) => k === key)
+      }
+    }
+
+    const form = new FormData()
+    t.equal(isFormDataLike(form), false)
+    t.end()
+  })
+
+  t.test('Invalid function FormData', (t) => {
+    function FormData () {
+      const data = []
+      return {
+        append (key, value) {
+          data.push([key, value])
+        },
+        get (key) {
+          return data.find(([k]) => k === key)
+        }
+      }
+    }
+
+    const form = new FormData()
+    t.equal(isFormDataLike(form), false)
+    t.end()
+  })
+
+  t.test('Valid FormData', (t) => {
+    const form = new FormData()
+    t.equal(isFormDataLike(form), true)
+    t.end()
+  })
+})
+
+test('FormData should be compatible with third-party libraries', (t) => {
+  t.plan(1)
+
+  class FormData {
+    constructor () {
+      this.data = []
+    }
+
+    append () {}
+    delete () {}
+    get () {}
+    getAll () {}
+    has () {}
+    set () {}
+    entries () {}
+    keys () {}
+    values () {}
+    forEach () {}
+  }
+
+  const form = new FormData()
+  t.equal(isFormDataLike(form), true)
 })
 
 test('arguments', (t) => {

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -5,6 +5,7 @@ const { FormData, File, Response } = require('../../')
 const { Blob: ThirdPartyBlob } = require('formdata-node')
 const { Blob } = require('buffer')
 const { isFormDataLike } = require('../../lib/core/util')
+const ThirdPartyFormDataInvalid = require('form-data')
 
 test('arg validation', (t) => {
   const form = new FormData()
@@ -323,6 +324,12 @@ test('formData should be an instance of FormData', (t) => {
     }
 
     const form = new FormData()
+    t.equal(isFormDataLike(form), false)
+    t.end()
+  })
+
+  test('Invalid third-party FormData', (t) => {
+    const form = new ThirdPartyFormDataInvalid()
     t.equal(isFormDataLike(form), false)
     t.end()
   })


### PR DESCRIPTION
This PR would implement #1872.

## Context

Actually, the `FormData` class needs the following declaration to work:

```js
  class FormData {
    constructor () {}

    append () {}
    delete () {}
    get () {}
    getAll () {}
    has () {}
    set () {}
    entries () {}
    keys () {}
    values () {}
    forEach () {}
  }
```

The `isFormDataLike` method was improved by checking the `constructor.name` and the declaration of those methods. This makes that control more strict and flexible. The check would be linear, there is no way to guess what API is requested by the `chunk`. This check allows **third-party libraries** to be compatible with this control.

## Tests

The tests were updated by adding some cases where the check should return false or true.
