### PR TITLE
added tracing channels on fetch

### DIFF
--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -202,3 +202,75 @@ diagnosticsChannel.channel('undici:websocket:pong').subscribe(({ payload }) => {
   console.log(payload)
 })
 ```
+
+[TracingChannel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) is used to trace `fetch` (currently available only on Node.js v19+).
+
+## `tracing:undici:start`
+
+This message is published after `fetch` has been called.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
+  console.log('url', input)
+  console.log('init', init)
+})
+```
+
+## `tracing:undici:asyncStart`
+
+This message is published after `fetch` resolves.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('response', result)
+})
+```
+
+## `tracing:undici:end`
+
+This message is published after `fetch` has been called.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('error', error)
+})
+```
+
+## `tracing:undici:asyncEnd`
+
+This message is published after `fetch` resolves.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(({ input, init, result, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('response', result)
+  // error should be undefined
+})
+```
+
+## `tracing:undici:error`
+
+This message is published when an error is thrown or promise rejects while calling `fetch`.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:error').subscribe(({ input, init, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('error', error)
+})
+```

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -62,6 +62,7 @@ const { TransformStream } = require('stream/web')
 const { getGlobalDispatcher } = require('../global')
 const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('http')
+const diagnosticsChannel = require('diagnostics_channel')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -122,7 +123,6 @@ class Fetch extends EE {
 
 let tracingChannel
 try {
-  const diagnosticsChannel = require('diagnostics_channel')
   tracingChannel = diagnosticsChannel.tracingChannel('undici')
 } catch {
   tracingChannel.start = { hasSubscribers: false }

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -120,137 +120,151 @@ class Fetch extends EE {
   }
 }
 
+let tracingChannel
+try {
+  const diagnosticsChannel = require('diagnostics_channel')
+  tracingChannel = diagnosticsChannel.tracingChannel('undici')
+} catch {
+  tracingChannel.start = { hasSubscribers: false }
+  tracingChannel.end = { hasSubscribers: false }
+  tracingChannel.asyncStart = { hasSubscribers: false }
+  tracingChannel.asyncEnd = { hasSubscribers: false }
+  tracingChannel.error = { hasSubscribers: false }
+}
+
 // https://fetch.spec.whatwg.org/#fetch-method
 async function fetch (input, init = {}) {
-  webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+  return tracingChannel.tracePromise(() => {
+    webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
 
-  // 1. Let p be a new promise.
-  const p = createDeferredPromise()
+    // 1. Let p be a new promise.
+    const p = createDeferredPromise()
 
-  // 2. Let requestObject be the result of invoking the initial value of
-  // Request as constructor with input and init as arguments. If this throws
-  // an exception, reject p with it and return p.
-  let requestObject
+    // 2. Let requestObject be the result of invoking the initial value of
+    // Request as constructor with input and init as arguments. If this throws
+    // an exception, reject p with it and return p.
+    let requestObject
 
-  try {
-    requestObject = new Request(input, init)
-  } catch (e) {
-    p.reject(e)
-    return p.promise
-  }
+    try {
+      requestObject = new Request(input, init)
+    } catch (e) {
+      p.reject(e)
+      return p.promise
+    }
 
-  // 3. Let request be requestObject’s request.
-  const request = requestObject[kState]
+    // 3. Let request be requestObject’s request.
+    const request = requestObject[kState]
 
-  // 4. If requestObject’s signal’s aborted flag is set, then:
-  if (requestObject.signal.aborted) {
-    // 1. Abort the fetch() call with p, request, null, and
-    //    requestObject’s signal’s abort reason.
-    abortFetch(p, request, null, requestObject.signal.reason)
+    // 4. If requestObject’s signal’s aborted flag is set, then:
+    if (requestObject.signal.aborted) {
+      // 1. Abort the fetch() call with p, request, null, and
+      //    requestObject’s signal’s abort reason.
+      abortFetch(p, request, null, requestObject.signal.reason)
 
-    // 2. Return p.
-    return p.promise
-  }
+      // 2. Return p.
+      return p.promise
+    }
 
-  // 5. Let globalObject be request’s client’s global object.
-  const globalObject = request.client.globalObject
+    // 5. Let globalObject be request’s client’s global object.
+    const globalObject = request.client.globalObject
 
-  // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-  // request’s service-workers mode to "none".
-  if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
-    request.serviceWorkers = 'none'
-  }
+    // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
+    // request’s service-workers mode to "none".
+    if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
+      request.serviceWorkers = 'none'
+    }
 
-  // 7. Let responseObject be null.
-  let responseObject = null
+    // 7. Let responseObject be null.
+    let responseObject = null
 
-  // 8. Let relevantRealm be this’s relevant Realm.
-  const relevantRealm = null
+    // 8. Let relevantRealm be this’s relevant Realm.
+    const relevantRealm = null
 
-  // 9. Let locallyAborted be false.
-  let locallyAborted = false
+    // 9. Let locallyAborted be false.
+    let locallyAborted = false
 
-  // 10. Let controller be null.
-  let controller = null
+    // 10. Let controller be null.
+    let controller = null
 
-  // 11. Add the following abort steps to requestObject’s signal:
-  requestObject.signal.addEventListener(
-    'abort',
-    () => {
-      // 1. Set locallyAborted to true.
-      locallyAborted = true
+    // 11. Add the following abort steps to requestObject’s signal:
+    requestObject.signal.addEventListener(
+      'abort',
+      () => {
+        // 1. Set locallyAborted to true.
+        locallyAborted = true
 
-      // 2. Abort the fetch() call with p, request, responseObject,
-      //    and requestObject’s signal’s abort reason.
-      abortFetch(p, request, responseObject, requestObject.signal.reason)
+        // 2. Abort the fetch() call with p, request, responseObject,
+        //    and requestObject’s signal’s abort reason.
+        abortFetch(p, request, responseObject, requestObject.signal.reason)
 
-      // 3. If controller is not null, then abort controller.
-      if (controller != null) {
-        controller.abort()
+        // 3. If controller is not null, then abort controller.
+        if (controller != null) {
+          controller.abort()
+        }
+      },
+      { once: true }
+    )
+
+    // 12. Let handleFetchDone given response response be to finalize and
+    // report timing with response, globalObject, and "fetch".
+    const handleFetchDone = (response) =>
+      finalizeAndReportTiming(response, 'fetch')
+
+    // 13. Set controller to the result of calling fetch given request,
+    // with processResponseEndOfBody set to handleFetchDone, and processResponse
+    // given response being these substeps:
+
+    const processResponse = (response) => {
+      // 1. If locallyAborted is true, terminate these substeps.
+      if (locallyAborted) {
+        return
       }
-    },
-    { once: true }
-  )
 
-  // 12. Let handleFetchDone given response response be to finalize and
-  // report timing with response, globalObject, and "fetch".
-  const handleFetchDone = (response) =>
-    finalizeAndReportTiming(response, 'fetch')
+      // 2. If response’s aborted flag is set, then:
+      if (response.aborted) {
+        // 1. Let deserializedError be the result of deserialize a serialized
+        //    abort reason given controller’s serialized abort reason and
+        //    relevantRealm.
 
-  // 13. Set controller to the result of calling fetch given request,
-  // with processResponseEndOfBody set to handleFetchDone, and processResponse
-  // given response being these substeps:
+        // 2. Abort the fetch() call with p, request, responseObject, and
+        //    deserializedError.
 
-  const processResponse = (response) => {
-    // 1. If locallyAborted is true, terminate these substeps.
-    if (locallyAborted) {
-      return
+        abortFetch(p, request, responseObject, controller.serializedAbortReason)
+        return
+      }
+
+      // 3. If response is a network error, then reject p with a TypeError
+      // and terminate these substeps.
+      if (response.type === 'error') {
+        p.reject(
+          Object.assign(new TypeError('fetch failed'), { cause: response.error })
+        )
+        return
+      }
+
+      // 4. Set responseObject to the result of creating a Response object,
+      // given response, "immutable", and relevantRealm.
+      responseObject = new Response()
+      responseObject[kState] = response
+      responseObject[kRealm] = relevantRealm
+      responseObject[kHeaders][kHeadersList] = response.headersList
+      responseObject[kHeaders][kGuard] = 'immutable'
+      responseObject[kHeaders][kRealm] = relevantRealm
+
+      // 5. Resolve p with responseObject.
+      p.resolve(responseObject)
     }
 
-    // 2. If response’s aborted flag is set, then:
-    if (response.aborted) {
-      // 1. Let deserializedError be the result of deserialize a serialized
-      //    abort reason given controller’s serialized abort reason and
-      //    relevantRealm.
+    controller = fetching({
+      request,
+      processResponseEndOfBody: handleFetchDone,
+      processResponse,
+      dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+    })
 
-      // 2. Abort the fetch() call with p, request, responseObject, and
-      //    deserializedError.
-
-      abortFetch(p, request, responseObject, controller.serializedAbortReason)
-      return
-    }
-
-    // 3. If response is a network error, then reject p with a TypeError
-    // and terminate these substeps.
-    if (response.type === 'error') {
-      p.reject(
-        Object.assign(new TypeError('fetch failed'), { cause: response.error })
-      )
-      return
-    }
-
-    // 4. Set responseObject to the result of creating a Response object,
-    // given response, "immutable", and relevantRealm.
-    responseObject = new Response()
-    responseObject[kState] = response
-    responseObject[kRealm] = relevantRealm
-    responseObject[kHeaders][kHeadersList] = response.headersList
-    responseObject[kHeaders][kGuard] = 'immutable'
-    responseObject[kHeaders][kRealm] = relevantRealm
-
-    // 5. Resolve p with responseObject.
-    p.resolve(responseObject)
-  }
-
-  controller = fetching({
-    request,
-    processResponseEndOfBody: handleFetchDone,
-    processResponse,
-    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
-  })
-
-  // 14. Return p.
-  return p.promise
+    // 14. Return p.
+    return p.promise
+  }, { input, init })
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/test/diagnostics-channel/fetch.js
+++ b/test/diagnostics-channel/fetch.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const t = require('tap')
+const fetch = require('../..').fetch
+
+let diagnosticsChannel
+
+try {
+  diagnosticsChannel = require('diagnostics_channel')
+} catch {
+  t.skip('missing diagnostics_channel')
+  process.exit(0)
+}
+
+const { createServer } = require('http')
+
+t.plan(35)
+
+const server = createServer((req, res) => {
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('trailer', 'foo')
+  res.write('hello')
+  res.addTrailers({
+    foo: 'oof'
+  })
+  res.end()
+})
+t.teardown(server.close.bind(server))
+
+let startCalled = 0
+diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
+  startCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+})
+
+let endCalled = 0
+diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, result, error }) => {
+  endCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+  t.notOk(result)
+  t.notOk(error)
+})
+
+let asyncStartCalled = 0
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init }) => {
+  asyncStartCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+})
+
+let asyncEndCalled = 0
+diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(async ({ input, init, result, error }) => {
+  asyncEndCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+    t.notOk(result)
+    t.ok(error)
+    t.equal(error.cause.code, 'ERR_INVALID_URL')
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+    t.ok(result)
+    t.equal(result.status, 200)
+    t.notOk(error)
+  }
+})
+
+let errorCalled = 0
+diagnosticsChannel.channel('tracing:undici:error').subscribe(async ({ input, init, error }) => {
+  errorCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+    t.ok(error)
+    t.equal(error.cause.code, 'ERR_INVALID_URL')
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+    t.notOk(error)
+  }
+})
+
+server.listen(0, async () => {
+  await fetch(`http://localhost:${server.address().port}`)
+  try {
+    await fetch('badrequest', { redirect: 'error' })
+  } catch (e) {}
+  server.close()
+  t.equal(startCalled, 2)
+  t.equal(endCalled, 2)
+  t.equal(asyncStartCalled, 2)
+  t.equal(asyncEndCalled, 2)
+  t.equal(errorCalled, 1)
+})

--- a/test/diagnostics-channel/fetch.js
+++ b/test/diagnostics-channel/fetch.js
@@ -14,7 +14,7 @@ try {
 
 const { createServer } = require('http')
 
-t.plan(35)
+t.plan(37)
 
 const server = createServer((req, res) => {
   res.setHeader('Content-Type', 'text/plain')
@@ -54,14 +54,16 @@ diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, resul
 })
 
 let asyncStartCalled = 0
-diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init }) => {
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
   asyncStartCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
     t.same(init, { redirect: 'error' })
+    t.notOk(result)
   } else {
     t.equal(input, `http://localhost:${server.address().port}`)
     t.same(init, {})
+    t.ok(result)
   }
 })
 


### PR DESCRIPTION
We added tracing channels on fetch to support fetch instrumentation. The [channels](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) added emit the following events:

- tracing:undici:start emits input (url) and init settings
- tracing:undici:end emits input (url), init settings and error
- tracing:undici:asyncStart emits input (url), init settings, result (response) and error
- tracing:undici:asyncEnd emits input (url), init settings, result (response) and error

Use case: APM tools could provide support for fetch by using the tracing channels.