### PR TITLE
deprecate support for 3rd party blobs

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -6,7 +6,6 @@ const { IncomingMessage } = require('http')
 const stream = require('stream')
 const net = require('net')
 const { InvalidArgumentError } = require('./errors')
-const { Blob } = require('buffer')
 const nodeUtil = require('util')
 const { stringify } = require('querystring')
 const { headerNameLowerCasedRecord } = require('./constants')
@@ -22,7 +21,7 @@ function isStream (obj) {
 
 // based on https://github.com/node-fetch/fetch-blob/blob/8ab587d34080de94140b54f07168451e7d0b655e/index.js#L229-L241 (MIT License)
 function isBlobLike (object) {
-  return (Blob && object instanceof Blob) || (
+  return object instanceof Blob || (
     object &&
     typeof object === 'object' &&
     (typeof object.stream === 'function' ||

--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -13,7 +13,7 @@ const {
 const { FormData } = require('./formdata')
 const { kState } = require('./symbols')
 const { webidl } = require('./webidl')
-const { Blob, File: NativeFile } = require('buffer')
+const { File: NativeFile } = require('buffer')
 const { kBodyUsed, kHeadersList } = require('../core/symbols')
 const assert = require('assert')
 const { isErrored } = require('../core/util')

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { Blob, File: NativeFile } = require('buffer')
-const { types } = require('util')
+const { File: NativeFile } = require('buffer')
+const { types, deprecate } = require('util')
 const { kState } = require('./symbols')
 const { isBlobLike } = require('./util')
 const { webidl } = require('./webidl')
@@ -341,4 +341,11 @@ function isFileLike (object) {
   )
 }
 
-module.exports = { File, FileLike, isFileLike }
+module.exports = {
+  File,
+  FileLike: deprecate(
+    FileLike,
+    'Support for 3rd party blobs will be removed in a future version of undici.'
+  ),
+  isFileLike
+}

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -4,7 +4,7 @@ const { isBlobLike, toUSVString, makeIterator } = require('./util')
 const { kState } = require('./symbols')
 const { File: UndiciFile, FileLike, isFileLike } = require('./file')
 const { webidl } = require('./webidl')
-const { Blob, File: NativeFile } = require('buffer')
+const { File: NativeFile } = require('buffer')
 
 /** @type {globalThis['File']} */
 const File = NativeFile ?? UndiciFile


### PR DESCRIPTION
Blob has been global since node v18 and File is in node v20. When we drop support for node 18, we should drop support for third party blobs/files.