### PR TITLE
test: only include WebSocket in WPT Report where it's landed

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:tdd": "tap test/*.js test/diagnostics-channel/*.js -w",
     "test:typescript": "node scripts/verifyVersion.js 14 || tsd && tsc --skipLibCheck test/imports/undici-import.ts",
     "test:websocket": "node scripts/verifyVersion.js 18 || tap test/websocket/*.js",
-    "test:wpt": "node scripts/verifyVersion 18 || (node test/wpt/start-fetch.mjs && node test/wpt/start-FileAPI.mjs && node test/wpt/start-mimesniff.mjs && node test/wpt/start-xhr.mjs && node --no-warnings test/wpt/start-websockets.mjs)",
+    "test:wpt": "node scripts/verifyVersion 18 || (node test/wpt/start-fetch.mjs && node test/wpt/start-FileAPI.mjs && node test/wpt/start-mimesniff.mjs && node test/wpt/start-xhr.mjs && node --no-warnings --expose-internals test/wpt/start-websockets.mjs)",
     "coverage": "nyc --reporter=text --reporter=html npm run test",
     "coverage:ci": "nyc --reporter=lcov npm run test",
     "bench": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench:run",

--- a/test/wpt/start-websockets.mjs
+++ b/test/wpt/start-websockets.mjs
@@ -3,8 +3,17 @@ import { join } from 'path'
 import { fileURLToPath } from 'url'
 import { fork } from 'child_process'
 import { on } from 'events'
+import options from 'internal/options'
 
 const { WPT_REPORT } = process.env
+
+function isGlobalAvailable () {
+  if (typeof WebSocket !== 'undefined') {
+    return true
+  }
+
+  return typeof options.getOptionValue('--experimental-websocket') === 'boolean'
+}
 
 if (process.env.CI) {
   // TODO(@KhafraDev): figure out *why* these tests are flaky in the CI.
@@ -22,7 +31,7 @@ child.on('exit', (code) => process.exit(code))
 for await (const [message] of on(child, 'message')) {
   if (message.server) {
     const runner = new WPTRunner('websockets', message.server, {
-      appendReport: !!WPT_REPORT,
+      appendReport: !!WPT_REPORT && isGlobalAvailable(),
       reportPath: WPT_REPORT
     })
     runner.run()


### PR DESCRIPTION
This makes the inclusion of WebSocket in the daily WPT Report uploaded depend on whether it has landed in the respective tested release line or not (or whether it's already made global by default).

[Currently](https://wpt.fyi/results/websockets?run_id=6203937658503168&run_id=5195270930825216&run_id=5093410379137024) it's reported even for releases where the experimental flag is not available (yet).