### PR TITLE
fix: expose EventSource for nodejs

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -14,4 +14,7 @@ module.exports.FormData = require('./lib/fetch/formdata').FormData
 module.exports.Headers = require('./lib/fetch/headers').Headers
 module.exports.Response = require('./lib/fetch/response').Response
 module.exports.Request = require('./lib/fetch/request').Request
+
 module.exports.WebSocket = require('./lib/websocket/websocket').WebSocket
+
+module.exports.EventSource = require('./lib/eventsource/eventsource').EventSource


### PR DESCRIPTION
I would actually recommend to rename index-fetch.js to index-node.js as it is not only exposing fetch but also Websocket and now EventSource. 

But this would mean that we also have to patch the dependency updater for undici in nodejs

This is afaik blocking https://github.com/nodejs/node/pull/51575


<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
