### PR TITLE
Fix publish undici-types once and for all!

### DIFF
--- a/.github/workflows/publish-undici-types.yml
+++ b/.github/workflows/publish-undici-types.yml
@@ -1,3 +1,5 @@
+name: Publish undici-types
+
 on:
   push:
     tags:
@@ -18,7 +20,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: node scripts/generate-undici-types-package-json.js
-      - run: cd types
       - run: npm publish
+        working-directory: './types'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Apologies for the churn on this, GitHub actions is just my favorite thing to work with. 

I tested this manually here: https://github.com/nodejs/undici/actions/runs/6484620059 so I think we are finally all good after this merges. 