### PR TITLE
fix: remove optional chainning for compatible with Nodejs12 and below

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -180,7 +180,7 @@ module.exports = class BodyReadable extends Readable {
       this
         .on('close', function () {
           signalListenerCleanup()
-          if (signal?.aborted) {
+          if (signal && signal.aborted) {
             reject(signal.reason || Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }))
           } else {
             resolve(null)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

There are a lot of packages those built on top of **undici** but they are still in Nodejs 12 or below so it can not optional chainning.

See the issue: https://github.com/nodejs/undici/issues/2469

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->
To make sure that undici can work with Nodejs 12 or below.

## Changes

<!-- Write a summary or list of changes here -->
- Replace optional chainning with a normal check.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->
N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->
To fix the issue: https://github.com/nodejs/undici/issues/2469

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->
n/a

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [] Documented
- [] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
