### PR TITLE
feat(websocket): allow setting custom headers

### DIFF
--- a/lib/websocket/connection.js
+++ b/lib/websocket/connection.js
@@ -13,7 +13,9 @@ const { fireEvent, failWebsocketConnection } = require('./util')
 const { CloseEvent } = require('./events')
 const { makeRequest } = require('../fetch/request')
 const { fetching } = require('../fetch/index')
+const { Headers } = require('../fetch/headers')
 const { getGlobalDispatcher } = require('../global')
+const { kHeadersList } = require('../core/symbols')
 
 const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
@@ -48,6 +50,13 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
     cache: 'no-store',
     redirect: 'error'
   })
+
+  // Note: undici extension, allow setting custom headers.
+  if (options.headers) {
+    const headersList = new Headers(options.headers)[kHeadersList]
+
+    request.headersList = headersList
+  }
 
   // 3. Append (`Upgrade`, `websocket`) to request’s header list.
   // 4. Append (`Connection`, `Upgrade`) to request’s header list.

--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -596,6 +596,10 @@ webidl.converters.WebSocketInit = webidl.dictionaryConverter([
     get defaultValue () {
       return getGlobalDispatcher()
     }
+  },
+  {
+    key: 'headers',
+    converter: webidl.nullableConverter(webidl.converters.HeadersInit)
   }
 ])
 

--- a/test/websocket/custom-headers.js
+++ b/test/websocket/custom-headers.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('tap')
+const assert = require('assert')
+const { Agent, WebSocket } = require('../..')
+
+test('Setting custom headers', (t) => {
+  t.plan(1)
+
+  const headers = {
+    'x-khafra-hello': 'hi',
+    Authorization: 'Bearer base64orsomethingitreallydoesntmatter'
+  }
+
+  class TestAgent extends Agent {
+    dispatch (options) {
+      t.match(options.headers, headers)
+
+      return false
+    }
+  }
+
+  const ws = new WebSocket('wss://echo.websocket.events', {
+    headers,
+    dispatcher: new TestAgent()
+  })
+
+  // We don't want to make a request, just ensure the headers are set.
+  ws.onclose = ws.onerror = ws.onmessage = assert.fail
+})

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -11,6 +11,7 @@ import {
   EventListenerOrEventListenerObject
 } from './patch'
 import Dispatcher from './dispatcher'
+import { HeadersInit } from './fetch'
 
 export type BinaryType = 'blob' | 'arraybuffer'
 
@@ -125,5 +126,6 @@ export declare const MessageEvent: {
 
 interface WebSocketInit {
   protocols?: string | string[],
-  dispatcher?: Dispatcher
+  dispatcher?: Dispatcher,
+  headers?: HeadersInit
 }


### PR DESCRIPTION
Refs: https://bun.sh/docs/api/websockets#connect-to-a-websocket-server

This is easier than intercepting headers via dispatcher. Also matches bun's api.
