### PR TITLE
test(wpt): handle uncaught exceptions

### DIFF
--- a/test/wpt/runner/runner/runner.mjs
+++ b/test/wpt/runner/runner/runner.mjs
@@ -159,6 +159,8 @@ export class WPTRunner extends EventEmitter {
             this.handleTestCompletion(worker)
           } else if (message.type === 'error') {
             this.#uncaughtExceptions.push(message.error)
+            this.#stats.failed += 1
+            this.#stats.success -= 1
           }
         })
 

--- a/test/wpt/runner/runner/worker.mjs
+++ b/test/wpt/runner/runner/worker.mjs
@@ -18,6 +18,17 @@ import { CloseEvent } from '../../../../lib/websocket/events.js'
 
 const { initScripts, meta, test, url, path } = workerData
 
+process.on('uncaughtException', (err) => {
+  parentPort.postMessage({
+    type: 'error',
+    error: {
+      message: err.message,
+      name: err.name,
+      stack: err.stack
+    }
+  })
+})
+
 const basePath = join(process.cwd(), 'test/wpt/tests')
 const urlPath = path.slice(basePath.length)
 

--- a/test/wpt/tests/fetch/api/abort/general.any.js
+++ b/test/wpt/tests/fetch/api/abort/general.any.js
@@ -519,6 +519,7 @@ promise_test(async t => {
   const fetchPromise = fetch('../resources/empty.txt', {
     body, signal,
     method: 'POST',
+    duplex: 'half',
     headers: {
       'Content-Type': 'text/plain'
     }


### PR DESCRIPTION
Fixes #1963 (...hopefully)

I can't repro the abort test failing locally, but when an uncatchable error is thrown the runner won't crash. This makes us more like browsers where we ignore errors and keep on running smoothly, lol

```js
// META: timeout=long
// META: global=window,worker

promise_test(async t => {
  queueMicrotask(() => {
    throw new TypeError('missing option')
  })
}, "this is test");

promise_test(async t => {
  assert_equals(1, 1)
}, "not a test");

```

Before (hard crash):
```
undefined:0

TypeError [Error]: missing option
    at evalmachine.<anonymous>:6:11
    at node:internal/process/task_queues:140:7
    at AsyncResource.runInAsyncScope (node:async_hooks:204:9)
    at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
```

after:
```js
================================================================================================
Started \undici\test\wpt\tests\fetch\api\abort\test.any.js
[1/158] PASSED - \undici\test\wpt\tests\fetch\api\abort\test.any.js
Test took 113.58ms
================================================================================================
{}
Uncaught exception: TypeError: missing option
    at evalmachine.<anonymous>:6:11
    at node:internal/process/task_queues:140:7
    at AsyncResource.runInAsyncScope (node:async_hooks:204:9)
    at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
================================================================================================
[fetch]: Completed: 2, failed: 1, success: 1, expected failures: 0, unexpected failures: 1, skipped: 0
```