### PR TITLE
fix(wpts): Blob is a global getter in >=v19.x.x

### DIFF
--- a/test/wpt/runner/runner/worker.mjs
+++ b/test/wpt/runner/runner/worker.mjs
@@ -64,6 +64,11 @@ Object.defineProperties(globalThis, {
   CloseEvent: {
     ...globalPropertyDescriptors,
     value: CloseEvent
+  },
+  Blob: {
+    ...globalPropertyDescriptors,
+    // See https://github.com/nodejs/node/pull/45659
+    value: buffer.Blob
   }
 })
 


### PR DESCRIPTION
refs: https://github.com/nodejs/undici/pull/1879#issuecomment-1401966074

I already knew the bug would occur, just forgot about it honestly.