### PR TITLE
perf(request): optimize if headers are given

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -129,8 +129,8 @@ function headersListCopy (A, B) {
     for (const entry of B[kHeadersMap]) {
       A[kHeadersMap].set(entry[0], entry[1])
     }
-    A.cookies = B.cookies === null ? null : [...B.cookies]
   }
+  A.cookies = B.cookies === null ? null : [...B.cookies]
 }
 
 class HeadersList {

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -126,8 +126,8 @@ function appendHeader (headers, name, value) {
  */
 function headersListCopy (A, B) {
   if (B[kHeadersMap].size !== 0) {
-    for (const [key, { name, value }] of B[kHeadersMap]) {
-      A[kHeadersMap].set(key, { name, value })
+    for (const entry of B[kHeadersMap]) {
+      A[kHeadersMap].set(entry[0], entry[1])
     }
     A.cookies = B.cookies === null ? null : [...B.cookies]
   }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -120,6 +120,19 @@ function appendHeader (headers, name, value) {
   //    privileged no-CORS request headers from headers
 }
 
+/**
+ * @param {HeadersList} A copy destination
+ * @param {HeadersList} B copy source
+ */
+function headersListCopy (A, B) {
+  if (B[kHeadersMap].size !== 0) {
+    for (const [key, { name, value }] of B[kHeadersMap]) {
+      A[kHeadersMap].set(key, { name, value })
+    }
+    A.cookies = B.cookies === null ? null : [...B.cookies]
+  }
+}
+
 class HeadersList {
   /** @type {[string, string][]|null} */
   cookies = null
@@ -222,6 +235,10 @@ class HeadersList {
     for (const [name, { value }] of this[kHeadersMap]) {
       yield [name, value]
     }
+  }
+
+  get mapSize () {
+    return this[kHeadersMap].size
   }
 
   get entries () {
@@ -581,6 +598,7 @@ webidl.converters.HeadersInit = function (V) {
 
 module.exports = {
   fill,
+  headersListCopy,
   Headers,
   HeadersList
 }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -120,19 +120,6 @@ function appendHeader (headers, name, value) {
   //    privileged no-CORS request headers from headers
 }
 
-/**
- * @param {HeadersList} A copy destination
- * @param {HeadersList} B copy source
- */
-function headersListCopy (A, B) {
-  if (B[kHeadersMap].size !== 0) {
-    for (const entry of B[kHeadersMap]) {
-      A[kHeadersMap].set(entry[0], entry[1])
-    }
-  }
-  A.cookies = B.cookies === null ? null : [...B.cookies]
-}
-
 class HeadersList {
   /** @type {[string, string][]|null} */
   cookies = null
@@ -235,10 +222,6 @@ class HeadersList {
     for (const [name, { value }] of this[kHeadersMap]) {
       yield [name, value]
     }
-  }
-
-  get mapSize () {
-    return this[kHeadersMap].size
   }
 
   get entries () {
@@ -598,7 +581,6 @@ webidl.converters.HeadersInit = function (V) {
 
 module.exports = {
   fill,
-  headersListCopy,
   Headers,
   HeadersList
 }

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -440,7 +440,7 @@ class Request {
         for (const [key, val] of headers) {
           headersList.append(key, val)
         }
-        // Note: Copy the `set-cooke` meta-data.
+        // Note: Copy the `set-cookie` meta-data.
         headersList.cookies = headers.cookies
       } else {
         // 5. Otherwise, fill this’s headers with headers.

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -423,6 +423,7 @@ class Request {
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
       let headers
+
       // 2. If init["headers"] exists, then set headers to init["headers"].
       if (init.headers !== undefined) {
         headers = init.headers

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -183,8 +183,10 @@ class Request {
       urlList: [...request.urlList]
     })
 
+    const initHasKey = Object.keys(init).length !== 0
+
     // 13. If init is not empty, then:
-    if (Object.keys(init).length > 0) {
+    if (initHasKey) {
       // 1. If request’s mode is "navigate", then set it to "same-origin".
       if (request.mode === 'navigate') {
         request.mode = 'same-origin'
@@ -415,23 +417,23 @@ class Request {
     }
 
     // 32. If init is not empty, then:
-    // Note: Avoid call `Object.keys` if init["headers"] is not undefined.
-    if (init.headers !== undefined || Object.keys(init).length !== 0) {
+    if (initHasKey) {
+      const headersList = this[kHeaders][kHeadersList]
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
       // 2. If init["headers"] exists, then set headers to init["headers"].
       // Note: Avoid call `HeadersList` if init["headers"] is not undefined
-      const headers = init.headers !== undefined ? init.headers : new HeadersList(request.headersList)
+      const headers = init.headers !== undefined ? init.headers : new HeadersList(headersList)
 
       // 3. Empty this’s headers’s header list.
       // Note: Avoid call `HeadersList#clear` if already empty
-      if (request.headersList.mapSize !== 0) request.headersList.clear()
+      if (headersList.mapSize !== 0) headersList.clear()
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       // Note: If init["headers"] is undefined, then it is `HeadersList`.
       if (init.headers === undefined) {
-        headersListCopy(request.headersList, headers)
+        headersListCopy(headersList, headers)
       } else {
         // 5. Otherwise, fill this’s headers with headers.
         fillHeaders(this[kHeaders], headers)

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -437,8 +437,8 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        for (const [key, value] of headers) {
-          headersList.set(key, value)
+        for (const [key, val] of headers) {
+          headersList.set(key, val)
         }
         headersList.cookies = headers.cookies
       } else {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -440,6 +440,7 @@ class Request {
         for (const [key, val] of headers) {
           headersList.set(key, val)
         }
+        // Note: Copy the `set-cooke` meta-data.
         headersList.cookies = headers.cookies
       } else {
         // 5. Otherwise, fill this’s headers with headers.

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -422,8 +422,8 @@ class Request {
       const headersList = this[kHeaders][kHeadersList]
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
-      // 2. If init["headers"] exists, then set headers to init["headers"].
       let headers
+      // 2. If init["headers"] exists, then set headers to init["headers"].
       if (init.headers !== undefined) {
         headers = init.headers
       } else {
@@ -436,8 +436,8 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        for (const entry of headers) {
-          headersList.set(entry[0], entry[1])
+        for (const [key, value] of headers) {
+          headersList.set(key, value)
         }
         headersList.cookies = headers.cookies
       } else {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -422,14 +422,8 @@ class Request {
       const headersList = this[kHeaders][kHeadersList]
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
-      let headers
-
       // 2. If init["headers"] exists, then set headers to init["headers"].
-      if (init.headers !== undefined) {
-        headers = init.headers
-      } else {
-        headers = new HeadersList(headersList)
-      }
+      const headers = init.headers !== undefined ? init.headers : new HeadersList(headersList)
 
       // 3. Empty this’s headers’s header list.
       headersList.clear()

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -428,7 +428,7 @@ class Request {
       if (init.headers !== undefined) {
         headers = init.headers
       } else {
-        init.headers = new HeadersList(headersList)
+        headers = new HeadersList(headersList)
       }
 
       // 3. Empty this’s headers’s header list.

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -3,7 +3,7 @@
 'use strict'
 
 const { extractBody, mixinBody, cloneBody } = require('./body')
-const { Headers, fill: fillHeaders, HeadersList, headersListCopy } = require('./headers')
+const { Headers, fill: fillHeaders, HeadersList } = require('./headers')
 const { FinalizationRegistry } = require('../compat/dispatcher-weakref')()
 const util = require('../core/util')
 const {
@@ -418,22 +418,28 @@ class Request {
 
     // 32. If init is not empty, then:
     if (initHasKey) {
+      /** @type {HeadersList} */
       const headersList = this[kHeaders][kHeadersList]
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
       // 2. If init["headers"] exists, then set headers to init["headers"].
-      // Note: Avoid call `HeadersList` if init["headers"] is not undefined
-      const headers = init.headers !== undefined ? init.headers : new HeadersList(headersList)
+      let headers
+      if (init.headers !== undefined) {
+        headers = init.headers
+      } else {
+        init.headers = new HeadersList(headersList)
+      }
 
       // 3. Empty this’s headers’s header list.
-      // Note: Avoid call `HeadersList#clear` if already empty
-      if (headersList.mapSize !== 0) headersList.clear()
+      headersList.clear()
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
-      // Note: If init["headers"] is undefined, then it is `HeadersList`.
-      if (init.headers === undefined) {
-        headersListCopy(headersList, headers)
+      if (headers instanceof HeadersList) {
+        for (const entry of headers) {
+          headersList.set(entry[0], entry[1])
+        }
+        headersList.cookies = headers.cookies
       } else {
         // 5. Otherwise, fill this’s headers with headers.
         fillHeaders(this[kHeaders], headers)

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -438,7 +438,7 @@ class Request {
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
         for (const [key, val] of headers) {
-          headersList.set(key, val)
+          headersList.append(key, val)
         }
         // Note: Copy the `set-cooke` meta-data.
         headersList.cookies = headers.cookies

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -3,7 +3,7 @@
 'use strict'
 
 const { extractBody, mixinBody, cloneBody } = require('./body')
-const { Headers, fill: fillHeaders, HeadersList } = require('./headers')
+const { Headers, fill: fillHeaders, HeadersList, headersListCopy } = require('./headers')
 const { FinalizationRegistry } = require('../compat/dispatcher-weakref')()
 const util = require('../core/util')
 const {
@@ -415,25 +415,23 @@ class Request {
     }
 
     // 32. If init is not empty, then:
-    if (Object.keys(init).length !== 0) {
+    // Note: Avoid call `Object.keys` if init["headers"] is not undefined.
+    if (init.headers !== undefined || Object.keys(init).length !== 0) {
       // 1. Let headers be a copy of this’s headers and its associated header
       // list.
-      let headers = new Headers(this[kHeaders])
-
       // 2. If init["headers"] exists, then set headers to init["headers"].
-      if (init.headers !== undefined) {
-        headers = init.headers
-      }
+      // Note: Avoid call `HeadersList` if init["headers"] is not undefined
+      const headers = init.headers !== undefined ? init.headers : new HeadersList(request.headersList)
 
       // 3. Empty this’s headers’s header list.
-      this[kHeaders][kHeadersList].clear()
+      // Note: Avoid call `HeadersList#clear` if already empty
+      if (request.headersList.mapSize !== 0) request.headersList.clear()
 
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
-      if (headers.constructor.name === 'Headers') {
-        for (const [key, val] of headers) {
-          this[kHeaders].append(key, val)
-        }
+      // Note: If init["headers"] is undefined, then it is `HeadersList`.
+      if (init.headers === undefined) {
+        headersListCopy(request.headersList, headers)
       } else {
         // 5. Otherwise, fill this’s headers with headers.
         fillHeaders(this[kHeaders], headers)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

For performance improvement:
1. Do not call `Object.keys` more than once.
2. When copying the `headersList`, use `HeadersList` instead of `Headers`.
3. Avoid call `HeadersList` if init["headers"] is not undefined
4. When looping through headers, use `HeadersList` instead of `Headers`, which eliminates the sorting process and is faster.

## Benchmark

```js
// bench.js
const { Request } = require(".");
const benchmark = require("benchmark");

const suite = new benchmark.Suite();

const headers = {
  "Content-Type": "application/json",
  "X-Content-Type": "application/json",
  Date: "Wed, 01 Nov 2023 00:00:00 GMT",
  "X-NodeJS-Version": "v21.1.0",
  "Powered-By": "NodeJS",
  "Content-Encoding": "gzip",
  "Set-Cookie": "__Secure-ID=123; Secure; Domain=example.com",
  "Content-Length": "150",
  Vary: "Accept-Encoding, Accept, X-Requested-With",
};

const headersEntries = Object.entries(headers);
suite.add("new Request() - record", () => {
  new Request("https://example.com/post", {
    headers: headers,
  });
});

suite.add("new Request() - record without constructor", () => {
  const request = new Request("https://example.com/post", {});
  const h = request.headers
  const keys = Object.keys(headers);
  for (let i = 0; i < keys.length; ++i) {
    h.append(keys[i], headers[keys[i]]);
  } 
})

suite.add("new Request() - entires", () => {
  new Request("https://example.com/post", {
    headers: headersEntries,
  });
});

suite.add("new Request() - entires without constructor", () => {
  const request = new Request("https://example.com/post", {});
  const h = request.headers
  for (let i = 0; i < headersEntries.length; ++i) {
    h.append(headersEntries[i][0], headersEntries[i][1]);
  }
});

suite.on("cycle", function (event) {
  console.log(String(event.target));
});

// run async
suite.run({ async: true });
```

- *v5.27.2*
```
new Request() - record x 34,814 ops/sec ±3.33% (75 runs sampled)
new Request() - record without constructor x 64,510 ops/sec ±2.22% (85 runs sampled)
new Request() - entires x 34,316 ops/sec ±3.31% (77 runs sampled)
new Request() - entires without constructor x 61,662 ops/sec ±3.00% (79 runs sampled)
```

- *main*
```
new Request() - record x 41,193 ops/sec ±5.16% (75 runs sampled)
new Request() - record without constructor x 65,217 ops/sec ±2.69% (80 runs sampled)
new Request() - entires x 38,771 ops/sec ±2.78% (78 runs sampled)
new Request() - entires without constructor x 68,280 ops/sec ±2.86% (83 runs sampled)
```

- *this patch*
```
new Request() - record x 68,534 ops/sec ±2.08% (80 runs sampled)
new Request() - record without constructor x 69,161 ops/sec ±2.31% (83 runs sampled)
new Request() - entires x 65,713 ops/sec ±2.13% (84 runs sampled)
new Request() - entires without constructor x 67,820 ops/sec ±2.57% (79 runs sampled)
```

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
