### PR TITLE
fetch: treat content-encoding as case-insensitive & remove x-deflate

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1984,7 +1984,9 @@ async function httpNetworkFetch (
             const val = headersList[n + 1].toString('latin1')
 
             if (key.toLowerCase() === 'content-encoding') {
-              codings = val.split(',').map((x) => x.trim())
+              // https://www.rfc-editor.org/rfc/rfc7231#section-3.1.2.1
+              // "All content-coding values are case-insensitive..."
+              codings = val.toLowerCase().split(',').map((x) => x.trim())
             } else if (key.toLowerCase() === 'location') {
               location = val
             }
@@ -2003,9 +2005,10 @@ async function httpNetworkFetch (
           // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
           if (request.method !== 'HEAD' && request.method !== 'CONNECT' && !nullBodyStatus.includes(status) && !willFollow) {
             for (const coding of codings) {
-              if (/(x-)?gzip/.test(coding)) {
+              // https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2
+              if (coding === 'x-gzip' || coding === 'gzip') {
                 decoders.push(zlib.createGunzip())
-              } else if (/(x-)?deflate/.test(coding)) {
+              } else if (coding === 'deflate') {
                 decoders.push(zlib.createInflate())
               } else if (coding === 'br') {
                 decoders.push(zlib.createBrotliDecompress())

--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { test } = require('tap')
+const { createServer } = require('http')
+const { once } = require('events')
+const { fetch } = require('../..')
+const { createBrotliCompress, createGzip } = require('zlib')
+
+test('content-encoding header is case-iNsENsITIve', async (t) => {
+  const contentCodings = 'GZiP, bR'
+  const text = 'Hello, World!'
+
+  const server = createServer((req, res) => {
+    const gzip = createGzip()
+    const brotli = createBrotliCompress()
+
+    res.setHeader('Content-Encoding', contentCodings)
+    res.setHeader('Content-Type', 'text/plain')
+
+    brotli.pipe(gzip).pipe(res)
+
+    brotli.write(text)
+    brotli.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const response = await fetch(`http://localhost:${server.address().port}`)
+
+  t.equal(await response.text(), text)
+  t.equal(response.headers.get('content-encoding'), contentCodings)
+})


### PR DESCRIPTION
RFC 7231 says that content-condings should be treated as case-insensitive.

I also removed x-deflate support because it doesn't seem to be an official content-coding, feel free to correct me if I'm wrong.

Also removes the regexes that would match invalid codings such as `agzip` etc., although I think this was caught elsewhere as the bodies weren't being decompressed from my testing.