### PR TITLE
perf(headers): Improve Headers

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -56,7 +56,7 @@ function fill (headers, object) {
       }
 
       // 2. Append (header’s first item, header’s second item) to headers.
-      headers.append(header[0], header[1])
+      appendHeader(headers, header[0], header[1])
     }
   } else if (typeof object === 'object' && object !== null) {
     // Note: null should throw
@@ -65,7 +65,7 @@ function fill (headers, object) {
     //    append (key, value) to headers
     const keys = Object.keys(object)
     for (let i = 0; i < keys.length; ++i) {
-      headers.append(keys[i], object[keys[i]])
+      appendHeader(headers, keys[i], object[keys[i]])
     }
   } else {
     throw webidl.errors.conversionFailed({
@@ -74,6 +74,49 @@ function fill (headers, object) {
       types: ['sequence<sequence<ByteString>>', 'record<ByteString, ByteString>']
     })
   }
+}
+
+/**
+ * @see https://fetch.spec.whatwg.org/#concept-headers-append
+ */
+function appendHeader (headers, name, value) {
+  // 1. Normalize value.
+  value = headerValueNormalize(value)
+
+  // 2. If name is not a header name or value is not a
+  //    header value, then throw a TypeError.
+  if (!isValidHeaderName(name)) {
+    throw webidl.errors.invalidArgument({
+      prefix: 'Headers.append',
+      value: name,
+      type: 'header name'
+    })
+  } else if (!isValidHeaderValue(value)) {
+    throw webidl.errors.invalidArgument({
+      prefix: 'Headers.append',
+      value,
+      type: 'header value'
+    })
+  }
+
+  // 3. If headers’s guard is "immutable", then throw a TypeError.
+  // 4. Otherwise, if headers’s guard is "request" and name is a
+  //    forbidden header name, return.
+  // Note: undici does not implement forbidden header names
+  if (headers[kGuard] === 'immutable') {
+    throw new TypeError('immutable')
+  } else if (headers[kGuard] === 'request-no-cors') {
+    // 5. Otherwise, if headers’s guard is "request-no-cors":
+    // TODO
+  }
+
+  // 6. Otherwise, if headers’s guard is "response" and name is a
+  //    forbidden response-header name, return.
+
+  // 7. Append (name, value) to headers’s header list.
+  // 8. If headers’s guard is "request-no-cors", then remove
+  //    privileged no-CORS request headers from headers
+  return headers[kHeadersList].append(name, value)
 }
 
 class HeadersList {
@@ -221,43 +264,7 @@ class Headers {
     name = webidl.converters.ByteString(name)
     value = webidl.converters.ByteString(value)
 
-    // 1. Normalize value.
-    value = headerValueNormalize(value)
-
-    // 2. If name is not a header name or value is not a
-    //    header value, then throw a TypeError.
-    if (!isValidHeaderName(name)) {
-      throw webidl.errors.invalidArgument({
-        prefix: 'Headers.append',
-        value: name,
-        type: 'header name'
-      })
-    } else if (!isValidHeaderValue(value)) {
-      throw webidl.errors.invalidArgument({
-        prefix: 'Headers.append',
-        value,
-        type: 'header value'
-      })
-    }
-
-    // 3. If headers’s guard is "immutable", then throw a TypeError.
-    // 4. Otherwise, if headers’s guard is "request" and name is a
-    //    forbidden header name, return.
-    // Note: undici does not implement forbidden header names
-    if (this[kGuard] === 'immutable') {
-      throw new TypeError('immutable')
-    } else if (this[kGuard] === 'request-no-cors') {
-      // 5. Otherwise, if headers’s guard is "request-no-cors":
-      // TODO
-    }
-
-    // 6. Otherwise, if headers’s guard is "response" and name is a
-    //    forbidden response-header name, return.
-
-    // 7. Append (name, value) to headers’s header list.
-    // 8. If headers’s guard is "request-no-cors", then remove
-    //    privileged no-CORS request headers from headers
-    return this[kHeadersList].append(name, value)
+    return appendHeader(this, name, value)
   }
 
   // https://fetch.spec.whatwg.org/#dom-headers-delete

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -34,7 +34,7 @@ function headerValueNormalize (potentialValue) {
   let i = 0; let j = potentialValue.length
 
   while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j
-  while (i > j && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i
+  while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i
 
   return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.substring(i, j)
 }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -36,7 +36,7 @@ function headerValueNormalize (potentialValue) {
   while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j
   while (i > j && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i
 
-  return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.slice(i, j)
+  return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.substring(i, j)
 }
 
 function fill (headers, object) {

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -20,7 +20,7 @@ const kHeadersSortedMap = Symbol('headers map sorted')
  * @param {number} code
  */
 function isHTTPWhiteSpaceCharCode (code) {
-  return code === 0x00a || code === 0x00d || code === 0x009 || code === 0x020;
+  return code === 0x00a || code === 0x00d || code === 0x009 || code === 0x020
 }
 
 /**

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -114,9 +114,10 @@ function appendHeader (headers, name, value) {
   //    forbidden response-header name, return.
 
   // 7. Append (name, value) to headers’s header list.
+  return headers[kHeadersList].append(name, value)
+
   // 8. If headers’s guard is "request-no-cors", then remove
   //    privileged no-CORS request headers from headers
-  return headers[kHeadersList].append(name, value)
 }
 
 class HeadersList {

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -20,15 +20,7 @@ const kHeadersSortedMap = Symbol('headers map sorted')
  * @param {number} code
  */
 function isHTTPWhiteSpaceCharCode (code) {
-  switch (code) {
-    case 0x00a:
-    case 0x00d:
-    case 0x009:
-    case 0x020:
-      return true
-    default:
-      return false
-  }
+  return code === 0x00a || code === 0x00d || code === 0x009 || code === 0x020;
 }
 
 /**

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -53,7 +53,7 @@ function fill (headers, object) {
   // 1. If object is a sequence, then for each header in object:
   // Note: webidl conversion to array has already been done.
   if (Array.isArray(object)) {
-    for (let i = 0; i < object.length; i++) {
+    for (let i = 0; i < object.length; ++i) {
       const header = object[i]
       // 1. If header does not contain exactly two items, then throw a TypeError.
       if (header.length !== 2) {
@@ -72,9 +72,8 @@ function fill (headers, object) {
     // 2. Otherwise, object is a record, then for each key → value in object,
     //    append (key, value) to headers
     const keys = Object.keys(object)
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i]
-      headers.append(key, object[key])
+    for (let i = 0; i < keys.length; ++i) {
+      headers.append(keys[i], object[keys[i]])
     }
   } else {
     throw webidl.errors.conversionFailed({
@@ -440,7 +439,7 @@ class Headers {
     const cookies = this[kHeadersList].cookies
 
     // 3. For each name of names:
-    for (let i = 0; i < names.length; i++) {
+    for (let i = 0; i < names.length; ++i) {
       const [name, value] = names[i]
       // 1. If name is `set-cookie`, then:
       if (name === 'set-cookie') {
@@ -449,7 +448,7 @@ class Headers {
 
         // 2. For each value of values:
         // 1. Append (name, value) to headers.
-        for (let j = 0; j < cookies.length; j++) {
+        for (let j = 0; j < cookies.length; ++j) {
           headers.push([name, cookies[j]])
         }
       } else {

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -17,6 +17,21 @@ const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
 
 /**
+ * @param {number} code
+ */
+function isHTTPWhiteSpaceCharCode (code) {
+  switch (code) {
+    case 0x00a:
+    case 0x00d:
+    case 0x009:
+    case 0x020:
+      return true
+    default:
+      return false
+  }
+}
+
+/**
  * @see https://fetch.spec.whatwg.org/#concept-header-value-normalize
  * @param {string} potentialValue
  */
@@ -24,12 +39,12 @@ function headerValueNormalize (potentialValue) {
   //  To normalize a byte sequence potentialValue, remove
   //  any leading and trailing HTTP whitespace bytes from
   //  potentialValue.
+  let i = 0; let j = potentialValue.length
 
-  // Trimming the end with `.replace()` and a RegExp is typically subject to
-  // ReDoS. This is safer and faster.
-  let i = potentialValue.length
-  while (/[\r\n\t ]/.test(potentialValue.charAt(--i)));
-  return potentialValue.slice(0, i + 1).replace(/^[\r\n\t ]+/, '')
+  while (j > i && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(j - 1))) --j
+  while (i > j && isHTTPWhiteSpaceCharCode(potentialValue.charCodeAt(i))) ++i
+
+  return i === 0 && j === potentialValue.length ? potentialValue : potentialValue.slice(i, j)
 }
 
 function fill (headers, object) {
@@ -38,7 +53,8 @@ function fill (headers, object) {
   // 1. If object is a sequence, then for each header in object:
   // Note: webidl conversion to array has already been done.
   if (Array.isArray(object)) {
-    for (const header of object) {
+    for (let i = 0; i < object.length; i++) {
+      const header = object[i]
       // 1. If header does not contain exactly two items, then throw a TypeError.
       if (header.length !== 2) {
         throw webidl.errors.exception({
@@ -55,8 +71,10 @@ function fill (headers, object) {
 
     // 2. Otherwise, object is a record, then for each key → value in object,
     //    append (key, value) to headers
-    for (const [key, value] of Object.entries(object)) {
-      headers.append(key, value)
+    const keys = Object.keys(object)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      headers.append(key, object[key])
     }
   } else {
     throw webidl.errors.conversionFailed({
@@ -422,7 +440,8 @@ class Headers {
     const cookies = this[kHeadersList].cookies
 
     // 3. For each name of names:
-    for (const [name, value] of names) {
+    for (let i = 0; i < names.length; i++) {
+      const [name, value] = names[i]
       // 1. If name is `set-cookie`, then:
       if (name === 'set-cookie') {
         // 1. Let values be a list of all values of headers in list whose name
@@ -430,8 +449,8 @@ class Headers {
 
         // 2. For each value of values:
         // 1. Append (name, value) to headers.
-        for (const value of cookies) {
-          headers.push([name, value])
+        for (let j = 0; j < cookies.length; j++) {
+          headers.push([name, cookies[j]])
         }
       } else {
         // 2. Otherwise:

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -399,6 +399,11 @@ webidl.nullableConverter = function (converter) {
 
 // https://webidl.spec.whatwg.org/#es-DOMString
 webidl.converters.DOMString = function (V, opts = {}) {
+  // Note: avoid re-stringify
+  if (typeof V === 'string') {
+    return V
+  }
+
   // 1. If V is null and the conversion is to an IDL type
   //    associated with the [LegacyNullToEmptyString]
   //    extended attribute, then return the DOMString value
@@ -427,12 +432,10 @@ webidl.converters.ByteString = function (V) {
   // 2. If the value of any element of x is greater than
   //    255, then throw a TypeError.
   for (let index = 0; index < x.length; index++) {
-    const charCode = x.charCodeAt(index)
-
-    if (charCode > 255) {
+    if (x.charCodeAt(index) > 255) {
       throw new TypeError(
         'Cannot convert argument to a ByteString because the character at ' +
-        `index ${index} has a value of ${charCode} which is greater than 255.`
+        `index ${index} has a value of ${x.charCodeAt(index)} which is greater than 255.`
       )
     }
   }

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -399,11 +399,6 @@ webidl.nullableConverter = function (converter) {
 
 // https://webidl.spec.whatwg.org/#es-DOMString
 webidl.converters.DOMString = function (V, opts = {}) {
-  // Note: avoid re-stringify
-  if (typeof V === 'string') {
-    return V
-  }
-
   // 1. If V is null and the conversion is to an IDL type
   //    associated with the [LegacyNullToEmptyString]
   //    extended attribute, then return the DOMString value


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

This eliminates the `Headers` performance bottleneck.

- `for...of` is slower than `for(;;)`.
- `Object.entries` is slower than  `Object.keys`.
- Reduced the number of variables in the function `ByteString`.
- When trimming `HTTP whitespace`, using RegExp is slow, so change to using `charCodeAt` instead.

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->


### Features

<!-- List the new features here (if applicable), or write N/A if not -->

N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

N/A

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

N/A

## Benchmark


```js
// bench.js
const Headers = require("./lib/fetch/headers.js").Headers;
const benchmark = require("benchmark");

const suite = new benchmark.Suite();

const headers = {
  "Content-Type": "application/json",
  "X-Content-Type": "application/json",
  Date: "Wed, 01 Nov 2023 00:00:00 GMT",
  "X-NodeJS-Version": "v21.1.0",
  "Powered-By": "NodeJS",
  "Content-Encoding": "gzip",
  "Set-Cookie": "__Secure-ID=123; Secure; Domain=example.com",
  "Content-Length": "150",
  Vary: "Accept-Encoding, Accept, X-Requested-With",
};

const headersEntries = Object.entries(headers);


suite.add("new Headers - record", () => {
  new Headers(headers);
});

suite.add("new Headers - entries", () => {
  new Headers(headersEntries);
});

suite.on("cycle", function (event) {
  console.log(String(event.target));
});

// run async
suite.run({ async: true });
```

- main
```
new Headers - record x 144,160 ops/sec ±1.91% (85 runs sampled)
new Headers - entries x 156,706 ops/sec ±1.88% (83 runs sampled)
```

- this patch
```
new Headers - record x 179,333 ops/sec ±4.49% (72 runs sampled)
new Headers - entries x 170,316 ops/sec ±2.39% (80 runs sampled)
```

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
