### PR TITLE
fix: reverse decompression order of "Content-Encoding" encodings (fixes #2158)

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1986,7 +1986,7 @@ async function httpNetworkFetch (
             if (key.toLowerCase() === 'content-encoding') {
               // https://www.rfc-editor.org/rfc/rfc7231#section-3.1.2.1
               // "All content-coding values are case-insensitive..."
-              codings = val.toLowerCase().split(',').map((x) => x.trim())
+              codings = val.toLowerCase().split(',').map((x) => x.trim()).reverse()
             } else if (key.toLowerCase() === 'location') {
               location = val
             }

--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { createServer } = require('http')
 const { once } = require('events')
 const { fetch } = require('../..')
-const { createBrotliCompress, createGzip } = require('zlib')
+const { createBrotliCompress, createGzip, createDeflate } = require('zlib')
 
 test('content-encoding header is case-iNsENsITIve', async (t) => {
   const contentCodings = 'GZiP, bR'
@@ -17,10 +17,10 @@ test('content-encoding header is case-iNsENsITIve', async (t) => {
     res.setHeader('Content-Encoding', contentCodings)
     res.setHeader('Content-Type', 'text/plain')
 
-    brotli.pipe(gzip).pipe(res)
+    gzip.pipe(brotli).pipe(res)
 
-    brotli.write(text)
-    brotli.end()
+    gzip.write(text)
+    gzip.end()
   }).listen(0)
 
   t.teardown(server.close.bind(server))
@@ -30,4 +30,29 @@ test('content-encoding header is case-iNsENsITIve', async (t) => {
 
   t.equal(await response.text(), text)
   t.equal(response.headers.get('content-encoding'), contentCodings)
+})
+
+test('response decompression according to content-encoding should be handled in a correct order', async (t) => {
+  const contentCodings = 'deflate, gzip'
+  const text = 'Hello, World!'
+
+  const server = createServer((req, res) => {
+    const gzip = createGzip()
+    const deflate = createDeflate()
+
+    res.setHeader('Content-Encoding', contentCodings)
+    res.setHeader('Content-Type', 'text/plain')
+
+    deflate.pipe(gzip).pipe(res)
+
+    deflate.write(text)
+    deflate.end()
+  }).listen(0)
+
+  t.teardown(server.close.bind(server))
+  await once(server, 'listening')
+
+  const response = await fetch(`http://localhost:${server.address().port}`)
+
+  t.equal(await response.text(), text)
 })


### PR DESCRIPTION
## This relates to...

#2158 

## Rationale

It fixes #2158

## Changes

I'v reversed the order decompressors that get applied to response body

### Features

N/A

### Bug Fixes

fixes #2158

### Breaking Changes and Deprecations

No breaking changes 

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
