### PR TITLE
refactor: removed unnecessary default

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -57,7 +57,7 @@ class Pool extends PoolBase {
         maxCachedSessions,
         allowH2,
         socketPath,
-        timeout: connectTimeout == null ? 10e3 : connectTimeout,
+        timeout: connectTimeout,
         ...(util.nodeHasAutoSelectFamily && autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect
       })


### PR DESCRIPTION
## Rationale
In Pool() constructor there is unnecessary check `connectTimeout == null ? 10e3 : connectTimeout`
```javascript
class Pool extends PoolBase {
  constructor (origin, {
    connections,
    factory = defaultFactory,
    connect,
    connectTimeout,
    tls,
    maxCachedSessions,
    socketPath,
    autoSelectFamily,
    autoSelectFamilyAttemptTimeout,
    allowH2,
    ...options
  } = {}) {
    super()
    //.........
    if (typeof connect !== 'function') {
      connect = buildConnector({
        ...tls,
        maxCachedSessions,
        allowH2,
        socketPath,
        timeout: connectTimeout == null ? 10e3 : connectTimeout,
        ...(util.nodeHasAutoSelectFamily && autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
        ...connect
      })
    }
   // ...............
}
```
It is unnecessary because buildConnector already has it:
```javascript
function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...opts }) {
  // .............
  timeout = timeout == null ? 10e3 : timeout
  // .............
```
So I removed it from Pool() constructor.

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
