### PR TITLE
fix: h2 without body

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1762,17 +1762,21 @@ function writeH2 (client, session, request) {
 
   session.ref()
 
+  const shouldEndStream = method === 'GET' || method === 'HEAD'
   if (expectContinue) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
     /**
      * @type {import('node:http2').ClientHttp2Stream}
      */
-    stream = session.request(headers, { signal })
+    stream = session.request(headers, { endStream: shouldEndStream, signal })
 
     stream.once('continue', writeBodyH2)
   } else {
     /** @type {import('node:http2').ClientHttp2Stream} */
-    stream = session.request(headers, { signal })
+    stream = session.request(headers, {
+      endStream: shouldEndStream,
+      signal
+    })
     writeBodyH2()
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1687,6 +1687,7 @@ function writeH2 (client, session, request) {
     // we are already connected, streams are pending, first request
     // will create a new stream. We trigger a request to create the stream and wait until
     // `ready` event is triggered
+    // We disabled endStream to allow the user to write to the stream
     stream = session.request(headers, { endStream: false, signal })
 
     if (stream.id && !stream.pending) {
@@ -1766,12 +1767,12 @@ function writeH2 (client, session, request) {
     /**
      * @type {import('node:http2').ClientHttp2Stream}
      */
-    stream = session.request(headers, { endStream: false, signal })
+    stream = session.request(headers, { signal })
 
     stream.once('continue', writeBodyH2)
   } else {
     /** @type {import('node:http2').ClientHttp2Stream} */
-    stream = session.request(headers, { endStream: false, signal })
+    stream = session.request(headers, { signal })
     writeBodyH2()
   }
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -320,10 +320,12 @@ class Request {
 
   static [kHTTP2CopyHeaders] (raw) {
     const rawHeaders = raw.split('\r\n')
-
     const headers = {}
+
     for (const header of rawHeaders) {
       const [key, value] = header.split(': ')
+
+      if (value == null || value.length === 0) continue
 
       if (headers[key]) headers[key] += `,${value}`
       else headers[key] = value


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

- H2 Support #2061
- Fixes #2257

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

- Fix H2 connection with empty body.
A method such as `GET` or `HEAD` is not meant to expect a body to be sent. For instance, the `writable` side of the duplex stream can be closed by default.
Not doing so, hangs the request as the server is expecting to finish delivering a body for the request that was not meant to be delivered in the first place.

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
