### PR TITLE
fix: check the content-type of invalid formData

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -14,7 +14,7 @@ const { FormData } = require('./formdata')
 const { kState } = require('./symbols')
 const { webidl } = require('./webidl')
 const { Blob, File: NativeFile } = require('buffer')
-const { kBodyUsed } = require('../core/symbols')
+const { kBodyUsed, kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 const { isErrored } = require('../core/util')
 const { isUint8Array, isArrayBuffer } = require('util/types')
@@ -369,10 +369,12 @@ function bodyMixinMethods (instance) {
 
       throwIfAborted(this[kState])
 
-      const contentType = this.headers.get('Content-Type')
+      const contentType = this.headers[kHeadersList].get('content-type', true)
+
+      const essence = contentType !== null && parseMIMEType(contentType)
 
       // If mimeType’s essence is "multipart/form-data", then:
-      if (/multipart\/form-data/.test(contentType)) {
+      if (essence === 'multipart/form-data') {
         const headers = {}
         for (const [key, value] of this.headers) headers[key] = value
 
@@ -430,7 +432,7 @@ function bodyMixinMethods (instance) {
         await busboyResolve
 
         return responseFormData
-      } else if (/application\/x-www-form-urlencoded/.test(contentType)) {
+      } else if (essence === 'application/x-www-form-urlencoded') {
         // Otherwise, if mimeType’s essence is "application/x-www-form-urlencoded", then:
 
         // 1. Let entries be the result of parsing bytes.

--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -371,10 +371,10 @@ function bodyMixinMethods (instance) {
 
       const contentType = this.headers[kHeadersList].get('content-type', true)
 
-      const essence = contentType !== null && parseMIMEType(contentType)
+      const mimeType = contentType !== null ? parseMIMEType(contentType) : 'failure'
 
       // If mimeType’s essence is "multipart/form-data", then:
-      if (essence === 'multipart/form-data') {
+      if (mimeType !== 'failure' && mimeType.essence === 'multipart/form-data') {
         const headers = {}
         for (const [key, value] of this.headers) headers[key] = value
 
@@ -432,7 +432,7 @@ function bodyMixinMethods (instance) {
         await busboyResolve
 
         return responseFormData
-      } else if (essence === 'application/x-www-form-urlencoded') {
+      } else if (mimeType !== 'failure' && mimeType.essence === 'application/x-www-form-urlencoded') {
         // Otherwise, if mimeType’s essence is "application/x-www-form-urlencoded", then:
 
         // 1. Let entries be the result of parsing bytes.

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -2,7 +2,8 @@
 
 const { test } = require('tap')
 const {
-  Response
+  Response,
+  FormData
 } = require('../../')
 const {
   Blob: ThirdPartyBlob,
@@ -253,4 +254,36 @@ test('Issue#2465', async (t) => {
   t.plan(1)
   const response = new Response(new SharedArrayBuffer(0))
   t.equal(await response.text(), '[object SharedArrayBuffer]')
+})
+
+test('Check the Content-Type of invalid formData', (t) => {
+  t.plan(4)
+
+  t.test('_application/x-www-form-urlencoded', async (t) => {
+    t.plan(1)
+    const response = new Response('x=y', { headers: { 'content-type': '_application/x-www-form-urlencoded' } })
+    await t.rejects(response.formData(), TypeError)
+  })
+
+  t.test('_multipart/form-data', async (t) => {
+    t.plan(1)
+    const formData = new FormData()
+    formData.append('x', 'y')
+    const response = new Response(formData, { headers: { 'content-type': '_multipart/form-data' } })
+    await t.rejects(response.formData(), TypeError)
+  })
+
+  t.test('application/x-www-form-urlencoded_', async (t) => {
+    t.plan(1)
+    const response = new Response('x=y', { headers: { 'content-type': 'application/x-www-form-urlencoded_' } })
+    await t.rejects(response.formData(), TypeError)
+  })
+
+  t.test('multipart/form-data_', async (t) => {
+    t.plan(1)
+    const formData = new FormData()
+    formData.append('x', 'y')
+    const response = new Response(formData, { headers: { 'content-type': 'multipart/form-data_' } })
+    await t.rejects(response.formData(), TypeError)
+  })
 })


### PR DESCRIPTION
The Content-Type is not strictly checked.
If `multipart/form-data` or `application/x-www-form-urlencoded` is included, Error is not thrown.
```shell
> $ node
Welcome to Node.js v21.5.0.
Type ".help" for more information.
> [...await (new Response("x=y", { headers: { "content-type": "application/x-www-form-urlencoded_" } }).formData())]
[ [ 'x', 'y' ] ]
```