### PR TITLE
README: h3 not showing ### as a header

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Refs: https://fetch.spec.whatwg.org/#atomic-http-redirect-handling
 
 ## Workarounds
 
-### Network address family autoselection.
+### Network address family autoselection.
 
 If you experience problem when connecting to a remote server that is resolved by your DNS servers to a IPv6 (AAAA record)
 first, there are chances that your local router or ISP might have problem connecting to IPv6 networks. In that case


### PR DESCRIPTION
Screenshot taken from master branch [readme](https://github.com/nodejs/undici#workarounds):

<img width="415" alt="Screenshot 2023-02-27 at 09 00 08" src="https://user-images.githubusercontent.com/9430821/221506603-0f12199f-2717-4a0c-aaea-e61d731aeb0c.png">
