### PR TITLE
fix undici when node is built with --without-ssl

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,6 @@
 
 const assert = require('assert')
 const net = require('net')
-const http2 = require('http2')
 const { pipeline } = require('stream')
 const util = require('./core/util')
 const timers = require('./timers')
@@ -79,6 +78,16 @@ const {
   kHTTP2CopyHeaders,
   kHTTP1BuildRequest
 } = require('./core/symbols')
+
+/** @type {import('http2')} */
+let http2
+try {
+  http2 = require('http2')
+} catch {
+  // @ts-ignore
+  http2 = { constants: {} }
+}
+
 const {
   constants: {
     HTTP2_HEADER_AUTHORITY,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/49559#issuecomment-1712238921

tested and confirmed undici can be required