### PR TITLE
fix: use isArrayBuffer instead of isAnyArrayBuffer

### DIFF
--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -279,7 +279,7 @@ function processBlobParts (parts, options) {
 
       // 3. Append the result of UTF-8 encoding s to bytes.
       bytes.push(encoder.encode(s))
-    } else if (types.isArrayBuffer(element) || types.isTypedArray(element)) {
+    } else if (ArrayBuffer.isView(element) || types.isArrayBuffer(element)) {
       // 2. If element is a BufferSource, get a copy of the
       //    bytes held by the buffer source, and append those
       //    bytes to bytes.

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -211,10 +211,7 @@ webidl.converters.BlobPart = function (V, opts) {
       return webidl.converters.Blob(V, { strict: false })
     }
 
-    if (
-      ArrayBuffer.isView(V) ||
-      types.isAnyArrayBuffer(V)
-    ) {
+    if (ArrayBuffer.isView(V) || types.isArrayBuffer(V)) {
       return webidl.converters.BufferSource(V, opts)
     }
   }
@@ -282,10 +279,7 @@ function processBlobParts (parts, options) {
 
       // 3. Append the result of UTF-8 encoding s to bytes.
       bytes.push(encoder.encode(s))
-    } else if (
-      types.isAnyArrayBuffer(element) ||
-      types.isTypedArray(element)
-    ) {
+    } else if (types.isArrayBuffer(element) || types.isTypedArray(element)) {
       // 2. If element is a BufferSource, get a copy of the
       //    bytes held by the buffer source, and append those
       //    bytes to bytes.

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -211,7 +211,7 @@ webidl.converters.BlobPart = function (V, opts) {
       return webidl.converters.Blob(V, { strict: false })
     }
 
-    if (ArrayBuffer.isView(V) || types.isArrayBuffer(V)) {
+    if (ArrayBuffer.isView(V) || types.isAnyArrayBuffer(V)) {
       return webidl.converters.BufferSource(V, opts)
     }
   }

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -524,7 +524,7 @@ webidl.converters.XMLHttpRequestBodyInit = function (V) {
     return webidl.converters.Blob(V, { strict: false })
   }
 
-  if (types.isArrayBuffer(V) || types.isTypedArray(V) || types.isDataView(V)) {
+  if (ArrayBuffer.isView(V) || types.isArrayBuffer(V)) {
     return webidl.converters.BufferSource(V)
   }
 

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -613,7 +613,7 @@ webidl.converters.DataView = function (V, opts = {}) {
 
 // https://webidl.spec.whatwg.org/#BufferSource
 webidl.converters.BufferSource = function (V, opts = {}) {
-  if (types.isAnyArrayBuffer(V)) {
+  if (types.isArrayBuffer(V)) {
     return webidl.converters.ArrayBuffer(V, opts)
   }
 

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -614,15 +614,15 @@ webidl.converters.DataView = function (V, opts = {}) {
 // https://webidl.spec.whatwg.org/#BufferSource
 webidl.converters.BufferSource = function (V, opts = {}) {
   if (types.isArrayBuffer(V)) {
-    return webidl.converters.ArrayBuffer(V, opts)
+    return webidl.converters.ArrayBuffer(V, { ...opts, allowShared: false })
   }
 
   if (types.isTypedArray(V)) {
-    return webidl.converters.TypedArray(V, V.constructor)
+    return webidl.converters.TypedArray(V, V.constructor, { ...opts, allowShared: false })
   }
 
   if (types.isDataView(V)) {
-    return webidl.converters.DataView(V, opts)
+    return webidl.converters.DataView(V, opts, { ...opts, allowShared: false })
   }
 
   throw new TypeError(`Could not convert ${V} to a BufferSource.`)

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -613,7 +613,7 @@ webidl.converters.DataView = function (V, opts = {}) {
 
 // https://webidl.spec.whatwg.org/#BufferSource
 webidl.converters.BufferSource = function (V, opts = {}) {
-  if (types.isArrayBuffer(V)) {
+  if (types.isAnyArrayBuffer(V)) {
     return webidl.converters.ArrayBuffer(V, { ...opts, allowShared: false })
   }
 

--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -627,7 +627,7 @@ webidl.converters.WebSocketSendData = function (V) {
       return webidl.converters.Blob(V, { strict: false })
     }
 
-    if (ArrayBuffer.isView(V) || types.isAnyArrayBuffer(V)) {
+    if (ArrayBuffer.isView(V) || types.isArrayBuffer(V)) {
       return webidl.converters.BufferSource(V)
     }
   }

--- a/test/fetch/file.js
+++ b/test/fetch/file.js
@@ -175,3 +175,16 @@ test('endings=native', async () => {
     assert.strictEqual(text, 'Hello\nWorld', `on ${process.platform} LF stays LF`)
   }
 })
+
+test('not allow SharedArrayBuffer', () => {
+  const buffer = new SharedArrayBuffer(0)
+  assert.throws(() => {
+    // eslint-disable-next-line no-new
+    new File([buffer], 'text.txt')
+  }, TypeError)
+
+  assert.throws(() => {
+    // eslint-disable-next-line no-new
+    new File([new Uint8Array(buffer)], 'text.txt')
+  }, TypeError)
+})

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -167,6 +167,10 @@ test('BufferSource', () => {
   assert.throws(() => {
     webidl.converters.BufferSource(3)
   }, TypeError)
+
+  assert.throws(() => {
+    webidl.converters.BufferSource(new SharedArrayBuffer(0))
+  }, TypeError)
 })
 
 test('ByteString', () => {

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -167,10 +167,6 @@ test('BufferSource', () => {
   assert.throws(() => {
     webidl.converters.BufferSource(3)
   }, TypeError)
-
-  assert.throws(() => {
-    webidl.converters.BufferSource(new SharedArrayBuffer(0))
-  }, TypeError)
 })
 
 test('ByteString', () => {

--- a/test/websocket/send.js
+++ b/test/websocket/send.js
@@ -211,4 +211,27 @@ describe('Sending data to a server', () => {
       })
     })
   })
+
+  test('Cannot send with SharedArrayBuffer', () => {
+    const sab = new SharedArrayBuffer(0)
+    const server = new WebSocketServer({ port: 0 })
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    ws.addEventListener('open', () => {
+      ws.send(sab)
+    })
+
+    return new Promise((resolve) => {
+      server.on('connection', (ws) => {
+        ws.on('message', (data, isBinary) => {
+          assert.ok(!isBinary)
+          assert.deepStrictEqual(data, Buffer.from('[object SharedArrayBuffer]'))
+          ws.close(1000)
+          server.close()
+          resolve()
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
From [BufferSource]( https://webidl.spec.whatwg.org/#BufferSource) of webidl spec.

> Note: [[AllowShared](https://webidl.spec.whatwg.org/#AllowShared)] cannot be used with [BufferSource](https://webidl.spec.whatwg.org/#BufferSource) as [ArrayBuffer](https://webidl.spec.whatwg.org/#idl-ArrayBuffer) does not support it. Use [AllowSharedBufferSource](https://webidl.spec.whatwg.org/#AllowSharedBufferSource) instead.

BufferSource does not contain SharedArrayBuffer.