### PR TITLE
perf: avoid Response initialization

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -54,7 +54,7 @@ const {
   requestBodyHeader,
   subresourceSet
 } = require('./constants')
-const { kHeadersList } = require('../core/symbols')
+const { kHeadersList, kConstruct } = require('../core/symbols')
 const EE = require('events')
 const { Readable, pipeline } = require('stream')
 const { addAbortListener, isErrored, isReadable, nodeMajor, nodeMinor } = require('../core/util')
@@ -231,9 +231,10 @@ function fetch (input, init = {}) {
 
     // 4. Set responseObject to the result of creating a Response object,
     // given response, "immutable", and relevantRealm.
-    responseObject = new Response()
+    responseObject = new Response(kConstruct)
     responseObject[kState] = response
     responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders] = new Headers(kConstruct)
     responseObject[kHeaders][kHeadersList] = response.headersList
     responseObject[kHeaders][kGuard] = 'immutable'
     responseObject[kHeaders][kRealm] = relevantRealm

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -38,9 +38,10 @@ class Response {
     // The static error() method steps are to return the result of creating a
     // Response object, given a new network error, "immutable", and this’s
     // relevant Realm.
-    const responseObject = new Response()
+    const responseObject = new Response(kConstruct)
     responseObject[kState] = makeNetworkError()
     responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders] = new Headers(kConstruct)
     responseObject[kHeaders][kHeadersList] = responseObject[kState].headersList
     responseObject[kHeaders][kGuard] = 'immutable'
     responseObject[kHeaders][kRealm] = relevantRealm
@@ -66,8 +67,11 @@ class Response {
     // 3. Let responseObject be the result of creating a Response object, given a new response,
     //    "response", and this’s relevant Realm.
     const relevantRealm = { settingsObject: {} }
-    const responseObject = new Response()
+    const responseObject = new Response(kConstruct)
+    responseObject[kState] = makeResponse({})
     responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders] = new Headers(kConstruct)
+    responseObject[kHeaders][kHeadersList] = responseObject[kState].headersList
     responseObject[kHeaders][kGuard] = 'response'
     responseObject[kHeaders][kRealm] = relevantRealm
 
@@ -107,8 +111,11 @@ class Response {
 
     // 4. Let responseObject be the result of creating a Response object,
     // given a new response, "immutable", and this’s relevant Realm.
-    const responseObject = new Response()
+    const responseObject = new Response(kConstruct)
+    responseObject[kState] = makeResponse({})
     responseObject[kRealm] = relevantRealm
+    responseObject[kHeaders] = new Headers(kConstruct)
+    responseObject[kHeaders][kHeadersList] = responseObject[kState].headersList
     responseObject[kHeaders][kGuard] = 'immutable'
     responseObject[kHeaders][kRealm] = relevantRealm
 
@@ -127,6 +134,10 @@ class Response {
 
   // https://fetch.spec.whatwg.org/#dom-response
   constructor (body = null, init = {}) {
+    if (body === kConstruct) {
+      return
+    }
+
     if (body !== null) {
       body = webidl.converters.BodyInit(body)
     }
@@ -258,9 +269,10 @@ class Response {
 
     // 3. Return the result of creating a Response object, given
     // clonedResponse, this’s headers’s guard, and this’s relevant Realm.
-    const clonedResponseObject = new Response()
+    const clonedResponseObject = new Response(kConstruct)
     clonedResponseObject[kState] = clonedResponse
     clonedResponseObject[kRealm] = this[kRealm]
+    clonedResponseObject[kHeaders] = new Headers(kConstruct)
     clonedResponseObject[kHeaders][kHeadersList] = clonedResponse.headersList
     clonedResponseObject[kHeaders][kGuard] = this[kHeaders][kGuard]
     clonedResponseObject[kHeaders][kRealm] = this[kHeaders][kRealm]


### PR DESCRIPTION
Improves performance by avoiding the initialization process of Response.

## Benchmark
```js
const benchmark = require("benchmark");

const suite = new benchmark.Suite();

const { Response } = require(".");

const targetResponse = new Response(null);

suite.add("Response.json", () => {
  Response.json("Hi", undefined);
});

suite.add("Response.redirect", () => {
  Response.redirect("https://localhost", 302);
});

suite.add("Response#clone", () => {
  targetResponse.clone();
});

suite.on("cycle", function (event) {
  console.log(String(event.target));
});

// run async
new Promise((resolve) => setTimeout(resolve, 7000)).then(() =>
  suite.run({ async: true })
);
```

- *main*
```
Response.json x 127,860 ops/sec ±4.86% (71 runs sampled)
Response.redirect x 475,359 ops/sec ±2.67% (85 runs sampled)
Response#clone x 569,317 ops/sec ±1.18% (91 runs sampled)```
```

- *this patch*
```
Response.json x 143,726 ops/sec ±5.54% (76 runs sampled)
Response.redirect x 638,497 ops/sec ±1.73% (89 runs sampled)
Response#clone x 1,286,776 ops/sec ±1.36% (85 runs sampled)
```