### PR TITLE
Avoid structuredClone in Response()

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -274,17 +274,13 @@ function cloneBody (body) {
 
   // 1. Let « out1, out2 » be the result of teeing body’s stream.
   const [out1, out2] = body.stream.tee()
-  const out2Clone = structuredClone(out2, { transfer: [out2] })
-  // This, for whatever reasons, unrefs out2Clone which allows
-  // the process to exit by itself.
-  const [, finalClone] = out2Clone.tee()
 
   // 2. Set body’s stream to out1.
   body.stream = out1
 
   // 3. Return a body whose stream is out2 and other members are copied from body.
   return {
-    stream: finalClone,
+    stream: out2,
     length: body.length,
     source: body.source
   }

--- a/test/mock-interceptor-unused-assertions.js
+++ b/test/mock-interceptor-unused-assertions.js
@@ -7,7 +7,7 @@ const util = require('../lib/core/util')
 
 // Since Node.js v21 `console.table` rows are aligned to the left
 // https://github.com/nodejs/node/pull/50135
-const tableRowsAlignedToLeft = util.nodeMajor >= 21
+const tableRowsAlignedToLeft = util.nodeMajor >= 21 || (util.nodeMajor === 20 && util.nodeMinor >= 11)
 
 // Avoid colors in the output for inline snapshots.
 const pendingInterceptorsFormatter = new PendingInterceptorsFormatter({ disableColors: true })


### PR DESCRIPTION
Fixes https://github.com/nodejs/undici/issues/2615
Fixes https://github.com/nodejs/undici/pull/2618 (to make the tests pass on Node 20)

Note that this is caused by https://github.com/nodejs/node/pull/51255 by @jasnell.
It can also be reproduced with:

```js
import { test } from 'node:test'
import assert from 'node:assert'

test('repro', async (t) => {
  const buf = new Uint8Array(1)
  const readable = new ReadableStream({
    start (controller) {
      controller.enqueue(buf)
      controller.close()
    }
  })

  const [out1, out2] = readable.tee()
  const cloned = structuredClone(out2, { transfer: [out2] })

  for await (const chunk of cloned) {
    assert.deepStrictEqual(chunk, buf)
  }

  for await (const chunk of out2) {
    assert.deepStrictEqual(chunk, buf)
  }

  for await (const chunk of out1) {
    assert.deepStrictEqual(chunk, buf)
  }
})
```

which will fail with:

```
✖ repro (5.626125ms)
  'Promise resolution is still pending but the event loop has already resolved'

ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 0
ℹ cancelled 1
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 8.293458

✖ failing tests:

test at file:/Users/matteo/Repositories/node/repro.mjs:6:1
✖ repro (5.626125ms)
  'Promise resolution is still pending but the event loop has already resolved'
```