### PR TITLE
Make the fetch() abort test pass locally, on Linux and Mac, Node 18/19.

### DIFF
--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -43,25 +43,14 @@ test('allows aborting with custom errors', { skip: semver.satisfies(process.vers
   t.teardown(server.close.bind(server))
   await once(server, 'listening')
 
-  t.test('Using AbortSignal.timeout without cause', { skip: semver.satisfies(process.version, '>= 19.0.0') }, async (t) => {
-    await t.rejects(
-      fetch(`http://localhost:${server.address().port}`, {
-        signal: AbortSignal.timeout(50)
-      }),
-      {
-        name: 'TimeoutError',
-        code: DOMException.TIMEOUT_ERR
-      }
-    )
-  })
-
-  t.test('Using AbortSignal.timeout with cause', { skip: semver.satisfies(process.version, '< 19.0.0') }, async (t) => {
+  t.test('Using AbortSignal.timeout with cause', async (t) => {
     t.plan(2)
 
     try {
       await fetch(`http://localhost:${server.address().port}`, {
         signal: AbortSignal.timeout(50)
       })
+      t.fail('should throw')
     } catch (err) {
       if (err.name === 'TypeError') {
         const cause = err.cause


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>