### PR TITLE
Fix fetch in node v20.6.0

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -355,6 +355,15 @@ function getSocketInfo (socket) {
   }
 }
 
+async function * convertIterableToBuffer (iterable) {
+  for await (let chunk of iterable) {
+    if (!Buffer.isBuffer(chunk)) {
+      chunk = Buffer.from(chunk)
+    }
+    yield chunk
+  }
+}
+
 let ReadableStream
 function ReadableStreamFrom (iterable) {
   if (!ReadableStream) {
@@ -362,8 +371,7 @@ function ReadableStreamFrom (iterable) {
   }
 
   if (ReadableStream.from) {
-    // https://github.com/whatwg/streams/pull/1083
-    return ReadableStream.from(iterable)
+    return ReadableStream.from(convertIterableToBuffer(iterable))
   }
 
   let iterator

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -356,11 +356,8 @@ function getSocketInfo (socket) {
 }
 
 async function * convertIterableToBuffer (iterable) {
-  for await (let chunk of iterable) {
-    if (!Buffer.isBuffer(chunk)) {
-      chunk = Buffer.from(chunk)
-    }
-    yield chunk
+  for await (const chunk of iterable) {
+    yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
   }
 }
 


### PR DESCRIPTION
Node v20.6.0 added `ReadableStream.from()` and we broke.