### PR TITLE
fix: defer error accross micro task queue execution

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -62,9 +62,13 @@ module.exports = class BodyReadable extends Readable {
     // never get a chance and will always encounter an unhandled exception.
     // - tick => process.nextTick(fn)
     // - micro tick => queueMicrotask(fn)
-    queueMicrotask(() => {
+    if (err) {
+      setImmediate(() => {
+        callback(err)
+      })
+    } else {
       callback(err)
-    })
+    }
   }
 
   on (ev, ...args) {


### PR DESCRIPTION
Just deferring a micro task is not sufficient. I still encounter the original issue in production.