### PR TITLE
test: skip content-disposition test in node 18

### DIFF
--- a/test/issue-1903.js
+++ b/test/issue-1903.js
@@ -13,7 +13,7 @@ function createPromise () {
   return result
 }
 
-test('should parse content-disposition consistently', { skip: nodeMajor >= 19 }, async (t) => {
+test('should parse content-disposition consistently', { skip: nodeMajor >= 18 }, async (t) => {
   t.plan(5)
 
   // create promise to allow server spinup in parallel


### PR DESCRIPTION
I guess the behavior got backported so now this test fails in some v18 versions as well.

Refs: https://github.com/nodejs/undici/actions/runs/4757580670/jobs/8454569794