### PR TITLE
Add request examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Returns a promise with the result of the `Dispatcher.request` method.
 
 Calls `options.dispatcher.request(options)`.
 
-See [Dispatcher.request](./docs/api/Dispatcher.md#dispatcherrequestoptions-callback) for more details.
+See [Dispatcher.request](./docs/api/Dispatcher.md#dispatcherrequestoptions-callback) for more details, and [request examples](./examples/README.md) for examples.
 
 ### `undici.stream([url, options, ]factory): Promise`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -87,9 +87,11 @@ async function deleteRequest (port = 3001) {
 
   console.log('response received', statusCode)
   console.log('headers', headers)
-  // For a DELETE request we expect a 204 response with no body if successful, in which case getting the body content with .text() or .json() will fail
-  if (statusCode !== 204) {
+  // For a DELETE request we expect a 204 response with no body if successful, in which case getting the body content with .json() will fail
+  if (statusCode === 204) {
     console.log('delete successful')
+    // always consume the body if there is one:
+    await body.dump()
   } else {
     const data = await body.text()
     console.log('received unexpected data', data)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,9 @@
-'use strict'
 
-const { request } = require('../')
+## undici.request() examples
 
+### A simple GET request, read the response body as text:
+```js
+const { request } = require('undici')
 async function getRequest (port = 3001) {
   // A simple GET request
   const {
@@ -15,10 +17,12 @@ async function getRequest (port = 3001) {
   console.log('headers', headers)
   console.log('data', data)
 }
+```
 
+### A JSON POST request, read the response body as json:
+```js
+const { request } = require('undici')
 async function postJSONRequest (port = 3001) {
-  // Make a JSON POST request:
-
   const requestBody = {
     hello: 'JSON POST Example body'
   }
@@ -38,7 +42,11 @@ async function postJSONRequest (port = 3001) {
   console.log('headers', headers)
   console.log('data', decodedJson)
 }
+```
 
+### A Form POST request, read the response body as text:
+```js
+const { request } = require('undici')
 async function postFormRequest (port = 3001) {
   // Make a URL-encoded form POST request:
   const qs = require('querystring')
@@ -61,7 +69,11 @@ async function postFormRequest (port = 3001) {
   console.log('headers', headers)
   console.log('data', data)
 }
+```
 
+### A DELETE request
+```js
+const { request } = require('undici')
 async function deleteRequest (port = 3001) {
   // Make a DELETE request
   const {
@@ -83,10 +95,4 @@ async function deleteRequest (port = 3001) {
     console.log('received unexpected data', data)
   }
 }
-
-module.exports = {
-  getRequest,
-  postJSONRequest,
-  postFormRequest,
-  deleteRequest
-}
+```

--- a/examples/request.js
+++ b/examples/request.js
@@ -75,9 +75,11 @@ async function deleteRequest (port = 3001) {
 
   console.log('response received', statusCode)
   console.log('headers', headers)
-  // For a DELETE request we expect a 204 response with no body if successful, in which case getting the body content with .text() or .json() will fail
-  if (statusCode !== 204) {
+  // For a DELETE request we expect a 204 response with no body if successful, in which case getting the body content with .json() will fail
+  if (statusCode === 204) {
     console.log('delete successful')
+    // always consume the body if there is one:
+    await body.dump()
   } else {
     const data = await body.text()
     console.log('received unexpected data', data)

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { createServer } = require('http')
+const { test } = require('tap')
+const examples = require('../examples/request.js')
+
+test('request examples', async (t) => {
+  let lastReq
+  const exampleServer = createServer((req, res) => {
+    lastReq = req
+    if (req.method === 'DELETE') {
+      res.statusCode = 204
+      return res.end()
+    } else if (req.method === 'POST') {
+      res.statusCode = 200
+      if (req.url === '/json') {
+        res.end('{"hello":"JSON Response"}')
+      } else {
+        res.end('hello=form')
+      }
+    } else {
+      res.statusCode = 200
+      res.end('hello')
+    }
+  })
+
+  t.teardown(exampleServer.close.bind(exampleServer))
+
+  await exampleServer.listen(0)
+
+  await examples.getRequest(exampleServer.address().port)
+  t.equal(lastReq.method, 'GET')
+
+  await examples.postJSONRequest(exampleServer.address().port)
+  t.equal(lastReq.method, 'POST')
+  t.equal(lastReq.headers['content-type'], 'application/json')
+
+  await examples.postFormRequest(exampleServer.address().port)
+  t.equal(lastReq.method, 'POST')
+  t.equal(lastReq.headers['content-type'], 'application/x-www-form-urlencoded')
+
+  await examples.deleteRequest(exampleServer.address().port)
+  t.equal(lastReq.method, 'DELETE')
+
+  t.end()
+})


### PR DESCRIPTION
## Rationale

Help people to get started smoothly by adding some new examples of making basic sorts of requests using `undici.request()`.

Some examples of mistakes I have made at various times using undici that I'm aiming to help others to avoid with this:
 * passing an object to `options.body`, instead of stringified JSON,
 * using the incorrect case for http verbs,
 * missing the necessary content-types for JSON and form POST requests.
 * attempting to decode an empty body as JSON

## Changes

Extended `examples/request.js` with additional examples, and added `test/examples.js` to test them.

### Features

n/a

### Bug Fixes

n/a
### Breaking Changes and Deprecations

n/adeprecations (removed features) here -->

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
