### PR TITLE
Call fg.unregister() after a dispatcher is done, adds UNDICI_NO_FG to…

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -122,6 +122,7 @@ class Agent extends DispatcherBase {
     const closePromises = []
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
+      this[kFinalizer].unregister(client)
       /* istanbul ignore else: gc is undeterministic */
       if (client) {
         closePromises.push(client.close())
@@ -135,6 +136,7 @@ class Agent extends DispatcherBase {
     const destroyPromises = []
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
+      this[kFinalizer].unregister(client)
       /* istanbul ignore else: gc is undeterministic */
       if (client) {
         destroyPromises.push(client.destroy(err))

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -122,9 +122,9 @@ class Agent extends DispatcherBase {
     const closePromises = []
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      this[kFinalizer].unregister(client)
       /* istanbul ignore else: gc is undeterministic */
       if (client) {
+        this[kFinalizer].unregister(client)
         closePromises.push(client.close())
       }
     }
@@ -136,9 +136,9 @@ class Agent extends DispatcherBase {
     const destroyPromises = []
     for (const ref of this[kClients].values()) {
       const client = ref.deref()
-      this[kFinalizer].unregister(client)
       /* istanbul ignore else: gc is undeterministic */
       if (client) {
+        this[kFinalizer].unregister(client)
         destroyPromises.push(client.destroy(err))
       }
     }

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -15,7 +15,7 @@ let tls // include tls conditionally since it is not always available
 let SessionCache
 // FIXME: remove workaround when the Node bug is fixed
 // https://github.com/nodejs/node/issues/49344#issuecomment-1741776308
-if (global.FinalizationRegistry && !process.env.NODE_V8_COVERAGE) {
+if (global.FinalizationRegistry && !(process.env.NODE_V8_COVERAGE || process.env.UNDICI_NO_FG)) {
   SessionCache = class WeakSessionCache {
     constructor (maxCachedSessions) {
       this._maxCachedSessions = maxCachedSessions

--- a/test/balanced-pool.js
+++ b/test/balanced-pool.js
@@ -437,7 +437,7 @@ const cases = [
     expectedRatios: [0.34, 0.34, 0.32],
 
     // Skip because the behavior of Node.js has changed
-    skip: nodeMajor >= 19
+    skip: nodeMajor >= 18
   },
 
   // 8


### PR DESCRIPTION
This adds `process.env.UNDICI_NO_FG` to disable the use of FinalizationRegistry to protect against Node.js Core Bug https://github.com/nodejs/node/issues/49344 (which is not on coverage, but rather FinalizationRegistry) - this is a workaround, and we would get rid of it eventually.