### PR TITLE
fix: throw if invalid content-type header

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -279,9 +279,12 @@ class Request {
 }
 
 function processHeaderValue (key, val) {
-  if (typeof val !== 'string' && headerCharRegex.exec(val) !== null) {
+  if (val && (typeof val === 'object' && !Array.isArray(val))) {
+    throw new InvalidArgumentError(`invalid ${key} header`)
+  } else if (headerCharRegex.exec(val) !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   }
+
   return `${key}: ${val}\r\n`
 }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -279,9 +279,7 @@ class Request {
 }
 
 function processHeaderValue (key, val) {
-  if (val && (typeof val === 'object' && !Array.isArray(val))) {
-    throw new InvalidArgumentError(`invalid ${key} header`)
-  } else if (headerCharRegex.exec(val) !== null) {
+  if (typeof val !== 'string' && headerCharRegex.exec(val) !== null) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   }
   return `${key}: ${val}\r\n`
@@ -313,11 +311,10 @@ function processHeader (request, key, val) {
   } else if (
     request.contentType === null &&
     key.length === 12 &&
-    key.toLowerCase() === 'content-type' &&
-    headerCharRegex.exec(val) === null
+    key.toLowerCase() === 'content-type'
   ) {
     request.contentType = val
-    request.headers += `${key}: ${val}\r\n`
+    request.headers += processHeaderValue(key, val)
   } else if (
     key.length === 17 &&
     key.toLowerCase() === 'transfer-encoding'


### PR DESCRIPTION
If content-type header value is not a string we should throw.