### PR TITLE
webidl: implement resizable arraybuffer checks

### DIFF
--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -536,7 +536,12 @@ webidl.converters.ArrayBuffer = function (V, opts = {}) {
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V) is true, then throw a
   //    TypeError.
-  // Note: resizable ArrayBuffers are currently a proposal.
+  if (V.resizable || V.growable) {
+    throw webidl.errors.exception({
+      header: 'ArrayBuffer',
+      message: 'Received a resizable ArrayBuffer.'
+    })
+  }
 
   // 4. Return the IDL ArrayBuffer value that is a
   //    reference to the same object as V.
@@ -576,7 +581,12 @@ webidl.converters.TypedArray = function (V, T, opts = {}) {
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
   //    true, then throw a TypeError.
-  // Note: resizable array buffers are currently a proposal
+  if (V.buffer.resizable || V.buffer.growable) {
+    throw webidl.errors.exception({
+      header: 'ArrayBuffer',
+      message: 'Received a resizable ArrayBuffer.'
+    })
+  }
 
   // 5. Return the IDL value of type T that is a reference
   //    to the same object as V.
@@ -608,7 +618,12 @@ webidl.converters.DataView = function (V, opts = {}) {
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
   //    true, then throw a TypeError.
-  // Note: resizable ArrayBuffers are currently a proposal
+  if (V.buffer.resizable || V.buffer.growable) {
+    throw webidl.errors.exception({
+      header: 'ArrayBuffer',
+      message: 'Received a resizable ArrayBuffer.'
+    })
+  }
 
   // 4. Return the IDL DataView value that is a reference
   //    to the same object as V.


### PR DESCRIPTION
With node 20 we got access to the resizable ArrayBuffer proposal, so now these steps can be added.

Refs: https://github.com/tc39/proposal-resizablearraybuffer