### PR TITLE
fix: don't call onConnect multiple times for sub handler

### DIFF
--- a/lib/handler/RedirectHandler.js
+++ b/lib/handler/RedirectHandler.js
@@ -34,6 +34,8 @@ class RedirectHandler {
     this.dispatch = dispatch
     this.location = null
     this.abort = null
+    this.aborted = false
+    this.reason = null
     this.opts = { ...opts, maxRedirections: 0 } // opts must be a copy
     this.maxRedirections = maxRedirections
     this.handler = handler
@@ -71,11 +73,23 @@ class RedirectHandler {
       // or through some other flag?
       this.opts.body = new BodyAsyncIterable(this.opts.body)
     }
+
+    this.handler.onConnect((reason) => {
+      this.aborted = true
+      if (this.abort) {
+        this.abort(reason)
+      } else {
+        this.reason = reason
+      }
+    }, { history: this.history })
   }
 
   onConnect (abort) {
-    this.abort = abort
-    this.handler.onConnect(abort, { history: this.history })
+    if (this.aborted) {
+      abort(this.reason)
+    } else {
+      this.abort = abort
+    }
   }
 
   onUpgrade (statusCode, headers, socket) {


### PR DESCRIPTION
Many sub-handlers (e.g. api-request) don't expect onConnect (or any other handler other than onData or onBodySent) to be called multiple times.

I'm not sure why/how we haven't caught this earlier. Should fail at https://github.com/nodejs/undici/blob/4013c4b8932e73728809e4106d5c9d9d40648031/lib/api/api-request.js#L73