### PR TITLE
doc: update outdated command in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ npm i
 > This requires [docker](https://www.docker.com/) installed on your machine.
 
 ```bash
-npm run build:wasm
+npm run build-wasm
 ```
 
 #### Copy the sources to `undici`


### PR DESCRIPTION
llhttp no longer has `npm run build:wasm`

https://github.com/nodejs/llhttp/blob/c0f4e754b75c033fd3bd2018c8f3ffb673d43d90/package.json#L16