### PR TITLE
fix: call explicitly unregister

### DIFF
--- a/lib/compat/dispatcher-weakref.js
+++ b/lib/compat/dispatcher-weakref.js
@@ -28,6 +28,8 @@ class CompatFinalizer {
       })
     }
   }
+
+  unregister (key) {}
 }
 
 module.exports = function () {

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -371,6 +371,18 @@ class Request {
         const abort = function () {
           const ac = acRef.deref()
           if (ac !== undefined) {
+            // Currently, there is a problem with FinalizationRegistry.
+            // https://github.com/nodejs/node/issues/49344
+            // https://github.com/nodejs/node/issues/47748
+            // In the case of abort, the first step is to unregister from it.
+            // If the controller can refer to it, it is still registered.
+            // It will be removed in the future.
+            requestFinalizer.unregister(abort)
+
+            // Unsubscribe a listener.
+            // FinalizationRegistry will no longer be called, so this must be done.
+            this.removeEventListener('abort', abort)
+
             ac.abort(this.reason)
           }
         }
@@ -388,7 +400,11 @@ class Request {
         } catch {}
 
         util.addAbortListener(signal, abort)
-        requestFinalizer.register(ac, { signal, abort })
+        // The third argument must be a registry key to be unregistered.
+        // Without it, you cannot unregister.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
+        // abort is used as the unregister key. (because it is unique)
+        requestFinalizer.register(ac, { signal, abort }, abort)
       }
     }
 


### PR DESCRIPTION
 Fix flaky CI test of `jsdom-abortcontroller-1910-1464495619.js`