### PR TITLE
fix(types): Add missing Blob import

### DIFF
--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import type { Blob } from 'buffer'
 import type { MessagePort } from 'worker_threads'
 import {
   EventTarget,


### PR DESCRIPTION
This stops TypeScript from complaining:
```
error TS2304: Cannot find name 'Blob'.
```