### PR TITLE
enabling `ProxyAgent` take an instance of `Agent` as an option

### DIFF
--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -38,7 +38,6 @@ class ProxyAgent extends DispatcherBase {
   constructor (opts) {
     super(opts)
     this[kProxy] = buildProxyOptions(opts)
-    this[kAgent] = new Agent(opts)
     this[kInterceptors] = opts.interceptors && opts.interceptors.ProxyAgent && Array.isArray(opts.interceptors.ProxyAgent)
       ? opts.interceptors.ProxyAgent
       : []
@@ -51,6 +50,7 @@ class ProxyAgent extends DispatcherBase {
       throw new InvalidArgumentError('Proxy opts.uri is mandatory')
     }
 
+    this[kAgent] = (opts.agent instanceof Agent) ? opts.agent : new Agent(opts)
     this[kRequestTls] = opts.requestTls
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = opts.headers || {}

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -608,6 +608,26 @@ test('Proxy via HTTP to HTTP endpoint', async (t) => {
   proxyAgent.close()
 })
 
+test('ProxyAgent should use provided instance of Agent', (t) => {
+  const agent = new https.Agent({ keepAlive: true })
+
+  const proxyAgent = new ProxyAgent({ agent })
+
+  t.equal(proxyAgent[kAgent], agent, 'ProxyAgent should use provided instance of Agent')
+  t.end()
+  proxyAgent.close()
+})
+
+test('ProxyAgent should create a new instance of Agent if not provided', (t) => {
+  const opts = {}
+ß
+  const proxyAgent = new ProxyAgent(opts)
+
+  t.type(proxyAgent[kAgent], https.Agent, 'ProxyAgent should create a new instance of Agent')
+  t.end()
+  proxyAgent.close()
+})
+
 function buildServer () {
   return new Promise((resolve) => {
     const server = createServer()


### PR DESCRIPTION
In the updated constructor, the `opts` parameter is checked to see if it contains an `agent` property that is an instance of `Agent`. If it is, then the `[kAgent]` is set to the provided instance. Otherwise, a new `Agent` instance is created and assigned to the `[kAgent]`.

fixes: https://github.com/nodejs/undici/issues/1962