### PR TITLE
Fix tests for Node.js v21

### DIFF
--- a/test/mock-interceptor-unused-assertions.js
+++ b/test/mock-interceptor-unused-assertions.js
@@ -3,6 +3,11 @@
 const { test, beforeEach, afterEach } = require('tap')
 const { MockAgent, setGlobalDispatcher } = require('..')
 const PendingInterceptorsFormatter = require('../lib/mock/pending-interceptors-formatter')
+const util = require('../lib/core/util')
+
+// Since Node.js v21 `console.table` rows are aligned to the left
+// https://github.com/nodejs/node/pull/50135
+const tableRowsAlignedToLeft = util.nodeMajor >= 21
 
 // Avoid colors in the output for inline snapshots.
 const pendingInterceptorsFormatter = new PendingInterceptorsFormatter({ disableColors: true })
@@ -40,7 +45,17 @@ test('1 pending interceptor', t => {
 
   const err = t.throws(() => mockAgentWithOneInterceptor().assertNoPendingInterceptors({ pendingInterceptorsFormatter }))
 
-  t.same(err.message, `
+  t.same(err.message, tableRowsAlignedToLeft
+    ? `
+1 interceptor is pending:
+
+┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
+│ (index) │ Method │ Origin                │ Path │ Status code │ Persistent │ Invocations │ Remaining │
+├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
+│ 0       │ 'GET'  │ 'https://example.com' │ '/'  │ 200         │ '❌'       │ 0           │ 1         │
+└─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
+`.trim()
+    : `
 1 interceptor is pending:
 
 ┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
@@ -61,7 +76,18 @@ test('2 pending interceptors', t => {
     .reply(204, 'OK')
   const err = t.throws(() => withTwoInterceptors.assertNoPendingInterceptors({ pendingInterceptorsFormatter }))
 
-  t.same(err.message, `
+  t.same(err.message, tableRowsAlignedToLeft
+    ? `
+2 interceptors are pending:
+
+┌─────────┬────────┬──────────────────────────┬──────────────┬─────────────┬────────────┬─────────────┬───────────┐
+│ (index) │ Method │ Origin                   │ Path         │ Status code │ Persistent │ Invocations │ Remaining │
+├─────────┼────────┼──────────────────────────┼──────────────┼─────────────┼────────────┼─────────────┼───────────┤
+│ 0       │ 'GET'  │ 'https://example.com'    │ '/'          │ 200         │ '❌'       │ 0           │ 1         │
+│ 1       │ 'GET'  │ 'https://localhost:9999' │ '/some/path' │ 204         │ '❌'       │ 0           │ 1         │
+└─────────┴────────┴──────────────────────────┴──────────────┴─────────────┴────────────┴─────────────┴───────────┘
+`.trim()
+    : `
 2 interceptors are pending:
 
 ┌─────────┬────────┬──────────────────────────┬──────────────┬─────────────┬────────────┬─────────────┬───────────┐
@@ -123,7 +149,20 @@ test('Variations of persist(), times(), and pending status', async t => {
 
   const err = t.throws(() => agent.assertNoPendingInterceptors({ pendingInterceptorsFormatter }))
 
-  t.same(err.message, `
+  t.same(err.message, tableRowsAlignedToLeft
+    ? `
+4 interceptors are pending:
+
+┌─────────┬────────┬──────────────────────────┬──────────────────────┬─────────────┬────────────┬─────────────┬───────────┐
+│ (index) │ Method │ Origin                   │ Path                 │ Status code │ Persistent │ Invocations │ Remaining │
+├─────────┼────────┼──────────────────────────┼──────────────────────┼─────────────┼────────────┼─────────────┼───────────┤
+│ 0       │ 'GET'  │ 'https://example.com'    │ '/'                  │ 200         │ '❌'       │ 0           │ 1         │
+│ 1       │ 'GET'  │ 'https://localhost:9999' │ '/persistent/unused' │ 200         │ '✅'       │ 0           │ Infinity  │
+│ 2       │ 'GET'  │ 'https://localhost:9999' │ '/times/partial'     │ 200         │ '❌'       │ 1           │ 4         │
+│ 3       │ 'GET'  │ 'https://localhost:9999' │ '/times/unused'      │ 200         │ '❌'       │ 0           │ 2         │
+└─────────┴────────┴──────────────────────────┴──────────────────────┴─────────────┴────────────┴─────────────┴───────────┘
+`.trim()
+    : `
 4 interceptors are pending:
 
 ┌─────────┬────────┬──────────────────────────┬──────────────────────┬─────────────┬────────────┬─────────────┬───────────┐
@@ -172,7 +211,17 @@ test('defaults to rendering output with terminal color when process.env.CI is un
 
   const err = t.throws(
     () => mockAgentWithOneInterceptor().assertNoPendingInterceptors())
-  t.same(err.message, `
+  t.same(err.message, tableRowsAlignedToLeft
+    ? `
+1 interceptor is pending:
+
+┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
+│ (index) │ Method │ Origin                │ Path │ Status code │ Persistent │ Invocations │ Remaining │
+├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
+│ 0       │ \u001b[32m'GET'\u001b[39m  │ \u001b[32m'https://example.com'\u001b[39m │ \u001b[32m'/'\u001b[39m  │ \u001b[33m200\u001b[39m         │ \u001b[32m'❌'\u001b[39m       │ \u001b[33m0\u001b[39m           │ \u001b[33m1\u001b[39m         │
+└─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
+`.trim()
+    : `
 1 interceptor is pending:
 
 ┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

https://github.com/nodejs/undici/pull/2434 now runs node.js v21 tests in CI

Tests of https://github.com/nodejs/undici/actions/runs/7484065756/job/20370320723?pr=2608 are failed for Node.js v21 matrix. The difference seems to have occurred because the row of console.table is now aligned to the left ( https://github.com/nodejs/node/pull/50135 ).

So this PR uses left aligned tables for testing when running on node v21 and above.

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
