### PR TITLE
cacheStorage: separate matchAll logic

### DIFF
--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -49,7 +49,7 @@ class Cache {
     request = webidl.converters.RequestInfo(request)
     options = webidl.converters.CacheQueryOptions(options)
 
-    const p = await this.matchAll(request, options)
+    const p = this.#internalMatchAll(request, options, 1)
 
     if (p.length === 0) {
       return
@@ -64,64 +64,7 @@ class Cache {
     if (request !== undefined) request = webidl.converters.RequestInfo(request)
     options = webidl.converters.CacheQueryOptions(options)
 
-    // 1.
-    let r = null
-
-    // 2.
-    if (request !== undefined) {
-      if (request instanceof Request) {
-        // 2.1.1
-        r = request[kState]
-
-        // 2.1.2
-        if (r.method !== 'GET' && !options.ignoreMethod) {
-          return []
-        }
-      } else if (typeof request === 'string') {
-        // 2.2.1
-        r = new Request(request)[kState]
-      }
-    }
-
-    // 5.
-    // 5.1
-    const responses = []
-
-    // 5.2
-    if (request === undefined) {
-      // 5.2.1
-      for (const requestResponse of this.#relevantRequestResponseList) {
-        responses.push(requestResponse[1])
-      }
-    } else { // 5.3
-      // 5.3.1
-      const requestResponses = this.#queryCache(r, options)
-
-      // 5.3.2
-      for (const requestResponse of requestResponses) {
-        responses.push(requestResponse[1])
-      }
-    }
-
-    // 5.4
-    // We don't implement CORs so we don't need to loop over the responses, yay!
-
-    // 5.5.1
-    const responseList = []
-
-    // 5.5.2
-    for (const response of responses) {
-      // 5.5.2.1
-      const responseObject = new Response(null)
-      responseObject[kState] = response
-      responseObject[kHeaders][kHeadersList] = response.headersList
-      responseObject[kHeaders][kGuard] = 'immutable'
-
-      responseList.push(responseObject.clone())
-    }
-
-    // 6.
-    return Object.freeze(responseList)
+    return this.#internalMatchAll(request, options)
   }
 
   async add (request) {
@@ -788,6 +731,71 @@ class Cache {
     }
 
     return true
+  }
+
+  #internalMatchAll (request, options, maxResponses = Infinity) {
+    // 1.
+    let r = null
+
+    // 2.
+    if (request !== undefined) {
+      if (request instanceof Request) {
+        // 2.1.1
+        r = request[kState]
+
+        // 2.1.2
+        if (r.method !== 'GET' && !options.ignoreMethod) {
+          return []
+        }
+      } else if (typeof request === 'string') {
+        // 2.2.1
+        r = new Request(request)[kState]
+      }
+    }
+
+    // 5.
+    // 5.1
+    const responses = []
+
+    // 5.2
+    if (request === undefined) {
+      // 5.2.1
+      for (const requestResponse of this.#relevantRequestResponseList) {
+        responses.push(requestResponse[1])
+      }
+    } else { // 5.3
+      // 5.3.1
+      const requestResponses = this.#queryCache(r, options)
+
+      // 5.3.2
+      for (const requestResponse of requestResponses) {
+        responses.push(requestResponse[1])
+      }
+    }
+
+    // 5.4
+    // We don't implement CORs so we don't need to loop over the responses, yay!
+
+    // 5.5.1
+    const responseList = []
+
+    // 5.5.2
+    for (const response of responses) {
+      // 5.5.2.1
+      const responseObject = new Response(null)
+      responseObject[kState] = response
+      responseObject[kHeaders][kHeadersList] = response.headersList
+      responseObject[kHeaders][kGuard] = 'immutable'
+
+      responseList.push(responseObject.clone())
+
+      if (responseList.length >= maxResponses) {
+        break
+      }
+    }
+
+    // 6.
+    return Object.freeze(responseList)
   }
 }
 


### PR DESCRIPTION
The biggest benefit can be seen from Cache.match where we can now limit the number of responses fetched, instead of returning the entire list while match only requires the first.