### PR TITLE
better stack trace for body.json

### DIFF
--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -379,11 +379,7 @@ class Cache {
       const reader = stream.getReader()
 
       // 11.3
-      readAllBytes(
-        reader,
-        (bytes) => bodyReadPromise.resolve(bytes),
-        (error) => bodyReadPromise.reject(error)
-      )
+      readAllBytes(reader).then(bodyReadPromise.resolve, bodyReadPromise.reject)
     } else {
       bodyReadPromise.resolve(undefined)
     }

--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -532,7 +532,7 @@ async function specConsumeBody (object, convertBytesToJSValue, instance) {
 
   // 6. Otherwise, fully read object’s body given successSteps,
   //    errorSteps, and object’s relevant global object.
-  fullyReadBody(object[kState].body, successSteps, errorSteps)
+  await fullyReadBody(object[kState].body, successSteps, errorSteps)
 
   // 7. Return promise.
   return promise.promise

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -812,17 +812,17 @@ function iteratorResult (pair, kind) {
 /**
  * @see https://fetch.spec.whatwg.org/#body-fully-read
  */
-function fullyReadBody (body, processBody, processBodyError) {
+async function fullyReadBody (body, processBody, processBodyError) {
   // 1. If taskDestination is null, then set taskDestination to
   //    the result of starting a new parallel queue.
 
   // 2. Let successSteps given a byte sequence bytes be to queue a
   //    fetch task to run processBody given bytes, with taskDestination.
-  const successSteps = (bytes) => queueMicrotask(() => processBody(bytes))
+  const successSteps = (bytes) => processBody(bytes)
 
   // 3. Let errorSteps be to queue a fetch task to run processBodyError,
   //    with taskDestination.
-  const errorSteps = (error) => queueMicrotask(() => processBodyError(error))
+  const errorSteps = (error) => processBodyError(error)
 
   // 4. Let reader be the result of getting a reader for body’s stream.
   //    If that threw an exception, then run errorSteps with that
@@ -837,7 +837,14 @@ function fullyReadBody (body, processBody, processBodyError) {
   }
 
   // 5. Read all bytes from reader, given successSteps and errorSteps.
-  readAllBytes(reader, successSteps, errorSteps)
+  try {
+    const result = await readAllBytes(reader)
+    await true
+    successSteps(result)
+  } catch (e) {
+    await true
+    errorSteps(e)
+  }
 }
 
 /** @type {ReadableStream} */
@@ -906,36 +913,23 @@ function isomorphicEncode (input) {
  * @see https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes
  * @see https://streams.spec.whatwg.org/#read-loop
  * @param {ReadableStreamDefaultReader} reader
- * @param {(bytes: Uint8Array) => void} successSteps
- * @param {(error: Error) => void} failureSteps
  */
-async function readAllBytes (reader, successSteps, failureSteps) {
+async function readAllBytes (reader) {
   const bytes = []
   let byteLength = 0
 
   while (true) {
-    let done
-    let chunk
-
-    try {
-      ({ done, value: chunk } = await reader.read())
-    } catch (e) {
-      // 1. Call failureSteps with e.
-      failureSteps(e)
-      return
-    }
+    const { done, value: chunk } = await reader.read()
 
     if (done) {
       // 1. Call successSteps with bytes.
-      successSteps(Buffer.concat(bytes, byteLength))
-      return
+      return Buffer.concat(bytes, byteLength)
     }
 
     // 1. If chunk is not a Uint8Array object, call failureSteps
     //    with a TypeError and abort these steps.
     if (!isUint8Array(chunk)) {
-      failureSteps(new TypeError('Received non-Uint8Array chunk'))
-      return
+      throw new TypeError('Received non-Uint8Array chunk')
     }
 
     // 2. Append the bytes represented by chunk to bytes.

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -839,10 +839,8 @@ async function fullyReadBody (body, processBody, processBodyError) {
   // 5. Read all bytes from reader, given successSteps and errorSteps.
   try {
     const result = await readAllBytes(reader)
-    await true
     successSteps(result)
   } catch (e) {
-    await true
     errorSteps(e)
   }
 }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -818,11 +818,11 @@ async function fullyReadBody (body, processBody, processBodyError) {
 
   // 2. Let successSteps given a byte sequence bytes be to queue a
   //    fetch task to run processBody given bytes, with taskDestination.
-  const successSteps = (bytes) => processBody(bytes)
+  const successSteps = processBody
 
   // 3. Let errorSteps be to queue a fetch task to run processBodyError,
   //    with taskDestination.
-  const errorSteps = (error) => processBodyError(error)
+  const errorSteps = processBodyError
 
   // 4. Let reader be the result of getting a reader for body’s stream.
   //    If that threw an exception, then run errorSteps with that


### PR DESCRIPTION
fixes #2212 

I'm not totally thrilled with the solution, but it does fix the issue.

old stack trace is in the issue

new
```
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (\undici\lib\fetch\body.js:580:15)
    at successSteps (\undici\lib\fetch\body.js:520:23)
    at successSteps (\undici\lib\fetch\util.js:821:35)
    at fullyReadBody (\undici\lib\fetch\util.js:843:5)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async specConsumeBody (\undici\lib\fetch\body.js:535:3)
    at async /undici/test.mjs:3:1
```