### PR TITLE
perf: optimize HeadersList.clear

### DIFF
--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -146,7 +146,7 @@ class HeadersList {
   }
 
   clear () {
-    this[kHeadersMap].clear()
+    if (this[kHeadersMap].size) this[kHeadersMap].clear()
     this[kHeadersSortedMap] = null
     this.cookies = null
   }


### PR DESCRIPTION
## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Checking the Map size and not clearing is thirty times faster if the map is empty.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
