### PR TITLE
refactor: better integrity check

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -300,7 +300,7 @@ class Request {
     }
 
     // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
-    if (init.integrity !== undefined) {
+    if (init.integrity != null) {
       request.integrity = String(init.integrity)
     }
 

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -300,7 +300,7 @@ class Request {
     }
 
     // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
-    if (init.integrity !== undefined && init.integrity != null) {
+    if (init.integrity !== undefined) {
       request.integrity = String(init.integrity)
     }
 


### PR DESCRIPTION
If the integrity is null, it is safe to delete it because it will be converted to the string 'null' by `DOMString`.