### PR TITLE
websocket: use dataview

### DIFF
--- a/lib/websocket/frame.js
+++ b/lib/websocket/frame.js
@@ -43,7 +43,7 @@ class WebsocketFrameSend {
     buffer[1] = payloadLength
 
     if (payloadLength === 126) {
-      buffer.writeUInt16BE(bodyLength, 2)
+      new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength).setUint16(2, bodyLength)
     } else if (payloadLength === 127) {
       // Clear extended payload length
       buffer[2] = buffer[3] = 0


### PR DESCRIPTION
We use a dataview here for performance reasons. I should have addressed this in #2106 but I did not.

Refs: https://github.com/nodejs/performance/issues/2