### PR TITLE
chore: Renable autoSelectFamily tests.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 16.8
       exclude: |
         - runs-on: windows-latest
+          node-version: 14
+        - runs-on: windows-latest
           node-version: 16
   automerge:
     if: >


### PR DESCRIPTION
## This relates to...

* #2096 - See 

## Rationale

`autoSelectFamily` issues should have been fixed in Node 20.3.0 and 20.4.0 so it makes sense to reenable tests.

## Changes

In `test/autoselectfamily.js`:

* All tests are enabled by default.
* The entire file is skipped if the Node version does not supported `autoSelectFamily`.
* All tests specified `autoSelectFamily` property explicitly to avoid incompatibilities between Node release lines.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A
## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
