### PR TITLE
perf: reduce tst built time

### DIFF
--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -1,6 +1,9 @@
 'use strict'
 
-const { wellknownHeaderNames } = require('./constants')
+const {
+  wellknownHeaderNames,
+  headerNameLowerCasedRecord
+} = require('./constants')
 
 class TstNode {
   /** @type {any} */
@@ -16,14 +19,15 @@ class TstNode {
   /**
    * @param {Uint8Array} key
    * @param {any} value
+   * @param {number} index
    */
-  constructor (key, value) {
-    if (key.length === 0) {
+  constructor (key, value, index) {
+    if (index === undefined || index >= key.length) {
       throw new TypeError('Unreachable')
     }
-    this.code = key[0]
-    if (key.length > 1) {
-      this.middle = new TstNode(key.subarray(1), value)
+    this.code = key[index]
+    if (key.length !== ++index) {
+      this.middle = new TstNode(key, value, index)
     } else {
       this.value = value
     }
@@ -32,31 +36,32 @@ class TstNode {
   /**
    * @param {Uint8Array} key
    * @param {any} value
+   * @param {number} index
    */
-  add (key, value) {
-    if (key.length === 0) {
+  add (key, value, index) {
+    if (index === undefined || index >= key.length) {
       throw new TypeError('Unreachable')
     }
-    const code = key[0]
+    const code = key[index]
     if (this.code === code) {
-      if (key.length === 1) {
+      if (key.length === ++index) {
         this.value = value
       } else if (this.middle !== null) {
-        this.middle.add(key.subarray(1), value)
+        this.middle.add(key, value, index)
       } else {
-        this.middle = new TstNode(key.subarray(1), value)
+        this.middle = new TstNode(key, value, index)
       }
     } else if (this.code < code) {
       if (this.left !== null) {
-        this.left.add(key, value)
+        this.left.add(key, value, index)
       } else {
-        this.left = new TstNode(key, value)
+        this.left = new TstNode(key, value, index)
       }
     } else {
       if (this.right !== null) {
-        this.right.add(key, value)
+        this.right.add(key, value, index)
       } else {
-        this.right = new TstNode(key, value)
+        this.right = new TstNode(key, value, index)
       }
     }
   }
@@ -102,9 +107,9 @@ class TernarySearchTree {
    * */
   insert (key, value) {
     if (this.node === null) {
-      this.node = new TstNode(key, value)
+      this.node = new TstNode(key, value, 0)
     } else {
-      this.node.add(key, value)
+      this.node.add(key, value, 0)
     }
   }
 
@@ -119,7 +124,7 @@ class TernarySearchTree {
 const tree = new TernarySearchTree()
 
 for (let i = 0; i < wellknownHeaderNames.length; ++i) {
-  const key = wellknownHeaderNames[i].toLowerCase()
+  const key = headerNameLowerCasedRecord[wellknownHeaderNames[i]]
   tree.insert(Buffer.from(key), key)
 }
 


### PR DESCRIPTION
```js
import { bench, group, run } from 'mitata'
import {
  wellknownHeaderNames,
  headerNameLowerCasedRecord
} from '../lib/core/constants.js'
import { TernarySearchTree } from '../lib/core/tree.js'
// copy new implementation
import { TernarySearchTree2 } from '../lib/core/tree2.js'

// avoid JIT bias
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})

group('built', () => {
  bench('current', () => {
    const tst = new TernarySearchTree()
    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
      const key = wellknownHeaderNames[i].toLowerCase()
      tst.insert(Buffer.from(key), key)
    }
  })
  bench('new', () => {
    const tst = new TernarySearchTree2()
    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
      const key = headerNameLowerCasedRecord[wellknownHeaderNames[i]]
      tst.insert(Buffer.from(key), key)
    }
  })
})

await new Promise((resolve) => setTimeout(resolve, 7000))

await run()
```


```
• built
------------------------------------------------- -----------------------------
current     225.8 µs/iter    (155.4 µs … 1.54 ms)  234.8 µs  654.9 µs  841.7 µs
new          80.6 µs/iter       (62 µs … 2.25 ms)   73.9 µs  262.1 µs  328.4 µs

summary for built
  new
   2.8x faster than current
```