### PR TITLE
chore: reduce noise in test logs test/client-node-max-header-size.js

### DIFF
--- a/test/client-node-max-header-size.js
+++ b/test/client-node-max-header-size.js
@@ -1,22 +1,21 @@
 'use strict'
 
 const { execSync } = require('node:child_process')
-const { test } = require('tap')
+const { throws, doesNotThrow } = require('node:assert')
+const { test } = require('node:test')
 
 const command = 'node -e "require(\'.\').request(\'https://httpbin.org/get\')"'
 
-test("respect Node.js' --max-http-header-size", async (t) => {
-  t.throws(
-    () => execSync(`${command} --max-http-header-size=1`),
+test("respect Node.js' --max-http-header-size", () => {
+  throws(
+    () => execSync(`${command} --max-http-header-size=1`, { stdio: 'pipe' }),
     /UND_ERR_HEADERS_OVERFLOW/,
     'max-http-header-size=1 should throw'
   )
 
-  t.doesNotThrow(
+  doesNotThrow(
     () => execSync(command),
     /UND_ERR_HEADERS_OVERFLOW/,
     'default max-http-header-size should not throw'
   )
-
-  t.end()
 })


### PR DESCRIPTION
Does not print the output of the execSync call into the console. Also refactored to use node core test runner.