### PR TITLE
fix: check response for timinginfo allow flag

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -286,7 +286,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
   }
 
   // 8. If response’s timing allow passed flag is not set, then:
-  if (!timingInfo.timingAllowPassed) {
+  if (!response.timingAllowPassed) {
     //  1. Set timingInfo to a the result of creating an opaque timing info for timingInfo.
     timingInfo = createOpaqueTimingInfo({
       startTime: timingInfo.startTime

--- a/test/fetch/resource-timing.js
+++ b/test/fetch/resource-timing.js
@@ -46,3 +46,27 @@ test('should create a PerformanceResourceTiming after each fetch request', { ski
 
   t.teardown(server.close.bind(server))
 })
+
+test('should include encodedBodySize in performance entry', { skip }, (t) => {
+  t.plan(4)
+  const obs = new PerformanceObserver(list => {
+    const [entry] = list.getEntries()
+    t.equal(entry.encodedBodySize, 2)
+    t.equal(entry.decodedBodySize, 2)
+    t.equal(entry.transferSize, 2+300)
+
+    obs.disconnect()
+    performance.clearResourceTimings()
+  })
+
+  obs.observe({ entryTypes: ['resource'] })
+
+  const server = createServer((req, res) => {
+    res.end('ok')
+  }).listen(0, async () => {
+    const body = await fetch(`http://localhost:${server.address().port}`)
+    t.strictSame('ok', await body.text())
+  })
+
+  t.teardown(server.close.bind(server))
+})

--- a/test/fetch/resource-timing.js
+++ b/test/fetch/resource-timing.js
@@ -53,7 +53,7 @@ test('should include encodedBodySize in performance entry', { skip }, (t) => {
     const [entry] = list.getEntries()
     t.equal(entry.encodedBodySize, 2)
     t.equal(entry.decodedBodySize, 2)
-    t.equal(entry.transferSize, 2+300)
+    t.equal(entry.transferSize, 2 + 300)
 
     obs.disconnect()
     performance.clearResourceTimings()


### PR DESCRIPTION
## This relates to...

Fixes #2476 

## Rationale

Explained in #2476

## Changes

Fix property, add test verifying fixed behavior

### Features

N/A

### Bug Fixes

Performance entry now includes decodedBodySize, encodedBodySize and transferSize values

### Breaking Changes and Deprecations


## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
