### PR TITLE
Implement the requirement of IncomingHttpHeaders["set-cookie"]

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -209,6 +209,10 @@ function parseKeepAliveTimeout (val) {
   return m ? parseInt(m[1], 10) * 1000 : null
 }
 
+function splitCookie (val) {
+  return val.toString().split(';')
+}
+
 function parseHeaders (headers, obj = {}) {
   for (let i = 0; i < headers.length; i += 2) {
     const key = headers[i].toString().toLowerCase()
@@ -216,6 +220,8 @@ function parseHeaders (headers, obj = {}) {
     if (!val) {
       if (Array.isArray(headers[i + 1])) {
         obj[key] = headers[i + 1]
+      } else if (key === 'set-cookie') {
+        obj[key] = splitCookie(headers[i + 1])
       } else {
         obj[key] = headers[i + 1].toString()
       }
@@ -224,7 +230,12 @@ function parseHeaders (headers, obj = {}) {
         val = [val]
         obj[key] = val
       }
-      val.push(headers[i + 1].toString())
+
+      if (key === 'set-cookie') {
+        val.push(...splitCookie(headers[i + 1]))
+      } else {
+        val.push(headers[i + 1].toString())
+      }
     }
   }
   return obj

--- a/test/util.js
+++ b/test/util.js
@@ -83,12 +83,27 @@ test('validateHandler', (t) => {
 })
 
 test('parseHeaders', (t) => {
-  t.plan(5)
+  t.plan(7)
   t.same(util.parseHeaders(['key', 'value']), { key: 'value' })
   t.same(util.parseHeaders([Buffer.from('key'), Buffer.from('value')]), { key: 'value' })
   t.same(util.parseHeaders(['Key', 'Value']), { key: 'Value' })
   t.same(util.parseHeaders(['Key', 'value', 'key', 'Value']), { key: ['value', 'Value'] })
   t.same(util.parseHeaders(['key', ['value1', 'value2', 'value3']]), { key: ['value1', 'value2', 'value3'] })
+  t.same(util.parseHeaders(['set-cookie', '123456|123456|123456;Path=/']), { 'set-cookie': ['123456|123456|123456', 'Path=/'] })
+  t.same(util.parseHeaders([
+    'set-cookie',
+    '123456|123456|123456;Path=/',
+    'set-cookie',
+    '233333|114514;1919810;Hello=World'
+  ]), {
+    'set-cookie': [
+      '123456|123456|123456',
+      'Path=/',
+      '233333|114514',
+      '1919810',
+      'Hello=World'
+    ]
+  })
 })
 
 test('parseRawHeaders', (t) => {


### PR DESCRIPTION
## This relates to...

Fixed #1892

## Rationale

Currently `headers["set-cookie"]` does not split, which can't match the expected type of IncomingHttpHeader.

## Changes

This commit attempts to split `headers["set-cookie"]` by `;` like what 'node:http' does: <https://nodejs.org/api/http.html#class-httpserverresponse>

### Bug Fixes

See above.

### Breaking Changes and Deprecations

- `set-cookie` is now always an `string[]`.

## Status

KEY: S = Skipped, x = complete

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
