### PR TITLE
cleanup index

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,6 @@ const DecoratorHandler = require('./lib/handler/DecoratorHandler')
 const RedirectHandler = require('./lib/handler/RedirectHandler')
 const createRedirectInterceptor = require('./lib/interceptor/redirectInterceptor')
 
-let hasCrypto
-try {
-  require('crypto')
-  hasCrypto = true
-} catch {
-  hasCrypto = false
-}
-
 Object.assign(Dispatcher.prototype, api)
 
 module.exports.Dispatcher = Dispatcher
@@ -102,14 +94,10 @@ function makeDispatcher (fn) {
 module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
-let fetchImpl = null
-module.exports.fetch = async function fetch (resource) {
-  if (!fetchImpl) {
-    fetchImpl = require('./lib/fetch').fetch
-  }
-
+const fetchImpl = require('./lib/fetch').fetch
+module.exports.fetch = async function fetch (init, options = undefined) {
   try {
-    return await fetchImpl(...arguments)
+    return await fetchImpl(init, options)
   } catch (err) {
     if (typeof err === 'object') {
       Error.captureStackTrace(err, this)
@@ -149,11 +137,7 @@ const { parseMIMEType, serializeAMimeType } = require('./lib/fetch/dataURL')
 module.exports.parseMIMEType = parseMIMEType
 module.exports.serializeAMimeType = serializeAMimeType
 
-if (hasCrypto) {
-  const { WebSocket } = require('./lib/websocket/websocket')
-
-  module.exports.WebSocket = WebSocket
-}
+module.exports.WebSocket = require('./lib/websocket/websocket').WebSocket
 
 module.exports.request = makeDispatcher(api.request)
 module.exports.stream = makeDispatcher(api.stream)

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -122,7 +122,7 @@ class Fetch extends EE {
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
-function fetch (input, init = {}) {
+function fetch (input, init = undefined) {
   webidl.argumentLengthCheck(arguments, 1, { header: 'globalThis.fetch' })
 
   // 1. Let p be a new promise.
@@ -248,7 +248,7 @@ function fetch (input, init = {}) {
     request,
     processResponseEndOfBody: handleFetchDone,
     processResponse,
-    dispatcher: init.dispatcher ?? getGlobalDispatcher() // undici
+    dispatcher: init?.dispatcher ?? getGlobalDispatcher() // undici
   })
 
   // 14. Return p.


### PR DESCRIPTION
- crypto check is done directly in WebSocket now, it's not needed anymore
- I don't think we need to lazy load fetch anymore?
- default the second argument to `undefined` in fetch because we don't need it to be an object