### PR TITLE
perf(content-type parser): faster string collector

### DIFF
--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -31,8 +31,8 @@ function dataURLProcessor (dataURL) {
   // 5. Let mimeType be the result of collecting a
   // sequence of code points that are not equal
   // to U+002C (,), given position.
-  let mimeType = collectASequenceOfCodePoints(
-    (char) => char !== ',',
+  let mimeType = collectASequenceOfCodePointsFast(
+    ',',
     input,
     position
   )
@@ -145,6 +145,25 @@ function collectASequenceOfCodePoints (condition, input, position) {
   return result
 }
 
+/**
+ * A faster collectASequenceOfCodePoints that only works when comparing a single character.
+ * @param {string} char
+ * @param {string} input
+ * @param {{ position: number }} position
+ */
+function collectASequenceOfCodePointsFast (char, input, position) {
+  const idx = input.indexOf(char, position.position)
+  const start = position.position
+
+  if (idx === -1) {
+    position.position = input.length
+    return input.slice(start)
+  }
+
+  position.position = idx
+  return input.slice(start, position.position)
+}
+
 // https://url.spec.whatwg.org/#string-percent-decode
 /** @param {string} input */
 function stringPercentDecode (input) {
@@ -214,8 +233,8 @@ function parseMIMEType (input) {
   // 3. Let type be the result of collecting a sequence
   // of code points that are not U+002F (/) from
   // input, given position.
-  const type = collectASequenceOfCodePoints(
-    (char) => char !== '/',
+  const type = collectASequenceOfCodePointsFast(
+    '/',
     input,
     position
   )
@@ -239,8 +258,8 @@ function parseMIMEType (input) {
   // 7. Let subtype be the result of collecting a sequence of
   // code points that are not U+003B (;) from input, given
   // position.
-  let subtype = collectASequenceOfCodePoints(
-    (char) => char !== ';',
+  let subtype = collectASequenceOfCodePointsFast(
+    ';',
     input,
     position
   )
@@ -324,8 +343,8 @@ function parseMIMEType (input) {
 
       // 2. Collect a sequence of code points that are not
       // U+003B (;) from input, given position.
-      collectASequenceOfCodePoints(
-        (char) => char !== ';',
+      collectASequenceOfCodePointsFast(
+        ';',
         input,
         position
       )
@@ -335,8 +354,8 @@ function parseMIMEType (input) {
       // 1. Set parameterValue to the result of collecting
       // a sequence of code points that are not U+003B (;)
       // from input, given position.
-      parameterValue = collectASequenceOfCodePoints(
-        (char) => char !== ';',
+      parameterValue = collectASequenceOfCodePointsFast(
+        ';',
         input,
         position
       )


### PR DESCRIPTION
This implements a faster way of collecting strings up to a certain character.

Performance is either equal/slightly faster or faster in every use-case I tried.

<details>
<summary>String with one unquoted param</summary>

```mjs
import { parseMIMEType } from './lib/fetch/dataURL.js'
import { MIMEType } from 'util'
import cronometro from 'cronometro'
import { parseMIMEType as parseMIMEType2 } from 'undici/lib/fetch/dataURL.js'

const type = 'application'//.repeat(100)
const subtype = 'json'//.repeat(100)

const essence = `${type}/${subtype}`

cronometro({
  'undici - new' () {
    return parseMIMEType(`${essence}; a=bcdefg`)
  },
  'undici - old' () {
    return parseMIMEType2(`${essence}; a=bcdefg`)
  },
  'node' () {
    return new MIMEType(`${essence}; a=bcdefg`)
  }
})
```

```
╔══════════════╤═════════╤═══════════════════╤═══════════╗
║ Slower tests │ Samples │            Result │ Tolerance ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ node         │   10000 │  620724.72 op/sec │  ± 2.84 % ║
║ undici - old │   10000 │  941859.04 op/sec │  ± 4.25 % ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ Fastest test │ Samples │            Result │ Tolerance ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ undici - new │   10000 │ 1081314.88 op/sec │  ± 3.58 % ║
╚══════════════╧═════════╧═══════════════════╧═══════════╝
```

</details>

<details>
<summary>String with an unquoted & quoted param</summary>

```mjs
import { parseMIMEType } from './lib/fetch/dataURL.js'
import { MIMEType } from 'util'
import cronometro from 'cronometro'
import { parseMIMEType as parseMIMEType2 } from 'undici/lib/fetch/dataURL.js'

const type = 'application'//.repeat(100)
const subtype = 'json'//.repeat(100)

const essence = `${type}/${subtype}`

cronometro({
  'undici - new' () {
    return parseMIMEType(`${essence}; a=bcdefg; b="abc"`)
  },
  'undici - old' () {
    return parseMIMEType2(`${essence}; a=bcdefg; b="abc"`)
  },
  'node' () {
    return new MIMEType(`${essence}; a=bcdefg; b="abc"`)
  }
})
```

```
╔══════════════╤═════════╤══════════════════╤═══════════╗
║ Slower tests │ Samples │           Result │ Tolerance ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ node         │   10000 │ 525179.74 op/sec │  ± 2.02 % ║
║ undici - old │   10000 │ 769396.49 op/sec │  ± 3.14 % ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ Fastest test │ Samples │           Result │ Tolerance ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ undici - new │   10000 │ 864999.45 op/sec │  ± 3.20 % ║
╚══════════════╧═════════╧══════════════════╧═══════════╝
```

</details>

<details>
<summary>with a long string</summary>

```mjs
import { parseMIMEType } from './lib/fetch/dataURL.js'
import { MIMEType } from 'util'
import cronometro from 'cronometro'
import { parseMIMEType as parseMIMEType2 } from 'undici/lib/fetch/dataURL.js'

const type = 'application'.repeat(100)
const subtype = 'json'.repeat(100)

const essence = `${type}/${subtype}`

cronometro({
  'undici - new' () {
    return parseMIMEType(`${essence}; a=bcdefg; b="abc"`)
  },
  'undici - old' () {
    return parseMIMEType2(`${essence}; a=bcdefg; b="abc"`)
  },
  'node' () {
    return new MIMEType(`${essence}; a=bcdefg; b="abc"`)
  }
})
```

```
╔══════════════╤═════════╤══════════════════╤═══════════╗
║ Slower tests │ Samples │           Result │ Tolerance ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ undici - old │    6000 │  52940.63 op/sec │  ± 0.97 % ║
║ node         │    9999 │  74040.56 op/sec │  ± 0.98 % ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ Fastest test │ Samples │           Result │ Tolerance ║
╟──────────────┼─────────┼──────────────────┼───────────╢
║ undici - new │   10000 │ 308513.42 op/sec │  ± 1.61 % ║
╚══════════════╧═════════╧══════════════════╧═══════════╝
```

</details>

<details>
<summary>basic type (no params, etc.) - equal perf</summary>

```
╔══════════════╤═════════╤═══════════════════╤═══════════╗
║ Slower tests │ Samples │            Result │ Tolerance ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ node         │   10000 │  813802.08 op/sec │  ± 3.31 % ║
║ undici - old │   10000 │ 1346076.19 op/sec │  ± 2.80 % ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ Fastest test │ Samples │            Result │ Tolerance ║
╟──────────────┼─────────┼───────────────────┼───────────╢
║ undici - new │   10000 │ 1350767.24 op/sec │  ± 1.58 % ║
╚══════════════╧═════════╧═══════════════════╧═══════════╝
```
</details>