### PR TITLE
perf: optimize HeadersList.get

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -208,9 +208,7 @@ class HeadersList {
 
   // https://fetch.spec.whatwg.org/#concept-header-list-get
   get (name) {
-    name = name.toLowerCase()
-
-    const value = this[kHeadersMap].get(name)
+    const value = this[kHeadersMap].get(name.toLowerCase())
 
     // 1. If list does not contain name, then return null.
     // 2. Return the values of all headers in list whose name

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -208,15 +208,15 @@ class HeadersList {
 
   // https://fetch.spec.whatwg.org/#concept-header-list-get
   get (name) {
-    // 1. If list does not contain name, then return null.
-    if (!this.contains(name)) {
-      return null
-    }
+    name = name.toLowerCase()
 
+    const value = this[kHeadersMap].get(name)
+
+    // 1. If list does not contain name, then return null.
     // 2. Return the values of all headers in list whose name
     //    is a byte-case-insensitive match for name,
     //    separated from each other by 0x2C 0x20, in order.
-    return this[kHeadersMap].get(name.toLowerCase())?.value ?? null
+    return value === undefined ? null : value.value
   }
 
   * [Symbol.iterator] () {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Reducing the number of calls `String#toLowerCase` showed a 2-fold improvement over main.
However, if no value is present, it will be slightly slower.
See Benchmark

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

N/A

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

N/A

## Benchmark

```js
// bench.js
const { Headers } = require("./lib/fetch/headers.js");
const { kHeadersList } = require("./lib/core/symbols.js");
const benchmark = require("benchmark");
const suite = new benchmark.Suite();

const headers = new Headers({ "Accept-Encoding": "gzip" });

const headersList = headers[kHeadersList];

suite.add("HeadersList.get - Existing", () => {
  headersList.get("Accept-Encoding");
});

suite.add("HeadersList.get - non Existing", () => {
  headersList.get("Accept-Language");
});

suite.add("Headers.get - Existing", () => {
  headers.get("Accept-Encoding");
});

suite.add("Headers.get - non Existing", () => {
  headers.get("Accept-Language");
});

suite.on("cycle", function (event) {
  console.log(String(event.target));
});

// run async
suite.run({ async: true });
```

- *main*
```
HeadersList.get - Existing x 33,034,921 ops/sec ±3.75% (85 runs sampled)
HeadersList.get - non Existing x 159,049,670 ops/sec ±1.70% (86 runs sampled)
Headers.get - Existing x 4,780,193 ops/sec ±2.16% (77 runs sampled)
Headers.get - non Existing x 4,809,305 ops/sec ±2.08% (80 runs sampled)
```

- *this PR*
```
HeadersList.get - Existing x 62,210,720 ops/sec ±2.63% (82 runs sampled)
HeadersList.get - non Existing x 144,683,562 ops/sec ±2.14% (85 runs sampled)
Headers.get - Existing x 5,080,302 ops/sec ±2.22% (85 runs sampled)
Headers.get - non Existing x 4,974,778 ops/sec ±2.75% (83 runs sampled)```
```

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
