### PR TITLE
lib: fix Host header when CONNECT ProxyAgent

### DIFF
--- a/lib/proxy-agent.js
+++ b/lib/proxy-agent.js
@@ -66,7 +66,7 @@ class ProxyAgent extends DispatcherBase {
     this[kProxyHeaders] = opts.headers || {}
 
     const resolvedUrl = new URL(opts.uri)
-    const { origin, port, host, username, password } = resolvedUrl
+    const { origin, port, username, password } = resolvedUrl
 
     if (opts.auth && opts.token) {
       throw new InvalidArgumentError('opts.auth cannot be used in combination with opts.token')
@@ -97,7 +97,7 @@ class ProxyAgent extends DispatcherBase {
             signal: opts.signal,
             headers: {
               ...this[kProxyHeaders],
-              host
+              host: requestedHost
             }
           })
           if (statusCode !== 200) {

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -393,7 +393,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623', async
   }
 
   const expectedProxyHeaders = {
-    host: `localhost:${proxy.address().port}`,
+    host: `localhost:${server.address().port}`,
     connection: 'close'
   }
 


### PR DESCRIPTION
Fixes #2542 

FYI @pimterry I believe HttpToolkit isn't validating Host headers when accepting request instrumentation through proxy. 

According to the RFC, the Host header must be the same as the CONNECT one. If an invalid Host is provided, the proxy must return 400 (as happening the linked issue)