### PR TITLE
fix fetch with coverage enabled

### DIFF
--- a/lib/compat/dispatcher-weakref.js
+++ b/lib/compat/dispatcher-weakref.js
@@ -22,11 +22,13 @@ class CompatFinalizer {
   }
 
   register (dispatcher, key) {
-    dispatcher.on('disconnect', () => {
-      if (dispatcher[kConnected] === 0 && dispatcher[kSize] === 0) {
-        this.finalizer(key)
-      }
-    })
+    if (dispatcher.on) {
+      dispatcher.on('disconnect', () => {
+        if (dispatcher[kConnected] === 0 && dispatcher[kSize] === 0) {
+          this.finalizer(key)
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
fixes #2328

FinalizationRegister gets disabled with coverage -> use undici's compat one -> attempt to use `.on` with an AbortController -> error. idk what the expected behavior here is.