### PR TITLE
ci: unpin nodejs workflow version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Test
-    uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1.7
+    uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1
     with:
       runs-on: ubuntu-latest, windows-latest
       test-command: npm run coverage:ci


### PR DESCRIPTION
Not 100% sure if it was pinned deliberately earlier - there are several other things that are pinned to major only, and I think that's fine. When this is pinned, it might sometimes not receive new versions of Node.js (as the release dates are cached inside the action, as opposed to getting resolved each time).

For some reason, dependabot did not open a PR here 🤷

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->
