### PR TITLE
perf: Improve processHeader

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -7,16 +7,10 @@ const {
 const assert = require('assert')
 const { kHTTP2BuildRequest, kHTTP2CopyHeaders, kHTTP1BuildRequest } = require('./symbols')
 const util = require('./util')
+const { headerNameLowerCasedRecord } = require('./constants')
 
-// tokenRegExp and headerCharRegex have been lifted from
+// headerCharRegex have been lifted from
 // https://github.com/nodejs/node/blob/main/lib/_http_common.js
-
-/**
- * Verifies that the given val is a valid HTTP token
- * per the rules defined in RFC 7230
- * See https://tools.ietf.org/html/rfc7230#section-3.2.6
- */
-const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/
 
 /**
  * Matches if val contains an invalid field-vchar
@@ -416,6 +410,72 @@ function processHeader (request, key, val, skipAppend = false) {
     return
   }
 
+  const mayBeLowerCasedKey = headerNameLowerCasedRecord[key]
+
+  if (mayBeLowerCasedKey !== undefined) {
+    switch (mayBeLowerCasedKey) {
+      case 'host': {
+        if (request.host !== null) break
+        if (headerCharRegex.exec(val) !== null) {
+          throw new InvalidArgumentError(`invalid ${key} header`)
+        }
+        // Consumed by Client
+        request.host = val
+        return
+      }
+      case 'content-length': {
+        if (request.contentLength !== null) break
+        request.contentLength = parseInt(val, 10)
+        if (!Number.isFinite(request.contentLength)) {
+          throw new InvalidArgumentError('invalid content-length header')
+        }
+        return
+      }
+      case 'content-type': {
+        if (request.contentType !== null) break
+        request.contentType = val
+        if (skipAppend) request.headers[key] = processHeaderValue(key, val, skipAppend)
+        else request.headers += processHeaderValue(key, val)
+        return
+      }
+      case 'transfer-encoding': {
+        throw new InvalidArgumentError('invalid transfer-encoding header')
+      }
+      case 'connection': {
+        const value = typeof val === 'string' ? val.toLowerCase() : null
+        if (value !== 'close' && value !== 'keep-alive') {
+          throw new InvalidArgumentError('invalid connection header')
+        } else if (value === 'close') {
+          request.reset = true
+        }
+        return
+      }
+      case 'keep-alive': {
+        throw new InvalidArgumentError('invalid keep-alive header')
+      }
+      case 'upgrade': {
+        throw new InvalidArgumentError('invalid upgrade header')
+      }
+      case 'expect': {
+        throw new NotSupportedError('expect header not supported')
+      }
+    }
+    if (Array.isArray(val)) {
+      for (let i = 0; i < val.length; i++) {
+        if (skipAppend) {
+          if (request.headers[key]) request.headers[key] += `,${processHeaderValue(key, val[i], skipAppend)}`
+          else request.headers[key] = processHeaderValue(key, val[i], skipAppend)
+        } else {
+          request.headers += processHeaderValue(key, val[i])
+        }
+      }
+    } else {
+      if (skipAppend) request.headers[key] = processHeaderValue(key, val, skipAppend)
+      else request.headers += processHeaderValue(key, val)
+    }
+    return
+  }
+
   if (
     request.host === null &&
     key.length === 4 &&
@@ -473,7 +533,7 @@ function processHeader (request, key, val, skipAppend = false) {
     key.toLowerCase() === 'expect'
   ) {
     throw new NotSupportedError('expect header not supported')
-  } else if (tokenRegExp.exec(key) === null) {
+  } else if (!util.isValidHTTPToken(key)) {
     throw new InvalidArgumentError('invalid header key')
   } else {
     if (Array.isArray(val)) {


### PR DESCRIPTION
## Benchmark

<details>
<summary>Benchmark Script</summary>

```js
import { bench, group, run } from "mitata";
import { headerNameLowerCasedRecord } from "../lib/core/constants.js";
import { InvalidArgumentError, NotSupportedError } from "../lib/core/errors.js";
import util from "../lib/core/util.js";

const tokenRegExp = /^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/;
const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;

function processHeaderValue(key, val, skipAppend) {
  if (val && typeof val === "object") {
    throw new InvalidArgumentError(`invalid ${key} header`);
  }

  val = val != null ? `${val}` : "";

  if (headerCharRegex.exec(val) !== null) {
    throw new InvalidArgumentError(`invalid ${key} header`);
  }

  return skipAppend ? val : `${key}: ${val}\r\n`;
}

function processHeaderCurrent(request, key, val, skipAppend = false) {
  if (val && typeof val === "object" && !Array.isArray(val)) {
    throw new InvalidArgumentError(`invalid ${key} header`);
  } else if (val === undefined) {
    return;
  }

  if (
    request.host === null &&
    key.length === 4 &&
    key.toLowerCase() === "host"
  ) {
    if (headerCharRegex.exec(val) !== null) {
      throw new InvalidArgumentError(`invalid ${key} header`);
    }
    // Consumed by Client
    request.host = val;
  } else if (
    request.contentLength === null &&
    key.length === 14 &&
    key.toLowerCase() === "content-length"
  ) {
    request.contentLength = parseInt(val, 10);
    if (!Number.isFinite(request.contentLength)) {
      throw new InvalidArgumentError("invalid content-length header");
    }
  } else if (
    request.contentType === null &&
    key.length === 12 &&
    key.toLowerCase() === "content-type"
  ) {
    request.contentType = val;
    if (skipAppend)
      request.headers[key] = processHeaderValue(key, val, skipAppend);
    else request.headers += processHeaderValue(key, val);
  } else if (key.length === 17 && key.toLowerCase() === "transfer-encoding") {
    throw new InvalidArgumentError("invalid transfer-encoding header");
  } else if (key.length === 10 && key.toLowerCase() === "connection") {
    const value = typeof val === "string" ? val.toLowerCase() : null;
    if (value !== "close" && value !== "keep-alive") {
      throw new InvalidArgumentError("invalid connection header");
    } else if (value === "close") {
      request.reset = true;
    }
  } else if (key.length === 10 && key.toLowerCase() === "keep-alive") {
    throw new InvalidArgumentError("invalid keep-alive header");
  } else if (key.length === 7 && key.toLowerCase() === "upgrade") {
    throw new InvalidArgumentError("invalid upgrade header");
  } else if (key.length === 6 && key.toLowerCase() === "expect") {
    throw new NotSupportedError("expect header not supported");
  } else if (tokenRegExp.exec(key) === null) {
    throw new InvalidArgumentError("invalid header key");
  } else {
    if (Array.isArray(val)) {
      for (let i = 0; i < val.length; i++) {
        if (skipAppend) {
          if (request.headers[key])
            request.headers[key] += `,${processHeaderValue(
              key,
              val[i],
              skipAppend
            )}`;
          else
            request.headers[key] = processHeaderValue(key, val[i], skipAppend);
        } else {
          request.headers += processHeaderValue(key, val[i]);
        }
      }
    } else {
      if (skipAppend)
        request.headers[key] = processHeaderValue(key, val, skipAppend);
      else request.headers += processHeaderValue(key, val);
    }
  }
}

function processHeaderNew(request, key, val, skipAppend = false) {
  if (val && typeof val === "object" && !Array.isArray(val)) {
    throw new InvalidArgumentError(`invalid ${key} header`);
  } else if (val === undefined) {
    return;
  }

  const mayBeLowerCasedKey = headerNameLowerCasedRecord[key];

  if (mayBeLowerCasedKey !== undefined) {
    switch (mayBeLowerCasedKey) {
      case "host": {
        if (request.host !== null) break;
        if (headerCharRegex.exec(val) !== null) {
          throw new InvalidArgumentError(`invalid ${key} header`);
        }
        // Consumed by Client
        request.host = val;
        return;
      }
      case "content-length": {
        if (request.contentLength !== null) break;
        request.contentLength = parseInt(val, 10);
        if (!Number.isFinite(request.contentLength)) {
          throw new InvalidArgumentError("invalid content-length header");
        }
        return;
      }
      case "content-type": {
        if (request.contentType !== null) break;
        request.contentType = val;
        if (skipAppend)
          request.headers[key] = processHeaderValue(key, val, skipAppend);
        else request.headers += processHeaderValue(key, val);
        return;
      }
      case "transfer-encoding": {
        throw new InvalidArgumentError("invalid transfer-encoding header");
      }
      case "connection": {
        const value = typeof val === "string" ? val.toLowerCase() : null;
        if (value !== "close" && value !== "keep-alive") {
          throw new InvalidArgumentError("invalid connection header");
        } else if (value === "close") {
          request.reset = true;
        }
        return;
      }
      case "keep-alive": {
        throw new InvalidArgumentError("invalid keep-alive header");
      }
      case "upgrade": {
        throw new InvalidArgumentError("invalid upgrade header");
      }
      case "expect": {
        throw new NotSupportedError("expect header not supported");
      }
    }
    if (Array.isArray(val)) {
      for (let i = 0; i < val.length; i++) {
        if (skipAppend) {
          if (request.headers[key])
            request.headers[key] += `,${processHeaderValue(
              key,
              val[i],
              skipAppend
            )}`;
          else
            request.headers[key] = processHeaderValue(key, val[i], skipAppend);
        } else {
          request.headers += processHeaderValue(key, val[i]);
        }
      }
    } else {
      if (skipAppend)
        request.headers[key] = processHeaderValue(key, val, skipAppend);
      else request.headers += processHeaderValue(key, val);
    }
    return;
  }

  if (
    request.host === null &&
    key.length === 4 &&
    key.toLowerCase() === "host"
  ) {
    if (headerCharRegex.exec(val) !== null) {
      throw new InvalidArgumentError(`invalid ${key} header`);
    }
    // Consumed by Client
    request.host = val;
  } else if (
    request.contentLength === null &&
    key.length === 14 &&
    key.toLowerCase() === "content-length"
  ) {
    request.contentLength = parseInt(val, 10);
    if (!Number.isFinite(request.contentLength)) {
      throw new InvalidArgumentError("invalid content-length header");
    }
  } else if (
    request.contentType === null &&
    key.length === 12 &&
    key.toLowerCase() === "content-type"
  ) {
    request.contentType = val;
    if (skipAppend)
      request.headers[key] = processHeaderValue(key, val, skipAppend);
    else request.headers += processHeaderValue(key, val);
  } else if (key.length === 17 && key.toLowerCase() === "transfer-encoding") {
    throw new InvalidArgumentError("invalid transfer-encoding header");
  } else if (key.length === 10 && key.toLowerCase() === "connection") {
    const value = typeof val === "string" ? val.toLowerCase() : null;
    if (value !== "close" && value !== "keep-alive") {
      throw new InvalidArgumentError("invalid connection header");
    } else if (value === "close") {
      request.reset = true;
    }
  } else if (key.length === 10 && key.toLowerCase() === "keep-alive") {
    throw new InvalidArgumentError("invalid keep-alive header");
  } else if (key.length === 7 && key.toLowerCase() === "upgrade") {
    throw new InvalidArgumentError("invalid upgrade header");
  } else if (key.length === 6 && key.toLowerCase() === "expect") {
    throw new NotSupportedError("expect header not supported");
  } else if (!util.isValidHTTPToken(key)) {
    throw new InvalidArgumentError("invalid header key");
  } else {
    if (Array.isArray(val)) {
      for (let i = 0; i < val.length; i++) {
        if (skipAppend) {
          if (request.headers[key])
            request.headers[key] += `,${processHeaderValue(
              key,
              val[i],
              skipAppend
            )}`;
          else
            request.headers[key] = processHeaderValue(key, val[i], skipAppend);
        } else {
          request.headers += processHeaderValue(key, val[i]);
        }
      }
    } else {
      if (skipAppend)
        request.headers[key] = processHeaderValue(key, val, skipAppend);
      else request.headers += processHeaderValue(key, val);
    }
  }
}

const headers = Object.entries({
  "Content-Type": "application/json",
  Date: "Wed, 01 Nov 2023 00:00:00 GMT",
  "Powered-By": "NodeJS",
  "Content-Encoding": "gzip",
  "Set-Cookie": "__Secure-ID=123; Secure; Domain=example.com",
  "Content-Length": "150",
  Vary: "Accept-Encoding, Accept, X-Requested-With",
}).flat();

// avoid JIT bias
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});

group("processHeader", () => {
  bench("current", () => {
    const request = {
      headers: "",
      host: null,
      contentLength: null,
      contentType: null,
    };
    for (let i = 0; i < headers.length; i += 2) {
      processHeaderCurrent(request, headers[i], headers[i + 1], false);
    }
  });
  bench("new", () => {
    const request = {
      headers: "",
      host: null,
      contentLength: null,
      contentType: null,
    };
    for (let i = 0; i < headers.length; i += 2) {
      processHeaderNew(request, headers[i], headers[i + 1], false);
    }
  });
});

await new Promise((resolve) => setTimeout(resolve, 7000));

await run();
```

</details>

```
• processHeader
------------------------------------------------- -----------------------------
current      1.29 µs/iter     (1.18 µs … 1.74 µs)   1.33 µs   1.74 µs   1.74 µs
new        893.78 ns/iter   (840.82 ns … 1.28 µs) 873.13 ns   1.28 µs   1.28 µs

summary for parseHeaders
  new
   1.45x faster than current
```