### PR TITLE
fix: correctly calculate resource timing duration

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -297,7 +297,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
   // capability.
   // TODO: given global’s relevant settings object’s cross-origin isolated
   // capability?
-  response.timingInfo.endTime = coarsenedSharedCurrentTime()
+  timingInfo.endTime = coarsenedSharedCurrentTime()
 
   // 10. Set response’s timing info to timingInfo.
   response.timingInfo = timingInfo

--- a/test/fetch/resource-timing.js
+++ b/test/fetch/resource-timing.js
@@ -13,7 +13,7 @@ const {
 const skip = nodeMajor < 18 || (nodeMajor === 18 && nodeMinor < 2)
 
 test('should create a PerformanceResourceTiming after each fetch request', { skip }, (t) => {
-  t.plan(4)
+  t.plan(6)
   const obs = new PerformanceObserver(list => {
     const entries = list.getEntries()
     t.equal(entries.length, 1)
@@ -24,6 +24,9 @@ test('should create a PerformanceResourceTiming after each fetch request', { ski
       protocol: 'http'
     })
     t.strictSame(entry.entryType, 'resource')
+
+    t.ok(entry.duration >= 0)
+    t.ok(entry.startTime >= 0)
 
     obs.disconnect()
     performance.clearResourceTimings()


### PR DESCRIPTION
`duration` for PerformanceResourceTiming` entries is always zero, which causes all resource timing durations to be negative.

example:

```
{
  // ...
  entryType: 'resource',
  startTime: 70.6499160528183,
  duration: -70.6499160528183,
},
```

**root cause**

`duration` is computed from `response.timingInfo.endTime`. `response.timingInfo.endTime` is [computed correctly](https://github.com/nodejs/undici/tree/main#L300) but its value is discarded when [`response.timingInfo` is reassigned](https://github.com/nodejs/undici/tree/main#L303). this causes `createOpaqueTimingInfo`'s [endTime of 0 to be used](https://github.com/nodejs/undici/blob/main/lib/fetch/util.js#L324).