### PR TITLE
fix: hide statusOutput if empty in handleRunnerCompletion

### DIFF
--- a/test/wpt/runner/runner.mjs
+++ b/test/wpt/runner/runner.mjs
@@ -301,13 +301,16 @@ export class WPTRunner extends EventEmitter {
    * Called after every test has completed.
    */
   handleRunnerCompletion () {
-    console.log(this.#statusOutput) // tests that failed
+    // tests that failed
+    if (Object.keys(this.#statusOutput).length !== 0) {
+      console.log(this.#statusOutput)
+    }
 
     this.emit('completion')
     const { completed, failed, success, expectedFailures, skipped } = this.#stats
     console.log(
       `[${this.#folderName}]: ` +
-      `Completed: ${completed}, failed: ${failed}, success: ${success}, ` +
+      `completed: ${completed}, failed: ${failed}, success: ${success}, ` +
       `expected failures: ${expectedFailures}, ` +
       `unexpected failures: ${failed - expectedFailures}, ` +
       `skipped: ${skipped}`


### PR DESCRIPTION
It was confusing to see the serialized empty object. I was thinking, that I have put an console log somewhere and forgot to remove it.

before:
![image](https://github.com/nodejs/undici/assets/5059100/58339beb-cf85-4844-8770-c2629636008b)
after:
![image](https://github.com/nodejs/undici/assets/5059100/121decd8-3879-47d0-ab98-cc87685e8c8b)


<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
