### PR TITLE
remove npm run test from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
-npm run test


### PR DESCRIPTION
This PR will remove `npm run test` from pre-commit hook as per https://github.com/nodejs/undici/issues/2274

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
