### PR TITLE
fix(types): add missing keepAlive params

### DIFF
--- a/test/types/connector.test-d.ts
+++ b/test/types/connector.test-d.ts
@@ -25,6 +25,8 @@ expectAssignable<Client>(new Client('', {
 expectAssignable<buildConnector.BuildOptions>({
   checkServerIdentity: () => undefined, // Test if ConnectionOptions is assignable
   localPort: 1234, // Test if TcpNetConnectOpts is assignable
+  keepAlive: true,
+  keepAliveInitialDelay: 12345,
 });
 
 expectAssignable<buildConnector.Options>({

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -10,6 +10,8 @@ declare namespace buildConnector {
     socketPath?: string | null;
     timeout?: number | null;
     port?: number;
+    keepAlive?: boolean | null;
+    keepAliveInitialDelay?: number | null;
   }
 
   export interface Options {


### PR DESCRIPTION
Add missing `keepAlive*` params that are present were added in #1904 [docs](https://undici.nodejs.org/#/docs/api/Client?id=parameter-connectoptions) and [code](https://github.com/nodejs/undici/blob/main/lib/core/connect.js#L124), but missing in typings. 