### PR TITLE
fix: fetch resource timing performance entry names should be strings

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -320,7 +320,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
 // https://w3c.github.io/resource-timing/#dfn-mark-resource-timing
 function markResourceTiming (timingInfo, originalURL, initiatorType, globalThis, cacheState) {
   if (nodeMajor > 18 || (nodeMajor === 18 && nodeMinor >= 2)) {
-    performance.markResourceTiming(timingInfo, originalURL.toString(), initiatorType, globalThis, cacheState)
+    performance.markResourceTiming(timingInfo, originalURL.href, initiatorType, globalThis, cacheState)
   }
 }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -320,7 +320,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
 // https://w3c.github.io/resource-timing/#dfn-mark-resource-timing
 function markResourceTiming (timingInfo, originalURL, initiatorType, globalThis, cacheState) {
   if (nodeMajor > 18 || (nodeMajor === 18 && nodeMinor >= 2)) {
-    performance.markResourceTiming(timingInfo, originalURL, initiatorType, globalThis, cacheState)
+    performance.markResourceTiming(timingInfo, originalURL.toString(), initiatorType, globalThis, cacheState)
   }
 }
 

--- a/test/fetch/resource-timing.js
+++ b/test/fetch/resource-timing.js
@@ -13,21 +13,23 @@ const {
 const skip = nodeMajor < 18 || (nodeMajor === 18 && nodeMinor < 2)
 
 test('should create a PerformanceResourceTiming after each fetch request', { skip }, (t) => {
-  t.plan(6)
+  t.plan(8)
 
   const obs = new PerformanceObserver(list => {
+    const expectedResourceEntryName = `http://localhost:${server.address().port}/`
+
     const entries = list.getEntries()
     t.equal(entries.length, 1)
     const [entry] = entries
-    t.same(entry.name, {
-      href: `http://localhost:${server.address().port}/`,
-      origin: `http://localhost:${server.address().port}`,
-      protocol: 'http'
-    })
+    t.same(entry.name, expectedResourceEntryName)
     t.strictSame(entry.entryType, 'resource')
 
     t.ok(entry.duration >= 0)
     t.ok(entry.startTime >= 0)
+
+    const entriesByName = list.getEntriesByName(expectedResourceEntryName)
+    t.equal(entriesByName.length, 1)
+    t.strictSame(entriesByName[0], entry)
 
     obs.disconnect()
     performance.clearResourceTimings()


### PR DESCRIPTION
The performance resource timings api expects the name parameter to be a string. Undici's fetch implementation is currently passing a URL object when calling `markResourceTiming`. This is outside the spec and makes it impossible to call `getEntriesByName(name)` to find the performance entry for a given url.

The fix is simple and I added a test to verify `getEntriesByName` can find the performance entries created by undici.

References:
- https://nodejs.org/docs/latest-v18.x/api/perf_hooks.html#performancemarkresourcetimingtiminginfo-requestedurl-initiatortype-global-cachemode - `requestedUrl` should be a `string`
- https://w3c.github.io/resource-timing/#dfn-requested-url - `A PerformanceResourceTiming has an associated DOMString requested URL.`
- https://www.w3.org/TR/performance-timeline/#the-performanceentry-interface - `PerformanceEntry.name` should be a `DOMString`.
