### PR TITLE
fix: non-object error in abort throws bad error

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -4,7 +4,9 @@ const fetchImpl = require('./lib/fetch').fetch
 
 module.exports.fetch = function fetch (resource, init = undefined) {
   return fetchImpl(resource, init).catch((err) => {
-    Error.captureStackTrace(err, this)
+    if (typeof err === 'object') {
+      Error.captureStackTrace(err, this)
+    }
     throw err
   })
 }

--- a/test/fetch/issue-2242.js
+++ b/test/fetch/issue-2242.js
@@ -3,10 +3,20 @@
 const { test } = require('node:test')
 const assert = require('node:assert')
 const { fetch } = require('../..')
+const nodeFetch = require('../../index-fetch')
 
 test('fetch with signal already aborted', async () => {
   await assert.rejects(
     fetch('http://localhost', {
+      signal: AbortSignal.abort('Already aborted')
+    }),
+    /Already aborted/
+  )
+})
+
+test('fetch with signal already aborted (from index-fetch)', async () => {
+  await assert.rejects(
+    nodeFetch.fetch('http://localhost', {
       signal: AbortSignal.abort('Already aborted')
     }),
     /Already aborted/


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/49557.
Refs: #2243.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md


## This relates to...


## Rationale

## Changes


### Features


### Bug Fixes


### Breaking Changes and Deprecations


## Status


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
-->