### PR TITLE
doc(mock): update out-of-date reply documentation

### DIFF
--- a/docs/api/MockPool.md
+++ b/docs/api/MockPool.md
@@ -63,7 +63,8 @@ Returns: `MockInterceptor` corresponding to the input options.
 
 We can define the behaviour of an intercepted request with the following options.
 
-* **reply** `(statusCode: number, replyData: string | Buffer | object | MockInterceptor.MockResponseDataHandler, responseOptions?: MockResponseOptions) => MockScope` - define a reply for a matching request. You can define this as a callback to read incoming request data. Default for `responseOptions` is `{}`.
+* **reply** `(statusCode: number, replyData: string | Buffer | object | MockInterceptor.MockResponseDataHandler, responseOptions?: MockResponseOptions) => MockScope` - define a reply for a matching request. You can define the replyData as a callback to read incoming request data. Default for `responseOptions` is `{}`.
+* **reply** `(callback: MockInterceptor.MockReplyOptionsCallback) => MockScope` - define a reply for a matching request, allowing dynamic mocking of all reply options rather than just the data.
 * **replyWithError** `(error: Error) => MockScope` - define an error for a matching request to throw.
 * **defaultReplyHeaders** `(headers: Record<string, string>) => MockInterceptor` - define default headers to be included in subsequent replies. These are in addition to headers on a specific reply.
 * **defaultReplyTrailers** `(trailers: Record<string, string>) => MockInterceptor` - define default trailers to be included in subsequent replies. These are in addition to trailers on a specific reply.


### PR DESCRIPTION
https://github.com/nodejs/undici/pull/1211 introduced a way to dynamically mock all the reply options, including the `statusCode`, which is very handy.

However, despite this behaviour [being presented in the doc](https://undici.nodejs.org/#/docs/api/MockPool?id=example-mocked-request-using-reply-options-callback), the [API method specification](https://undici.nodejs.org/#/docs/api/MockPool?id=return-mockinterceptor) does not take it into account which is confusing.

I am not sure about the wording here - happy to take any suggestions.