### PR TITLE
Added diagnostics channels on fetch

### DIFF
--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -266,8 +266,8 @@ if (process.env.PORT) {
     })
   }
 
-  experiments['undici - fetch (with tracing channel)'] = () => {
-    diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(() => {})
+  experiments['undici - fetch (with diagnostics channel)'] = () => {
+    diagnosticsChannel.channel('undici:fetch:asyncEnd').subscribe(() => {})
     return makeParallelRequests(resolve => {
       fetch(dest.url).then(res => {
         res.body.pipeTo(new WritableStream({ write () {}, close () { resolve() } }))

--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -203,73 +203,74 @@ diagnosticsChannel.channel('undici:websocket:pong').subscribe(({ payload }) => {
 })
 ```
 
-[TracingChannel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) is used to trace `fetch` (currently available only on Node.js v19+).
+The below channels collectively act as [`tracingChannel.tracePromise`](https://nodejs.org/api/diagnostics_channel.html#tracingchanneltracepromisefn-context-thisarg-args) on `fetch`. So all of them will publish the arguments passed to `fetch`.
 
-## `tracing:undici:start`
+## `undici:fetch:start`
 
-This message is published after `fetch` has been called.
+This message is published when `fetch` is called, and will publish the arguments passed to `fetch`.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
-  console.log('url', input)
+diagnosticsChannel.channel('undici:fetch:start').subscribe(({ input, init }) => {
+  console.log('input', input)
   console.log('init', init)
 })
 ```
 
-## `tracing:undici:asyncStart`
+## `undici:fetch:end`
 
-This message is published after `fetch` resolves.
+This message is published at the end of `fetch`'s execution, and will publish any `error` from the synchronous part of `fetch`. Since `fetch` is asynchronous, this should be empty. This channel will publish the same values as `undici:fetch:start`, but we are including it to track when `fetch` finishes execution and to be consistent with [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel).
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
-  console.log('url', input)
+diagnosticsChannel.channel('undici:fetch:end').subscribe(({ input, init, error }) => {
+  console.log('input', input)
+  console.log('init', init)
+  console.log('error', error) // should be empty
+})
+```
+
+## `undici:fetch:asyncStart`
+
+This message is published after `fetch` resolves or rejects. If `fetch` resolves, it publishes the response in `result`. If it rejects, it publishes the error in `error`.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:fetch:asyncStart').subscribe(({ input, init, result, error }) => {
+  console.log('input', input)
   console.log('init', init)
   console.log('response', result)
-})
-```
-
-## `tracing:undici:end`
-
-This message is published after `fetch` has been called.
-
-```js
-import diagnosticsChannel from 'diagnostics_channel'
-
-diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, error }) => {
-  console.log('url', input)
-  console.log('init', init)
   console.log('error', error)
 })
 ```
 
-## `tracing:undici:asyncEnd`
+## `undici:fetch:asyncEnd`
 
-This message is published after `fetch` resolves.
+This channel gets published the same values as and at the same time as `undici:fetch:asyncStart` in the case of [`tracingChannel.tracePromise`](https://nodejs.org/api/diagnostics_channel.html#tracingchanneltracepromisefn-context-thisarg-args)
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(({ input, init, result, error }) => {
-  console.log('url', input)
+diagnosticsChannel.channel('undici:fetch:asyncEnd').subscribe(({ input, init, result, error }) => {
+  console.log('input', input)
   console.log('init', init)
   console.log('response', result)
-  // error should be undefined
+  console.log('error', error)
 })
 ```
 
-## `tracing:undici:error`
+## `undici:fetch:error`
 
 This message is published when an error is thrown or promise rejects while calling `fetch`.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('tracing:undici:error').subscribe(({ input, init, error }) => {
-  console.log('url', input)
+diagnosticsChannel.channel('undici:fetch:error').subscribe(({ input, init, error }) => {
+  console.log('input', input)
   console.log('init', init)
   console.log('error', error)
 })

--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -202,3 +202,75 @@ diagnosticsChannel.channel('undici:websocket:pong').subscribe(({ payload }) => {
   console.log(payload)
 })
 ```
+
+[TracingChannel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) is used to trace `fetch` (currently available only on Node.js v19+).
+
+## `tracing:undici:start`
+
+This message is published after `fetch` has been called.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
+  console.log('url', input)
+  console.log('init', init)
+})
+```
+
+## `tracing:undici:asyncStart`
+
+This message is published after `fetch` resolves.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('response', result)
+})
+```
+
+## `tracing:undici:end`
+
+This message is published after `fetch` has been called.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('error', error)
+})
+```
+
+## `tracing:undici:asyncEnd`
+
+This message is published after `fetch` resolves.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(({ input, init, result, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('response', result)
+  // error should be undefined
+})
+```
+
+## `tracing:undici:error`
+
+This message is published when an error is thrown or promise rejects while calling `fetch`.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('tracing:undici:error').subscribe(({ input, init, error }) => {
+  console.log('url', input)
+  console.log('init', init)
+  console.log('error', error)
+})
+```

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -61,8 +61,6 @@ const { TransformStream } = require('stream/web')
 const { getGlobalDispatcher } = require('../global')
 const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('http')
-const diagnosticsChannel = require('diagnostics_channel')
-const { start } = require('repl')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -163,140 +161,134 @@ function createDeferredPromise (context) {
 
 // https://fetch.spec.whatwg.org/#fetch-method
 async function fetch (input, init = {}) {
-    webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+  webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
 
-    // 1. Let p be a new promise.
-    const p = createDeferredPromise({ input: input, init: init })
+  // 1. Let p be a new promise.
+  const p = createDeferredPromise({ input, init })
 
-    // 2. Let requestObject be the result of invoking the initial value of
-    // Request as constructor with input and init as arguments. If this throws
-    // an exception, reject p with it and return p.
-    let requestObject
+  // 2. Let requestObject be the result of invoking the initial value of
+  // Request as constructor with input and init as arguments. If this throws
+  // an exception, reject p with it and return p.
+  let requestObject
 
-    try {
-      requestObject = new Request(input, init)
-    } catch (e) {
-      p.reject(e)
-      return p.promise
-    }
-
-    // 3. Let request be requestObject’s request.
-    const request = requestObject[kState]
-
-    // 4. If requestObject’s signal’s aborted flag is set, then:
-    if (requestObject.signal.aborted) {
-      // 1. Abort the fetch() call with p, request, null, and
-      //    requestObject’s signal’s abort reason.
-      abortFetch(p, request, null, requestObject.signal.reason)
-
-      // 2. Return p.
-      return p.promise
-    }
-
-    // 5. Let globalObject be request’s client’s global object.
-    const globalObject = request.client.globalObject
-
-    // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-    // request’s service-workers mode to "none".
-    if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
-      request.serviceWorkers = 'none'
-    }
-
-    // 7. Let responseObject be null.
-    let responseObject = null
-
-    // 8. Let relevantRealm be this’s relevant Realm.
-    const relevantRealm = null
-
-    // 9. Let locallyAborted be false.
-    let locallyAborted = false
-
-    // 10. Let controller be null.
-    let controller = null
-
-    // 11. Add the following abort steps to requestObject’s signal:
-    requestObject.signal.addEventListener(
-      'abort',
-      () => {
-        // 1. Set locallyAborted to true.
-        locallyAborted = true
-
-        // 2. Abort the fetch() call with p, request, responseObject,
-        //    and requestObject’s signal’s abort reason.
-        abortFetch(p, request, responseObject, requestObject.signal.reason)
-
-        // 3. If controller is not null, then abort controller.
-        if (controller != null) {
-          controller.abort()
-        }
-      },
-      { once: true }
-    )
-
-    // 12. Let handleFetchDone given response response be to finalize and
-    // report timing with response, globalObject, and "fetch".
-    const handleFetchDone = (response) =>
-      finalizeAndReportTiming(response, 'fetch')
-
-    // 13. Set controller to the result of calling fetch given request,
-    // with processResponseEndOfBody set to handleFetchDone, and processResponse
-    // given response being these substeps:
-
-    const processResponse = (response) => {
-      // 1. If locallyAborted is true, terminate these substeps.
-      if (locallyAborted) {
-        return
-      }
-
-      // 2. If response’s aborted flag is set, then:
-      if (response.aborted) {
-        // 1. Let deserializedError be the result of deserialize a serialized
-        //    abort reason given controller’s serialized abort reason and
-        //    relevantRealm.
-
-        // 2. Abort the fetch() call with p, request, responseObject, and
-        //    deserializedError.
-
-        abortFetch(p, request, responseObject, controller.serializedAbortReason)
-        return
-      }
-
-      // 3. If response is a network error, then reject p with a TypeError
-      // and terminate these substeps.
-      if (response.type === 'error') {
-        const error = Object.assign(new TypeError('fetch failed'), { cause: response.error })
-        p.reject(error)
-        return
-      }
-
-      // 4. Set responseObject to the result of creating a Response object,
-      // given response, "immutable", and relevantRealm.
-      responseObject = new Response()
-      responseObject[kState] = response
-      responseObject[kRealm] = relevantRealm
-      responseObject[kHeaders][kHeadersList] = response.headersList
-      responseObject[kHeaders][kGuard] = 'immutable'
-      responseObject[kHeaders][kRealm] = relevantRealm
-
-      // 5. Resolve p with responseObject.
-      p.resolve(responseObject)
-    }
-
-    controller = fetching({
-      request,
-      processResponseEndOfBody: handleFetchDone,
-      processResponse,
-      dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
-    })
-
-    // 14. Return p.
+  try {
+    requestObject = new Request(input, init)
+  } catch (e) {
+    p.reject(e)
     return p.promise
-}
+  }
 
-function fetchWrapper() {
-  start
-  PromisePrototypeThen(fetch, resolve, reject);
-  end
+  // 3. Let request be requestObject’s request.
+  const request = requestObject[kState]
+
+  // 4. If requestObject’s signal’s aborted flag is set, then:
+  if (requestObject.signal.aborted) {
+    // 1. Abort the fetch() call with p, request, null, and
+    //    requestObject’s signal’s abort reason.
+    abortFetch(p, request, null, requestObject.signal.reason)
+
+    // 2. Return p.
+    return p.promise
+  }
+
+  // 5. Let globalObject be request’s client’s global object.
+  const globalObject = request.client.globalObject
+
+  // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
+  // request’s service-workers mode to "none".
+  if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
+    request.serviceWorkers = 'none'
+  }
+
+  // 7. Let responseObject be null.
+  let responseObject = null
+
+  // 8. Let relevantRealm be this’s relevant Realm.
+  const relevantRealm = null
+
+  // 9. Let locallyAborted be false.
+  let locallyAborted = false
+
+  // 10. Let controller be null.
+  let controller = null
+
+  // 11. Add the following abort steps to requestObject’s signal:
+  requestObject.signal.addEventListener(
+    'abort',
+    () => {
+      // 1. Set locallyAborted to true.
+      locallyAborted = true
+
+      // 2. Abort the fetch() call with p, request, responseObject,
+      //    and requestObject’s signal’s abort reason.
+      abortFetch(p, request, responseObject, requestObject.signal.reason)
+
+      // 3. If controller is not null, then abort controller.
+      if (controller != null) {
+        controller.abort()
+      }
+    },
+    { once: true }
+  )
+
+  // 12. Let handleFetchDone given response response be to finalize and
+  // report timing with response, globalObject, and "fetch".
+  const handleFetchDone = (response) =>
+    finalizeAndReportTiming(response, 'fetch')
+
+  // 13. Set controller to the result of calling fetch given request,
+  // with processResponseEndOfBody set to handleFetchDone, and processResponse
+  // given response being these substeps:
+
+  const processResponse = (response) => {
+    // 1. If locallyAborted is true, terminate these substeps.
+    if (locallyAborted) {
+      return
+    }
+
+    // 2. If response’s aborted flag is set, then:
+    if (response.aborted) {
+      // 1. Let deserializedError be the result of deserialize a serialized
+      //    abort reason given controller’s serialized abort reason and
+      //    relevantRealm.
+
+      // 2. Abort the fetch() call with p, request, responseObject, and
+      //    deserializedError.
+
+      abortFetch(p, request, responseObject, controller.serializedAbortReason)
+      return
+    }
+
+    // 3. If response is a network error, then reject p with a TypeError
+    // and terminate these substeps.
+    if (response.type === 'error') {
+      const error = Object.assign(new TypeError('fetch failed'), { cause: response.error })
+      p.reject(error)
+      return
+    }
+
+    // 4. Set responseObject to the result of creating a Response object,
+    // given response, "immutable", and relevantRealm.
+    responseObject = new Response()
+    responseObject[kState] = response
+    responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders][kHeadersList] = response.headersList
+    responseObject[kHeaders][kGuard] = 'immutable'
+    responseObject[kHeaders][kRealm] = relevantRealm
+
+    // 5. Resolve p with responseObject.
+    p.resolve(responseObject)
+  }
+
+  controller = fetching({
+    request,
+    processResponseEndOfBody: handleFetchDone,
+    processResponse,
+    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+  })
+
+  // 14. Return p.
+  return p.promise
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -62,6 +62,7 @@ const { TransformStream } = require('stream/web')
 const { getGlobalDispatcher } = require('../global')
 const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('http')
+const diagnosticsChannel = require('diagnostics_channel')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -122,7 +123,6 @@ class Fetch extends EE {
 
 let tracingChannel
 try {
-  const diagnosticsChannel = require('diagnostics_channel')
   tracingChannel = diagnosticsChannel.tracingChannel('undici')
 } catch {
   tracingChannel.start = { hasSubscribers: false }

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -137,7 +137,6 @@ try {
 }
 
 function createDeferredPromise (context) {
-  if (channels.start.hasSubscribers) channels.start.publish(context)
   let res
   let rej
   const promise = new Promise((resolve, reject) => {
@@ -155,140 +154,143 @@ function createDeferredPromise (context) {
       reject(error)
     }
   })
-  if (channels.end.hasSubscribers) channels.end.publish(context)
   return { promise, resolve: res, reject: rej }
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
-async function fetch (input, init = {}) {
-  webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+function fetch (input, init = {}) {
+  const context = { input, init }
+  if (channels.start.hasSubscribers) channels.start.publish(context)
+  const promise = async (context) => {
+    webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+    // 1. Let p be a new promise.
+    const p = createDeferredPromise(context)
 
-  // 1. Let p be a new promise.
-  const p = createDeferredPromise({ input, init })
+    // 2. Let requestObject be the result of invoking the initial value of
+    // Request as constructor with input and init as arguments. If this throws
+    // an exception, reject p with it and return p.
+    let requestObject
 
-  // 2. Let requestObject be the result of invoking the initial value of
-  // Request as constructor with input and init as arguments. If this throws
-  // an exception, reject p with it and return p.
-  let requestObject
+    try {
+      requestObject = new Request(input, init)
+    } catch (e) {
+      p.reject(e)
+      return p.promise
+    }
 
-  try {
-    requestObject = new Request(input, init)
-  } catch (e) {
-    p.reject(e)
-    return p.promise
-  }
+    // 3. Let request be requestObject’s request.
+    const request = requestObject[kState]
 
-  // 3. Let request be requestObject’s request.
-  const request = requestObject[kState]
+    // 4. If requestObject’s signal’s aborted flag is set, then:
+    if (requestObject.signal.aborted) {
+      // 1. Abort the fetch() call with p, request, null, and
+      //    requestObject’s signal’s abort reason.
+      abortFetch(p, request, null, requestObject.signal.reason)
 
-  // 4. If requestObject’s signal’s aborted flag is set, then:
-  if (requestObject.signal.aborted) {
-    // 1. Abort the fetch() call with p, request, null, and
-    //    requestObject’s signal’s abort reason.
-    abortFetch(p, request, null, requestObject.signal.reason)
+      // 2. Return p.
+      return p.promise
+    }
 
-    // 2. Return p.
-    return p.promise
-  }
+    // 5. Let globalObject be request’s client’s global object.
+    const globalObject = request.client.globalObject
 
-  // 5. Let globalObject be request’s client’s global object.
-  const globalObject = request.client.globalObject
+    // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
+    // request’s service-workers mode to "none".
+    if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
+      request.serviceWorkers = 'none'
+    }
 
-  // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-  // request’s service-workers mode to "none".
-  if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
-    request.serviceWorkers = 'none'
-  }
+    // 7. Let responseObject be null.
+    let responseObject = null
 
-  // 7. Let responseObject be null.
-  let responseObject = null
+    // 8. Let relevantRealm be this’s relevant Realm.
+    const relevantRealm = null
 
-  // 8. Let relevantRealm be this’s relevant Realm.
-  const relevantRealm = null
+    // 9. Let locallyAborted be false.
+    let locallyAborted = false
 
-  // 9. Let locallyAborted be false.
-  let locallyAborted = false
+    // 10. Let controller be null.
+    let controller = null
 
-  // 10. Let controller be null.
-  let controller = null
+    // 11. Add the following abort steps to requestObject’s signal:
+    requestObject.signal.addEventListener(
+      'abort',
+      () => {
+        // 1. Set locallyAborted to true.
+        locallyAborted = true
 
-  // 11. Add the following abort steps to requestObject’s signal:
-  requestObject.signal.addEventListener(
-    'abort',
-    () => {
-      // 1. Set locallyAborted to true.
-      locallyAborted = true
+        // 2. Abort the fetch() call with p, request, responseObject,
+        //    and requestObject’s signal’s abort reason.
+        abortFetch(p, request, responseObject, requestObject.signal.reason)
 
-      // 2. Abort the fetch() call with p, request, responseObject,
-      //    and requestObject’s signal’s abort reason.
-      abortFetch(p, request, responseObject, requestObject.signal.reason)
+        // 3. If controller is not null, then abort controller.
+        if (controller != null) {
+          controller.abort()
+        }
+      },
+      { once: true }
+    )
 
-      // 3. If controller is not null, then abort controller.
-      if (controller != null) {
-        controller.abort()
+    // 12. Let handleFetchDone given response response be to finalize and
+    // report timing with response, globalObject, and "fetch".
+    const handleFetchDone = (response) =>
+      finalizeAndReportTiming(response, 'fetch')
+
+    // 13. Set controller to the result of calling fetch given request,
+    // with processResponseEndOfBody set to handleFetchDone, and processResponse
+    // given response being these substeps:
+
+    const processResponse = (response) => {
+      // 1. If locallyAborted is true, terminate these substeps.
+      if (locallyAborted) {
+        return
       }
-    },
-    { once: true }
-  )
 
-  // 12. Let handleFetchDone given response response be to finalize and
-  // report timing with response, globalObject, and "fetch".
-  const handleFetchDone = (response) =>
-    finalizeAndReportTiming(response, 'fetch')
+      // 2. If response’s aborted flag is set, then:
+      if (response.aborted) {
+        // 1. Let deserializedError be the result of deserialize a serialized
+        //    abort reason given controller’s serialized abort reason and
+        //    relevantRealm.
 
-  // 13. Set controller to the result of calling fetch given request,
-  // with processResponseEndOfBody set to handleFetchDone, and processResponse
-  // given response being these substeps:
+        // 2. Abort the fetch() call with p, request, responseObject, and
+        //    deserializedError.
 
-  const processResponse = (response) => {
-    // 1. If locallyAborted is true, terminate these substeps.
-    if (locallyAborted) {
-      return
+        abortFetch(p, request, responseObject, controller.serializedAbortReason)
+        return
+      }
+
+      // 3. If response is a network error, then reject p with a TypeError
+      // and terminate these substeps.
+      if (response.type === 'error') {
+        p.reject(Object.assign(new TypeError('fetch failed'), { cause: response.error }))
+        return
+      }
+
+      // 4. Set responseObject to the result of creating a Response object,
+      // given response, "immutable", and relevantRealm.
+      responseObject = new Response()
+      responseObject[kState] = response
+      responseObject[kRealm] = relevantRealm
+      responseObject[kHeaders][kHeadersList] = response.headersList
+      responseObject[kHeaders][kGuard] = 'immutable'
+      responseObject[kHeaders][kRealm] = relevantRealm
+
+      // 5. Resolve p with responseObject.
+      p.resolve(responseObject)
     }
 
-    // 2. If response’s aborted flag is set, then:
-    if (response.aborted) {
-      // 1. Let deserializedError be the result of deserialize a serialized
-      //    abort reason given controller’s serialized abort reason and
-      //    relevantRealm.
+    controller = fetching({
+      request,
+      processResponseEndOfBody: handleFetchDone,
+      processResponse,
+      dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+    })
 
-      // 2. Abort the fetch() call with p, request, responseObject, and
-      //    deserializedError.
-
-      abortFetch(p, request, responseObject, controller.serializedAbortReason)
-      return
-    }
-
-    // 3. If response is a network error, then reject p with a TypeError
-    // and terminate these substeps.
-    if (response.type === 'error') {
-      const error = Object.assign(new TypeError('fetch failed'), { cause: response.error })
-      p.reject(error)
-      return
-    }
-
-    // 4. Set responseObject to the result of creating a Response object,
-    // given response, "immutable", and relevantRealm.
-    responseObject = new Response()
-    responseObject[kState] = response
-    responseObject[kRealm] = relevantRealm
-    responseObject[kHeaders][kHeadersList] = response.headersList
-    responseObject[kHeaders][kGuard] = 'immutable'
-    responseObject[kHeaders][kRealm] = relevantRealm
-
-    // 5. Resolve p with responseObject.
-    p.resolve(responseObject)
+    // 14. Return p.
+    return p.promise
   }
-
-  controller = fetching({
-    request,
-    processResponseEndOfBody: handleFetchDone,
-    processResponse,
-    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
-  })
-
-  // 14. Return p.
-  return p.promise
+  if (channels.end.hasSubscribers) channels.end.publish(context)
+  return promise(context)
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -120,137 +120,151 @@ class Fetch extends EE {
   }
 }
 
+let tracingChannel
+try {
+  const diagnosticsChannel = require('diagnostics_channel')
+  tracingChannel = diagnosticsChannel.tracingChannel('undici')
+} catch {
+  tracingChannel.start = { hasSubscribers: false }
+  tracingChannel.end = { hasSubscribers: false }
+  tracingChannel.asyncStart = { hasSubscribers: false }
+  tracingChannel.asyncEnd = { hasSubscribers: false }
+  tracingChannel.error = { hasSubscribers: false }
+}
+
 // https://fetch.spec.whatwg.org/#fetch-method
 async function fetch (input, init = {}) {
-  webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+  return tracingChannel.tracePromise(() => {
+    webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
 
-  // 1. Let p be a new promise.
-  const p = createDeferredPromise()
+    // 1. Let p be a new promise.
+    const p = createDeferredPromise()
 
-  // 2. Let requestObject be the result of invoking the initial value of
-  // Request as constructor with input and init as arguments. If this throws
-  // an exception, reject p with it and return p.
-  let requestObject
+    // 2. Let requestObject be the result of invoking the initial value of
+    // Request as constructor with input and init as arguments. If this throws
+    // an exception, reject p with it and return p.
+    let requestObject
 
-  try {
-    requestObject = new Request(input, init)
-  } catch (e) {
-    p.reject(e)
-    return p.promise
-  }
+    try {
+      requestObject = new Request(input, init)
+    } catch (e) {
+      p.reject(e)
+      return p.promise
+    }
 
-  // 3. Let request be requestObject’s request.
-  const request = requestObject[kState]
+    // 3. Let request be requestObject’s request.
+    const request = requestObject[kState]
 
-  // 4. If requestObject’s signal’s aborted flag is set, then:
-  if (requestObject.signal.aborted) {
-    // 1. Abort the fetch() call with p, request, null, and
-    //    requestObject’s signal’s abort reason.
-    abortFetch(p, request, null, requestObject.signal.reason)
+    // 4. If requestObject’s signal’s aborted flag is set, then:
+    if (requestObject.signal.aborted) {
+      // 1. Abort the fetch() call with p, request, null, and
+      //    requestObject’s signal’s abort reason.
+      abortFetch(p, request, null, requestObject.signal.reason)
 
-    // 2. Return p.
-    return p.promise
-  }
+      // 2. Return p.
+      return p.promise
+    }
 
-  // 5. Let globalObject be request’s client’s global object.
-  const globalObject = request.client.globalObject
+    // 5. Let globalObject be request’s client’s global object.
+    const globalObject = request.client.globalObject
 
-  // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-  // request’s service-workers mode to "none".
-  if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
-    request.serviceWorkers = 'none'
-  }
+    // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
+    // request’s service-workers mode to "none".
+    if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
+      request.serviceWorkers = 'none'
+    }
 
-  // 7. Let responseObject be null.
-  let responseObject = null
+    // 7. Let responseObject be null.
+    let responseObject = null
 
-  // 8. Let relevantRealm be this’s relevant Realm.
-  const relevantRealm = null
+    // 8. Let relevantRealm be this’s relevant Realm.
+    const relevantRealm = null
 
-  // 9. Let locallyAborted be false.
-  let locallyAborted = false
+    // 9. Let locallyAborted be false.
+    let locallyAborted = false
 
-  // 10. Let controller be null.
-  let controller = null
+    // 10. Let controller be null.
+    let controller = null
 
-  // 11. Add the following abort steps to requestObject’s signal:
-  requestObject.signal.addEventListener(
-    'abort',
-    () => {
-      // 1. Set locallyAborted to true.
-      locallyAborted = true
+    // 11. Add the following abort steps to requestObject’s signal:
+    requestObject.signal.addEventListener(
+      'abort',
+      () => {
+        // 1. Set locallyAborted to true.
+        locallyAborted = true
 
-      // 2. Abort the fetch() call with p, request, responseObject,
-      //    and requestObject’s signal’s abort reason.
-      abortFetch(p, request, responseObject, requestObject.signal.reason)
+        // 2. Abort the fetch() call with p, request, responseObject,
+        //    and requestObject’s signal’s abort reason.
+        abortFetch(p, request, responseObject, requestObject.signal.reason)
 
-      // 3. If controller is not null, then abort controller.
-      if (controller != null) {
-        controller.abort()
+        // 3. If controller is not null, then abort controller.
+        if (controller != null) {
+          controller.abort()
+        }
+      },
+      { once: true }
+    )
+
+    // 12. Let handleFetchDone given response response be to finalize and
+    // report timing with response, globalObject, and "fetch".
+    const handleFetchDone = (response) =>
+      finalizeAndReportTiming(response, 'fetch')
+
+    // 13. Set controller to the result of calling fetch given request,
+    // with processResponseEndOfBody set to handleFetchDone, and processResponse
+    // given response being these substeps:
+
+    const processResponse = (response) => {
+      // 1. If locallyAborted is true, terminate these substeps.
+      if (locallyAborted) {
+        return
       }
-    },
-    { once: true }
-  )
 
-  // 12. Let handleFetchDone given response response be to finalize and
-  // report timing with response, globalObject, and "fetch".
-  const handleFetchDone = (response) =>
-    finalizeAndReportTiming(response, 'fetch')
+      // 2. If response’s aborted flag is set, then:
+      if (response.aborted) {
+        // 1. Let deserializedError be the result of deserialize a serialized
+        //    abort reason given controller’s serialized abort reason and
+        //    relevantRealm.
 
-  // 13. Set controller to the result of calling fetch given request,
-  // with processResponseEndOfBody set to handleFetchDone, and processResponse
-  // given response being these substeps:
+        // 2. Abort the fetch() call with p, request, responseObject, and
+        //    deserializedError.
 
-  const processResponse = (response) => {
-    // 1. If locallyAborted is true, terminate these substeps.
-    if (locallyAborted) {
-      return
+        abortFetch(p, request, responseObject, controller.serializedAbortReason)
+        return
+      }
+
+      // 3. If response is a network error, then reject p with a TypeError
+      // and terminate these substeps.
+      if (response.type === 'error') {
+        p.reject(
+          Object.assign(new TypeError('fetch failed'), { cause: response.error })
+        )
+        return
+      }
+
+      // 4. Set responseObject to the result of creating a Response object,
+      // given response, "immutable", and relevantRealm.
+      responseObject = new Response()
+      responseObject[kState] = response
+      responseObject[kRealm] = relevantRealm
+      responseObject[kHeaders][kHeadersList] = response.headersList
+      responseObject[kHeaders][kGuard] = 'immutable'
+      responseObject[kHeaders][kRealm] = relevantRealm
+
+      // 5. Resolve p with responseObject.
+      p.resolve(responseObject)
     }
 
-    // 2. If response’s aborted flag is set, then:
-    if (response.aborted) {
-      // 1. Let deserializedError be the result of deserialize a serialized
-      //    abort reason given controller’s serialized abort reason and
-      //    relevantRealm.
+    controller = fetching({
+      request,
+      processResponseEndOfBody: handleFetchDone,
+      processResponse,
+      dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+    })
 
-      // 2. Abort the fetch() call with p, request, responseObject, and
-      //    deserializedError.
-
-      abortFetch(p, request, responseObject, controller.serializedAbortReason)
-      return
-    }
-
-    // 3. If response is a network error, then reject p with a TypeError
-    // and terminate these substeps.
-    if (response.type === 'error') {
-      p.reject(
-        Object.assign(new TypeError('fetch failed'), { cause: response.error })
-      )
-      return
-    }
-
-    // 4. Set responseObject to the result of creating a Response object,
-    // given response, "immutable", and relevantRealm.
-    responseObject = new Response()
-    responseObject[kState] = response
-    responseObject[kRealm] = relevantRealm
-    responseObject[kHeaders][kHeadersList] = response.headersList
-    responseObject[kHeaders][kGuard] = 'immutable'
-    responseObject[kHeaders][kRealm] = relevantRealm
-
-    // 5. Resolve p with responseObject.
-    p.resolve(responseObject)
-  }
-
-  controller = fetching({
-    request,
-    processResponseEndOfBody: handleFetchDone,
-    processResponse,
-    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
-  })
-
-  // 14. Return p.
-  return p.promise
+    // 14. Return p.
+    return p.promise
+  }, { input, init })
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -144,6 +144,7 @@ function createDeferredPromise (context) {
       context.result = result
       if (channels.asyncStart.hasSubscribers) channels.asyncStart.publish(context)
       if (channels.asyncEnd.hasSubscribers) channels.asyncEnd.publish(context)
+      delete context.result
       resolve(result)
     }
     rej = (error) => {
@@ -151,6 +152,7 @@ function createDeferredPromise (context) {
       if (channels.error.hasSubscribers) channels.error.publish(context)
       if (channels.asyncStart.hasSubscribers) channels.asyncStart.publish(context)
       if (channels.asyncEnd.hasSubscribers) channels.asyncEnd.publish(context)
+      delete context.error
       reject(error)
     }
   })
@@ -158,139 +160,141 @@ function createDeferredPromise (context) {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
+async function innerFetch (input, init = {}, context) {
+  webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
+  // 1. Let p be a new promise.
+  const p = createDeferredPromise(context)
+
+  // 2. Let requestObject be the result of invoking the initial value of
+  // Request as constructor with input and init as arguments. If this throws
+  // an exception, reject p with it and return p.
+  let requestObject
+
+  try {
+    requestObject = new Request(input, init)
+  } catch (e) {
+    p.reject(e)
+    return p.promise
+  }
+
+  // 3. Let request be requestObject’s request.
+  const request = requestObject[kState]
+
+  // 4. If requestObject’s signal’s aborted flag is set, then:
+  if (requestObject.signal.aborted) {
+    // 1. Abort the fetch() call with p, request, null, and
+    //    requestObject’s signal’s abort reason.
+    abortFetch(p, request, null, requestObject.signal.reason)
+
+    // 2. Return p.
+    return p.promise
+  }
+
+  // 5. Let globalObject be request’s client’s global object.
+  const globalObject = request.client.globalObject
+
+  // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
+  // request’s service-workers mode to "none".
+  if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
+    request.serviceWorkers = 'none'
+  }
+
+  // 7. Let responseObject be null.
+  let responseObject = null
+
+  // 8. Let relevantRealm be this’s relevant Realm.
+  const relevantRealm = null
+
+  // 9. Let locallyAborted be false.
+  let locallyAborted = false
+
+  // 10. Let controller be null.
+  let controller = null
+
+  // 11. Add the following abort steps to requestObject’s signal:
+  requestObject.signal.addEventListener(
+    'abort',
+    () => {
+      // 1. Set locallyAborted to true.
+      locallyAborted = true
+
+      // 2. Abort the fetch() call with p, request, responseObject,
+      //    and requestObject’s signal’s abort reason.
+      abortFetch(p, request, responseObject, requestObject.signal.reason)
+
+      // 3. If controller is not null, then abort controller.
+      if (controller != null) {
+        controller.abort()
+      }
+    },
+    { once: true }
+  )
+
+  // 12. Let handleFetchDone given response response be to finalize and
+  // report timing with response, globalObject, and "fetch".
+  const handleFetchDone = (response) =>
+    finalizeAndReportTiming(response, 'fetch')
+
+  // 13. Set controller to the result of calling fetch given request,
+  // with processResponseEndOfBody set to handleFetchDone, and processResponse
+  // given response being these substeps:
+
+  const processResponse = (response) => {
+    // 1. If locallyAborted is true, terminate these substeps.
+    if (locallyAborted) {
+      return
+    }
+
+    // 2. If response’s aborted flag is set, then:
+    if (response.aborted) {
+      // 1. Let deserializedError be the result of deserialize a serialized
+      //    abort reason given controller’s serialized abort reason and
+      //    relevantRealm.
+
+      // 2. Abort the fetch() call with p, request, responseObject, and
+      //    deserializedError.
+
+      abortFetch(p, request, responseObject, controller.serializedAbortReason)
+      return
+    }
+
+    // 3. If response is a network error, then reject p with a TypeError
+    // and terminate these substeps.
+    if (response.type === 'error') {
+      p.reject(Object.assign(new TypeError('fetch failed'), { cause: response.error }))
+      return
+    }
+
+    // 4. Set responseObject to the result of creating a Response object,
+    // given response, "immutable", and relevantRealm.
+    responseObject = new Response()
+    responseObject[kState] = response
+    responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders][kHeadersList] = response.headersList
+    responseObject[kHeaders][kGuard] = 'immutable'
+    responseObject[kHeaders][kRealm] = relevantRealm
+
+    // 5. Resolve p with responseObject.
+    p.resolve(responseObject)
+  }
+
+  controller = fetching({
+    request,
+    processResponseEndOfBody: handleFetchDone,
+    processResponse,
+    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+  })
+
+  // 14. Return p.
+  return p.promise
+}
+
 function fetch (input, init = {}) {
   const context = { input, init }
   if (channels.start.hasSubscribers) channels.start.publish(context)
-  const promise = async (context) => {
-    webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
-    // 1. Let p be a new promise.
-    const p = createDeferredPromise(context)
-
-    // 2. Let requestObject be the result of invoking the initial value of
-    // Request as constructor with input and init as arguments. If this throws
-    // an exception, reject p with it and return p.
-    let requestObject
-
-    try {
-      requestObject = new Request(input, init)
-    } catch (e) {
-      p.reject(e)
-      return p.promise
-    }
-
-    // 3. Let request be requestObject’s request.
-    const request = requestObject[kState]
-
-    // 4. If requestObject’s signal’s aborted flag is set, then:
-    if (requestObject.signal.aborted) {
-      // 1. Abort the fetch() call with p, request, null, and
-      //    requestObject’s signal’s abort reason.
-      abortFetch(p, request, null, requestObject.signal.reason)
-
-      // 2. Return p.
-      return p.promise
-    }
-
-    // 5. Let globalObject be request’s client’s global object.
-    const globalObject = request.client.globalObject
-
-    // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-    // request’s service-workers mode to "none".
-    if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
-      request.serviceWorkers = 'none'
-    }
-
-    // 7. Let responseObject be null.
-    let responseObject = null
-
-    // 8. Let relevantRealm be this’s relevant Realm.
-    const relevantRealm = null
-
-    // 9. Let locallyAborted be false.
-    let locallyAborted = false
-
-    // 10. Let controller be null.
-    let controller = null
-
-    // 11. Add the following abort steps to requestObject’s signal:
-    requestObject.signal.addEventListener(
-      'abort',
-      () => {
-        // 1. Set locallyAborted to true.
-        locallyAborted = true
-
-        // 2. Abort the fetch() call with p, request, responseObject,
-        //    and requestObject’s signal’s abort reason.
-        abortFetch(p, request, responseObject, requestObject.signal.reason)
-
-        // 3. If controller is not null, then abort controller.
-        if (controller != null) {
-          controller.abort()
-        }
-      },
-      { once: true }
-    )
-
-    // 12. Let handleFetchDone given response response be to finalize and
-    // report timing with response, globalObject, and "fetch".
-    const handleFetchDone = (response) =>
-      finalizeAndReportTiming(response, 'fetch')
-
-    // 13. Set controller to the result of calling fetch given request,
-    // with processResponseEndOfBody set to handleFetchDone, and processResponse
-    // given response being these substeps:
-
-    const processResponse = (response) => {
-      // 1. If locallyAborted is true, terminate these substeps.
-      if (locallyAborted) {
-        return
-      }
-
-      // 2. If response’s aborted flag is set, then:
-      if (response.aborted) {
-        // 1. Let deserializedError be the result of deserialize a serialized
-        //    abort reason given controller’s serialized abort reason and
-        //    relevantRealm.
-
-        // 2. Abort the fetch() call with p, request, responseObject, and
-        //    deserializedError.
-
-        abortFetch(p, request, responseObject, controller.serializedAbortReason)
-        return
-      }
-
-      // 3. If response is a network error, then reject p with a TypeError
-      // and terminate these substeps.
-      if (response.type === 'error') {
-        p.reject(Object.assign(new TypeError('fetch failed'), { cause: response.error }))
-        return
-      }
-
-      // 4. Set responseObject to the result of creating a Response object,
-      // given response, "immutable", and relevantRealm.
-      responseObject = new Response()
-      responseObject[kState] = response
-      responseObject[kRealm] = relevantRealm
-      responseObject[kHeaders][kHeadersList] = response.headersList
-      responseObject[kHeaders][kGuard] = 'immutable'
-      responseObject[kHeaders][kRealm] = relevantRealm
-
-      // 5. Resolve p with responseObject.
-      p.resolve(responseObject)
-    }
-
-    controller = fetching({
-      request,
-      processResponseEndOfBody: handleFetchDone,
-      processResponse,
-      dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
-    })
-
-    // 14. Return p.
-    return p.promise
-  }
+  const promise = innerFetch(input, init, context)
   if (channels.end.hasSubscribers) channels.end.publish(context)
-  return promise(context)
+  return promise
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -29,7 +29,6 @@ const {
   crossOriginResourcePolicyCheck,
   determineRequestsReferrer,
   coarsenedSharedCurrentTime,
-  createDeferredPromise,
   isBlobLike,
   sameOrigin,
   isCancelled,
@@ -63,6 +62,7 @@ const { getGlobalDispatcher } = require('../global')
 const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('http')
 const diagnosticsChannel = require('diagnostics_channel')
+const { start } = require('repl')
 
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
@@ -121,24 +121,52 @@ class Fetch extends EE {
   }
 }
 
-let tracingChannel
+const channels = {}
+
 try {
-  tracingChannel = diagnosticsChannel.tracingChannel('undici')
+  const diagnosticsChannel = require('diagnostics_channel')
+  channels.start = diagnosticsChannel.channel('undici:fetch:start')
+  channels.end = diagnosticsChannel.channel('undici:fetch:end')
+  channels.asyncStart = diagnosticsChannel.channel('undici:fetch:asyncStart')
+  channels.asyncEnd = diagnosticsChannel.channel('undici:fetch:asyncEnd')
+  channels.error = diagnosticsChannel.channel('undici:fetch:error')
 } catch {
-  tracingChannel.start = { hasSubscribers: false }
-  tracingChannel.end = { hasSubscribers: false }
-  tracingChannel.asyncStart = { hasSubscribers: false }
-  tracingChannel.asyncEnd = { hasSubscribers: false }
-  tracingChannel.error = { hasSubscribers: false }
+  channels.start = { hasSubscribers: false }
+  channels.end = { hasSubscribers: false }
+  channels.asyncStart = { hasSubscribers: false }
+  channels.asyncEnd = { hasSubscribers: false }
+  channels.error = { hasSubscribers: false }
+}
+
+function createDeferredPromise (context) {
+  if (channels.start.hasSubscribers) channels.start.publish(context)
+  let res
+  let rej
+  const promise = new Promise((resolve, reject) => {
+    res = (result) => {
+      context.result = result
+      if (channels.asyncStart.hasSubscribers) channels.asyncStart.publish(context)
+      if (channels.asyncEnd.hasSubscribers) channels.asyncEnd.publish(context)
+      resolve(result)
+    }
+    rej = (error) => {
+      context.error = error
+      if (channels.error.hasSubscribers) channels.error.publish(context)
+      if (channels.asyncStart.hasSubscribers) channels.asyncStart.publish(context)
+      if (channels.asyncEnd.hasSubscribers) channels.asyncEnd.publish(context)
+      reject(error)
+    }
+  })
+  if (channels.end.hasSubscribers) channels.end.publish(context)
+  return { promise, resolve: res, reject: rej }
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
 async function fetch (input, init = {}) {
-  return tracingChannel.tracePromise(() => {
     webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
 
     // 1. Let p be a new promise.
-    const p = createDeferredPromise()
+    const p = createDeferredPromise({ input: input, init: init })
 
     // 2. Let requestObject be the result of invoking the initial value of
     // Request as constructor with input and init as arguments. If this throws
@@ -236,9 +264,8 @@ async function fetch (input, init = {}) {
       // 3. If response is a network error, then reject p with a TypeError
       // and terminate these substeps.
       if (response.type === 'error') {
-        p.reject(
-          Object.assign(new TypeError('fetch failed'), { cause: response.error })
-        )
+        const error = Object.assign(new TypeError('fetch failed'), { cause: response.error })
+        p.reject(error)
         return
       }
 
@@ -264,7 +291,12 @@ async function fetch (input, init = {}) {
 
     // 14. Return p.
     return p.promise
-  }, { input, init })
+}
+
+function fetchWrapper() {
+  start
+  PromisePrototypeThen(fetch, resolve, reject);
+  end
 }
 
 // https://fetch.spec.whatwg.org/#finalize-and-report-timing

--- a/test/diagnostics-channel/fetch.js
+++ b/test/diagnostics-channel/fetch.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const t = require('tap')
+const fetch = require('../..').fetch
+
+let diagnosticsChannel
+
+try {
+  diagnosticsChannel = require('diagnostics_channel')
+} catch {
+  t.skip('missing diagnostics_channel')
+  process.exit(0)
+}
+
+const { createServer } = require('http')
+
+t.plan(35)
+
+const server = createServer((req, res) => {
+  res.setHeader('Content-Type', 'text/plain')
+  res.setHeader('trailer', 'foo')
+  res.write('hello')
+  res.addTrailers({
+    foo: 'oof'
+  })
+  res.end()
+})
+t.teardown(server.close.bind(server))
+
+let startCalled = 0
+diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
+  startCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+})
+
+let endCalled = 0
+diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, result, error }) => {
+  endCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+  t.notOk(result)
+  t.notOk(error)
+})
+
+let asyncStartCalled = 0
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init }) => {
+  asyncStartCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+  }
+})
+
+let asyncEndCalled = 0
+diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(async ({ input, init, result, error }) => {
+  asyncEndCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+    t.notOk(result)
+    t.ok(error)
+    t.equal(error.cause.code, 'ERR_INVALID_URL')
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+    t.ok(result)
+    t.equal(result.status, 200)
+    t.notOk(error)
+  }
+})
+
+let errorCalled = 0
+diagnosticsChannel.channel('tracing:undici:error').subscribe(async ({ input, init, error }) => {
+  errorCalled += 1
+  if (init.redirect) {
+    t.equal(input, 'badrequest')
+    t.same(init, { redirect: 'error' })
+    t.ok(error)
+    t.equal(error.cause.code, 'ERR_INVALID_URL')
+  } else {
+    t.equal(input, `http://localhost:${server.address().port}`)
+    t.same(init, {})
+    t.notOk(error)
+  }
+})
+
+server.listen(0, async () => {
+  await fetch(`http://localhost:${server.address().port}`)
+  try {
+    await fetch('badrequest', { redirect: 'error' })
+  } catch (e) {}
+  server.close()
+  t.equal(startCalled, 2)
+  t.equal(endCalled, 2)
+  t.equal(asyncStartCalled, 2)
+  t.equal(asyncEndCalled, 2)
+  t.equal(errorCalled, 1)
+})

--- a/test/diagnostics-channel/fetch.js
+++ b/test/diagnostics-channel/fetch.js
@@ -14,7 +14,7 @@ try {
 
 const { createServer } = require('http')
 
-t.plan(35)
+t.plan(37)
 
 const server = createServer((req, res) => {
   res.setHeader('Content-Type', 'text/plain')
@@ -54,14 +54,16 @@ diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, resul
 })
 
 let asyncStartCalled = 0
-diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init }) => {
+diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
   asyncStartCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
     t.same(init, { redirect: 'error' })
+    t.notOk(result)
   } else {
     t.equal(input, `http://localhost:${server.address().port}`)
     t.same(init, {})
+    t.ok(result)
   }
 })
 

--- a/test/diagnostics-channel/fetch.js
+++ b/test/diagnostics-channel/fetch.js
@@ -28,7 +28,7 @@ const server = createServer((req, res) => {
 t.teardown(server.close.bind(server))
 
 let startCalled = 0
-diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) => {
+diagnosticsChannel.channel('undici:fetch:start').subscribe(({ input, init }) => {
   startCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
@@ -40,7 +40,7 @@ diagnosticsChannel.channel('tracing:undici:start').subscribe(({ input, init }) =
 })
 
 let endCalled = 0
-diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, result, error }) => {
+diagnosticsChannel.channel('undici:fetch:end').subscribe(({ input, init, result, error }) => {
   endCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
@@ -54,7 +54,7 @@ diagnosticsChannel.channel('tracing:undici:end').subscribe(({ input, init, resul
 })
 
 let asyncStartCalled = 0
-diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init, result }) => {
+diagnosticsChannel.channel('undici:fetch:asyncStart').subscribe(({ input, init, result }) => {
   asyncStartCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
@@ -68,7 +68,7 @@ diagnosticsChannel.channel('tracing:undici:asyncStart').subscribe(({ input, init
 })
 
 let asyncEndCalled = 0
-diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(async ({ input, init, result, error }) => {
+diagnosticsChannel.channel('undici:fetch:asyncEnd').subscribe(async ({ input, init, result, error }) => {
   asyncEndCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')
@@ -86,7 +86,7 @@ diagnosticsChannel.channel('tracing:undici:asyncEnd').subscribe(async ({ input, 
 })
 
 let errorCalled = 0
-diagnosticsChannel.channel('tracing:undici:error').subscribe(async ({ input, init, error }) => {
+diagnosticsChannel.channel('undici:fetch:error').subscribe(async ({ input, init, error }) => {
   errorCalled += 1
   if (init.redirect) {
     t.equal(input, 'badrequest')


### PR DESCRIPTION
We added five diagnostics channels on fetch to trace the same information as would [tracingChannel.tracePromise](https://nodejs.org/api/diagnostics_channel.html#tracingchanneltracepromisefn-context-thisarg-args). Some channels won't make perfect sense but we want to stay consistent with [TracingChannel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) as we want to use it to trace fetch and maybe other functions when TracingChannel become available in the most commonly used versions of node.js. The descriptions of each channel and what gets published to them are detailed in DiagnosticsChannel.md

Use case: enable APM tools to trace fetch