### PR TITLE
wpt: make runner more resilient

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",
     "test:typescript": "tsd && tsc test/imports/undici-import.ts",
     "test:websocket": "node scripts/verifyVersion.js 18 || tap test/websocket/*.js",
-    "test:wpt": "node scripts/verifyVersion 18 || (node test/wpt/start-fetch.mjs && node test/wpt/start-FileAPI.mjs && node test/wpt/start-mimesniff.mjs && node test/wpt/start-xhr.mjs && node test/wpt/start-websockets.mjs)",
+    "test:wpt": "node scripts/verifyVersion 18 || (node test/wpt/start-fetch.mjs && node test/wpt/start-FileAPI.mjs && node test/wpt/start-mimesniff.mjs && node test/wpt/start-xhr.mjs && node --no-warnings test/wpt/start-websockets.mjs)",
     "coverage": "nyc --reporter=text --reporter=html npm run test",
     "coverage:ci": "nyc --reporter=lcov npm run test",
     "bench": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench:run",

--- a/test/wpt/server/server.mjs
+++ b/test/wpt/server/server.mjs
@@ -354,7 +354,7 @@ send({ server: `http://localhost:${server.address().port}` })
 
 process.on('message', (message) => {
   if (message === 'shutdown') {
-    server.close((err) => err ? send(err) : send({ message: 'shutdown' }))
+    server.close((err) => process.exit(err ? 1 : 0))
   }
 })
 

--- a/test/wpt/start-FileAPI.mjs
+++ b/test/wpt/start-FileAPI.mjs
@@ -10,6 +10,8 @@ const child = fork(serverPath, [], {
   stdio: ['pipe', 'pipe', 'pipe', 'ipc']
 })
 
+child.on('exit', (code) => process.exit(code))
+
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
     const runner = new WPTRunner('FileAPI', message.server)
@@ -18,11 +20,7 @@ for await (const [message] of on(child, 'message')) {
     runner.once('completion', () => {
       if (child.connected) {
         child.send('shutdown')
-      } else {
-        process.exit()
       }
     })
-  } else if (message.message === 'shutdown') {
-    process.exit()
   }
 }

--- a/test/wpt/start-FileAPI.mjs
+++ b/test/wpt/start-FileAPI.mjs
@@ -16,7 +16,11 @@ for await (const [message] of on(child, 'message')) {
     runner.run()
 
     runner.once('completion', () => {
-      child.send('shutdown')
+      if (child.connected) {
+        child.send('shutdown')
+      } else {
+        process.exit()
+      }
     })
   } else if (message.message === 'shutdown') {
     process.exit()

--- a/test/wpt/start-fetch.mjs
+++ b/test/wpt/start-fetch.mjs
@@ -16,7 +16,11 @@ for await (const [message] of on(child, 'message')) {
     runner.run()
 
     runner.once('completion', () => {
-      child.send('shutdown')
+      if (child.connected) {
+        child.send('shutdown')
+      } else {
+        process.exit()
+      }
     })
   } else if (message.message === 'shutdown') {
     process.exit()

--- a/test/wpt/start-fetch.mjs
+++ b/test/wpt/start-fetch.mjs
@@ -10,6 +10,8 @@ const child = fork(serverPath, [], {
   stdio: ['pipe', 'pipe', 'pipe', 'ipc']
 })
 
+child.on('exit', (code) => process.exit(code))
+
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
     const runner = new WPTRunner('fetch', message.server)
@@ -18,11 +20,7 @@ for await (const [message] of on(child, 'message')) {
     runner.once('completion', () => {
       if (child.connected) {
         child.send('shutdown')
-      } else {
-        process.exit()
       }
     })
-  } else if (message.message === 'shutdown') {
-    process.exit()
   }
 }

--- a/test/wpt/start-mimesniff.mjs
+++ b/test/wpt/start-mimesniff.mjs
@@ -10,6 +10,8 @@ const child = fork(serverPath, [], {
   stdio: ['pipe', 'pipe', 'pipe', 'ipc']
 })
 
+child.on('exit', (code) => process.exit(code))
+
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
     const runner = new WPTRunner('mimesniff', message.server)
@@ -18,11 +20,7 @@ for await (const [message] of on(child, 'message')) {
     runner.once('completion', () => {
       if (child.connected) {
         child.send('shutdown')
-      } else {
-        process.exit()
       }
     })
-  } else if (message.message === 'shutdown') {
-    process.exit()
   }
 }

--- a/test/wpt/start-mimesniff.mjs
+++ b/test/wpt/start-mimesniff.mjs
@@ -16,7 +16,11 @@ for await (const [message] of on(child, 'message')) {
     runner.run()
 
     runner.once('completion', () => {
-      child.send('shutdown')
+      if (child.connected) {
+        child.send('shutdown')
+      } else {
+        process.exit()
+      }
     })
   } else if (message.message === 'shutdown') {
     process.exit()

--- a/test/wpt/start-websockets.mjs
+++ b/test/wpt/start-websockets.mjs
@@ -10,6 +10,8 @@ const child = fork(serverPath, [], {
   stdio: ['pipe', 'pipe', 'pipe', 'ipc']
 })
 
+child.on('exit', (code) => process.exit(code))
+
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
     const runner = new WPTRunner('websockets', message.server)
@@ -18,11 +20,7 @@ for await (const [message] of on(child, 'message')) {
     runner.once('completion', () => {
       if (child.connected) {
         child.send('shutdown')
-      } else {
-        process.exit()
       }
     })
-  } else if (message.message === 'shutdown') {
-    process.exit()
   }
 }

--- a/test/wpt/start-websockets.mjs
+++ b/test/wpt/start-websockets.mjs
@@ -18,6 +18,8 @@ for await (const [message] of on(child, 'message')) {
     runner.once('completion', () => {
       if (child.connected) {
         child.send('shutdown')
+      } else {
+        process.exit()
       }
     })
   } else if (message.message === 'shutdown') {


### PR DESCRIPTION
I have no idea if any of these changes will have an effect, but hopefully they will help on windows.

- Hide experimental warnings from websocket tests
- Limit number of workers to the number of cpus available (about 2-3 seconds slower locally, but less resource intensive)
- If a message can't be sent to a child process, exit the process rather than doing nothing (this *might* be the hanging issue)
- detect when to shutdown using a more reliable system (listening to the exit event on the child process and exiting once the subprocess exited)