### PR TITLE
fix(fetch): use semicolon for Cookie header delimiter

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -104,7 +104,11 @@ class HeadersList {
 
     // 2. Append (name, value) to list.
     if (exists) {
-      this[kHeadersMap].set(lowercaseName, { name: exists.name, value: `${exists.value}, ${value}` })
+      const delimiter = lowercaseName === 'cookie' ? '; ' : ', '
+      this[kHeadersMap].set(lowercaseName, {
+        name: exists.name,
+        value: `${exists.value}${delimiter}${value}`
+      })
     } else {
       this[kHeadersMap].set(lowercaseName, { name, value })
     }

--- a/test/fetch/cookies.js
+++ b/test/fetch/cookies.js
@@ -48,3 +48,22 @@ test('Can send cookies to a server with fetch - issue #1463', async (t) => {
 
   t.end()
 })
+
+test('Cookie header is delimited with a semicolon rather than a comma - issue #1905', async (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    t.equal(req.headers.cookie, 'FOO=lorem-ipsum-dolor-sit-amet; BAR=the-quick-brown-fox')
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    headers: [
+      ['cookie', 'FOO=lorem-ipsum-dolor-sit-amet'],
+      ['cookie', 'BAR=the-quick-brown-fox']
+    ]
+  })
+})


### PR DESCRIPTION
Fixes #1905 

In browsers, the cookie header is filtered out so there's no mention of special handling. While technically being compliant, will lead to incorrect parsing on the receiving side (from the issue). Deno matches this behavior - delimiting cookie headers with a semicolon rather than a comma, and I believe node core does similar.