### PR TITLE
websocket: add websocketinit

### DIFF
--- a/docs/api/WebSocket.md
+++ b/docs/api/WebSocket.md
@@ -1,17 +1,40 @@
 # Class: WebSocket
 
-> ⚠️ Warning: the WebSocket API is experimental and has known bugs.
+> ⚠️ Warning: the WebSocket API is experimental.
 
 Extends: [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
 
-The WebSocket object provides a way to manage a WebSocket connection to a server, allowing bidirectional communication. The API follows the [WebSocket spec](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
+The WebSocket object provides a way to manage a WebSocket connection to a server, allowing bidirectional communication. The API follows the [WebSocket spec](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) and [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455).
 
 ## `new WebSocket(url[, protocol])`
 
 Arguments:
 
 * **url** `URL | string` - The url's protocol *must* be `ws` or `wss`.
-* **protocol** `string | string[]` (optional) - Subprotocol(s) to request the server use. 
+* **protocol** `string | string[] | WebSocketInit` (optional) - Subprotocol(s) to request the server use, or a [`Dispatcher`](./Dispatcher.md).
+
+### Example:
+
+This example will not work in browsers or other platforms that don't allow passing an object.
+
+```mjs
+import { WebSocket, ProxyAgent } from 'undici'
+
+const proxyAgent = new ProxyAgent('my.proxy.server')
+
+const ws = new WebSocket('wss://echo.websocket.events', {
+  dispatcher: proxyAgent,
+  protocols: ['echo', 'chat']
+})
+```
+
+If you do not need a custom Dispatcher, it's recommended to use the following pattern:
+
+```mjs
+import { WebSocket } from 'undici'
+
+const ws = new WebSocket('wss://echo.websocket.events', ['echo', 'chat'])
+```
 
 ## Read More
 

--- a/lib/websocket/connection.js
+++ b/lib/websocket/connection.js
@@ -13,6 +13,7 @@ const { fireEvent, failWebsocketConnection } = require('./util')
 const { CloseEvent } = require('./events')
 const { makeRequest } = require('../fetch/request')
 const { fetching } = require('../fetch/index')
+const { getGlobalDispatcher } = require('../global')
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -25,6 +26,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
  * @param {string|string[]} protocols
  * @param {import('./websocket').WebSocket} ws
  * @param {(response: any) => void} onEstablish
+ * @param {Partial<import('../../types/websocket').WebSocketInit>} options
  */
 function establishWebSocketConnection (url, protocols, ws, onEstablish, options) {
   // 1. Let requestURL be a copy of url, with its scheme set to "http", if url’s
@@ -87,7 +89,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
   const controller = fetching({
     request,
     useParallelQueue: true,
-    dispatcher: options.dispatcher,
+    dispatcher: options.dispatcher ?? getGlobalDispatcher(),
     processResponse (response) {
       // 1. If response is a network error or its status is not 101,
       //    fail the WebSocket connection.

--- a/lib/websocket/connection.js
+++ b/lib/websocket/connection.js
@@ -13,7 +13,6 @@ const { fireEvent, failWebsocketConnection } = require('./util')
 const { CloseEvent } = require('./events')
 const { makeRequest } = require('../fetch/request')
 const { fetching } = require('../fetch/index')
-const { getGlobalDispatcher } = require('../global')
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -27,7 +26,7 @@ channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error
  * @param {import('./websocket').WebSocket} ws
  * @param {(response: any) => void} onEstablish
  */
-function establishWebSocketConnection (url, protocols, ws, onEstablish) {
+function establishWebSocketConnection (url, protocols, ws, onEstablish, options) {
   // 1. Let requestURL be a copy of url, with its scheme set to "http", if url’s
   //    scheme is "ws", and to "https" otherwise.
   const requestURL = url
@@ -88,7 +87,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish) {
   const controller = fetching({
     request,
     useParallelQueue: true,
-    dispatcher: getGlobalDispatcher(),
+    dispatcher: options.dispatcher,
     processResponse (response) {
       // 1. If response is a network error or its status is not 101,
       //    fail the WebSocket connection.

--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -40,7 +40,7 @@ class WebSocket extends EventTarget {
    * @param {string} url
    * @param {string|string[]} protocols
    */
-  constructor (url, protocols = [], options = undefined) {
+  constructor (url, protocols = []) {
     super()
 
     webidl.argumentLengthCheck(arguments, 1, { header: 'WebSocket constructor' })
@@ -52,20 +52,10 @@ class WebSocket extends EventTarget {
       })
     }
 
-    url = webidl.converters.USVString(url)
-    protocols = webidl.converters['DOMString or sequence<DOMString> or WebSocketInit'](protocols)
+    const options = webidl.converters['DOMString or sequence<DOMString> or WebSocketInit'](protocols)
 
-    // user passed a WebSocketInit as 2nd argument
-    if (!Array.isArray(protocols) && typeof protocols === 'object') {
-      options = protocols
-      protocols = protocols.protocols
-    } else {
-      if (options != null && typeof options === 'object') {
-        options = webidl.converters.WebSocketInit(options)
-      } else {
-        options = webidl.converters.WebSocketInit({})
-      }
-    }
+    url = webidl.converters.USVString(url)
+    protocols = options.protocols
 
     // 1. Let urlRecord be the result of applying the URL parser to url.
     let urlRecord
@@ -614,7 +604,7 @@ webidl.converters['DOMString or sequence<DOMString> or WebSocketInit'] = functio
     return webidl.converters.WebSocketInit(V)
   }
 
-  return webidl.converters['DOMString or sequence<DOMString>'](V)
+  return { protocols: webidl.converters['DOMString or sequence<DOMString>'](V) }
 }
 
 webidl.converters.WebSocketSendData = function (V) {

--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -18,6 +18,7 @@ const { establishWebSocketConnection } = require('./connection')
 const { WebsocketFrameSend } = require('./frame')
 const { ByteParser } = require('./receiver')
 const { kEnumerableProperty, isBlobLike } = require('../core/util')
+const { getGlobalDispatcher } = require('../global')
 const { types } = require('util')
 
 let experimentalWarned = false
@@ -39,7 +40,7 @@ class WebSocket extends EventTarget {
    * @param {string} url
    * @param {string|string[]} protocols
    */
-  constructor (url, protocols = []) {
+  constructor (url, protocols = [], options = undefined) {
     super()
 
     webidl.argumentLengthCheck(arguments, 1, { header: 'WebSocket constructor' })
@@ -52,7 +53,19 @@ class WebSocket extends EventTarget {
     }
 
     url = webidl.converters.USVString(url)
-    protocols = webidl.converters['DOMString or sequence<DOMString>'](protocols)
+    protocols = webidl.converters['DOMString or sequence<DOMString> or WebSocketInit'](protocols)
+
+    // user passed a WebSocketInit as 2nd argument
+    if (!Array.isArray(protocols) && typeof protocols === 'object') {
+      options = protocols
+      protocols = protocols.protocols
+    } else {
+      if (options != null && typeof options === 'object') {
+        options = webidl.converters.WebSocketInit(options)
+      } else {
+        options = webidl.converters.WebSocketInit({})
+      }
+    }
 
     // 1. Let urlRecord be the result of applying the URL parser to url.
     let urlRecord
@@ -110,7 +123,8 @@ class WebSocket extends EventTarget {
       urlRecord,
       protocols,
       this,
-      (response) => this.#onConnectionEstablished(response)
+      (response) => this.#onConnectionEstablished(response),
+      options
     )
 
     // Each WebSocket object has an associated ready state, which is a
@@ -575,6 +589,32 @@ webidl.converters['DOMString or sequence<DOMString>'] = function (V) {
   }
 
   return webidl.converters.DOMString(V)
+}
+
+// This implements the propsal made in https://github.com/whatwg/websockets/issues/42
+webidl.converters.WebSocketInit = webidl.dictionaryConverter([
+  {
+    key: 'protocols',
+    converter: webidl.converters['DOMString or sequence<DOMString>'],
+    get defaultValue () {
+      return []
+    }
+  },
+  {
+    key: 'dispatcher',
+    converter: (V) => V,
+    get defaultValue () {
+      return getGlobalDispatcher()
+    }
+  }
+])
+
+webidl.converters['DOMString or sequence<DOMString> or WebSocketInit'] = function (V) {
+  if (webidl.util.Type(V) === 'Object' && !(Symbol.iterator in V)) {
+    return webidl.converters.WebSocketInit(V)
+  }
+
+  return webidl.converters['DOMString or sequence<DOMString>'](V)
 }
 
 webidl.converters.WebSocketSendData = function (V) {

--- a/test/websocket/websocketinit.js
+++ b/test/websocket/websocketinit.js
@@ -5,7 +5,7 @@ const { WebSocketServer } = require('ws')
 const { WebSocket, Dispatcher, Agent } = require('../..')
 
 test('WebSocketInit', (t) => {
-  t.plan(4)
+  t.plan(2)
 
   class WsDispatcher extends Dispatcher {
     constructor () {
@@ -33,36 +33,6 @@ test('WebSocketInit', (t) => {
     const ws = new WebSocket(`ws://localhost:${server.address().port}`, {
       dispatcher: new WsDispatcher()
     })
-
-    ws.onerror = t.fail
-
-    ws.addEventListener('message', async (event) => {
-      t.equal(await event.data.text(), 'hello, world')
-      server.close()
-      ws.close()
-    })
-  })
-
-  t.test('WebSocketInit as 3rd param', (t) => {
-    t.plan(1)
-
-    const server = new WebSocketServer({ port: 0 })
-
-    server.on('connection', (ws) => {
-      ws.send(Buffer.from('hello, world'))
-    })
-
-    t.teardown(server.close.bind(server))
-
-    const ws = new WebSocket(
-      `ws://localhost:${server.address().port}`,
-      undefined,
-      {
-        dispatcher: new WsDispatcher()
-      }
-    )
-
-    console.log(ws)
 
     ws.onerror = t.fail
 

--- a/test/websocket/websocketinit.js
+++ b/test/websocket/websocketinit.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { test } = require('tap')
+const { WebSocketServer } = require('ws')
+const { WebSocket, Dispatcher, Agent } = require('../..')
+
+test('WebSocketInit', (t) => {
+  t.plan(4)
+
+  class WsDispatcher extends Dispatcher {
+    constructor () {
+      super()
+      this.agent = new Agent()
+    }
+
+    dispatch () {
+      t.pass()
+      return this.agent.dispatch(...arguments)
+    }
+  }
+
+  t.test('WebSocketInit as 2nd param', (t) => {
+    t.plan(1)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.send(Buffer.from('hello, world'))
+    })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`, {
+      dispatcher: new WsDispatcher()
+    })
+
+    ws.onerror = t.fail
+
+    ws.addEventListener('message', async (event) => {
+      t.equal(await event.data.text(), 'hello, world')
+      server.close()
+      ws.close()
+    })
+  })
+
+  t.test('WebSocketInit as 3rd param', (t) => {
+    t.plan(1)
+
+    const server = new WebSocketServer({ port: 0 })
+
+    server.on('connection', (ws) => {
+      ws.send(Buffer.from('hello, world'))
+    })
+
+    t.teardown(server.close.bind(server))
+
+    const ws = new WebSocket(
+      `ws://localhost:${server.address().port}`,
+      undefined,
+      {
+        dispatcher: new WsDispatcher()
+      }
+    )
+
+    console.log(ws)
+
+    ws.onerror = t.fail
+
+    ws.addEventListener('message', async (event) => {
+      t.equal(await event.data.text(), 'hello, world')
+      server.close()
+      ws.close()
+    })
+  })
+})

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -10,6 +10,7 @@ import {
   AddEventListenerOptions,
   EventListenerOrEventListenerObject
 } from './patch'
+import Dispatcher from './dispatcher'
 
 export type BinaryType = 'blob' | 'arraybuffer'
 
@@ -67,7 +68,7 @@ interface WebSocket extends EventTarget {
 
 export declare const WebSocket: {
   prototype: WebSocket
-  new (url: string | URL, protocols?: string | string[]): WebSocket
+  new (url: string | URL, protocols?: string | string[] | WebSocketInit, options?: WebSocketInit): WebSocket
   readonly CLOSED: number
   readonly CLOSING: number
   readonly CONNECTING: number
@@ -120,4 +121,9 @@ interface MessageEvent<T = any> extends Event {
 export declare const MessageEvent: {
   prototype: MessageEvent
   new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>
+}
+
+interface WebSocketInit {
+  protocols?: string | string[],
+  dispatcher?: Dispatcher
 }

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -68,7 +68,7 @@ interface WebSocket extends EventTarget {
 
 export declare const WebSocket: {
   prototype: WebSocket
-  new (url: string | URL, protocols?: string | string[] | WebSocketInit, options?: WebSocketInit): WebSocket
+  new (url: string | URL, protocols?: string | string[] | WebSocketInit): WebSocket
   readonly CLOSED: number
   readonly CLOSING: number
   readonly CONNECTING: number


### PR DESCRIPTION
Refs: https://github.com/nodejs/undici/issues/1811#issuecomment-1518940816

This allows someone to supply an options bag to the WebSocket constructor :
```js
const ws = new WebSocket('ws://whatever', {
  dispatcher: new MyCustomDispatcher(),
  protocols: ['chat', 'echo']
})
```

Allowing it as the second param matches Bun and a proposal by a Deno maintainer (not implemented in Deno to my knowledge). Browsers (specifically Chrome) have no interest in expanding the spec to allow an options bag so this is the only way one will be added. The spec is unfortunately very limited, for both browser & server environments, so we do need to add this for any chance of having a useful WebSocket implementation.