### PR TITLE
ConnectOptions should include 'origin' field

### DIFF
--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -86,8 +86,13 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
   }))
 
   // connect
-  expectAssignable<Promise<Dispatcher.ConnectData>>(agent.connect({ path: '' }))
-  expectAssignable<void>(agent.connect({ path: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ConnectData>>(agent.connect({ origin: '', path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(agent.connect({ origin: new URL('http://localhost'), path: '' }))
+  expectAssignable<void>(agent.connect({ origin: '', path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ConnectData>(data)
+  }))
+  expectAssignable<void>(agent.connect({ origin: new URL('http://localhost'), path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
   }))

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -26,8 +26,13 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<boolean>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
 
   // connect
-  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ path: '', maxRedirections: 0 }))
-  expectAssignable<void>(dispatcher.connect({ path: '' }, (err, data) => {
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', maxRedirections: 0 }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: new URL('http://localhost'), path: '', maxRedirections: 0 }))
+  expectAssignable<void>(dispatcher.connect({ origin: '', path: '' }, (err, data) => {
+    expectAssignable<Error | null>(err)
+    expectAssignable<Dispatcher.ConnectData>(data)
+  }))
+  expectAssignable<void>(dispatcher.connect({ origin: new URL('http://localhost'), path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
   }))

--- a/types/balanced-pool.d.ts
+++ b/types/balanced-pool.d.ts
@@ -4,6 +4,8 @@ import { URL } from 'url'
 
 export default BalancedPool
 
+type BalancedPoolConnectOptions = Omit<Dispatcher.ConnectOptions, "origin">;
+
 declare class BalancedPool extends Dispatcher {
   constructor(url: string | string[] | URL | URL[], options?: Pool.Options);
 
@@ -15,4 +17,13 @@ declare class BalancedPool extends Dispatcher {
   closed: boolean;
   /** `true` after `pool.destroyed()` has been called or `pool.close()` has been called and the pool shutdown has completed. */
   destroyed: boolean;
+
+  // Override dispatcher APIs.
+  override connect(
+    options: BalancedPoolConnectOptions
+  ): Promise<Dispatcher.ConnectData>;
+  override connect(
+    options: BalancedPoolConnectOptions,
+    callback: (err: Error | null, data: Dispatcher.ConnectData) => void
+  ): void;
 }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -3,6 +3,8 @@ import { TlsOptions } from 'tls'
 import Dispatcher from './dispatcher'
 import buildConnector from "./connector";
 
+type ClientConnectOptions = Omit<Dispatcher.ConnectOptions, "origin">;
+
 /**
  * A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection. Pipelining is disabled by default.
  */
@@ -14,6 +16,15 @@ export class Client extends Dispatcher {
   closed: boolean;
   /** `true` after `client.destroyed()` has been called or `client.close()` has been called and the client shutdown has completed. */
   destroyed: boolean;
+
+  // Override dispatcher APIs.
+  override connect(
+    options: ClientConnectOptions
+  ): Promise<Dispatcher.ConnectData>;
+  override connect(
+    options: ClientConnectOptions,
+    callback: (err: Error | null, data: Dispatcher.ConnectData) => void
+  ): void;
 }
 
 export declare namespace Client {

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -121,7 +121,7 @@ declare namespace Dispatcher {
     expectContinue?: boolean;
   }
   export interface ConnectOptions {
-    origin?: string | URL;
+    origin: string | URL;
     path: string;
     /** Default: `null` */
     headers?: IncomingHttpHeaders | string[] | null;

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -121,6 +121,7 @@ declare namespace Dispatcher {
     expectContinue?: boolean;
   }
   export interface ConnectOptions {
+    origin?: string | URL;
     path: string;
     /** Default: `null` */
     headers?: IncomingHttpHeaders | string[] | null;

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -5,6 +5,8 @@ import Dispatcher from "./dispatcher";
 
 export default Pool
 
+type PoolConnectOptions = Omit<Dispatcher.ConnectOptions, "origin">;
+
 declare class Pool extends Dispatcher {
   constructor(url: string | URL, options?: Pool.Options)
   /** `true` after `pool.close()` has been called. */
@@ -13,6 +15,15 @@ declare class Pool extends Dispatcher {
   destroyed: boolean;
   /** Aggregate stats for a Pool. */
   readonly stats: TPoolStats;
+
+  // Override dispatcher APIs.
+  override connect(
+    options: PoolConnectOptions
+  ): Promise<Dispatcher.ConnectData>;
+  override connect(
+    options: PoolConnectOptions,
+    callback: (err: Error | null, data: Dispatcher.ConnectData) => void
+  ): void;
 }
 
 declare namespace Pool {


### PR DESCRIPTION
## Rationale

[HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT) requires host and port that already appear to be derived from the `origin` field. It's simply not declared in a type. Furthermore, `agent.connect()` currently fails without the `origin` field in [this line](https://github.com/nodejs/undici/blob/0c4c4504852c71dac1a6eb8dfae0f2411b6f2fc6/lib/agent.js#L90).

## Changes

The `origin` field is being added to the `ConnectOptions`.

### Breaking Changes and Deprecations

This should actually be a required field, but that would make the API non-backward compatible.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md

Fixes https://github.com/nodejs/undici/issues/2531