### PR TITLE
ci: remove duplicated runs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,13 @@
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+     - current
+     - next
+     - 'v*'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

- Duplicated CI runs

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->
I've noticed that the CI runs twice for each PR. Once following the `push` event and once following the `pull_request` event. We can scope the `push` to only `main`, `next`, and `v*` branches, meanwhile keeping `pull_request` events open.

<img width="712" alt="image" src="https://github.com/nodejs/undici/assets/10200776/a32d77bb-d7b8-4a72-8b00-91fb54e7e905">


## Changes

<!-- Write a summary or list of changes here -->
- Remove duplicated CI triggers

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
