### PR TITLE
fix: Avoid error for stream() being aborted

### DIFF
--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -104,6 +104,10 @@ class StreamHandler extends AsyncResource {
         { callback, body: res, contentType, statusCode, statusMessage, headers }
       )
     } else {
+      if (factory === null) {
+        return
+      }
+
       res = this.runInAsyncScope(factory, null, {
         statusCode,
         headers,
@@ -152,13 +156,17 @@ class StreamHandler extends AsyncResource {
   onData (chunk) {
     const { res } = this
 
-    return res.write(chunk)
+    return res ? res.write(chunk) : true
   }
 
   onComplete (trailers) {
     const { res } = this
 
     removeSignal(this)
+
+    if (!res) {
+      return
+    }
 
     this.trailers = util.parseHeaders(trailers)
 

--- a/test/issue-2349.js
+++ b/test/issue-2349.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const { test, skip } = require('tap')
+const { nodeMajor } = require('../lib/core/util')
+const { Writable } = require('stream')
+const { MockAgent, errors, stream } = require('..')
+
+if (nodeMajor < 16) {
+  skip('only for node 16')
+  process.exit(0)
+}
+
+test('stream() does not fail after request has been aborted', async (t) => {
+  t.plan(1)
+
+  const mockAgent = new MockAgent()
+
+  mockAgent.disableNetConnect()
+  mockAgent
+    .get('http://localhost:3333')
+    .intercept({
+      path: '/'
+    })
+    .reply(200, 'ok')
+    .delay(10)
+
+  const parts = []
+  const ac = new AbortController()
+
+  setTimeout(() => ac.abort('nevermind'), 5)
+
+  try {
+    await stream(
+      'http://localhost:3333/',
+      {
+        opaque: { parts },
+        signal: ac.signal,
+        dispatcher: mockAgent
+      },
+      ({ opaque: { parts } }) => {
+        return new Writable({
+          write (chunk, _encoding, callback) {
+            parts.push(chunk)
+            callback()
+          }
+        })
+      }
+    )
+  } catch (error) {
+    console.log(error)
+    t.equal(error instanceof errors.RequestAbortedError, true)
+  }
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes #2349 

## Changes

Now if `factory` is null, it will not be called. This also implies that `StreamHandler.res` may be null in places it was not before, so I also added a couple of checks for that.

### Features

N/A

### Bug Fixes

#2349 

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
