### PR TITLE
perf: avoid Headers initialization

### DIFF
--- a/lib/cache/symbols.js
+++ b/lib/cache/symbols.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = {
-  kConstruct: Symbol('constructable')
+  kConstruct: require('../core/symbols').kConstruct
 }

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -58,5 +58,6 @@ module.exports = {
   kHTTP1BuildRequest: Symbol('http1 build request'),
   kHTTP2CopyHeaders: Symbol('http2 copy headers'),
   kHTTPConnVersion: Symbol('http connection version'),
-  kRetryHandlerDefaultRetry: Symbol('retry agent default retry')
+  kRetryHandlerDefaultRetry: Symbol('retry agent default retry'),
+  kConstruct: Symbol('constructable')
 }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const { kHeadersList } = require('../core/symbols')
+const { kHeadersList, kConstruct } = require('../core/symbols')
 const { kGuard } = require('./symbols')
 const { kEnumerableProperty } = require('../core/util')
 const {
@@ -240,6 +240,7 @@ class HeadersList {
 // https://fetch.spec.whatwg.org/#headers-class
 class Headers {
   constructor (init = undefined) {
+    if (init === kConstruct) return
     this[kHeadersList] = new HeadersList()
 
     // The new Headers(init) constructor steps are:

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -28,7 +28,7 @@ const { kHeaders, kSignal, kState, kGuard, kRealm } = require('./symbols')
 const { webidl } = require('./webidl')
 const { getGlobalOrigin } = require('./global')
 const { URLSerializer } = require('./dataURL')
-const { kHeadersList } = require('../core/symbols')
+const { kHeadersList, kConstruct } = require('../core/symbols')
 const assert = require('assert')
 const { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = require('events')
 
@@ -398,7 +398,7 @@ class Request {
     // 30. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is request’s header list and guard is
     // "request".
-    this[kHeaders] = new Headers()
+    this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kGuard] = 'request'
     this[kHeaders][kRealm] = this[kRealm]
@@ -728,7 +728,7 @@ class Request {
     const clonedRequestObject = new Request(kInit)
     clonedRequestObject[kState] = clonedRequest
     clonedRequestObject[kRealm] = this[kRealm]
-    clonedRequestObject[kHeaders] = new Headers()
+    clonedRequestObject[kHeaders] = new Headers(kConstruct)
     clonedRequestObject[kHeaders][kHeadersList] = clonedRequest.headersList
     clonedRequestObject[kHeaders][kGuard] = this[kHeaders][kGuard]
     clonedRequestObject[kHeaders][kRealm] = this[kHeaders][kRealm]

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -23,7 +23,7 @@ const { webidl } = require('./webidl')
 const { FormData } = require('./formdata')
 const { getGlobalOrigin } = require('./global')
 const { URLSerializer } = require('./dataURL')
-const { kHeadersList } = require('../core/symbols')
+const { kHeadersList, kConstruct } = require('../core/symbols')
 const assert = require('assert')
 const { types } = require('util')
 
@@ -144,7 +144,7 @@ class Response {
     // 2. Set this’s headers to a new Headers object with this’s relevant
     // Realm, whose header list is this’s response’s header list and guard
     // is "response".
-    this[kHeaders] = new Headers()
+    this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kGuard] = 'response'
     this[kHeaders][kHeadersList] = this[kState].headersList
     this[kHeaders][kRealm] = this[kRealm]


### PR DESCRIPTION
## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Improves performance by avoiding the initialization process of `Headers`.

## Benchmark

```js
// bench.js
const { Request, Response } = require(".");

const benchmark = require("benchmark");

const suite = new benchmark.Suite();

const input = "https://example.com/post";

suite.add("new Request()", () => {
  new Request(input, undefined);
});

suite.add("new Response()", () => {
  new Response(null, undefined);
});

suite.on("cycle", function (event) {
  console.log(String(event.target));
});

// run async
new Promise((resolve) => setTimeout(resolve, 7000)).then(() =>
  suite.run({ async: true })
);

```

- *main*
```
new Request() x 100,116 ops/sec ±4.53% (74 runs sampled)
new Response() x 1,922,146 ops/sec ±2.12% (83 runs sampled)
```

- *this patch*
```
new Request() x 106,769 ops/sec ±3.77% (80 runs sampled)
new Response() x 2,330,854 ops/sec ±1.48% (89 runs sampled)
```