### PR TITLE
fix: Added support for inline URL username:password proxy auth

### DIFF
--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -75,7 +75,7 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
     } else if (opts.token) {
       this[kProxyHeaders]['proxy-authorization'] = opts.token
-    } else if(username && password) {
+    } else if (username && password) {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
     }
 

--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -65,6 +65,9 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyTls] = opts.proxyTls
     this[kProxyHeaders] = opts.headers || {}
 
+    const resolvedUrl = new URL(opts.uri)
+    const { origin, port, host, username, password } = resolvedUrl
+
     if (opts.auth && opts.token) {
       throw new InvalidArgumentError('opts.auth cannot be used in combination with opts.token')
     } else if (opts.auth) {
@@ -72,10 +75,9 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${opts.auth}`
     } else if (opts.token) {
       this[kProxyHeaders]['proxy-authorization'] = opts.token
+    } else if(username && password) {
+      this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
     }
-
-    const resolvedUrl = new URL(opts.uri)
-    const { origin, port, host } = resolvedUrl
 
     const connect = buildConnector({ ...opts.proxyTls })
     this[kConnectEndpoint] = buildConnector({ ...opts.requestTls })
@@ -100,7 +102,7 @@ class ProxyAgent extends DispatcherBase {
           })
           if (statusCode !== 200) {
             socket.on('error', () => {}).destroy()
-            callback(new RequestAbortedError('Proxy response !== 200 when HTTP Tunneling'))
+            callback(new RequestAbortedError(`Proxy response (${statusCode}) !== 200 when HTTP Tunneling`))
           }
           if (opts.protocol !== 'https:') {
             callback(null, socket)


### PR DESCRIPTION
## Rationale

Currently the following code fails with a non 200 status tunneling issue:

```
await fetch(url, {
  dispatcher: new ProxyAgent(`http://<username>:<password>@myproxyurl.com:9000`)
})
```

This is because an inline username/password is ignored, and no auth header is created. This PR creates a Basic 'proxy-authorization' header if an inline username & password is provided.

## Related

`https-proxy-agent` implements this for node-fetch: https://github.com/TooTallNate/proxy-agents/blob/main/packages/http-proxy-agent/src/index.ts#L102

## Changes

* Add proxy-authorization header when an inline username/password is provided (opts.token takes precedence)
* Improved the non 200 error message to include the `statusCode`

### Features

* Can now use inline URL auth

### Bug Fixes

See above

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
