### PR TITLE
perf: bypass method validation

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -313,21 +313,28 @@ class Request {
       // 1. Let method be init["method"].
       let method = init.method
 
-      // 2. If method is not a method or method is a forbidden method, then
-      // throw a TypeError.
-      if (!isValidHTTPToken(method)) {
-        throw new TypeError(`'${method}' is not a valid HTTP method.`)
+      const mayBeNormalized = normalizeMethodRecord[method]
+
+      if (mayBeNormalized !== undefined) {
+        // Note: Bypass validation DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH and these lowercase ones
+        request.method = mayBeNormalized
+      } else {
+        // 2. If method is not a method or method is a forbidden method, then
+        // throw a TypeError.
+        if (!isValidHTTPToken(method)) {
+          throw new TypeError(`'${method}' is not a valid HTTP method.`)
+        }
+
+        if (forbiddenMethodsSet.has(method.toUpperCase())) {
+          throw new TypeError(`'${method}' HTTP method is unsupported.`)
+        }
+
+        // 3. Normalize method.
+        method = normalizeMethod(method)
+
+        // 4. Set request’s method to method.
+        request.method = method
       }
-
-      if (forbiddenMethodsSet.has(method.toUpperCase())) {
-        throw new TypeError(`'${method}' HTTP method is unsupported.`)
-      }
-
-      // 3. Normalize method.
-      method = normalizeMethodRecord[method] ?? normalizeMethod(method)
-
-      // 4. Set request’s method to method.
-      request.method = method
     }
 
     // 26. If init["signal"] exists, then set signal to it.

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -681,7 +681,7 @@ function isCancelled (fetchParams) {
     fetchParams.controller.state === 'terminated'
 }
 
-const normalizeMethodRecord = {
+const normalizeMethodRecordBase = {
   delete: 'DELETE',
   DELETE: 'DELETE',
   get: 'GET',
@@ -696,7 +696,14 @@ const normalizeMethodRecord = {
   PUT: 'PUT'
 }
 
+const normalizeMethodRecord = {
+  ...normalizeMethodRecordBase,
+  patch: 'patch',
+  PATCH: 'PATCH'
+}
+
 // Note: object prototypes should not be able to be referenced. e.g. `Object#hasOwnProperty`.
+Object.setPrototypeOf(normalizeMethodRecordBase, null)
 Object.setPrototypeOf(normalizeMethodRecord, null)
 
 /**
@@ -704,7 +711,7 @@ Object.setPrototypeOf(normalizeMethodRecord, null)
  * @param {string} method
  */
 function normalizeMethod (method) {
-  return normalizeMethodRecord[method.toLowerCase()] ?? method
+  return normalizeMethodRecordBase[method.toLowerCase()] ?? method
 }
 
 // https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-a-json-string


### PR DESCRIPTION
<details>
<summary>Benchmark Script</summary>

```js
import { bench, run } from 'mitata'
import { Request } from '../index.js'
// avoid JIT bias
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})

const input = "https://localhost/post"

const method = "post"

bench('new Request(input, { method })', () => {
    return new Request(input, { method })
})

await new Promise((resolve) => setTimeout(resolve, 7000))

await run()

```
</details>

- *main*
```
benchmark                           time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------------------- -----------------------------
new Request(input, { method })   12.47 µs/iter      (8.5 µs … 2.37 ms)   13.6 µs   27.4 µs   38.4 µs
```

- *this patch*
```
benchmark                           time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------------------- -----------------------------
new Request(input, { method })   11.79 µs/iter      (8.5 µs … 2.17 ms)   12.1 µs     24 µs     33 µs
```
