### PR TITLE
perf(request): avoid USVString in RequestInfo

### DIFF
--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -50,7 +50,7 @@ class Request {
 
     webidl.argumentLengthCheck(arguments, 1, { header: 'Request constructor' })
 
-    input = webidl.converters.RequestInfo(input)
+    input = webidl.converters.RequestInfo_DOMString(input)
     init = webidl.converters.RequestInit(init)
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
@@ -897,6 +897,19 @@ webidl.converters.RequestInfo = function (V) {
   }
 
   return webidl.converters.USVString(V)
+}
+
+// DOMString is used because the value is converted to a USVString in `new URL()`.
+webidl.converters.RequestInfo_DOMString = function (V) {
+  if (typeof V === 'string') {
+    return webidl.converters.DOMString(V)
+  }
+
+  if (V instanceof Request) {
+    return webidl.converters.Request(V)
+  }
+
+  return webidl.converters.DOMString(V)
 }
 
 webidl.converters.AbortSignal = webidl.interfaceConverter(


### PR DESCRIPTION
Since USVString is called in `new URL()`, conversion is performed in the `new URL()`, not in the RequestInfo.

You can check the conversion by doing the following.

```js
new URL(`https://localhost/${"\ud83d"}`).href === new URL(`https://localhost/${"\ud83d"}`.toWellFormed()).href; // true
```

<details>
<summary>Benchmark Script</summary>

```js
import { bench, run } from 'mitata'
import { Request } from './lib/fetch/request.js'
const input = 'https://example.com/post'

bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})
bench('noop', () => {})

bench('new Request', () => {
  return new Request(input, undefined)
})

await new Promise((resolve) => setTimeout(resolve, 20000))

await run();
```
</details>

- *main*

**v21.6.1**

```
benchmark        time (avg)             (min … max)       p75       p99      p995
--------------------------------------------------- -----------------------------
new Request   11.62 µs/iter      (7.4 µs … 4.07 ms)   10.2 µs   33.9 µs   43.1 µs
```

**v20.11.0**

```
benchmark        time (avg)             (min … max)       p75       p99      p995
--------------------------------------------------- -----------------------------
new Request    11.4 µs/iter      (7.4 µs … 6.84 ms)   10.2 µs   33.5 µs   41.7 µs
```

- *this patch*

**v21.6.1**

```
benchmark        time (avg)             (min … max)       p75       p99      p995
--------------------------------------------------- -----------------------------
new Request   11.27 µs/iter      (7.4 µs … 3.89 ms)     10 µs   32.6 µs   42.7 µs
```

**v20.11.0**

```
benchmark        time (avg)             (min … max)       p75       p99      p995
--------------------------------------------------- -----------------------------
new Request   10.88 µs/iter      (7.3 µs … 4.14 ms)    9.6 µs   30.1 µs   40.3 µs
```