### PR TITLE
fix(types): update error type definitions

### DIFF
--- a/test/types/errors.test-d.ts
+++ b/test/types/errors.test-d.ts
@@ -4,29 +4,44 @@ import Client from '../../types/client'
 
 expectAssignable<errors.UndiciError>(new errors.UndiciError())
 
+expectAssignable<errors.UndiciError>(new errors.ConnectTimeoutError())
+expectAssignable<errors.ConnectTimeoutError>(new errors.ConnectTimeoutError())
+expectAssignable<'ConnectTimeoutError'>(new errors.ConnectTimeoutError().name)
+expectAssignable<'UND_ERR_CONNECT_TIMEOUT'>(new errors.ConnectTimeoutError().code)
+
 expectAssignable<errors.UndiciError>(new errors.HeadersTimeoutError())
 expectAssignable<errors.HeadersTimeoutError>(new errors.HeadersTimeoutError())
 expectAssignable<'HeadersTimeoutError'>(new errors.HeadersTimeoutError().name)
 expectAssignable<'UND_ERR_HEADERS_TIMEOUT'>(new errors.HeadersTimeoutError().code)
+
+expectAssignable<errors.UndiciError>(new errors.HeadersOverflowError())
+expectAssignable<errors.HeadersOverflowError>(new errors.HeadersOverflowError())
+expectAssignable<'HeadersOverflowError'>(new errors.HeadersOverflowError().name)
+expectAssignable<'UND_ERR_HEADERS_OVERFLOW'>(new errors.HeadersOverflowError().code)
 
 expectAssignable<errors.UndiciError>(new errors.BodyTimeoutError())
 expectAssignable<errors.BodyTimeoutError>(new errors.BodyTimeoutError())
 expectAssignable<'BodyTimeoutError'>(new errors.BodyTimeoutError().name)
 expectAssignable<'UND_ERR_BODY_TIMEOUT'>(new errors.BodyTimeoutError().code)
 
-expectAssignable<errors.UndiciError>(new errors.SocketTimeoutError())
-expectAssignable<errors.SocketTimeoutError>(new errors.SocketTimeoutError())
-expectAssignable<'SocketTimeoutError'>(new errors.SocketTimeoutError().name)
-expectAssignable<'UND_ERR_SOCKET_TIMEOUT'>(new errors.SocketTimeoutError().code)
+expectAssignable<errors.UndiciError>(new errors.ResponseStatusCodeError())
+expectAssignable<errors.ResponseStatusCodeError>(new errors.ResponseStatusCodeError())
+expectAssignable<'ResponseStatusCodeError'>(new errors.ResponseStatusCodeError().name)
+expectAssignable<'UND_ERR_RESPONSE_STATUS_CODE'>(new errors.ResponseStatusCodeError().code)
 
-expectAssignable<errors.UndiciError>(new errors.InvalidReturnError())
-expectAssignable<errors.InvalidReturnError>(new errors.InvalidReturnError())
-expectAssignable<'InvalidReturnError'>(new errors.InvalidReturnError().name)
-expectAssignable<'UND_ERR_INVALID_RETURN_VALUE'>(new errors.InvalidReturnError().code)
+expectAssignable<errors.UndiciError>(new errors.InvalidArgumentError())
+expectAssignable<errors.InvalidArgumentError>(new errors.InvalidArgumentError())
+expectAssignable<'InvalidArgumentError'>(new errors.InvalidArgumentError().name)
+expectAssignable<'UND_ERR_INVALID_ARG'>(new errors.InvalidArgumentError().code)
+
+expectAssignable<errors.UndiciError>(new errors.InvalidReturnValueError())
+expectAssignable<errors.InvalidReturnValueError>(new errors.InvalidReturnValueError())
+expectAssignable<'InvalidReturnValueError'>(new errors.InvalidReturnValueError().name)
+expectAssignable<'UND_ERR_INVALID_RETURN_VALUE'>(new errors.InvalidReturnValueError().code)
 
 expectAssignable<errors.UndiciError>(new errors.RequestAbortedError())
 expectAssignable<errors.RequestAbortedError>(new errors.RequestAbortedError())
-expectAssignable<'RequestAbortedError'>(new errors.RequestAbortedError().name)
+expectAssignable<'AbortError'>(new errors.RequestAbortedError().name)
 expectAssignable<'UND_ERR_ABORTED'>(new errors.RequestAbortedError().code)
 
 expectAssignable<errors.UndiciError>(new errors.InformationalError())
@@ -38,6 +53,11 @@ expectAssignable<errors.UndiciError>(new errors.RequestContentLengthMismatchErro
 expectAssignable<errors.RequestContentLengthMismatchError>(new errors.RequestContentLengthMismatchError())
 expectAssignable<'RequestContentLengthMismatchError'>(new errors.RequestContentLengthMismatchError().name)
 expectAssignable<'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'>(new errors.RequestContentLengthMismatchError().code)
+
+expectAssignable<errors.UndiciError>(new errors.ResponseContentLengthMismatchError())
+expectAssignable<errors.ResponseContentLengthMismatchError>(new errors.ResponseContentLengthMismatchError())
+expectAssignable<'ResponseContentLengthMismatchError'>(new errors.ResponseContentLengthMismatchError().name)
+expectAssignable<'UND_ERR_RES_CONTENT_LENGTH_MISMATCH'>(new errors.ResponseContentLengthMismatchError().code)
 
 expectAssignable<errors.UndiciError>(new errors.ClientDestroyedError())
 expectAssignable<errors.ClientDestroyedError>(new errors.ClientDestroyedError())
@@ -60,15 +80,29 @@ expectAssignable<errors.NotSupportedError>(new errors.NotSupportedError())
 expectAssignable<'NotSupportedError'>(new errors.NotSupportedError().name)
 expectAssignable<'UND_ERR_NOT_SUPPORTED'>(new errors.NotSupportedError().code)
 
+expectAssignable<errors.UndiciError>(new errors.BalancedPoolMissingUpstreamError())
+expectAssignable<errors.BalancedPoolMissingUpstreamError>(new errors.BalancedPoolMissingUpstreamError())
+expectAssignable<'MissingUpstreamError'>(new errors.BalancedPoolMissingUpstreamError().name)
+expectAssignable<'UND_ERR_BPL_MISSING_UPSTREAM'>(new errors.BalancedPoolMissingUpstreamError().code)
+
+expectAssignable<errors.UndiciError>(new errors.HTTPParserError())
+expectAssignable<errors.HTTPParserError>(new errors.HTTPParserError())
+expectAssignable<'HTTPParserError'>(new errors.HTTPParserError().name)
+
+expectAssignable<errors.UndiciError>(new errors.ResponseExceededMaxSizeError())
+expectAssignable<errors.ResponseExceededMaxSizeError>(new errors.ResponseExceededMaxSizeError())
+expectAssignable<'ResponseExceededMaxSizeError'>(new errors.ResponseExceededMaxSizeError().name)
+expectAssignable<'UND_ERR_RES_EXCEEDED_MAX_SIZE'>(new errors.ResponseExceededMaxSizeError().code)
+
 {
   // @ts-ignore
-  function f (): errors.HeadersTimeoutError | errors.SocketTimeoutError { return }
+  function f (): errors.HeadersTimeoutError | errors.ConnectTimeoutError { return }
 
   const e = f()
 
   if (e.code === 'UND_ERR_HEADERS_TIMEOUT') {
     expectAssignable<errors.HeadersTimeoutError>(e)
-  } else if (e.code === 'UND_ERR_SOCKET_TIMEOUT') {
-    expectAssignable<errors.SocketTimeoutError>(e)
+  } else if (e.code === 'UND_ERR_CONNECT_TIMEOUT') {
+    expectAssignable<errors.ConnectTimeoutError>(e)
   }
 }

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -6,10 +6,22 @@ export default Errors
 declare namespace Errors {
   export class UndiciError extends Error { }
 
+  /** Connect timeout error. */
+  export class ConnectTimeoutError extends UndiciError {
+    name: 'ConnectTimeoutError';
+    code: 'UND_ERR_CONNECT_TIMEOUT';
+  }
+
   /** A header exceeds the `headersTimeout` option. */
   export class HeadersTimeoutError extends UndiciError {
     name: 'HeadersTimeoutError';
     code: 'UND_ERR_HEADERS_TIMEOUT';
+  }
+
+  /** Headers overflow error. */
+  export class HeadersOverflowError extends UndiciError {
+    name: 'HeadersOverflowError'
+    code: 'UND_ERR_HEADERS_OVERFLOW'
   }
 
   /** A body exceeds the `bodyTimeout` option. */
@@ -27,12 +39,6 @@ declare namespace Errors {
     headers: IncomingHttpHeaders | string[] | null;
   }
 
-  /** A socket exceeds the `socketTimeout` option. */
-  export class SocketTimeoutError extends UndiciError {
-    name: 'SocketTimeoutError';
-    code: 'UND_ERR_SOCKET_TIMEOUT';
-  }
-
   /** Passed an invalid argument. */
   export class InvalidArgumentError extends UndiciError {
     name: 'InvalidArgumentError';
@@ -40,14 +46,14 @@ declare namespace Errors {
   }
 
   /** Returned an invalid value. */
-  export class InvalidReturnError extends UndiciError {
-    name: 'InvalidReturnError';
+  export class InvalidReturnValueError extends UndiciError {
+    name: 'InvalidReturnValueError';
     code: 'UND_ERR_INVALID_RETURN_VALUE';
   }
 
   /** The request has been aborted by the user. */
   export class RequestAbortedError extends UndiciError {
-    name: 'RequestAbortedError';
+    name: 'AbortError';
     code: 'UND_ERR_ABORTED';
   }
 
@@ -57,10 +63,16 @@ declare namespace Errors {
     code: 'UND_ERR_INFO';
   }
 
-  /** Body does not match content-length header. */
+  /** Request body length does not match content-length header. */
   export class RequestContentLengthMismatchError extends UndiciError {
     name: 'RequestContentLengthMismatchError';
     code: 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH';
+  }
+
+  /** Response body length does not match content-length header. */
+  export class ResponseContentLengthMismatchError extends UndiciError {
+    name: 'ResponseContentLengthMismatchError';
+    code: 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH';
   }
 
   /** Trying to use a destroyed client. */
@@ -88,7 +100,18 @@ declare namespace Errors {
     code: 'UND_ERR_NOT_SUPPORTED';
   }
 
-  /** The response exceed the length allowed */
+  /** No upstream has been added to the BalancedPool. */
+  export class BalancedPoolMissingUpstreamError extends UndiciError {
+    name: 'MissingUpstreamError';
+    code: 'UND_ERR_BPL_MISSING_UPSTREAM';
+  }
+
+  export class HTTPParserError extends UndiciError {
+    name: 'HTTPParserError';
+    code: string;
+  }
+
+  /** The response exceed the length allowed. */
   export class ResponseExceededMaxSizeError extends UndiciError {
     name: 'ResponseExceededMaxSizeError';
     code: 'UND_ERR_RES_EXCEEDED_MAX_SIZE';


### PR DESCRIPTION
This PR adds missing type definitions for errors and removes others that were no longer in use. It also makes sure all `name`s and `code`s match the JS implementations.

Fixes #1883 