### PR TITLE
Fix: websocket.d.ts - error TS2304: Cannot find name 'MessagePort'

### DIFF
--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import type { MessagePort } from 'worker_threads'
 import {
   EventTarget,
   Event,


### PR DESCRIPTION
Added a missing import statement at the top of the file.