### PR TITLE
Fix parseHashWithOptions regex

### DIFF
--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -584,7 +584,7 @@ function bytesMatch (bytes, metadataList) {
 // https://w3c.github.io/webappsec-subresource-integrity/#grammardef-hash-with-options
 // https://www.w3.org/TR/CSP2/#source-list-syntax
 // https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
-const parseHashWithOptions = /((?<algo>sha256|sha384|sha512)-(?<hash>[A-z0-9+/]{1}.*={0,2}))( +[\x21-\x7e]?)?/i
+const parseHashWithOptions = /(?<algo>sha256|sha384|sha512)-(?<hash>[A-Za-z0-9+/]+={0,2}(?=\s|$))( +[!-~]*)?/i
 
 /**
  * @see https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
@@ -1213,5 +1213,6 @@ module.exports = {
   readAllBytes,
   normalizeMethodRecord,
   simpleRangeHeaderValue,
-  buildContentRange
+  buildContentRange,
+  parseMetadata
 }

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -5,6 +5,7 @@ const { test } = t
 
 const util = require('../../lib/fetch/util')
 const { HeadersList } = require('../../lib/fetch/headers')
+const { createHash } = require('crypto')
 
 test('responseURL', (t) => {
   t.plan(2)
@@ -278,4 +279,79 @@ test('setRequestReferrerPolicyOnRedirect', nested => {
 
     t.equal(request.referrerPolicy, initial)
   })
+})
+
+test('parseMetadata', t => {
+  t.test('should parse valid metadata with option', t => {
+    const body = 'Hello world!'
+    const hash256 = createHash('sha256').update(body).digest('base64')
+    const hash384 = createHash('sha384').update(body).digest('base64')
+    const hash512 = createHash('sha512').update(body).digest('base64')
+
+    const validMetadata = `sha256-${hash256} !@ sha384-${hash384} !@ sha512-${hash512} !@`
+    const result = util.parseMetadata(validMetadata)
+
+    t.same(result, [
+      { algo: 'sha256', hash: hash256 },
+      { algo: 'sha384', hash: hash384 },
+      { algo: 'sha512', hash: hash512 }
+    ])
+
+    t.end()
+  })
+
+  t.test('should parse valid metadata with non ASCII chars option', t => {
+    const body = 'Hello world!'
+    const hash256 = createHash('sha256').update(body).digest('base64')
+    const hash384 = createHash('sha384').update(body).digest('base64')
+    const hash512 = createHash('sha512').update(body).digest('base64')
+
+    const validMetadata = `sha256-${hash256} !© sha384-${hash384} !€ sha512-${hash512} !µ`
+    const result = util.parseMetadata(validMetadata)
+
+    t.same(result, [
+      { algo: 'sha256', hash: hash256 },
+      { algo: 'sha384', hash: hash384 },
+      { algo: 'sha512', hash: hash512 }
+    ])
+
+    t.end()
+  })
+
+  t.test('should parse valid metadata without option', t => {
+    const body = 'Hello world!'
+    const hash256 = createHash('sha256').update(body).digest('base64')
+    const hash384 = createHash('sha384').update(body).digest('base64')
+    const hash512 = createHash('sha512').update(body).digest('base64')
+
+    const validMetadata = `sha256-${hash256} sha384-${hash384} sha512-${hash512}`
+    const result = util.parseMetadata(validMetadata)
+
+    t.same(result, [
+      { algo: 'sha256', hash: hash256 },
+      { algo: 'sha384', hash: hash384 },
+      { algo: 'sha512', hash: hash512 }
+    ])
+
+    t.end()
+  })
+
+  t.test('should ignore invalid metadata with invalid base64 chars', t => {
+    const body = 'Hello world!'
+    const hash256 = createHash('sha256').update(body).digest('base64')
+    const invalidHash384 = 'zifp5hE1Xl5LQQqQz[]Bq/iaq9Wb6jVb//T7EfTmbXD2aEP5c2ZdJr9YTDfcTE1ZH+'
+    const hash512 = createHash('sha512').update(body).digest('base64')
+
+    const validMetadata = `sha256-${hash256} sha384-${invalidHash384} sha512-${hash512}`
+    const result = util.parseMetadata(validMetadata)
+
+    t.same(result, [
+      { algo: 'sha256', hash: hash256 },
+      { algo: 'sha512', hash: hash512 }
+    ])
+
+    t.end()
+  })
+
+  t.end()
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

#2441 

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

`[A-z]` will also match `[\]^_` which are invalid base64 characters.

The current regex `[A-z0-9+/]{1}.*={0,2})` will match the initial valid characters in the hash group, even if the rest of the string contains an invalid Base64 string like **zifp5hE1Xl5LQQqQz[]Bq/iaq9Wb6jVb/** where the matched part is **zifp5hE1Xl5LQQqQz**

## Changes

<!-- Write a summary or list of changes here -->

change the hash group to `(?<hash>[A-Za-z0-9+/]+={0,2}(?=\s|$))` where `[A-Za-z0-9+/]`+ are valid base64 chars and `(?=\s|$))` is a positive lookahead assertion.

`( +[!-~]*)` looks for a group of printable ASCII chars as documented in https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
