### PR TITLE
improve `HeadersInit` type

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -50,7 +50,7 @@ export interface SpecIterable<T> {
   [Symbol.iterator](): SpecIterator<T>;
 }
 
-export type HeadersInit = string[][] | Record<string, string | ReadonlyArray<string>> | Headers
+export type HeadersInit = string[][] | Record<string, string | ReadonlyArray<string> | undefined> | Headers
 
 export declare class Headers implements SpecIterable<[string, string]> {
   constructor (init?: HeadersInit)


### PR DESCRIPTION
This PR improves the `HeadersInit` type. The spec sorta gets this wrong (https://fetch.spec.whatwg.org/#typedefdef-headersinit) It only specifies `record<ByteString, ByteString>`, but `record<ByteString, ByteString | undefined` also works. I've tested it in multiple browsers and our implementation, and it works fine. 

This allows me to pass an `IncomingHTTPHeaders` object directly to the constructor (which is valid for all other reasons except for this missing `| undefined`).