### PR TITLE
fix: keep running WPTs if a test times out

### DIFF
--- a/test/wpt/runner/runner.mjs
+++ b/test/wpt/runner/runner.mjs
@@ -228,19 +228,15 @@ export class WPTRunner extends EventEmitter {
           if (variant) console.log('Variant:', variant)
           console.log(`Test took ${(performance.now() - start).toFixed(2)}ms`)
           console.log('='.repeat(96))
-
+        } catch (e) {
+          console.log(`${test} timed out after ${timeout}ms`)
+        } finally {
           if (result?.subtests.length > 0) {
             writeFileSync(this.#reportPath, JSON.stringify(report))
           }
 
           finishedFiles++
           activeWorkers.delete(worker)
-        } catch (e) {
-          console.log(`${test} timed out after ${timeout}ms`)
-          queueMicrotask(() => {
-            throw e
-          })
-          return
         }
       }
     }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/actions/runs/5295407475/jobs/9585718577#step:16:390

@panva told me about this.

(also fixes a small memory leak when a test times out)