### PR TITLE
Allow offline run of build:node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "docs"
   ],
   "scripts": {
-    "build:node": "npx esbuild@0.19.4 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1 --keep-names",
+    "build:node": "npx esbuild index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1 --keep-names",
     "prebuild:wasm": "node build/wasm.js --prebuild",
     "build:wasm": "node build/wasm.js --docker",
     "lint": "standard | snazzy",
@@ -113,6 +113,7 @@
     "delay": "^5.0.0",
     "dns-packet": "^5.4.0",
     "docsify-cli": "^4.4.3",
+    "esbuild": "^0.19.4",
     "form-data": "^4.0.0",
     "formdata-node": "^6.0.3",
     "https-pem": "^3.0.0",


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

https://github.com/nodejs/undici/pull/2342

## Rationale

During packaging for a Linux distribution, the build systems are usually/sometimes disconnected from the internet,
and can not use anything not present in source tarball or installed on the system.

To facilitate NodeJS packages, in Fedora we cache the `node_modules` directory when creating a package update, and then re-use this cached directory for all subsequent builds. That means that we need all the build-time dependencies installed after invoking `npm install --include=dev`. This is currently not true for the `build:node` script, which pulls `esbuild@0.19.4` at the point of invocation. If invoked in offline mode (`npm --offline run build:node`), this fails.

## Changes

- Include esbuild in `devDependencies`, so that it is installed on `npm install --include=dev`.
- Use the installed version when running the `build:node` script.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md