### PR TITLE
use npm install instead of npm ci

### DIFF
--- a/.github/workflows/publish-undici-types.yml
+++ b/.github/workflows/publish-undici-types.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm install
       - run: node scripts/generate-undici-types-package-json.js
       - run: cd types
       - run: npm publish


### PR DESCRIPTION
Didn't realize we didn't have a lock file. `npm ci` only works when we have a lock file.