### PR TITLE
fix: adjust number of arguments in `Response.json()`

### DIFF
--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -49,7 +49,7 @@ class Response {
   }
 
   // https://fetch.spec.whatwg.org/#dom-response-json
-  static json (data = undefined, init = {}) {
+  static json (data, init = {}) {
     webidl.argumentLengthCheck(arguments, 1, { header: 'Response.json' })
 
     if (init !== null) {

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -248,3 +248,9 @@ test('constructing Response with third party FormData body', async (t) => {
   t.equal(contentType[0], 'multipart/form-data; boundary')
   t.ok((await res.text()).startsWith(`--${contentType[1]}`))
 })
+
+test('static methods have correct number of mandatory arguments', async (t) => {
+  t.equal(Response.error.length, 0)
+  t.equal(Response.json.length, 1)
+  t.equal(Response.redirect.length, 1)
+})


### PR DESCRIPTION
`data` is not optional

Refs: https://fetch.spec.whatwg.org/#ref-for-dom-response-json