### PR TITLE
fix(fetch): improve Headers and Request type-compatibility

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -68,7 +68,7 @@ export declare class Headers implements SpecIterable<[string, string]> {
   readonly keys: () => SpecIterableIterator<string>
   readonly values: () => SpecIterableIterator<string>
   readonly entries: () => SpecIterableIterator<[string, string]>
-  readonly [Symbol.iterator]: () => SpecIterator<[string, string]>
+  readonly [Symbol.iterator]: () => SpecIterableIterator<[string, string]>
 }
 
 export type RequestCache =
@@ -146,7 +146,8 @@ export declare class Request implements BodyMixin {
   readonly method: string
   readonly mode: RequestMode
   readonly redirect: RequestRedirect
-  readonly referrerPolicy: string
+  readonly referrer: string
+  readonly referrerPolicy: ReferrerPolicy
   readonly url: string
 
   readonly keepalive: boolean


### PR DESCRIPTION
- Fixes #1943

I'm using a simple reproduction example to test type congruence of Undici against `lib/dom`:

```ts
import { Request as UndiciRequest } from 'undici'

function transform(r: Request): void {}

transform(new UndiciRequest('/hello'))
// ^^^ This won't compile in TypeScript!
```
