### PR TITLE
Add clientFactory option to ProxyAgent

### DIFF
--- a/docs/api/ProxyAgent.md
+++ b/docs/api/ProxyAgent.md
@@ -19,6 +19,7 @@ Extends: [`AgentOptions`](Agent.md#parameter-agentoptions)
 * **uri** `string` (required) - It can be passed either by a string or a object containing `uri` as string.
 * **token** `string` (optional) - It can be passed by a string of token for authentication.
 * **auth** `string` (**deprecated**) - Use token.
+* **clientFactory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)`
 
 Examples:
 

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -34,6 +34,10 @@ function buildProxyOptions (opts) {
   }
 }
 
+function defaultFactory (origin, opts) {
+  return new Client(origin, opts)
+}
+
 class ProxyAgent extends DispatcherBase {
   constructor (opts) {
     super(opts)
@@ -49,6 +53,12 @@ class ProxyAgent extends DispatcherBase {
 
     if (!opts || !opts.uri) {
       throw new InvalidArgumentError('Proxy opts.uri is mandatory')
+    }
+
+    const { clientFactory = defaultFactory } = opts
+
+    if (typeof clientFactory !== 'function') {
+      throw new InvalidArgumentError('Proxy opts.clientFactory must be a function.')
     }
 
     this[kRequestTls] = opts.requestTls
@@ -69,7 +79,7 @@ class ProxyAgent extends DispatcherBase {
 
     const connect = buildConnector({ ...opts.proxyTls })
     this[kConnectEndpoint] = buildConnector({ ...opts.requestTls })
-    this[kClient] = new Client(resolvedUrl, { connect })
+    this[kClient] = clientFactory(resolvedUrl, { connect })
     this[kAgent] = new Agent({
       ...opts,
       connect: async (opts, callback) => {

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -3,7 +3,7 @@
 const { kProxy, kClose, kDestroy, kInterceptors } = require('./core/symbols')
 const { URL } = require('url')
 const Agent = require('./agent')
-const Client = require('./client')
+const Pool = require('./pool')
 const DispatcherBase = require('./dispatcher-base')
 const { InvalidArgumentError, RequestAbortedError } = require('./core/errors')
 const buildConnector = require('./core/connect')
@@ -35,7 +35,7 @@ function buildProxyOptions (opts) {
 }
 
 function defaultFactory (origin, opts) {
-  return new Client(origin, opts)
+  return new Pool(origin, opts)
 }
 
 class ProxyAgent extends DispatcherBase {

--- a/test/types/proxy-agent.test-d.ts
+++ b/test/types/proxy-agent.test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable } from 'tsd'
 import { URL } from 'url'
-import { ProxyAgent, setGlobalDispatcher, getGlobalDispatcher, Agent } from '../..'
+import { ProxyAgent, setGlobalDispatcher, getGlobalDispatcher, Agent, Pool } from '../..'
 
 expectAssignable<ProxyAgent>(new ProxyAgent(''))
 expectAssignable<ProxyAgent>(new ProxyAgent({ uri: '' }))
@@ -25,7 +25,8 @@ expectAssignable<ProxyAgent>(
       cert: '',
       servername: '',
       timeout: 1
-    }
+    },
+    clientFactory: (origin: URL, opts: object) => new Pool(origin, opts)
   })
 )
 

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -1,7 +1,9 @@
 import Agent from './agent'
 import buildConnector from './connector';
+import Client from './client'
 import Dispatcher from './dispatcher'
 import { IncomingHttpHeaders } from './header'
+import Pool from './pool'
 
 export default ProxyAgent
 
@@ -23,5 +25,6 @@ declare namespace ProxyAgent {
     headers?: IncomingHttpHeaders;
     requestTls?: buildConnector.BuildOptions;
     proxyTls?: buildConnector.BuildOptions;
+    clientFactory?(origin: URL, opts: object): Client | Pool;
   }
 }

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -25,6 +25,6 @@ declare namespace ProxyAgent {
     headers?: IncomingHttpHeaders;
     requestTls?: buildConnector.BuildOptions;
     proxyTls?: buildConnector.BuildOptions;
-    clientFactory?(origin: URL, opts: object): Client | Pool;
+    clientFactory?(origin: URL, opts: object): Dispatcher;
   }
 }


### PR DESCRIPTION
The default use of a Client means that HTTP CONNECT requests to the Proxy will block successive requests. Giving consumers the option to use a Pool ensures that these requests will not block.

fixes: #2001
https://github.com/nodejs/undici/issues/2001