### PR TITLE
fix: Agent.Options.factory should pass in URL object

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -105,7 +105,7 @@ class Agent extends DispatcherBase {
 
     let dispatcher = ref ? ref.deref() : null
     if (!dispatcher) {
-      dispatcher = this[kFactory](opts.origin, this[kOptions])
+      dispatcher = this[kFactory](new URL(opts.origin), this[kOptions])
         .on('drain', this[kOnDrain])
         .on('connect', this[kOnConnect])
         .on('disconnect', this[kOnDisconnect])

--- a/test/agent.js
+++ b/test/agent.js
@@ -268,7 +268,7 @@ test('multiple connections', t => {
   })
 })
 
-test('agent should go through factory with correct parameters', (t) => {
+test('agent should call factory with URL parameter', (t) => {
   t.plan(4)
   const wanted = 'payload'
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

Based on the below declaration, the first parameter of `Agent.Options.factory` should be `URL` Object.  However, it's only being passed in `string` now.

```ts
declare namespace Agent {
  export interface Options extends Pool.Options {
    /** Default: `(origin, opts) => new Pool(origin, opts)`. */
    factory?(origin: URL, opts: Object): Dispatcher;
    /** Integer. Default: `0` */
    maxRedirections?: number;
    interceptors?: { Agent?: readonly Dispatcher.DispatchInterceptor[] } & Pool.Options["interceptors"]
  }
}
```


## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

`string` will be converted to `URL` object with `URL() constructor`, it allows `string | URL` parameter and returns a new `URL` object.

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
