### PR TITLE
perf: Improve percentDecode

### DIFF
--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -188,9 +188,26 @@ function stringPercentDecode (input) {
   return percentDecode(bytes)
 }
 
+/**
+ * @param {number} byte
+ */
 function isHexCharByte (byte) {
   // 0-9 A-F a-f
   return (byte >= 0x30 && byte <= 0x39) || (byte >= 0x41 && byte <= 0x46) || (byte >= 0x61 && byte <= 0x66)
+}
+
+/**
+ * @param {number} byte
+ */
+function hexByteToNumber (byte) {
+  return (
+    // 0-9
+    byte >= 0x30 && byte <= 0x39
+      ? (byte - 48)
+    // Convert to uppercase
+    // ((byte & 0xDF) - 65) + 10
+      : ((byte & 0xDF) - 55)
+  )
 }
 
 // https://url.spec.whatwg.org/#percent-decode
@@ -224,11 +241,8 @@ function percentDecode (input) {
     } else {
       // 1. Let bytePoint be the two bytes after byte in input,
       // decoded, and then interpreted as hexadecimal number.
-      const nextTwoBytes = String.fromCharCode(input[i + 1], input[i + 2])
-      const bytePoint = Number.parseInt(nextTwoBytes, 16)
-
       // 2. Append a byte whose value is bytePoint to output.
-      output[j++] = bytePoint
+      output[j++] = (hexByteToNumber(input[i + 1]) << 4) | hexByteToNumber(input[i + 2])
 
       // 3. Skip the next two bytes in input.
       i += 2


### PR DESCRIPTION
## Benchmark

<details>
<summary>Benchmark Script</summary>

```js
import { bench, group, run } from "mitata";

// avoid JIT bias
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});
bench("noop", () => {});

/**
 * @param {number} byte
 */
function isHexCharByte(byte) {
  // 0-9 A-F a-f
  return (
    (byte >= 0x30 && byte <= 0x39) ||
    (byte >= 0x41 && byte <= 0x46) ||
    (byte >= 0x61 && byte <= 0x66)
  );
}

/**
 * @param {number} byte
 */
function hexByteToNumber(byte) {
  return (
    // 0-9
    byte >= 0x30 && byte <= 0x39
      ? byte - 48
      : // Convert to uppercase
        // ((byte & 0xDF) - 65) + 10
        (byte & 0xdf) - 55
  );
}

function percentDecode(input) {
  const length = input.length;
  // 1. Let output be an empty byte sequence.
  /** @type {Uint8Array} */
  const output = new Uint8Array(length);
  let j = 0;
  // 2. For each byte byte in input:
  for (let i = 0; i < length; ++i) {
    const byte = input[i];

    // 1. If byte is not 0x25 (%), then append byte to output.
    if (byte !== 0x25) {
      output[j++] = byte;

      // 2. Otherwise, if byte is 0x25 (%) and the next two bytes
      // after byte in input are not in the ranges
      // 0x30 (0) to 0x39 (9), 0x41 (A) to 0x46 (F),
      // and 0x61 (a) to 0x66 (f), all inclusive, append byte
      // to output.
    } else if (
      byte === 0x25 &&
      !(isHexCharByte(input[i + 1]) && isHexCharByte(input[i + 2]))
    ) {
      output[j++] = 0x25;

      // 3. Otherwise:
    } else {
      // 1. Let bytePoint be the two bytes after byte in input,
      // decoded, and then interpreted as hexadecimal number.
      const nextTwoBytes = String.fromCharCode(input[i + 1], input[i + 2]);
      const bytePoint = Number.parseInt(nextTwoBytes, 16);

      // 2. Append a byte whose value is bytePoint to output.
      output[j++] = bytePoint;

      // 3. Skip the next two bytes in input.
      i += 2;
    }
  }

  // 3. Return output.
  return length === j ? output : output.subarray(0, j);
}

// https://url.spec.whatwg.org/#percent-decode
/** @param {Uint8Array} input */
function percentDecodeFast(input) {
  const length = input.length;
  // 1. Let output be an empty byte sequence.
  /** @type {Uint8Array} */
  const output = new Uint8Array(length);
  let j = 0;
  // 2. For each byte byte in input:
  for (let i = 0; i < length; ++i) {
    const byte = input[i];

    // 1. If byte is not 0x25 (%), then append byte to output.
    if (byte !== 0x25) {
      output[j++] = byte;

      // 2. Otherwise, if byte is 0x25 (%) and the next two bytes
      // after byte in input are not in the ranges
      // 0x30 (0) to 0x39 (9), 0x41 (A) to 0x46 (F),
      // and 0x61 (a) to 0x66 (f), all inclusive, append byte
      // to output.
    } else if (
      byte === 0x25 &&
      !(isHexCharByte(input[i + 1]) && isHexCharByte(input[i + 2]))
    ) {
      output[j++] = 0x25;

      // 3. Otherwise:
    } else {
      // 1. Let bytePoint be the two bytes after byte in input,
      // decoded, and then interpreted as hexadecimal number.
      // 2. Append a byte whose value is bytePoint to output.
      output[j++] =
        (hexByteToNumber(input[i + 1]) << 4) | hexByteToNumber(input[i + 2]);

      // 3. Skip the next two bytes in input.
      i += 2;
    }
  }

  // 3. Return output.
  return length === j ? output : output.subarray(0, j);
}

group("percentDecode", () => {
  const buffer = Buffer.from("%20".repeat(1000));

  bench("current", () => {
    return percentDecode(buffer);
  });

  bench("new", () => {
    return percentDecodeFast(buffer);
  });
});

await new Promise((resolve) => setTimeout(resolve, 7000));

await run();
```
</details>

```
• percentDecode
------------------------------------------------- -----------------------------
current     82.68 µs/iter    (59.5 µs … 14.27 ms)   73.8 µs  222.2 µs  264.7 µs
new          12.3 µs/iter     (6.9 µs … 10.58 ms)   10.6 µs  134.6 µs    148 µs

summary for percentDecode
  new
   6.72x faster than current
```