### PR TITLE
fix: user-agent by making __filename check more resilient

### DIFF
--- a/build/fetch.js
+++ b/build/fetch.js
@@ -1,0 +1,36 @@
+const esbuild = require('esbuild')
+const fs = require('fs')
+const path = require('path')
+
+// Copied from: https://github.com/evanw/esbuild/issues/859#issuecomment-829154955
+const nodeModules = /^(?:.*[\\/])?node_modules(?:[\\/].*)?$/
+
+const dirnamePlugin = {
+  name: 'dirname',
+  setup (build) {
+    build.onLoad({ filter: /.*/ }, ({ path: filePath }) => {
+      if (!filePath.match(nodeModules)) {
+        let contents = fs.readFileSync(filePath, 'utf8')
+        const loader = path.extname(filePath).substring(1)
+        const dirname = path.dirname(filePath)
+        contents = contents
+          .replace('__dirname', `"${dirname}"`)
+          .replace('__filename', `"${filePath}"`)
+        return {
+          contents,
+          loader
+        }
+      }
+    })
+  }
+}
+
+esbuild.build({
+  platform: 'node',
+  entryPoints: [path.resolve('index-fetch.js')],
+  bundle: true,
+  outfile: path.resolve('undici-fetch.js'),
+  plugins: [dirnamePlugin]
+}).then(() => {
+  console.log('Build complete.')
+})

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1344,8 +1344,8 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent')) {
-    const filename = __filename ?? globalThis.__filename ?? 'index.js'
-    httpRequest.headersList.append('user-agent', filename.endsWith('index.js') ? 'undici' : 'node')
+    // Node.js doesn't define `__filename` for dependencies, so when this is loaded via `undici-fetch.js` in Node core, this ternary will result in `'node'`. Similarly, if Node ever changes this behavior, this won't break because `'undici-fetch.js'.endsWith('index.js')` will still result in `'node'` being used.
+    httpRequest.headersList.append('user-agent', (globalThis.__filename ?? '').endsWith('index.js') ? 'undici' : 'node')
   }
 
   //    15. If httpRequest’s cache mode is "default" and httpRequest’s header

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1344,12 +1344,7 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent')) {
-    // Node.js doesn't define `__filename` for dependencies, so when this is
-    // loaded via `undici-fetch.js` in Node core, this ternary will result in
-    // `'node'`. Similarly, if Node ever changes this behavior, this won't
-    // break because `'undici-fetch.js'.endsWith('index.js')` will still result
-    // in `'node'` being used.
-    httpRequest.headersList.append('user-agent', (globalThis.__filename ?? '').endsWith('index.js') ? 'undici' : 'node')
+    httpRequest.headersList.append('user-agent', __filename.endsWith('index.js') ? 'undici' : 'node')
   }
 
   //    15. If httpRequest’s cache mode is "default" and httpRequest’s header

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1344,7 +1344,7 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent')) {
-    const filename = __filename ?? globalThis.__filename ?? 'index.js';
+    const filename = __filename ?? globalThis.__filename ?? 'index.js'
     httpRequest.headersList.append('user-agent', filename.endsWith('index.js') ? 'undici' : 'node')
   }
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1344,7 +1344,8 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent')) {
-    httpRequest.headersList.append('user-agent', __filename.endsWith('index.js') ? 'undici' : 'node')
+    const filename = __filename ?? globalThis.__filename ?? 'index.js';
+    httpRequest.headersList.append('user-agent', filename.endsWith('index.js') ? 'undici' : 'node')
   }
 
   //    15. If httpRequest’s cache mode is "default" and httpRequest’s header

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1344,7 +1344,11 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent')) {
-    // Node.js doesn't define `__filename` for dependencies, so when this is loaded via `undici-fetch.js` in Node core, this ternary will result in `'node'`. Similarly, if Node ever changes this behavior, this won't break because `'undici-fetch.js'.endsWith('index.js')` will still result in `'node'` being used.
+    // Node.js doesn't define `__filename` for dependencies, so when this is
+    // loaded via `undici-fetch.js` in Node core, this ternary will result in
+    // `'node'`. Similarly, if Node ever changes this behavior, this won't
+    // break because `'undici-fetch.js'.endsWith('index.js')` will still result
+    // in `'node'` being used.
     httpRequest.headersList.append('user-agent', (globalThis.__filename ?? '').endsWith('index.js') ? 'undici' : 'node')
   }
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "docs"
   ],
   "scripts": {
-    "build:node": "npx esbuild@0.14.38 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js",
+    "build:node": "node build/fetch.js",
     "prebuild:wasm": "node build/wasm.js --prebuild",
     "build:wasm": "node build/wasm.js --docker",
     "lint": "standard | snazzy",
@@ -109,6 +109,7 @@
     "delay": "^5.0.0",
     "dns-packet": "^5.4.0",
     "docsify-cli": "^4.4.3",
+    "esbuild": "^0.19.4",
     "form-data": "^4.0.0",
     "formdata-node": "^4.3.1",
     "https-pem": "^3.0.0",


### PR DESCRIPTION
Rel: https://github.com/nodejs/undici/pull/2310 https://github.com/nodejs/node/pull/50145

For some reason `__filename` is undefined when this gets loaded into node.js

Trying something else that might be more resilient. This also just falls back to `index.js` so that if all goes wrong at least we don't get a runtime error. WDYT? Should we switch the default to result in `'node'`?