### PR TITLE
'ReferenceError: AbortSignal is not defined' during jest execution

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -30,6 +30,7 @@ const { URLSerializer } = require('./dataURL')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 const { setMaxListeners, getEventListeners, defaultMaxListeners } = require('events')
+const { AbortSignal } = require('node-abort-controller')
 
 let TransformStream = globalThis.TransformStream
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -30,15 +30,20 @@ const { URLSerializer } = require('./dataURL')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 const { setMaxListeners, getEventListeners, defaultMaxListeners } = require('events')
-const { AbortSignal } = require('node-abort-controller')
 
 let TransformStream = globalThis.TransformStream
+let AbortSignal = global.AbortSignal;
 
 const kInit = Symbol('init')
 
 const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
   signal.removeEventListener('abort', abort)
 })
+
+// Jest removes an AbortSignal from global object. https://github.com/nodejs/undici/issues/1557
+if (typeof AbortSignal === undefined && (process.env.JEST_WORKER_ID || process.env.NODE_ENV === 'test')){
+  AbortSignal = AbortController.AbortSignal
+}
 
 // https://fetch.spec.whatwg.org/#request-class
 class Request {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/node": "^18.0.3",
+    "node-abort-controller": "^3.1.1",
     "abort-controller": "^3.0.0",
     "atomic-sleep": "^1.0.0",
     "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "devDependencies": {
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/node": "^18.0.3",
-    "node-abort-controller": "^3.1.1",
     "abort-controller": "^3.0.0",
     "atomic-sleep": "^1.0.0",
     "chai": "^4.3.4",


### PR DESCRIPTION
Fixes https://github.com/nodejs/undici/issues/1557
