### PR TITLE
test(wpt): add results to an existing WPT Report

### DIFF
--- a/test/wpt/start-fetch.mjs
+++ b/test/wpt/start-fetch.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url'
 import { fork } from 'child_process'
 import { on } from 'events'
 
+const { WPT_REPORT } = process.env
+
 const serverPath = fileURLToPath(join(import.meta.url, '../server/server.mjs'))
 
 const child = fork(serverPath, [], {
@@ -14,7 +16,10 @@ child.on('exit', (code) => process.exit(code))
 
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
-    const runner = new WPTRunner('fetch', message.server)
+    const runner = new WPTRunner('fetch', message.server, {
+      appendReport: !!WPT_REPORT,
+      reportPath: WPT_REPORT
+    })
     runner.run()
 
     runner.once('completion', () => {

--- a/test/wpt/start-mimesniff.mjs
+++ b/test/wpt/start-mimesniff.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url'
 import { fork } from 'child_process'
 import { on } from 'events'
 
+const { WPT_REPORT } = process.env
+
 const serverPath = fileURLToPath(join(import.meta.url, '../server/server.mjs'))
 
 const child = fork(serverPath, [], {
@@ -14,7 +16,10 @@ child.on('exit', (code) => process.exit(code))
 
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
-    const runner = new WPTRunner('mimesniff', message.server)
+    const runner = new WPTRunner('mimesniff', message.server, {
+      appendReport: !!WPT_REPORT,
+      reportPath: WPT_REPORT
+    })
     runner.run()
 
     runner.once('completion', () => {

--- a/test/wpt/start-xhr.mjs
+++ b/test/wpt/start-xhr.mjs
@@ -1,7 +1,12 @@
 import { WPTRunner } from './runner/runner/runner.mjs'
 import { once } from 'events'
 
-const runner = new WPTRunner('xhr/formdata', 'http://localhost:3333')
+const { WPT_REPORT } = process.env
+
+const runner = new WPTRunner('xhr/formdata', 'http://localhost:3333', {
+  appendReport: !!WPT_REPORT,
+  reportPath: WPT_REPORT
+})
 runner.run()
 
 await once(runner, 'completion')


### PR DESCRIPTION
I wish to extend the [daily Node.js WPT Report](https://github.com/nodejs/node/blob/main/.github/workflows/daily-wpt-fyi.yml) with your WPTs.

I plan to extend the workflow file with roughly the following

```
UNDICI_VERSION = cat deps/undici/src/package.json | jq -r '.version'
if (UNDICI_VERSION_INCLUDES_THIS_CHANGE(UNDICI_VERSION))
  actions/checkout nodejs/undici at $UNDICI_VERSION tag
  WPT_REPORT=$(pwd)/out/wpt/wptreport.json npm run test:wpt
```

In order for the WPTs to be comparable with other wpt.fyi results they must respect the variants (1st commit), must sanitize the subtest names and messages the same (part of the 2nd commit).


NB: per commit no whitespace review recommended