### PR TITLE
Update namespace type with Fetch exports

### DIFF
--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import Undici, {Pool, Client, errors, fetch, Interceptable, RedirectHandler, DecoratorHandler} from '../..'
+import Undici, {Pool, Client, errors, fetch, Interceptable, RedirectHandler, DecoratorHandler, Headers, Response, Request, FormData, File, FileReader} from '../..'
 import Dispatcher from "../../types/dispatcher";
 
 expectAssignable<Pool>(new Undici.Pool('', {}))
@@ -7,6 +7,12 @@ expectAssignable<Client>(new Undici.Client('', {}))
 expectAssignable<Interceptable>(new Undici.MockAgent().get(''))
 expectAssignable<typeof errors>(Undici.errors)
 expectAssignable<typeof fetch>(Undici.fetch)
+expectAssignable<typeof Headers>(Undici.Headers)
+expectAssignable<typeof Response>(Undici.Response)
+expectAssignable<typeof Request>(Undici.Request)
+expectAssignable<typeof FormData>(Undici.FormData)
+expectAssignable<typeof File>(Undici.File)
+expectAssignable<typeof FileReader>(Undici.FileReader)
 
 const client = new Undici.Client('', {})
 const handler: Dispatcher.DispatchHandlers =  {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,5 +53,11 @@ declare namespace Undici {
   var MockAgent: typeof import('./mock-agent').default;
   var mockErrors: typeof import('./mock-errors').default;
   var fetch: typeof import('./fetch').fetch;
+  var Headers: typeof import('./fetch').Headers;
+  var Response: typeof import('./fetch').Response;
+  var Request: typeof import('./fetch').Request;
+  var FormData: typeof import('./formdata').FormData;
+  var File: typeof import('./file').File;
+  var FileReader: typeof import('./filereader').FileReader;
   var caches: typeof import('./cache').caches;
 }


### PR DESCRIPTION
Now that 16 is EOL I think it is okay to update our default types to include the Fetch related exports. 

Corresponds to the exports in `index.js`. 