### PR TITLE
cache: fix most failing WPTs

### DIFF
--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -575,7 +575,7 @@ class Cache {
   }
 
   /**
-   * @see https://w3c.github.io/ServiceWorker/#batch-cache-operations
+   * @see https://w3c.github.io/ServiceWorker/#batch-cache-operations-algorithm
    * @param {CacheBatchOperation[]} operations
    * @returns {requestResponseList}
    */
@@ -746,11 +746,9 @@ class Cache {
     //   return false
     // }
 
-    /** @type {URL} */
-    const queryURL = requestQuery.url
+    const queryURL = new URL(requestQuery.url)
 
-    /** @type {URL} */
-    const cachedURL = request.url
+    const cachedURL = new URL(request.url)
 
     if (options?.ignoreSearch) {
       cachedURL.search = ''

--- a/test/wpt/status/service-workers/cache-storage.status.json
+++ b/test/wpt/status/service-workers/cache-storage.status.json
@@ -11,38 +11,13 @@
       "note": "probably can be fixed",
       "fail": [
         "Cache.put with a VARY:* opaque response should not reject",
-        "Cache.put with opaque-filtered HTTP 206 response",
-        "Cache.put with a relative URL"
+        "Cache.put with opaque-filtered HTTP 206 response"
       ]
     },
     "cache-match.https.any.js": {
       "note": "requires https server",
       "fail": [
-        "cors-exposed header should be stored correctly.",
-        "Cache.match ignores vary headers on opaque response."
-      ]
-    },
-    "cache-delete.https.any.js": {
-      "note": "spec bug? - https://github.com/w3c/ServiceWorker/issues/1677 (first fail)",
-      "fail": [
-        "Cache.delete with ignoreSearch option (when it is specified as false)"
-      ]
-    },
-    "cache-keys.https.any.js": {
-      "note": "probably can be fixed",
-      "fail": [
-        "Cache.keys with ignoreSearch option (request with search parameters)",
-        "Cache.keys without parameters",
-        "Cache.keys with explicitly undefined request"
-      ]
-    },
-    "cache-matchAll.https.any.js": {
-      "note": "probably can be fixed",
-      "fail": [
-        "Cache.matchAll with ignoreSearch option (request with search parameters)",
-        "Cache.matchAll without parameters",
-        "Cache.matchAll with explicitly undefined request",
-        "Cache.matchAll with explicitly undefined request and empty options"
+        "cors-exposed header should be stored correctly."
       ]
     }
   }


### PR DESCRIPTION
Before:
```
[service-workers/cache-storage]: Completed: 103, failed: 11, success: 92, expected failures: 11, unexpected failures: 0, skipped: 2
```

After:
```
[service-workers/cache-storage]: Completed: 103, failed: 3, success: 100, expected failures: 3, unexpected failures: 0, skipped: 2
```

You would not believe how many hours this took 😭

The spec doesn't mention that the URLs need to be copied, even though they might be mutated... 
![image](https://user-images.githubusercontent.com/42794878/235208250-7fa4f615-3f33-41e4-a7e8-b3ffc2f37142.png)
