### PR TITLE
fix: ensure header value is a string

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -279,9 +279,16 @@ class Request {
 }
 
 function processHeaderValue (key, val) {
-  if (typeof val !== 'string' || headerCharRegex.exec(val) !== null) {
+  if (val && typeof val === 'object') {
     throw new InvalidArgumentError(`invalid ${key} header`)
   }
+
+  val = val == null ? `${val}` : ''
+
+  if (headerCharRegex.exec(val) !== null) {
+    throw new InvalidArgumentError(`invalid ${key} header`)
+  }
+
   return `${key}: ${val}\r\n`
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -279,9 +279,7 @@ class Request {
 }
 
 function processHeaderValue (key, val) {
-  if (typeof val !== 'string') {
-    throw new InvalidArgumentError(`invalid ${key} header`)
-  } else if (headerCharRegex.exec(val) !== null) {
+  if (typeof val !== 'string' || headerCharRegex.exec(val) !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   }
   return `${key}: ${val}\r\n`

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -279,7 +279,7 @@ class Request {
 }
 
 function processHeaderValue (key, val) {
-  if (val && (typeof val === 'object' && !Array.isArray(val))) {
+  if (typeof val !== 'string') {
     throw new InvalidArgumentError(`invalid ${key} header`)
   } else if (headerCharRegex.exec(val) !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -283,7 +283,7 @@ function processHeaderValue (key, val) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   }
 
-  val = val == null ? `${val}` : ''
+  val = val != null ? `${val}` : ''
 
   if (headerCharRegex.exec(val) !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -94,7 +94,7 @@ test('basic dispatch get', (t) => {
     t.equal(`localhost:${server.address().port}`, req.headers.host)
     t.equal(undefined, req.headers.foo)
     t.equal('bar', req.headers.bar)
-    t.equal('null', req.headers.baz)
+    t.equal('', req.headers.baz)
     t.equal(undefined, req.headers['content-length'])
     res.end('hello')
   })


### PR DESCRIPTION
I don't think it's something else than a string in any of the branches but the check should still be correct.