### PR TITLE
perf: remove unnecessary c++ call with url.format

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -26,7 +26,6 @@ const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm } = require('./symbols')
 const { webidl } = require('./webidl')
 const { getGlobalOrigin } = require('./global')
-const { URLSerializer } = require('./dataURL')
 const { kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 const { setMaxListeners, getEventListeners, defaultMaxListeners } = require('events')
@@ -524,7 +523,7 @@ class Request {
     webidl.brandCheck(this, Request)
 
     // The url getter steps are to return this’s request’s URL, serialized.
-    return URLSerializer(this[kState].url)
+    return this[kState].url.toString()
   }
 
   // Returns a Headers object consisting of the headers associated with request.

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -117,7 +117,7 @@ class Response {
     responseObject[kState].status = status
 
     // 6. Let value be parsedURL, serialized and isomorphic encoded.
-    const value = isomorphicEncode(URLSerializer(parsedURL))
+    const value = isomorphicEncode(parsedURL.toString())
 
     // 7. Append `Location`/value to responseObject’s response’s header list.
     responseObject[kState].headersList.append('location', value)


### PR DESCRIPTION
Before

```
[bench:run] │ undici - fetch      │       1 │ 1506.39 req/sec │  ± 0.00 % │               + 12.58 % │
```

After

```
[bench:run] │ undici - fetch      │       1 │ 1562.92 req/sec │  ± 0.00 % │                       - │
```