### PR TITLE
fetch: simplify Object.prototype accessor preventions

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -53,8 +53,7 @@ function extractBody (object, keepalive = false) {
         )
         queueMicrotask(() => readableStreamClose(controller))
       },
-      start () {},
-      type: undefined
+      __proto__: null
     })
   }
 
@@ -228,7 +227,7 @@ function extractBody (object, keepalive = false) {
       async cancel (reason) {
         await iterator.return()
       },
-      type: undefined
+      __proto__: null
     })
   }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -962,15 +962,8 @@ async function fetchFinale (fetchParams, response) {
     const transformStream = new TransformStream({
       start () {},
       transform: identityTransformAlgorithm,
-      flush: processResponseEndOfBody
-    }, {
-      size () {
-        return 1
-      }
-    }, {
-      size () {
-        return 1
-      }
+      flush: processResponseEndOfBody,
+      __proto__: null
     })
 
     // 4. Set response’s body to the result of piping response’s body through transformStream.
@@ -1808,12 +1801,6 @@ async function httpNetworkFetch (
       },
       async cancel (reason) {
         await cancelAlgorithm(reason)
-      }
-    },
-    {
-      highWaterMark: 0,
-      size () {
-        return 1
       }
     }
   )


### PR DESCRIPTION
Creating a null prototype object works better than listing out each property!

Still some issues with TransformStreams because of https://github.com/nodejs/node/issues/46355 (for a while I thought this was an undici issue, but it isn't).