### PR TITLE
Expose HTTP errors that are not meant to be retried

### DIFF
--- a/lib/handler/RetryHandler.js
+++ b/lib/handler/RetryHandler.js
@@ -172,13 +172,22 @@ class RetryHandler {
     this.retryCount += 1
 
     if (statusCode >= 300) {
-      this.abort(
-        new RequestRetryError('Request failed', statusCode, {
-          headers,
-          count: this.retryCount
-        })
-      )
-      return false
+      if (this.retryOpts.statusCodes.includes(statusCode) === false) {
+        return this.handler.onHeaders(
+          statusCode,
+          rawHeaders,
+          resume,
+          statusMessage
+        )
+      } else {
+        this.abort(
+          new RequestRetryError('Request failed', statusCode, {
+            headers,
+            count: this.retryCount
+          })
+        )
+        return false
+      }
     }
 
     // Checkpoint for resume from where we left it

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -620,3 +620,72 @@ tap.test('retrying a request with a body', t => {
     )
   })
 })
+
+tap.test('should not error if request is not meant to be retried', { only: true }, t => {
+  const server = createServer()
+  server.on('request', (req, res) => {
+    res.writeHead(400)
+    res.end('Bad request')
+  })
+
+  t.plan(3)
+
+  const dispatchOptions = {
+    retryOptions: {
+      method: 'GET',
+      path: '/',
+      headers: {
+        'content-type': 'application/json'
+      }
+    }
+  }
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const chunks = []
+    const handler = new RetryHandler(dispatchOptions, {
+      dispatch: client.dispatch.bind(client),
+      handler: {
+        onConnect () {
+          t.pass()
+        },
+        onBodySent () {
+          t.pass()
+        },
+        onHeaders (status, _rawHeaders, resume, _statusMessage) {
+          t.equal(status, 400)
+          return true
+        },
+        onData (chunk) {
+          chunks.push(chunk)
+          return true
+        },
+        onComplete () {
+          t.equal(Buffer.concat(chunks).toString('utf-8'), 'Bad request')
+        },
+        onError (err) {
+          console.log({ err })
+          t.fail()
+        }
+      }
+    })
+
+    t.teardown(async () => {
+      await client.close()
+      server.close()
+
+      await once(server, 'close')
+    })
+
+    client.dispatch(
+      {
+        method: 'GET',
+        path: '/',
+        headers: {
+          'content-type': 'application/json'
+        }
+      },
+      handler
+    )
+  })
+})

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -621,7 +621,7 @@ tap.test('retrying a request with a body', t => {
   })
 })
 
-tap.test('should not error if request is not meant to be retried', { only: true }, t => {
+tap.test('should not error if request is not meant to be retried', t => {
   const server = createServer()
   server.on('request', (req, res) => {
     res.writeHead(400)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

`RetryHandler` works with requests that are both meant and not meant to be retried, as indicated in the `statusCodes` option. In its current state, any non-success HTTP status (statuses greater than 299) return a `RequestRetryError`.

## Changes

Check user-provided status codes to see if `RetryHandler` should handle an HTTP error or pass down to next handler

### Features

N/A

### Bug Fixes

When a response has a non-success status code, we check to see if this is a status code that the user wanted to retry. If it was, the handler aborts with a `RequestRetryError`. If the user was not retrying, the next handler is called.

### Breaking Changes and Deprecations

The bug fix could be seen as a breaking change

## Status

<!-- KEY: S = Skipped, x = complete -->


- [X] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [X] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [X] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
