### PR TITLE
change `statusCode` to `status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ The benchmarks below have the [simd](https://github.com/WebAssembly/simd) featur
 import { request } from 'undici'
 
 const {
-  statusCode,
+  status,
   headers,
   trailers,
   body
 } = await request('http://localhost:3000/foo')
 
-console.log('response received', statusCode)
+console.log('response received', status)
 console.log('headers', headers)
 
 for await (const data of body) {
@@ -79,13 +79,13 @@ Example usage:
 import { request } from 'undici'
 
 const {
-  statusCode,
+  status,
   headers,
   trailers,
   body
 } = await request('http://localhost:3000/foo')
 
-console.log('response received', statusCode)
+console.log('response received', status)
 console.log('headers', headers)
 console.log('data', await body.json())
 console.log('trailers', trailers)


### PR DESCRIPTION
I dont see `statusCode` in the request. Instead I see `status`:
![image](https://github.com/nodejs/undici/assets/92968534/8dc4641c-c41a-4074-ab39-49fb065ca6c1)

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
