### PR TITLE
fix loading websockets when node is built w/ --without-ssl

### DIFF
--- a/lib/websocket/connection.js
+++ b/lib/websocket/connection.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { randomBytes, createHash } = require('crypto')
 const diagnosticsChannel = require('diagnostics_channel')
 const { uid, states } = require('./constants')
 const {
@@ -21,6 +20,14 @@ const channels = {}
 channels.open = diagnosticsChannel.channel('undici:websocket:open')
 channels.close = diagnosticsChannel.channel('undici:websocket:close')
 channels.socketError = diagnosticsChannel.channel('undici:websocket:socket_error')
+
+/** @type {import('crypto')} */
+let crypto
+try {
+  crypto = require('crypto')
+} catch {
+
+}
 
 /**
  * @see https://websockets.spec.whatwg.org/#concept-websocket-establish
@@ -66,7 +73,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
   // 5. Let keyValue be a nonce consisting of a randomly selected
   //    16-byte value that has been forgiving-base64-encoded and
   //    isomorphic encoded.
-  const keyValue = randomBytes(16).toString('base64')
+  const keyValue = crypto.randomBytes(16).toString('base64')
 
   // 6. Append (`Sec-WebSocket-Key`, keyValue) to request’s
   //    header list.
@@ -148,7 +155,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
       //    trailing whitespace, the client MUST _Fail the WebSocket
       //    Connection_.
       const secWSAccept = response.headersList.get('Sec-WebSocket-Accept')
-      const digest = createHash('sha1').update(keyValue + uid).digest('base64')
+      const digest = crypto.createHash('sha1').update(keyValue + uid).digest('base64')
       if (secWSAccept !== digest) {
         failWebsocketConnection(ws, 'Incorrect hash received in Sec-WebSocket-Accept header.')
         return

--- a/lib/websocket/frame.js
+++ b/lib/websocket/frame.js
@@ -1,7 +1,14 @@
 'use strict'
 
-const { randomBytes } = require('crypto')
 const { maxUnsigned16Bit } = require('./constants')
+
+/** @type {import('crypto')} */
+let crypto
+try {
+  crypto = require('crypto')
+} catch {
+
+}
 
 class WebsocketFrameSend {
   /**
@@ -9,7 +16,7 @@ class WebsocketFrameSend {
    */
   constructor (data) {
     this.frameData = data
-    this.maskKey = randomBytes(4)
+    this.maskKey = crypto.randomBytes(4)
   }
 
   createFrame (opcode) {


### PR DESCRIPTION
I didn't catch this in my other PR because the main entry point (index.js) only exports WebSocket if crypto is available. The fetch bundle doesn't do this, which causes issues when node tries to require undici in an environment that doesn't have crypto.

Refs: https://ci.nodejs.org/job/node-test-commit-linux-containered/nodes=ubuntu1804_sharedlibs_withoutssl_x64/39416/