### PR TITLE
fix: make assertion a noop

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1494,9 +1494,11 @@ function writeStream ({ body, client, request, socket, contentLength, header, ex
   const writer = new AsyncWriter({ socket, request, contentLength, client, expectsPayload, header })
 
   const onData = function (chunk) {
-    try {
-      assert(!finished)
+    if (finished) {
+      return
+    }
 
+    try {
       if (!writer.write(chunk) && this.pause) {
         this.pause()
       }
@@ -1505,7 +1507,9 @@ function writeStream ({ body, client, request, socket, contentLength, header, ex
     }
   }
   const onDrain = function () {
-    assert(!finished)
+    if (finished) {
+      return
+    }
 
     if (body.resume) {
       body.resume()


### PR DESCRIPTION
Not sure how this can occur. I'm guessing if 'finished' and 'drain' are both queued then onDrain will be invoked even though event listeners have been removed.

Fixes: https://github.com/nodejs/undici/issues/2109