### PR TITLE
test: issue #2026

### DIFF
--- a/test/fetch/issue-2026.js
+++ b/test/fetch/issue-2026.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { cpus } = require('os')
+const { isMainThread, Worker, parentPort } = require('worker_threads')
+const { test } = require('tap')
+const { fetch } = require('../..')
+
+const THREADS = cpus().length - 1
+const ROUNDS = 50
+const PARALLEL_REQUESTS = 6
+
+if (isMainThread) {
+  test('https://github.com/nodejs/undici/issues/2026', async (t) => {
+    let stuckWorkers = 0
+    const timeout = setTimeout(() => {
+      if (stuckWorkers > 0) {
+        t.fail(
+          `Not finished in 40s. ${stuckWorkers} workers finished fetch() calls but cannot exit.`
+        )
+      }
+    }, 40_000)
+
+    async function task (workerId) {
+      const worker = new Worker(__filename)
+
+      await new Promise((resolve) =>
+        worker.on(
+          'message',
+          (message) => message === 'FETCH_FINISHED' && resolve()
+        )
+      )
+
+      const timer = setTimeout(() => {
+        stuckWorkers++
+        console.error(`Unable to terminate worker #${workerId}`)
+      }, 10_000)
+      await worker.terminate()
+      clearTimeout(timer)
+    }
+
+    const pool = Array(ROUNDS).fill(task)
+
+    async function execute () {
+      const task = pool.shift()
+
+      if (task) {
+        await task(ROUNDS - pool.length)
+        return execute()
+      }
+    }
+
+    await Promise.all(
+      Array(THREADS)
+        .fill(execute)
+        .map((task) => task())
+    )
+
+    clearTimeout(timeout)
+  })
+} else {
+  const urls = [
+    new URL('/v4/starlink', 'https://api.spacexdata.com'),
+    new URL(
+      '/v4/starlink/5eed770f096e59000698560d',
+      'https://api.spacexdata.com'
+    )
+  ]
+
+  const count = Math.round(PARALLEL_REQUESTS / urls.length)
+  const requests = Array(count)
+    .fill(urls.map((url) => fetch(url).then((r) => r.json())))
+    .flat()
+
+  Promise.all(requests).then(() => parentPort.postMessage('FETCH_FINISHED'))
+}


### PR DESCRIPTION
- Failing test case for #2026

![image](https://user-images.githubusercontent.com/14806298/228467131-56bc8749-8cfd-4a43-884a-830130d0d95b.png)

Example of failure on CI: https://github.com/AriPerkkio/undici/actions/runs/4551514748/jobs/8025677893#step:14:12832


Somehow `tap` is able to kill the process even though workers cannot terminate. I'm not sure how it does that as the reproduction case of #2026 cannot exit main thread even when it calls `process.exit()`.

Replace `fetch` with `request` and test case will pass.

```diff
const requests = Array(count)
-  .fill(urls.map((url) => fetch(url).then((r) => r.json())))
+  .fill(urls.map((url) => request(url).then((r) => r.body.json())))
```

