### PR TITLE
Add feature to specify custom headers for proxies

### DIFF
--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -53,7 +53,7 @@ class ProxyAgent extends DispatcherBase {
 
     this[kRequestTls] = opts.requestTls
     this[kProxyTls] = opts.proxyTls
-    this[kProxyHeaders] = {}
+    this[kProxyHeaders] = opts.headers || {}
 
     if (opts.auth && opts.token) {
       throw new InvalidArgumentError('opts.auth cannot be used in combination with opts.token')

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -1,3 +1,5 @@
+import { IncomingHttpHeaders } from 'http'
+
 import Agent from './agent'
 import buildConnector from './connector';
 import Dispatcher from './dispatcher'
@@ -19,6 +21,7 @@ declare namespace ProxyAgent {
      */
     auth?: string;
     token?: string;
+    headers?: IncomingHttpHeaders;
     requestTls?: buildConnector.BuildOptions;
     proxyTls?: buildConnector.BuildOptions;
   }


### PR DESCRIPTION
This adds a custom headers option in the ProxyAgent params, which allows specifying arbitrary headers. These will only provided in the initial CONNECT request to the proxy and never to the tunneled requests (they get their own headers specified in the request()).

Fixes #1876.