### PR TITLE
fix: make multipart/form-data boundary string more consistent

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -105,7 +105,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-${Math.random()}`.replace('.', '').slice(0, 32)
+    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -726,7 +726,7 @@ test('request with FormData body', { skip: nodeMajor < 16 }, (t) => {
   const server = createServer(async (req, res) => {
     const contentType = req.headers['content-type']
     // ensure we received a multipart/form-data header
-    t.ok(/^multipart\/form-data; boundary=-+formdata-undici-0.\d+$/.test(contentType))
+    t.ok(/^multipart\/form-data; boundary=-+formdata-undici-0\d+$/.test(contentType))
 
     const chunks = []
 


### PR DESCRIPTION
Stringifying `Math.random()` value directly sometimes produces very short boundary string.
Also there is an extreme corner case of it returning exactly `0.0`.