### PR TITLE
feat: add message to fetch failed error

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -224,7 +224,10 @@ async function fetch (input, init = {}) {
     // and terminate these substeps.
     if (response.type === 'error') {
       p.reject(
-        Object.assign(new TypeError('fetch failed'), { cause: response.error })
+        Object.assign(new TypeError('fetch failed'), {
+          cause: response.error,
+          message: 'fetch failed due to a network error'
+        })
       )
       return
     }


### PR DESCRIPTION
The `fetch failed` error is annoying to hit and little information is provided if the response error is unhelpful. This should help point the user in the right direction if they don't think to check the source. 