### PR TITLE
fix: flaky fetch tests

### DIFF
--- a/test/fetch/data-uri.js
+++ b/test/fetch/data-uri.js
@@ -180,14 +180,14 @@ test('too long base64 url', async (t) => {
 
 test('https://domain.com/#', (t) => {
   t.plan(1)
-  const domain = 'https://domain.com/#'
+  const domain = 'https://domain.com/#a'
   const serialized = URLSerializer(new URL(domain))
   t.equal(serialized, domain)
 })
 
 test('https://domain.com/?', (t) => {
   t.plan(1)
-  const domain = 'https://domain.com/?'
+  const domain = 'https://domain.com/?a=b'
   const serialized = URLSerializer(new URL(domain))
   t.equal(serialized, domain)
 })


### PR DESCRIPTION
Happened in https://github.com/nodejs/undici/actions/runs/4237639232/jobs/7363840543 and a few other places.

```
    # Subtest: https://domain.com/\#
        1..1
        not ok 1 - should be equal
          ---
          compare: ===
          at:
            line: 185
            column: 5
            file: test/fetch/data-uri.js
            type: Test
          stack: |
            Test.<anonymous> (test/fetch/data-uri.js:185:5)
          source: |2
              const serialized = URLSerializer(new URL(domain))
              t.equal(serialized, domain)
            ----^
            })
          diff: |
            --- expected
            +++ actual
            @@ -1,1 +1,1 @@
            -https://domain.com/#
            +https://domain.com/
          ...
        
        # failed 1 test
    not ok 7 - https://domain.com/\# # time=23.051ms
    
    # Subtest: https://domain.com/?
        1..1
        not ok 1 - should be equal
          ---
          compare: ===
          at:
            line: 192
            column: 5
            file: test/fetch/data-uri.js
            type: Test
          stack: |
            Test.<anonymous> (test/fetch/data-uri.js:192:5)
          source: |2
              const serialized = URLSerializer(new URL(domain))
              t.equal(serialized, domain)
            ----^
            })
          diff: |
            --- expected
            +++ actual
            @@ -1,1 +1,1 @@
            -https://domain.com/?
            +https://domain.com/
          ...
        
        # failed 1 test
    not ok 8 - https://domain.com/? # time=6.849ms
    
    1..8
    # failed 2 of 8 tests
    # time=460.086ms
not ok 9 - test/fetch/data-uri.js # time=460.086ms
```

When constructing a URL with an empty fragment or search, you get an empty string, so it's not serialized as expected. I'm pretty sure it's only flaky sometimes because other tests fail before it?