### PR TITLE
fix(parseHeaders): util.parseHeaders handle correctly array of buffer…

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -228,7 +228,7 @@ function parseHeaders (headers, obj = {}) {
 
     if (!val) {
       if (Array.isArray(headers[i + 1])) {
-        obj[key] = headers[i + 1]
+        obj[key] = headers[i + 1].map(x => x.toString('utf8'))
       } else {
         obj[key] = headers[i + 1].toString('utf8')
       }

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2594,5 +2594,9 @@ test('MockAgent - headers should be array of strings', async (t) => {
     method: 'GET'
   })
 
-  t.equal(headers['set-cookie'].length, 3)
+  t.same(headers['set-cookie'], [
+    'foo=bar',
+    'bar=baz',
+    'baz=qux'
+  ])
 })

--- a/test/util.js
+++ b/test/util.js
@@ -83,12 +83,13 @@ test('validateHandler', (t) => {
 })
 
 test('parseHeaders', (t) => {
-  t.plan(5)
+  t.plan(6)
   t.same(util.parseHeaders(['key', 'value']), { key: 'value' })
   t.same(util.parseHeaders([Buffer.from('key'), Buffer.from('value')]), { key: 'value' })
   t.same(util.parseHeaders(['Key', 'Value']), { key: 'Value' })
   t.same(util.parseHeaders(['Key', 'value', 'key', 'Value']), { key: ['value', 'Value'] })
   t.same(util.parseHeaders(['key', ['value1', 'value2', 'value3']]), { key: ['value1', 'value2', 'value3'] })
+  t.same(util.parseHeaders([Buffer.from('key'), [Buffer.from('value1'), Buffer.from('value2'), Buffer.from('value3')]]), { key: ['value1', 'value2', 'value3'] })
 })
 
 test('parseRawHeaders', (t) => {


### PR DESCRIPTION
This PR fixes the fact that the **core.util.parseHeaders** method doesn't handle correctly the array as value in the headers anymore, this is due to the fact that has been changed to be buffer.
So I've added .map to handle array of buffer and adjusted/added 2 tests for that.


## This relates to...

This PR is meant to refactor this https://github.com/nodejs/undici/pull/1598 in order to be compliant with the changes made here https://github.com/nodejs/undici/commit/c0ba75f784765e81722d0c2b31c08d273e04b0f6#diff-c4f217e7477ce1df4b03f4b49686fed580dd178618caba17e97bb75cbdff4eca that now return an array of buffer.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
