### PR TITLE
fix: 🐛 add URL upstream variations in BalancedPool types

### DIFF
--- a/test/types/balanced-pool.test-d.ts
+++ b/test/types/balanced-pool.test-d.ts
@@ -10,6 +10,7 @@ expectAssignable<BalancedPool>(new BalancedPool('', { factory: () => new Dispatc
 expectAssignable<BalancedPool>(new BalancedPool('', { factory: (origin, opts) => new Client(origin, opts) }))
 expectAssignable<BalancedPool>(new BalancedPool('', { connections: 1 }))
 expectAssignable<BalancedPool>(new BalancedPool(['http://localhost:4242', 'http://www.nodejs.org']))
+expectAssignable<BalancedPool>(new BalancedPool([new URL('http://localhost:4242'),new URL('http://www.nodejs.org')], {}))
 
 {
   const pool = new BalancedPool('', {})
@@ -21,6 +22,8 @@ expectAssignable<BalancedPool>(new BalancedPool(['http://localhost:4242', 'http:
   // upstreams
   expectAssignable<BalancedPool>(pool.addUpstream('http://www.nodejs.org'))
   expectAssignable<BalancedPool>(pool.removeUpstream('http://www.nodejs.org'))
+  expectAssignable<BalancedPool>(pool.addUpstream(new URL('http://www.nodejs.org')))
+  expectAssignable<BalancedPool>(pool.removeUpstream(new URL('http://www.nodejs.org')))
   expectAssignable<string[]>(pool.upstreams)
 
 

--- a/types/balanced-pool.d.ts
+++ b/types/balanced-pool.d.ts
@@ -5,10 +5,10 @@ import { URL } from 'url'
 export default BalancedPool
 
 declare class BalancedPool extends Dispatcher {
-  constructor(url: string | URL | string[], options?: Pool.Options);
+  constructor(url: string | string[] | URL | URL[], options?: Pool.Options);
 
-  addUpstream(upstream: string): BalancedPool;
-  removeUpstream(upstream: string): BalancedPool;
+  addUpstream(upstream: string | URL): BalancedPool;
+  removeUpstream(upstream: string | URL): BalancedPool;
   upstreams: Array<string>;
 
   /** `true` after `pool.close()` has been called. */


### PR DESCRIPTION
## Description
* Updated `BalancedPool` constructor to account for `URL[]`
* Updated `BalancedPool`'s `addUpstream` to account for `URL`
* Updated `BalancedPool`'s `removeUpstream` to account for `URL`

🏁 Closes: #1948

## Notes

This is more an fyi or could be a me issue. The `tsc test/imports/undici-import.ts` fails for me due to

```
node_modules/@types/eslint/index.d.ts:451:42 - error TS2724: '"/undici/node_modules/@types/estree/index"' has no exported member named 'ChainExpression'. Did you mean 'Expression'?

451         ChainExpression?: ((node: ESTree.ChainExpression & NodeParentExtension) => void) | undefined;
                                             ~~~~~~~~~~~~~~~
```

Looks `@types/eslint` is being used by
```
└─┬ tsd@0.25.0
  └─┬ eslint-formatter-pretty@4.1.0
    └── @types/eslint@7.29.0
```

Passing `--skipLibCheck` allowed me to run the `tsc test/imports/undici-import.ts` 