### PR TITLE
fix: Add `null` type to `signal` in `RequestInit`

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -42,7 +42,7 @@ expectType<HeadersInit | undefined>(requestInit.headers)
 expectType<BodyInit | undefined>(requestInit.body)
 expectType<RequestRedirect | undefined>(requestInit.redirect)
 expectType<string | undefined>(requestInit.integrity)
-expectType<AbortSignal | undefined>(requestInit.signal)
+expectType<AbortSignal | null | undefined>(requestInit.signal)
 expectType<RequestCredentials | undefined>(requestInit.credentials)
 expectType<RequestMode | undefined>(requestInit.mode)
 expectType<string | undefined>(requestInit.referrer);

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -108,7 +108,7 @@ export interface RequestInit {
   body?: BodyInit
   redirect?: RequestRedirect
   integrity?: string
-  signal?: AbortSignal
+  signal?: AbortSignal | null
   credentials?: RequestCredentials
   mode?: RequestMode
   referrer?: string


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes #2448.

## Rationale

## Changes

### Features

N/A

### Bug Fixes

- Add the missing `null` type to the `signal` property in `RequestInit`

### Breaking Changes and Deprecations

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
