### PR TITLE
fix: remove `node:` prefix

### DIFF
--- a/lib/handler/RetryHandler.js
+++ b/lib/handler/RetryHandler.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert')
+const assert = require('assert')
 
 const { kRetryHandlerDefaultRetry } = require('../core/symbols')
 const { RequestRetryError } = require('../core/errors')


### PR DESCRIPTION
Fixes #2467