### PR TITLE
test: remove --experimental-wasm-simd

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -5,4 +5,3 @@ coverage: false
 expose-gc: true
 timeout: 60
 check-coverage: false
-node-arg: --experimental-wasm-simd

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bench": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench:run",
     "bench:server": "node benchmarks/server.js",
     "prebench:run": "node benchmarks/wait.js",
-    "bench:run": "CONNECTIONS=1 node --experimental-wasm-simd benchmarks/benchmark.js; CONNECTIONS=50 node --experimental-wasm-simd benchmarks/benchmark.js",
+    "bench:run": "CONNECTIONS=1 node benchmarks/benchmark.js; CONNECTIONS=50 node benchmarks/benchmark.js",
     "serve:website": "docsify serve .",
     "prepare": "husky install",
     "fuzz": "jsfuzz test/fuzzing/fuzz.js corpus"


### PR DESCRIPTION
Fixes: #2086

Allows the tests to run in node v20, but a bunch of them are still failing.