### PR TITLE
refactor: remove Error.captureStackTrace

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -11,7 +11,6 @@ class UndiciError extends Error {
 class ConnectTimeoutError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, ConnectTimeoutError)
     this.name = 'ConnectTimeoutError'
     this.message = message || 'Connect Timeout Error'
     this.code = 'UND_ERR_CONNECT_TIMEOUT'
@@ -21,7 +20,6 @@ class ConnectTimeoutError extends UndiciError {
 class HeadersTimeoutError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, HeadersTimeoutError)
     this.name = 'HeadersTimeoutError'
     this.message = message || 'Headers Timeout Error'
     this.code = 'UND_ERR_HEADERS_TIMEOUT'
@@ -31,7 +29,6 @@ class HeadersTimeoutError extends UndiciError {
 class HeadersOverflowError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, HeadersOverflowError)
     this.name = 'HeadersOverflowError'
     this.message = message || 'Headers Overflow Error'
     this.code = 'UND_ERR_HEADERS_OVERFLOW'
@@ -41,7 +38,6 @@ class HeadersOverflowError extends UndiciError {
 class BodyTimeoutError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, BodyTimeoutError)
     this.name = 'BodyTimeoutError'
     this.message = message || 'Body Timeout Error'
     this.code = 'UND_ERR_BODY_TIMEOUT'
@@ -51,7 +47,6 @@ class BodyTimeoutError extends UndiciError {
 class ResponseStatusCodeError extends UndiciError {
   constructor (message, statusCode, headers, body) {
     super(message)
-    Error.captureStackTrace(this, ResponseStatusCodeError)
     this.name = 'ResponseStatusCodeError'
     this.message = message || 'Response Status Code Error'
     this.code = 'UND_ERR_RESPONSE_STATUS_CODE'
@@ -65,7 +60,6 @@ class ResponseStatusCodeError extends UndiciError {
 class InvalidArgumentError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, InvalidArgumentError)
     this.name = 'InvalidArgumentError'
     this.message = message || 'Invalid Argument Error'
     this.code = 'UND_ERR_INVALID_ARG'
@@ -75,7 +69,6 @@ class InvalidArgumentError extends UndiciError {
 class InvalidReturnValueError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, InvalidReturnValueError)
     this.name = 'InvalidReturnValueError'
     this.message = message || 'Invalid Return Value Error'
     this.code = 'UND_ERR_INVALID_RETURN_VALUE'
@@ -85,7 +78,6 @@ class InvalidReturnValueError extends UndiciError {
 class AbortError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, AbortError)
     this.name = 'AbortError'
     this.message = message || 'The operation was aborted'
   }
@@ -94,7 +86,6 @@ class AbortError extends UndiciError {
 class RequestAbortedError extends AbortError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, RequestAbortedError)
     this.name = 'AbortError'
     this.message = message || 'Request aborted'
     this.code = 'UND_ERR_ABORTED'
@@ -104,7 +95,6 @@ class RequestAbortedError extends AbortError {
 class InformationalError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, InformationalError)
     this.name = 'InformationalError'
     this.message = message || 'Request information'
     this.code = 'UND_ERR_INFO'
@@ -114,7 +104,6 @@ class InformationalError extends UndiciError {
 class RequestContentLengthMismatchError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, RequestContentLengthMismatchError)
     this.name = 'RequestContentLengthMismatchError'
     this.message = message || 'Request body length does not match content-length header'
     this.code = 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'
@@ -124,7 +113,6 @@ class RequestContentLengthMismatchError extends UndiciError {
 class ResponseContentLengthMismatchError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, ResponseContentLengthMismatchError)
     this.name = 'ResponseContentLengthMismatchError'
     this.message = message || 'Response body length does not match content-length header'
     this.code = 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH'
@@ -134,7 +122,6 @@ class ResponseContentLengthMismatchError extends UndiciError {
 class ClientDestroyedError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, ClientDestroyedError)
     this.name = 'ClientDestroyedError'
     this.message = message || 'The client is destroyed'
     this.code = 'UND_ERR_DESTROYED'
@@ -144,7 +131,6 @@ class ClientDestroyedError extends UndiciError {
 class ClientClosedError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, ClientClosedError)
     this.name = 'ClientClosedError'
     this.message = message || 'The client is closed'
     this.code = 'UND_ERR_CLOSED'
@@ -154,7 +140,6 @@ class ClientClosedError extends UndiciError {
 class SocketError extends UndiciError {
   constructor (message, socket) {
     super(message)
-    Error.captureStackTrace(this, SocketError)
     this.name = 'SocketError'
     this.message = message || 'Socket error'
     this.code = 'UND_ERR_SOCKET'
@@ -165,7 +150,6 @@ class SocketError extends UndiciError {
 class NotSupportedError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, NotSupportedError)
     this.name = 'NotSupportedError'
     this.message = message || 'Not supported error'
     this.code = 'UND_ERR_NOT_SUPPORTED'
@@ -175,7 +159,6 @@ class NotSupportedError extends UndiciError {
 class BalancedPoolMissingUpstreamError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, NotSupportedError)
     this.name = 'MissingUpstreamError'
     this.message = message || 'No upstream has been added to the BalancedPool'
     this.code = 'UND_ERR_BPL_MISSING_UPSTREAM'
@@ -185,7 +168,6 @@ class BalancedPoolMissingUpstreamError extends UndiciError {
 class HTTPParserError extends Error {
   constructor (message, code, data) {
     super(message)
-    Error.captureStackTrace(this, HTTPParserError)
     this.name = 'HTTPParserError'
     this.code = code ? `HPE_${code}` : undefined
     this.data = data ? data.toString() : undefined
@@ -195,7 +177,6 @@ class HTTPParserError extends Error {
 class ResponseExceededMaxSizeError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, ResponseExceededMaxSizeError)
     this.name = 'ResponseExceededMaxSizeError'
     this.message = message || 'Response content exceeded max size'
     this.code = 'UND_ERR_RES_EXCEEDED_MAX_SIZE'
@@ -205,7 +186,6 @@ class ResponseExceededMaxSizeError extends UndiciError {
 class RequestRetryError extends UndiciError {
   constructor (message, code, { headers, data }) {
     super(message)
-    Error.captureStackTrace(this, RequestRetryError)
     this.name = 'RequestRetryError'
     this.message = message || 'Request retry error'
     this.code = 'UND_ERR_REQ_RETRY'


### PR DESCRIPTION
class, the `Error.captureStackTrace` is not necessary since the stack trace is automatically collected by the Error constructor.
source: https://github.com/v8/v8/blob/8d0ffc5559c0aabe6551096d3e52386feec0aea4/src/execution/messages.cc#L636-L645

Within the Error constructor, it is set to skip frames above the function specified in `new.target`. This is the same behavior as specifying a custom class name (AbortError) for `Error.captureStackTrace`.
source: https://github.com/v8/v8/blob/8d0ffc5559c0aabe6551096d3e52386feec0aea4/src/execution/messages.cc#L550-L556