### PR TITLE
fix: set window option properly

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -133,7 +133,7 @@ class Request {
     }
 
     // 11. If init["window"] exists, then set window to "no-window".
-    if (init.window === null) {
+    if (window in init) {
       window = 'no-window'
     }
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -133,7 +133,7 @@ class Request {
     }
 
     // 11. If init["window"] exists, then set window to "no-window".
-    if (window in init) {
+    if ('window' in init) {
       window = 'no-window'
     }
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -133,7 +133,7 @@ class Request {
     }
 
     // 11. If init["window"] exists, then set window to "no-window".
-    if (init.window !== undefined) {
+    if (init.window === null) {
       window = 'no-window'
     }
 

--- a/test/fetch/407-statuscode-window-null.js
+++ b/test/fetch/407-statuscode-window-null.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { fetch } = require('../..')
+const { createServer } = require('http')
+const { once } = require('events')
+const { test } = require('tap')
+
+test('Receiving a 407 status code w/ a window option present should reject', async (t) => {
+  const server = createServer((req, res) => {
+    res.statusCode = 407
+    res.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  // if init.window exists, the spec tells us to set request.window to 'no-window',
+  // which later causes the request to be rejected if the status code is 407
+  await t.rejects(fetch(`http://localhost:${server.address().port}`, { window: null }))
+})


### PR DESCRIPTION
The line above we check that it's either null (only valid option) or undefined (missing), so for it to exist, it must be `null` here.