### PR TITLE
Fix typo in kPipelining symbol

### DIFF
--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -41,7 +41,7 @@ module.exports = {
   kClient: Symbol('client'),
   kParser: Symbol('parser'),
   kOnDestroyed: Symbol('destroy callbacks'),
-  kPipelining: Symbol('pipelinig'),
+  kPipelining: Symbol('pipelining'),
   kSocket: Symbol('socket'),
   kHostHeader: Symbol('host header'),
   kConnector: Symbol('connector'),


### PR DESCRIPTION
Noticed this while diving through the code, thought i'd put up a quick fix.