### PR TITLE
feat: allow customization of build environment

### DIFF
--- a/build/wasm.js
+++ b/build/wasm.js
@@ -9,6 +9,18 @@ const WASM_SRC = resolve(__dirname, '../deps/llhttp')
 const WASM_OUT = resolve(__dirname, '../lib/llhttp')
 const DOCKERFILE = resolve(__dirname, './Dockerfile')
 
+// These are defined by build environment
+const WASM_CC = process.env.WASM_CC || 'clang'
+let WASM_CFLAGS = process.env.WASM_CFLAGS || '--sysroot=/usr/share/wasi-sysroot -target wasm32-unknown-wasi'
+let WASM_LDFLAGS = process.env.WASM_LDFLAGS || ''
+const WASM_LDLIBS = process.env.WASM_LDLIBS || ''
+
+// These are relevant for undici and should not be overridden
+WASM_CFLAGS += ' -Ofast -fno-exceptions -fvisibility=hidden -mexec-model=reactor'
+WASM_LDFLAGS += ' -Wl,-error-limit=0 -Wl,-O3 -Wl,--lto-O3 -Wl,--strip-all'
+WASM_LDFLAGS += ' -Wl,--allow-undefined -Wl,--export-dynamic -Wl,--export-table'
+WASM_LDFLAGS += ' -Wl,--export=malloc -Wl,--export=free -Wl,--no-entry'
+
 let platform = process.env.WASM_PLATFORM
 if (!platform && process.argv[2]) {
   platform = execSync('docker info -f "{{.OSType}}/{{.Architecture}}"').toString().trim()
@@ -35,35 +47,25 @@ if (process.argv[2] === '--docker') {
   process.exit(0)
 }
 
-// Gather information about the tools used for the build
-const buildInfo = execSync('apk info -v').toString()
-if (!buildInfo.includes('wasi-sdk')) {
-  console.log('Failed to generate build environment information')
-  process.exit(-1)
+const hasApk = (function () {
+  try { execSync('command -v apk'); return true } catch (error) { return false }
+})()
+if (hasApk) {
+  // Gather information about the tools used for the build
+  const buildInfo = execSync('apk info -v').toString()
+  if (!buildInfo.includes('wasi-sdk')) {
+    console.log('Failed to generate build environment information')
+    process.exit(-1)
+  }
+  writeFileSync(join(WASM_OUT, 'wasm_build_env.txt'), buildInfo)
 }
-writeFileSync(join(WASM_OUT, 'wasm_build_env.txt'), buildInfo)
 
 // Build wasm binary
-execSync(`clang \
- --sysroot=/usr/share/wasi-sysroot \
- -target wasm32-unknown-wasi \
- -Ofast \
- -fno-exceptions \
- -fvisibility=hidden \
- -mexec-model=reactor \
- -Wl,-error-limit=0 \
- -Wl,-O3 \
- -Wl,--lto-O3 \
- -Wl,--strip-all \
- -Wl,--allow-undefined \
- -Wl,--export-dynamic \
- -Wl,--export-table \
- -Wl,--export=malloc \
- -Wl,--export=free \
- -Wl,--no-entry \
+execSync(`${WASM_CC} ${WASM_CFLAGS} ${WASM_LDFLAGS} \
  ${join(WASM_SRC, 'src')}/*.c \
  -I${join(WASM_SRC, 'include')} \
- -o ${join(WASM_OUT, 'llhttp.wasm')}`, { stdio: 'inherit' })
+ -o ${join(WASM_OUT, 'llhttp.wasm')} \
+ ${WASM_LDLIBS}`, { stdio: 'inherit' })
 
 const base64Wasm = readFileSync(join(WASM_OUT, 'llhttp.wasm')).toString('base64')
 writeFileSync(
@@ -72,27 +74,11 @@ writeFileSync(
 )
 
 // Build wasm simd binary
-execSync(`clang \
- --sysroot=/usr/share/wasi-sysroot \
- -target wasm32-unknown-wasi \
- -msimd128 \
- -Ofast \
- -fno-exceptions \
- -fvisibility=hidden \
- -mexec-model=reactor \
- -Wl,-error-limit=0 \
- -Wl,-O3 \
- -Wl,--lto-O3 \
- -Wl,--strip-all \
- -Wl,--allow-undefined \
- -Wl,--export-dynamic \
- -Wl,--export-table \
- -Wl,--export=malloc \
- -Wl,--export=free \
- -Wl,--no-entry \
+execSync(`${WASM_CC} ${WASM_CFLAGS} -msimd128 ${WASM_LDFLAGS} \
  ${join(WASM_SRC, 'src')}/*.c \
  -I${join(WASM_SRC, 'include')} \
- -o ${join(WASM_OUT, 'llhttp_simd.wasm')}`, { stdio: 'inherit' })
+ -o ${join(WASM_OUT, 'llhttp_simd.wasm')} \
+ ${WASM_LDLIBS}`, { stdio: 'inherit' })
 
 const base64WasmSimd = readFileSync(join(WASM_OUT, 'llhttp_simd.wasm')).toString('base64')
 writeFileSync(


### PR DESCRIPTION
This allows for the WASM artifacts to be built elsewhere than only in the alpine-based node container.

## Rationale

Pre-built WASM artifacts are often a no-go when creating packages for Linux distributions; they need to be rebuilt from source on trusted build system by the package maintainer. This PR allows me to easily tweak the build parameters and flags for the WASM build to do just that.

## Changes

The `build/wasm.js` script now checks for presence and content of several related environment variables (`WASM_CC`, `WASM_CFLAGS`, `WASM_LDFLAGS`, and `WASM_LDLIBS`; the names mirror those traditionally used in C Makefiles). If present, content of these variables override some of the compilation flags that are directly dependent on the build environment (i.e. `--target` and `--sysroot`).

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md

---

Note: This is a minimal change that does what I need. I was also toying with the idea to convert the build process (without container management) to separate Makefile; this would enable the WASM build to not require nodejs on the build machine. I'm not sure this is worth it or if it's anything you would want to maintain; let me know what you think.