### PR TITLE
fix: skip readMore call if parser is null or undefined

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1070,7 +1070,9 @@ function onParserTimeout (parser) {
 
 function onSocketReadable () {
   const { [kParser]: parser } = this
-  parser.readMore()
+  if (kParser) {
+    parser.readMore()
+  }
 }
 
 function onSocketError (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1070,7 +1070,7 @@ function onParserTimeout (parser) {
 
 function onSocketReadable () {
   const { [kParser]: parser } = this
-  if (kParser) {
+  if (parser) {
     parser.readMore()
   }
 }


### PR DESCRIPTION
## This relates to...

Fix #2345

/usr/src/app/node_modules/undici/lib/client.js:1073
  parser.readMore()
         ^

TypeError: Cannot read properties of undefined (reading 'readMore')
    at TLSSocket.onSocketReadable (/usr/src/app/node_modules/undici/lib/client.js:1073:10)
    at TLSSocket.emit (node:events:514:28)
    at emitReadable_ (node:internal/streams/readable:590:12)
    at onEofChunk (node:internal/streams/readable:568:5)
    at readableAddChunk (node:internal/streams/readable:275:5)
    at Readable.push (node:internal/streams/readable:234:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:232:12)

## Changes

Avoid to call the method is parser is not defined or null