### PR TITLE
stricter types for bodymixin.json

### DIFF
--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -119,5 +119,5 @@ declare const { body }: Dispatcher.ResponseData;
   expectType<Promise<Blob>>(body.blob())
   expectType<Promise<never>>(body.formData())
   expectType<Promise<string>>(body.text())
-  expectType<Promise<any>>(body.json())
+  expectType<Promise<unknown>>(body.json())
 }

--- a/test/types/readable.test-d.ts
+++ b/test/types/readable.test-d.ts
@@ -15,7 +15,7 @@ expectAssignable<BodyReadable>(new BodyReadable())
   expectAssignable<Promise<string>>(readable.text())
 
   // json
-  expectAssignable<Promise<any>>(readable.json())
+  expectAssignable<Promise<unknown>>(readable.json())
 
   // blob
   expectAssignable<Promise<Blob>>(readable.blob())

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -229,7 +229,7 @@ declare namespace Dispatcher {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<never>;
-    json(): Promise<any>;
+    json(): Promise<unknown>;
     text(): Promise<string>;
   }
 

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -18,7 +18,7 @@ declare class BodyReadable extends Readable {
   /** Consumes and returns the body as a JavaScript Object
    *  https://fetch.spec.whatwg.org/#dom-body-json
    */
-  json(): Promise<any>
+  json(): Promise<unknown>
 
   /** Consumes and returns the body as a Blob
    *  https://fetch.spec.whatwg.org/#dom-body-blob


### PR DESCRIPTION
When we first added types for these methods, I thought it would have been best to follow the official DOM types. Since then, I learned that the DOM types are garbage, and that using unknown would have been the better choice. When types were added for fetch (or soon thereafter), `.json()` was changed to use unknown instead of any, providing much better type safety.

IMO this is not a major change, ignoring that it is a types-only change, and someone can revert to using the old `any` behavior very easily:
```diff
- const value = await body.json()
+ const value: any = await body.json()
```
