### PR TITLE
fix(fetch): remove `undefined` error cause

### DIFF
--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -348,9 +348,7 @@ function makeNetworkError (reason) {
     status: 0,
     error: isError
       ? reason
-      : new Error(reason ? String(reason) : reason, {
-        cause: isError ? reason : undefined
-      }),
+      : new Error(reason ? String(reason) : reason),
     aborted: reason && reason.name === 'AbortError'
   })
 }


### PR DESCRIPTION
We have checked on the line before that `isError` is falsy, so the cause is always set to `undefined`, which is not very useful.