### PR TITLE
perf: cork socket before writing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1668,6 +1668,8 @@ class AsyncWriter {
       process.emitWarning(new RequestContentLengthMismatchError())
     }
 
+    socket.cork()
+
     if (bytesWritten === 0) {
       if (!expectsPayload) {
         socket[kReset] = true
@@ -1687,6 +1689,8 @@ class AsyncWriter {
     this.bytesWritten += len
 
     const ret = socket.write(chunk)
+
+    socket.uncork()
 
     request.onBodySent(chunk)
 


### PR DESCRIPTION
Ensures that headers and chunk len + body can be passed in same packet.

Fixes: https://github.com/nodejs/undici/issues/1981