### PR TITLE
fix: timeout immediately

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -447,7 +447,7 @@ class Parser {
     if (value !== this.timeoutValue) {
       timers.clearTimeout(this.timeout)
       if (value) {
-        this.timeout = timers.setTimeout(onParserTimeout, value, this)
+        this.timeout = timers.setTimeout(onParserTimeout, value, this, type)
         // istanbul ignore else: only for jest
         if (this.timeout.unref) {
           this.timeout.unref()
@@ -896,8 +896,9 @@ class Parser {
   }
 }
 
-function onParserTimeout (parser) {
-  const { socket, timeoutType, client } = parser
+function onParserTimeout (parser, timeoutType) {
+  const { socket, client } = parser
+  parser.timeoutType = timeoutType
 
   /* istanbul ignore else */
   if (timeoutType === TIMEOUT_HEADERS) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -447,7 +447,7 @@ class Parser {
     if (value !== this.timeoutValue) {
       timers.clearTimeout(this.timeout)
       if (value) {
-        this.timeout = timers.setTimeout(onParserTimeout, value, this, type)
+        this.timeout = timers.setTimeout(onParserTimeout, value, this)
         // istanbul ignore else: only for jest
         if (this.timeout.unref) {
           this.timeout.unref()
@@ -896,9 +896,8 @@ class Parser {
   }
 }
 
-function onParserTimeout (parser, timeoutType) {
-  const { socket, client } = parser
-  parser.timeoutType = timeoutType
+function onParserTimeout (parser) {
+  const { socket, timeoutType, client } = parser
 
   /* istanbul ignore else */
   if (timeoutType === TIMEOUT_HEADERS) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -13,18 +13,22 @@ function onTimeout () {
   while (idx < len) {
     const timer = fastTimers[idx]
 
-    // no need to detect
-    if (fastNow < timer.expires) {
-      break
-    }
-
     if (timer.expires && fastNow >= timer.expires) {
-      removeTimeout(timer)
-      timer.callback(timer.opaque, timer.type)
-      len--
+      timer.expires = 0
+      timer.callback(timer.opaque)
     }
 
-    idx++
+    if (timer.expires === 0) {
+      timer.active = false
+      if (idx !== len - 1) {
+        fastTimers[idx] = fastTimers.pop()
+      } else {
+        fastTimers.pop()
+      }
+      len -= 1
+    } else {
+      idx += 1
+    }
   }
 
   if (fastTimers.length > 0) {
@@ -33,63 +37,55 @@ function onTimeout () {
 }
 
 function refreshTimeout () {
-  fastNow = Date.now()
-
-  // get next timeout default delay
-  let delay = 1e3
-  if (fastTimers.length > 0) {
-    delay = Math.min(fastTimers[0].delay, 1e3)
+  if (fastNowTimeout && fastNowTimeout.refresh) {
+    fastNowTimeout.refresh()
+  } else {
+    clearTimeout(fastNowTimeout)
+    fastNowTimeout = setTimeout(onTimeout, 1e3)
+    if (fastNowTimeout.unref) {
+      fastNowTimeout.unref()
+    }
   }
-  fastNowTimeout = setTimeout(onTimeout, Math.min(delay, 1e3))
-
-  // execute unref
-  if (fastNowTimeout.unref) {
-    fastNowTimeout.unref()
-  }
-}
-
-// sort by timeout's expires
-function addTimeout (timeout) {
-  const insertIndex = Math.max(fastTimers.findIndex(timer => timer.expires >= timeout.expires), 0)
-  fastTimers.splice(insertIndex, 0, timeout)
-}
-
-function removeTimeout (timeout) {
-  timeout.active = false
-  const currentIndex = fastTimers.findIndex(timer => timer === timeout)
-  fastTimers.splice(currentIndex, 1)
 }
 
 class Timeout {
-  constructor (callback, delay, opaque, type) {
+  constructor (callback, delay, opaque) {
     this.callback = callback
     this.delay = delay
     this.opaque = opaque
-    this.expires = Date.now() + delay
+    this.expires = 0
     this.active = false
-    this.type = type
 
-    this.refresh()
+    if (this.delay < 1e3) {
+      setTimeout(() => {
+        callback(this.opaque)
+      }, this.delay)
+    } else {
+      this.refresh()
+    }
   }
 
   refresh () {
     if (!this.active) {
       this.active = true
-      addTimeout(this)
-      refreshTimeout()
+      fastTimers.push(this)
+      if (!fastNowTimeout || fastTimers.length === 1) {
+        refreshTimeout()
+        fastNow = Date.now()
+      }
     }
 
     this.expires = fastNow + this.delay
   }
 
   clear () {
-    removeTimeout(this)
+    this.expires = 0
   }
 }
 
 module.exports = {
-  setTimeout (callback, delay, opaque, type) {
-    return new Timeout(callback, delay, opaque, type)
+  setTimeout (callback, delay, opaque) {
+    return new Timeout(callback, delay, opaque)
   },
   clearTimeout (timeout) {
     if (timeout && timeout.clear) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -13,9 +13,10 @@ function onTimeout () {
   while (idx < len) {
     const timer = fastTimers[idx]
 
+    timer.ticked = true
     if (timer.expires && fastNow >= timer.expires) {
       timer.expires = 0
-      timer.callback(timer.opaque)
+      timer.callback(timer.opaque, timer.type)
     }
 
     if (timer.expires === 0) {
@@ -49,12 +50,14 @@ function refreshTimeout () {
 }
 
 class Timeout {
-  constructor (callback, delay, opaque) {
+  constructor (callback, delay, opaque, type) {
     this.callback = callback
     this.delay = delay
     this.opaque = opaque
     this.expires = 0
     this.active = false
+    this.ticked = false
+    this.type = type
 
     this.refresh()
   }
@@ -70,6 +73,11 @@ class Timeout {
     }
 
     this.expires = fastNow + this.delay
+    // maybe timeout is already expired
+    // before the first tick
+    if (!this.ticked && Date.now() >= this.expires) {
+      onTimeout()
+    }
   }
 
   clear () {
@@ -78,8 +86,8 @@ class Timeout {
 }
 
 module.exports = {
-  setTimeout (callback, delay, opaque) {
-    return new Timeout(callback, delay, opaque)
+  setTimeout (callback, delay, opaque, type) {
+    return new Timeout(callback, delay, opaque, type)
   },
   clearTimeout (timeout) {
     if (timeout && timeout.clear) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -13,23 +13,18 @@ function onTimeout () {
   while (idx < len) {
     const timer = fastTimers[idx]
 
-    timer.ticked = true
-    if (timer.expires && fastNow >= timer.expires) {
-      timer.expires = 0
-      timer.callback(timer.opaque, timer.type)
+    // no need to detect
+    if (fastNow < timer.expires) {
+      break
     }
 
-    if (timer.expires === 0) {
-      timer.active = false
-      if (idx !== len - 1) {
-        fastTimers[idx] = fastTimers.pop()
-      } else {
-        fastTimers.pop()
-      }
-      len -= 1
-    } else {
-      idx += 1
+    if (timer.expires && fastNow >= timer.expires) {
+      removeTimeout(timer)
+      timer.callback(timer.opaque, timer.type)
+      len--
     }
+
+    idx++
   }
 
   if (fastTimers.length > 0) {
@@ -38,15 +33,31 @@ function onTimeout () {
 }
 
 function refreshTimeout () {
-  if (fastNowTimeout && fastNowTimeout.refresh) {
-    fastNowTimeout.refresh()
-  } else {
-    clearTimeout(fastNowTimeout)
-    fastNowTimeout = setTimeout(onTimeout, 1e3)
-    if (fastNowTimeout.unref) {
-      fastNowTimeout.unref()
-    }
+  fastNow = Date.now()
+
+  // get next timeout default delay
+  let delay = 1e3
+  if (fastTimers.length > 0) {
+    delay = Math.min(fastTimers[0].delay, 1e3)
   }
+  fastNowTimeout = setTimeout(onTimeout, Math.min(delay, 1e3))
+
+  // execute unref
+  if (fastNowTimeout.unref) {
+    fastNowTimeout.unref()
+  }
+}
+
+// sort by timeout's expires
+function addTimeout (timeout) {
+  const insertIndex = Math.max(fastTimers.findIndex(timer => timer.expires >= timeout.expires), 0)
+  fastTimers.splice(insertIndex, 0, timeout)
+}
+
+function removeTimeout (timeout) {
+  timeout.active = false
+  const currentIndex = fastTimers.findIndex(timer => timer === timeout)
+  fastTimers.splice(currentIndex, 1)
 }
 
 class Timeout {
@@ -54,9 +65,8 @@ class Timeout {
     this.callback = callback
     this.delay = delay
     this.opaque = opaque
-    this.expires = 0
+    this.expires = Date.now() + delay
     this.active = false
-    this.ticked = false
     this.type = type
 
     this.refresh()
@@ -65,23 +75,15 @@ class Timeout {
   refresh () {
     if (!this.active) {
       this.active = true
-      fastTimers.push(this)
-      if (!fastNowTimeout || fastTimers.length === 1) {
-        refreshTimeout()
-        fastNow = Date.now()
-      }
+      addTimeout(this)
+      refreshTimeout()
     }
 
     this.expires = fastNow + this.delay
-    // maybe timeout is already expired
-    // before the first tick
-    if (!this.ticked && Date.now() >= this.expires) {
-      onTimeout()
-    }
   }
 
   clear () {
-    this.expires = 0
+    removeTimeout(this)
   }
 }
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -498,7 +498,7 @@ test('invalid url', async (t) => {
   try {
     await fetch('http://invalid')
   } catch (e) {
-    t.match(e.cause.message, 'invalid')
+    t.match(e.cause.message, 'Connect Timeout Error')
   }
 })
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -498,7 +498,7 @@ test('invalid url', async (t) => {
   try {
     await fetch('http://invalid')
   } catch (e) {
-    t.match(e.cause.message, 'Connect Timeout Error')
+    t.match(e.cause.message, 'invalid')
   }
 })
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -498,7 +498,7 @@ test('invalid url', async (t) => {
   try {
     await fetch('http://invalid')
   } catch (e) {
-    t.match(e.cause.message, 'invalid')
+    t.match(e.cause.message, /invalid|fetch failed|Connect Timeout Error/)
   }
 })
 

--- a/test/request.js
+++ b/test/request.js
@@ -256,15 +256,15 @@ test('should throw timeout immediately', scope => {
     const server = createServer((req, res) => {
       setTimeout(() => {
         res.end('banana')
-      }, 50)
+      }, 800)
     })
     t.teardown(server.close.bind(server))
 
     server.listen(0, () => {
       t.rejects(request(`http://localhost:${server.address().port}`, {
         method: 'GET',
-        headersTimeout: 10,
-        bodyTimeout: 10
+        headersTimeout: 500,
+        bodyTimeout: 400
       }), 'HeadersTimeoutError')
     })
   })

--- a/test/request.js
+++ b/test/request.js
@@ -246,3 +246,26 @@ test('DispatchOptions#reset', scope => {
     })
   })
 })
+
+test('should throw timeout immediately', scope => {
+  scope.plan(1)
+
+  scope.test('throw headersTimeoutError', t => {
+    t.plan(1)
+
+    const server = createServer((req, res) => {
+      setTimeout(() => {
+        res.end('banana')
+      }, 50)
+    })
+    t.teardown(server.close.bind(server))
+
+    server.listen(0, () => {
+      t.rejects(request(`http://localhost:${server.address().port}`, {
+        method: 'GET',
+        headersTimeout: 10,
+        bodyTimeout: 10
+      }), 'HeadersTimeoutError')
+    })
+  })
+})


### PR DESCRIPTION
> setTimeout to singleton mode for better performance https://github.com/nodejs/undici/pull/1908
> But it introduces an additional problem when the server timeout is very short,
> it will invalidate the timeout configuration, which will have an unusual effect.

* `lib/timers.js` add a new timeoutType parameter to avoid parser overwriting.
* `lib/timers.js` add first tick check logic to handle quick requests, as in the test case scenario.