### PR TITLE
fix: remove unnecessary WeakRef

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -354,9 +354,8 @@ class Request {
       if (signal.aborted) {
         ac.abort(signal.reason)
       } else {
-        const acRef = new WeakRef(ac)
         const abort = function () {
-          acRef.deref()?.abort(this.reason)
+          ac.abort(this.reason)
         }
 
         if (getEventListeners(signal, 'abort').length >= defaultMaxListeners) {


### PR DESCRIPTION
It's sufficient that the finalizer removes the closure.

Fixes: https://github.com/nodejs/undici/issues/1926