### PR TITLE
enforce latin-1 encoding in source

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -36,7 +36,7 @@ function extractBody (object, keepalive = false) {
     stream = object
   } else if (isBlobLike(object)) {
     // 3. Otherwise, if object is a Blob object, set stream to the
-    //    result of running object’s get stream.
+    //    result of running object's get stream.
     stream = object.stream()
   } else {
     // 4. Otherwise, set stream to a new ReadableStream object, and set
@@ -87,7 +87,7 @@ function extractBody (object, keepalive = false) {
     // See: https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/url.js#L490
     // and https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/lib/internal/url.js#L1100
 
-    // Set source to the result of running the application/x-www-form-urlencoded serializer with object’s list.
+    // Set source to the result of running the application/x-www-form-urlencoded serializer with object's list.
     source = object.toString()
 
     // Set type to `application/x-www-form-urlencoded;charset=UTF-8`.
@@ -106,13 +106,13 @@ function extractBody (object, keepalive = false) {
     const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
-    /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
+    /*! formdata-polyfill. MIT License. Jimmy Warting <https://jimmy.warting.se/opensource> */
     const escape = (str) =>
       str.replace(/\n/g, '%0A').replace(/\r/g, '%0D').replace(/"/g, '%22')
     const normalizeLinefeeds = (value) => value.replace(/\r?\n|\r/g, '\r\n')
 
     // Set action to this step: run the multipart/form-data
-    // encoding algorithm, with object’s entry list and UTF-8.
+    // encoding algorithm, with object's entry list and UTF-8.
     // - This ensures that the body is immutable and can't be changed afterwords
     // - That the content-length is calculated in advance.
     // - And that all parts are pre-encoded and ready to be sent.
@@ -174,10 +174,10 @@ function extractBody (object, keepalive = false) {
     // Set source to object.
     source = object
 
-    // Set length to object’s size.
+    // Set length to object's size.
     length = object.size
 
-    // If object’s type attribute is not the empty byte sequence, set
+    // If object's type attribute is not the empty byte sequence, set
     // type to its value.
     if (object.type) {
       type = object.type
@@ -200,7 +200,7 @@ function extractBody (object, keepalive = false) {
   }
 
   // 11. If source is a byte sequence, then set action to a
-  // step that returns source and length to source’s length.
+  // step that returns source and length to source's length.
   if (typeof source === 'string' || util.isBuffer(source)) {
     length = Buffer.byteLength(source)
   }
@@ -272,14 +272,14 @@ function cloneBody (body) {
 
   // https://fetch.spec.whatwg.org/#concept-body-clone
 
-  // 1. Let « out1, out2 » be the result of teeing body’s stream.
+  // 1. Let « out1, out2 » be the result of teeing body's stream.
   const [out1, out2] = body.stream.tee()
   const out2Clone = structuredClone(out2, { transfer: [out2] })
   // This, for whatever reasons, unrefs out2Clone which allows
   // the process to exit by itself.
   const [, finalClone] = out2Clone.tee()
 
-  // 2. Set body’s stream to out1.
+  // 2. Set body's stream to out1.
   body.stream = out1
 
   // 3. Return a body whose stream is out2 and other members are copied from body.
@@ -325,7 +325,7 @@ function bodyMixinMethods (instance) {
       // The blob() method steps are to return the result of
       // running consume body with this and the following step
       // given a byte sequence bytes: return a Blob whose
-      // contents are bytes and whose type attribute is this’s
+      // contents are bytes and whose type attribute is this's
       // MIME type.
       return specConsumeBody(this, (bytes) => {
         let mimeType = bodyMimeType(this)
@@ -373,7 +373,7 @@ function bodyMixinMethods (instance) {
 
       const mimeType = contentType !== null ? parseMIMEType(contentType) : 'failure'
 
-      // If mimeType’s essence is "multipart/form-data", then:
+      // If mimeType's essence is "multipart/form-data", then:
       if (mimeType !== 'failure' && mimeType.essence === 'multipart/form-data') {
         const headers = {}
         for (const [key, value] of this.headers) headers[key] = value
@@ -433,7 +433,7 @@ function bodyMixinMethods (instance) {
 
         return responseFormData
       } else if (mimeType !== 'failure' && mimeType.essence === 'application/x-www-form-urlencoded') {
-        // Otherwise, if mimeType’s essence is "application/x-www-form-urlencoded", then:
+        // Otherwise, if mimeType's essence is "application/x-www-form-urlencoded", then:
 
         // 1. Let entries be the result of parsing bytes.
         let entries
@@ -522,15 +522,15 @@ async function specConsumeBody (object, convertBytesToJSValue, instance) {
     }
   }
 
-  // 5. If object’s body is null, then run successSteps with an
+  // 5. If object's body is null, then run successSteps with an
   //    empty byte sequence.
   if (object[kState].body == null) {
     successSteps(new Uint8Array())
     return promise.promise
   }
 
-  // 6. Otherwise, fully read object’s body given successSteps,
-  //    errorSteps, and object’s relevant global object.
+  // 6. Otherwise, fully read object's body given successSteps,
+  //    errorSteps, and object's relevant global object.
   await fullyReadBody(object[kState].body, successSteps, errorSteps)
 
   // 7. Return promise.
@@ -541,7 +541,7 @@ async function specConsumeBody (object, convertBytesToJSValue, instance) {
 function bodyUnusable (body) {
   // An object including the Body interface mixin is
   // said to be unusable if its body is non-null and
-  // its body’s stream is disturbed or locked.
+  // its body's stream is disturbed or locked.
   return body != null && (body.stream.locked || util.isDisturbed(body.stream))
 }
 
@@ -563,7 +563,7 @@ function utf8DecodeBytes (buffer) {
     buffer = buffer.subarray(3)
   }
 
-  // 3. Process a queue with an instance of UTF-8’s
+  // 3. Process a queue with an instance of UTF-8's
   //    decoder, ioQueue, output, and "replacement".
   const output = textDecoder.decode(buffer)
 

--- a/lib/fetch/dataURL.js
+++ b/lib/fetch/dataURL.js
@@ -17,7 +17,7 @@ const HTTP_QUOTED_STRING_TOKENS = /[\u0009|\u0020-\u007E|\u0080-\u00FF]/ // esli
 // https://fetch.spec.whatwg.org/#data-url-processor
 /** @param {URL} dataURL */
 function dataURLProcessor (dataURL) {
-  // 1. Assert: dataURL’s scheme is "data".
+  // 1. Assert: dataURL's scheme is "data".
   assert(dataURL.protocol === 'data:')
 
   // 2. Let input be the result of running the URL
@@ -145,7 +145,7 @@ function collectASequenceOfCodePoints (condition, input, position) {
   // 1. Let result be the empty string.
   let result = ''
 
-  // 2. While position doesn’t point past the end of input and the
+  // 2. While position doesn't point past the end of input and the
   // code point at position within input meets the condition condition:
   while (position.position < input.length && condition(input[position.position])) {
     // 1. Append that code point to the end of result.
@@ -410,8 +410,8 @@ function parseMIMEType (input) {
     // - parameterName is not the empty string
     // - parameterName solely contains HTTP token code points
     // - parameterValue solely contains HTTP quoted-string token code points
-    // - mimeType’s parameters[parameterName] does not exist
-    // then set mimeType’s parameters[parameterName] to parameterValue.
+    // - mimeType's parameters[parameterName] does not exist
+    // then set mimeType's parameters[parameterName] to parameterValue.
     if (
       parameterName.length !== 0 &&
       HTTP_TOKEN_CODEPOINTS.test(parameterName) &&
@@ -433,7 +433,7 @@ function forgivingBase64 (data) {
   data = data.replace(ASCII_WHITESPACE_REPLACE_REGEX, '')  // eslint-disable-line
 
   let dataLength = data.length
-  // 2. If data’s code point length divides by 4 leaving
+  // 2. If data's code point length divides by 4 leaving
   // no remainder, then:
   if (dataLength % 4 === 0) {
     // 1. If data ends with one or two U+003D (=) code points,
@@ -446,7 +446,7 @@ function forgivingBase64 (data) {
     }
   }
 
-  // 3. If data’s code point length divides by 4 leaving
+  // 3. If data's code point length divides by 4 leaving
   // a remainder of 1, then return failure.
   if (dataLength % 4 === 1) {
     return 'failure'
@@ -551,11 +551,11 @@ function serializeAMimeType (mimeType) {
   assert(mimeType !== 'failure')
   const { parameters, essence } = mimeType
 
-  // 1. Let serialization be the concatenation of mimeType’s
-  //    type, U+002F (/), and mimeType’s subtype.
+  // 1. Let serialization be the concatenation of mimeType's
+  //    type, U+002F (/), and mimeType's subtype.
   let serialization = essence
 
-  // 2. For each name → value of mimeType’s parameters:
+  // 2. For each name → value of mimeType's parameters:
   for (let [name, value] of parameters.entries()) {
     // 1. Append U+003B (;) to serialization.
     serialization += ';'

--- a/lib/fetch/file.js
+++ b/lib/fetch/file.js
@@ -309,7 +309,7 @@ function convertLineEndingsNative (s) {
   // 1. Let native line ending be be the code point U+000A LF.
   let nativeLineEnding = '\n'
 
-  // 2. If the underlying platform’s conventions are to
+  // 2. If the underlying platform's conventions are to
   //    represent newlines as a carriage return and line feed
   //    sequence, set native line ending to the code point
   //    U+000D CR followed by the code point U+000A LF.

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -48,7 +48,7 @@ class FormData {
     // name, value, and filename if given.
     const entry = makeEntry(name, value, filename)
 
-    // 3. Append entry to this’s entry list.
+    // 3. Append entry to this's entry list.
     this[kState].push(entry)
   }
 
@@ -60,7 +60,7 @@ class FormData {
     name = webidl.converters.USVString(name)
 
     // The delete(name) method steps are to remove all entries whose name
-    // is name from this’s entry list.
+    // is name from this's entry list.
     this[kState] = this[kState].filter(entry => entry.name !== name)
   }
 
@@ -71,7 +71,7 @@ class FormData {
 
     name = webidl.converters.USVString(name)
 
-    // 1. If there is no entry whose name is name in this’s entry list,
+    // 1. If there is no entry whose name is name in this's entry list,
     // then return null.
     const idx = this[kState].findIndex((entry) => entry.name === name)
     if (idx === -1) {
@@ -79,7 +79,7 @@ class FormData {
     }
 
     // 2. Return the value of the first entry whose name is name from
-    // this’s entry list.
+    // this's entry list.
     return this[kState][idx].value
   }
 
@@ -90,10 +90,10 @@ class FormData {
 
     name = webidl.converters.USVString(name)
 
-    // 1. If there is no entry whose name is name in this’s entry list,
+    // 1. If there is no entry whose name is name in this's entry list,
     // then return the empty list.
     // 2. Return the values of all entries whose name is name, in order,
-    // from this’s entry list.
+    // from this's entry list.
     return this[kState]
       .filter((entry) => entry.name === name)
       .map((entry) => entry.value)
@@ -107,7 +107,7 @@ class FormData {
     name = webidl.converters.USVString(name)
 
     // The has(name) method steps are to return true if there is an entry
-    // whose name is name in this’s entry list; otherwise false.
+    // whose name is name in this's entry list; otherwise false.
     return this[kState].findIndex((entry) => entry.name === name) !== -1
   }
 
@@ -139,7 +139,7 @@ class FormData {
     // filename if given.
     const entry = makeEntry(name, value, filename)
 
-    // 3. If there are entries in this’s entry list whose name is name, then
+    // 3. If there are entries in this's entry list whose name is name, then
     // replace the first such entry with entry and remove the others.
     const idx = this[kState].findIndex((entry) => entry.name === name)
     if (idx !== -1) {
@@ -149,7 +149,7 @@ class FormData {
         ...this[kState].slice(idx + 1).filter((entry) => entry.name !== name)
       ]
     } else {
-      // 4. Otherwise, append entry to this’s entry list.
+      // 4. Otherwise, append entry to this's entry list.
       this[kState].push(entry)
     }
   }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -55,7 +55,7 @@ function fill (headers, object) {
         })
       }
 
-      // 2. Append (header’s first item, header’s second item) to headers.
+      // 2. Append (header's first item, header's second item) to headers.
       appendHeader(headers, header[0], header[1])
     }
   } else if (typeof object === 'object' && object !== null) {
@@ -99,24 +99,24 @@ function appendHeader (headers, name, value) {
     })
   }
 
-  // 3. If headers’s guard is "immutable", then throw a TypeError.
-  // 4. Otherwise, if headers’s guard is "request" and name is a
+  // 3. If headers's guard is "immutable", then throw a TypeError.
+  // 4. Otherwise, if headers's guard is "request" and name is a
   //    forbidden header name, return.
   // Note: undici does not implement forbidden header names
   if (headers[kGuard] === 'immutable') {
     throw new TypeError('immutable')
   } else if (headers[kGuard] === 'request-no-cors') {
-    // 5. Otherwise, if headers’s guard is "request-no-cors":
+    // 5. Otherwise, if headers's guard is "request-no-cors":
     // TODO
   }
 
-  // 6. Otherwise, if headers’s guard is "response" and name is a
+  // 6. Otherwise, if headers's guard is "response" and name is a
   //    forbidden response-header name, return.
 
-  // 7. Append (name, value) to headers’s header list.
+  // 7. Append (name, value) to headers's header list.
   return headers[kHeadersList].append(name, value, false)
 
-  // 8. If headers’s guard is "request-no-cors", then remove
+  // 8. If headers's guard is "request-no-cors", then remove
   //    privileged no-CORS request headers from headers
 }
 
@@ -164,7 +164,7 @@ class HeadersList {
     this[kHeadersSortedMap] = null
 
     // 1. If list contains name, then set name to the first such
-    //    header’s name.
+    //    header's name.
     const lowercaseName = isLowerCase ? name : name.toLowerCase()
     const exists = this[kHeadersMap].get(lowercaseName)
 
@@ -265,7 +265,7 @@ class Headers {
 
     // The new Headers(init) constructor steps are:
 
-    // 1. Set this’s guard to "none".
+    // 1. Set this's guard to "none".
     this[kGuard] = 'none'
 
     // 2. If init is given, then fill this with init.
@@ -304,14 +304,14 @@ class Headers {
       })
     }
 
-    // 2. If this’s guard is "immutable", then throw a TypeError.
-    // 3. Otherwise, if this’s guard is "request" and name is a
+    // 2. If this's guard is "immutable", then throw a TypeError.
+    // 3. Otherwise, if this's guard is "request" and name is a
     //    forbidden header name, return.
-    // 4. Otherwise, if this’s guard is "request-no-cors", name
+    // 4. Otherwise, if this's guard is "request-no-cors", name
     //    is not a no-CORS-safelisted request-header name, and
     //    name is not a privileged no-CORS request-header name,
     //    return.
-    // 5. Otherwise, if this’s guard is "response" and name is
+    // 5. Otherwise, if this's guard is "response" and name is
     //    a forbidden response-header name, return.
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
@@ -320,14 +320,14 @@ class Headers {
       // TODO
     }
 
-    // 6. If this’s header list does not contain name, then
+    // 6. If this's header list does not contain name, then
     //    return.
     if (!this[kHeadersList].contains(name, false)) {
       return
     }
 
-    // 7. Delete name from this’s header list.
-    // 8. If this’s guard is "request-no-cors", then remove
+    // 7. Delete name from this's header list.
+    // 8. If this's guard is "request-no-cors", then remove
     //    privileged no-CORS request headers from this.
     this[kHeadersList].delete(name, false)
   }
@@ -349,7 +349,7 @@ class Headers {
       })
     }
 
-    // 2. Return the result of getting name from this’s header
+    // 2. Return the result of getting name from this's header
     //    list.
     return this[kHeadersList].get(name, false)
   }
@@ -371,7 +371,7 @@ class Headers {
       })
     }
 
-    // 2. Return true if this’s header list contains name;
+    // 2. Return true if this's header list contains name;
     //    otherwise false.
     return this[kHeadersList].contains(name, false)
   }
@@ -404,13 +404,13 @@ class Headers {
       })
     }
 
-    // 3. If this’s guard is "immutable", then throw a TypeError.
-    // 4. Otherwise, if this’s guard is "request" and name is a
+    // 3. If this's guard is "immutable", then throw a TypeError.
+    // 4. Otherwise, if this's guard is "request" and name is a
     //    forbidden header name, return.
-    // 5. Otherwise, if this’s guard is "request-no-cors" and
+    // 5. Otherwise, if this's guard is "request-no-cors" and
     //    name/value is not a no-CORS-safelisted request-header,
     //    return.
-    // 6. Otherwise, if this’s guard is "response" and name is a
+    // 6. Otherwise, if this's guard is "response" and name is a
     //    forbidden response-header name, return.
     // Note: undici does not implement forbidden header names
     if (this[kGuard] === 'immutable') {
@@ -419,8 +419,8 @@ class Headers {
       // TODO
     }
 
-    // 7. Set (name, value) in this’s header list.
-    // 8. If this’s guard is "request-no-cors", then remove
+    // 7. Set (name, value) in this's header list.
+    // 8. If this's guard is "request-no-cors", then remove
     //    privileged no-CORS request headers from this
     this[kHeadersList].set(name, value, false)
   }
@@ -429,8 +429,8 @@ class Headers {
   getSetCookie () {
     webidl.brandCheck(this, Headers)
 
-    // 1. If this’s header list does not contain `Set-Cookie`, then return « ».
-    // 2. Return the values of all headers in this’s header list whose name is
+    // 1. If this's header list does not contain `Set-Cookie`, then return « ».
+    // 2. Return the values of all headers in this's header list whose name is
     //    a byte-case-insensitive match for `Set-Cookie`, in order.
 
     const list = this[kHeadersList].cookies

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -100,7 +100,7 @@ class Fetch extends EE {
       return
     }
 
-    // 1. Set controller’s state to "aborted".
+    // 1. Set controller's state to "aborted".
     this.state = 'aborted'
 
     // 2. Let fallbackError be an "AbortError" DOMException.
@@ -113,7 +113,7 @@ class Fetch extends EE {
     //    If that threw an exception, catch it, and let
     //    serializedError be StructuredSerialize(fallbackError).
 
-    // 5. Set controller’s serialized abort reason to serializedError.
+    // 5. Set controller's serialized abort reason to serializedError.
     this.serializedAbortReason = error
 
     this.connection?.destroy(error)
@@ -140,24 +140,24 @@ function fetch (input, init = undefined) {
     return p.promise
   }
 
-  // 3. Let request be requestObject’s request.
+  // 3. Let request be requestObject's request.
   const request = requestObject[kState]
 
-  // 4. If requestObject’s signal’s aborted flag is set, then:
+  // 4. If requestObject's signal's aborted flag is set, then:
   if (requestObject.signal.aborted) {
     // 1. Abort the fetch() call with p, request, null, and
-    //    requestObject’s signal’s abort reason.
+    //    requestObject's signal's abort reason.
     abortFetch(p, request, null, requestObject.signal.reason)
 
     // 2. Return p.
     return p.promise
   }
 
-  // 5. Let globalObject be request’s client’s global object.
+  // 5. Let globalObject be request's client's global object.
   const globalObject = request.client.globalObject
 
   // 6. If globalObject is a ServiceWorkerGlobalScope object, then set
-  // request’s service-workers mode to "none".
+  // request's service-workers mode to "none".
   if (globalObject?.constructor?.name === 'ServiceWorkerGlobalScope') {
     request.serviceWorkers = 'none'
   }
@@ -165,7 +165,7 @@ function fetch (input, init = undefined) {
   // 7. Let responseObject be null.
   let responseObject = null
 
-  // 8. Let relevantRealm be this’s relevant Realm.
+  // 8. Let relevantRealm be this's relevant Realm.
   const relevantRealm = null
 
   // 9. Let locallyAborted be false.
@@ -174,7 +174,7 @@ function fetch (input, init = undefined) {
   // 10. Let controller be null.
   let controller = null
 
-  // 11. Add the following abort steps to requestObject’s signal:
+  // 11. Add the following abort steps to requestObject's signal:
   addAbortListener(
     requestObject.signal,
     () => {
@@ -184,11 +184,11 @@ function fetch (input, init = undefined) {
       // 2. Assert: controller is non-null.
       assert(controller != null)
 
-      // 3. Abort controller with requestObject’s signal’s abort reason.
+      // 3. Abort controller with requestObject's signal's abort reason.
       controller.abort(requestObject.signal.reason)
 
       // 4. Abort the fetch() call with p, request, responseObject,
-      //    and requestObject’s signal’s abort reason.
+      //    and requestObject's signal's abort reason.
       abortFetch(p, request, responseObject, requestObject.signal.reason)
     }
   )
@@ -208,10 +208,10 @@ function fetch (input, init = undefined) {
       return Promise.resolve()
     }
 
-    // 2. If response’s aborted flag is set, then:
+    // 2. If response's aborted flag is set, then:
     if (response.aborted) {
       // 1. Let deserializedError be the result of deserialize a serialized
-      //    abort reason given controller’s serialized abort reason and
+      //    abort reason given controller's serialized abort reason and
       //    relevantRealm.
 
       // 2. Abort the fetch() call with p, request, responseObject, and
@@ -256,21 +256,21 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
     return
   }
 
-  // 2. If response’s URL list is null or empty, then return.
+  // 2. If response's URL list is null or empty, then return.
   if (!response.urlList?.length) {
     return
   }
 
-  // 3. Let originalURL be response’s URL list[0].
+  // 3. Let originalURL be response's URL list[0].
   const originalURL = response.urlList[0]
 
-  // 4. Let timingInfo be response’s timing info.
+  // 4. Let timingInfo be response's timing info.
   let timingInfo = response.timingInfo
 
-  // 5. Let cacheState be response’s cache state.
+  // 5. Let cacheState be response's cache state.
   let cacheState = response.cacheState
 
-  // 6. If originalURL’s scheme is not an HTTP(S) scheme, then return.
+  // 6. If originalURL's scheme is not an HTTP(S) scheme, then return.
   if (!urlIsHttpHttpsScheme(originalURL)) {
     return
   }
@@ -280,7 +280,7 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
     return
   }
 
-  // 8. If response’s timing allow passed flag is not set, then:
+  // 8. If response's timing allow passed flag is not set, then:
   if (!response.timingAllowPassed) {
     //  1. Set timingInfo to a the result of creating an opaque timing info for timingInfo.
     timingInfo = createOpaqueTimingInfo({
@@ -291,14 +291,14 @@ function finalizeAndReportTiming (response, initiatorType = 'other') {
     cacheState = ''
   }
 
-  // 9. Set timingInfo’s end time to the coarsened shared current time
-  // given global’s relevant settings object’s cross-origin isolated
+  // 9. Set timingInfo's end time to the coarsened shared current time
+  // given global's relevant settings object's cross-origin isolated
   // capability.
-  // TODO: given global’s relevant settings object’s cross-origin isolated
+  // TODO: given global's relevant settings object's cross-origin isolated
   // capability?
   timingInfo.endTime = coarsenedSharedCurrentTime()
 
-  // 10. Set response’s timing info to timingInfo.
+  // 10. Set response's timing info to timingInfo.
   response.timingInfo = timingInfo
 
   // 11. Mark resource timing for timingInfo, originalURL, initiatorType,
@@ -324,7 +324,7 @@ function abortFetch (p, request, responseObject, error) {
   // 1. Reject promise with error.
   p.reject(error)
 
-  // 2. If request’s body is not null and is readable, then cancel request’s
+  // 2. If request's body is not null and is readable, then cancel request's
   // body with error.
   if (request.body != null && isReadable(request.body?.stream)) {
     request.body.stream.cancel(error).catch((err) => {
@@ -341,10 +341,10 @@ function abortFetch (p, request, responseObject, error) {
     return
   }
 
-  // 4. Let response be responseObject’s response.
+  // 4. Let response be responseObject's response.
   const response = responseObject[kState]
 
-  // 5. If response’s body is not null and is readable, then error response’s
+  // 5. If response's body is not null and is readable, then error response's
   // body with error.
   if (response.body != null && isReadable(response.body?.stream)) {
     response.body.stream.cancel(error).catch((err) => {
@@ -377,12 +377,12 @@ function fetching ({
   // 2. Let crossOriginIsolatedCapability be false.
   let crossOriginIsolatedCapability = false
 
-  // 3. If request’s client is non-null, then:
+  // 3. If request's client is non-null, then:
   if (request.client != null) {
-    // 1. Set taskDestination to request’s client’s global object.
+    // 1. Set taskDestination to request's client's global object.
     taskDestination = request.client.globalObject
 
-    // 2. Set crossOriginIsolatedCapability to request’s client’s cross-origin
+    // 2. Set crossOriginIsolatedCapability to request's client's cross-origin
     // isolated capability.
     crossOriginIsolatedCapability =
       request.client.crossOriginIsolatedCapability
@@ -423,14 +423,14 @@ function fetching ({
     crossOriginIsolatedCapability
   }
 
-  // 7. If request’s body is a byte sequence, then set request’s body to
-  //    request’s body as a body.
+  // 7. If request's body is a byte sequence, then set request's body to
+  //    request's body as a body.
   // NOTE: Since fetching is only called from fetch, body should already be
   // extracted.
   assert(!request.body || request.body.stream)
 
-  // 8. If request’s window is "client", then set request’s window to request’s
-  // client, if request’s client’s global object is a Window object; otherwise
+  // 8. If request's window is "client", then set request's window to request's
+  // client, if request's client's global object is a Window object; otherwise
   // "no-window".
   if (request.window === 'client') {
     // TODO: What if request.client is null?
@@ -440,8 +440,8 @@ function fetching ({
         : 'no-window'
   }
 
-  // 9. If request’s origin is "client", then set request’s origin to request’s
-  // client’s origin.
+  // 9. If request's origin is "client", then set request's origin to request's
+  // client's origin.
   if (request.origin === 'client') {
     // TODO: What if request.client is null?
     request.origin = request.client?.origin
@@ -450,28 +450,28 @@ function fetching ({
   // 10. If all of the following conditions are true:
   // TODO
 
-  // 11. If request’s policy container is "client", then:
+  // 11. If request's policy container is "client", then:
   if (request.policyContainer === 'client') {
-    // 1. If request’s client is non-null, then set request’s policy
-    // container to a clone of request’s client’s policy container. [HTML]
+    // 1. If request's client is non-null, then set request's policy
+    // container to a clone of request's client's policy container. [HTML]
     if (request.client != null) {
       request.policyContainer = clonePolicyContainer(
         request.client.policyContainer
       )
     } else {
-      // 2. Otherwise, set request’s policy container to a new policy
+      // 2. Otherwise, set request's policy container to a new policy
       // container.
       request.policyContainer = makePolicyContainer()
     }
   }
 
-  // 12. If request’s header list does not contain `Accept`, then:
+  // 12. If request's header list does not contain `Accept`, then:
   if (!request.headersList.contains('accept', true)) {
     // 1. Let value be `*/*`.
     const value = '*/*'
 
     // 2. A user agent should set value to the first matching statement, if
-    // any, switching on request’s destination:
+    // any, switching on request's destination:
     // "document"
     // "frame"
     // "iframe"
@@ -482,19 +482,19 @@ function fetching ({
     // `text/css,*/*;q=0.1`
     // TODO
 
-    // 3. Append `Accept`/value to request’s header list.
+    // 3. Append `Accept`/value to request's header list.
     request.headersList.append('accept', value, true)
   }
 
-  // 13. If request’s header list does not contain `Accept-Language`, then
+  // 13. If request's header list does not contain `Accept-Language`, then
   // user agents should append `Accept-Language`/an appropriate value to
-  // request’s header list.
+  // request's header list.
   if (!request.headersList.contains('accept-language', true)) {
     request.headersList.append('accept-language', '*', true)
   }
 
-  // 14. If request’s priority is null, then use request’s initiator and
-  // destination appropriately in setting request’s priority to a
+  // 14. If request's priority is null, then use request's initiator and
+  // destination appropriately in setting request's priority to a
   // user-agent-defined object.
   if (request.priority === null) {
     // TODO
@@ -517,13 +517,13 @@ function fetching ({
 
 // https://fetch.spec.whatwg.org/#concept-main-fetch
 async function mainFetch (fetchParams, recursive = false) {
-  // 1. Let request be fetchParams’s request.
+  // 1. Let request be fetchParams's request.
   const request = fetchParams.request
 
   // 2. Let response be null.
   let response = null
 
-  // 3. If request’s local-URLs-only flag is set and request’s current URL is
+  // 3. If request's local-URLs-only flag is set and request's current URL is
   // not local, then set response to a network error.
   if (request.localURLsOnly && !urlIsLocal(requestCurrentURL(request))) {
     response = makeNetworkError('local URLs only')
@@ -544,23 +544,23 @@ async function mainFetch (fetchParams, recursive = false) {
   // TODO: should fetching request be blocked as mixed content?
   // TODO: should request be blocked by Content Security Policy?
 
-  // 7. If request’s referrer policy is the empty string, then set request’s
-  // referrer policy to request’s policy container’s referrer policy.
+  // 7. If request's referrer policy is the empty string, then set request's
+  // referrer policy to request's policy container's referrer policy.
   if (request.referrerPolicy === '') {
     request.referrerPolicy = request.policyContainer.referrerPolicy
   }
 
-  // 8. If request’s referrer is not "no-referrer", then set request’s
-  // referrer to the result of invoking determine request’s referrer.
+  // 8. If request's referrer is not "no-referrer", then set request's
+  // referrer to the result of invoking determine request's referrer.
   if (request.referrer !== 'no-referrer') {
     request.referrer = determineRequestsReferrer(request)
   }
 
-  // 9. Set request’s current URL’s scheme to "https" if all of the following
+  // 9. Set request's current URL's scheme to "https" if all of the following
   // conditions are true:
-  // - request’s current URL’s scheme is "http"
-  // - request’s current URL’s host is a domain
-  // - Matching request’s current URL’s host per Known HSTS Host Domain Name
+  // - request's current URL's scheme is "http"
+  // - request's current URL's host is a domain
+  // - Matching request's current URL's host per Known HSTS Host Domain Name
   //   Matching results in either a superdomain match with an asserted
   //   includeSubDomains directive or a congruent match (with or without an
   //   asserted includeSubDomains directive). [HSTS]
@@ -576,30 +576,30 @@ async function mainFetch (fetchParams, recursive = false) {
       const currentURL = requestCurrentURL(request)
 
       if (
-        // - request’s current URL’s origin is same origin with request’s origin,
-        //   and request’s response tainting is "basic"
+        // - request's current URL's origin is same origin with request's origin,
+        //   and request's response tainting is "basic"
         (sameOrigin(currentURL, request.url) && request.responseTainting === 'basic') ||
-        // request’s current URL’s scheme is "data"
+        // request's current URL's scheme is "data"
         (currentURL.protocol === 'data:') ||
-        // - request’s mode is "navigate" or "websocket"
+        // - request's mode is "navigate" or "websocket"
         (request.mode === 'navigate' || request.mode === 'websocket')
       ) {
-        // 1. Set request’s response tainting to "basic".
+        // 1. Set request's response tainting to "basic".
         request.responseTainting = 'basic'
 
         // 2. Return the result of running scheme fetch given fetchParams.
         return await schemeFetch(fetchParams)
       }
 
-      // request’s mode is "same-origin"
+      // request's mode is "same-origin"
       if (request.mode === 'same-origin') {
         // 1. Return a network error.
         return makeNetworkError('request mode cannot be "same-origin"')
       }
 
-      // request’s mode is "no-cors"
+      // request's mode is "no-cors"
       if (request.mode === 'no-cors') {
-        // 1. If request’s redirect mode is not "follow", then return a network
+        // 1. If request's redirect mode is not "follow", then return a network
         // error.
         if (request.redirect !== 'follow') {
           return makeNetworkError(
@@ -607,24 +607,24 @@ async function mainFetch (fetchParams, recursive = false) {
           )
         }
 
-        // 2. Set request’s response tainting to "opaque".
+        // 2. Set request's response tainting to "opaque".
         request.responseTainting = 'opaque'
 
         // 3. Return the result of running scheme fetch given fetchParams.
         return await schemeFetch(fetchParams)
       }
 
-      // request’s current URL’s scheme is not an HTTP(S) scheme
+      // request's current URL's scheme is not an HTTP(S) scheme
       if (!urlIsHttpHttpsScheme(requestCurrentURL(request))) {
         // Return a network error.
         return makeNetworkError('URL scheme must be a HTTP(S) scheme')
       }
 
-      // - request’s use-CORS-preflight flag is set
-      // - request’s unsafe-request flag is set and either request’s method is
+      // - request's use-CORS-preflight flag is set
+      // - request's unsafe-request flag is set and either request's method is
       //   not a CORS-safelisted method or CORS-unsafe request-header names with
-      //   request’s header list is not empty
-      //    1. Set request’s response tainting to "cors".
+      //   request's header list is not empty
+      //    1. Set request's response tainting to "cors".
       //    2. Let corsWithPreflightResponse be the result of running HTTP fetch
       //    given fetchParams and true.
       //    3. If corsWithPreflightResponse is a network error, then clear cache
@@ -633,7 +633,7 @@ async function mainFetch (fetchParams, recursive = false) {
       // TODO
 
       // Otherwise
-      //    1. Set request’s response tainting to "cors".
+      //    1. Set request's response tainting to "cors".
       request.responseTainting = 'cors'
 
       //    2. Return the result of running HTTP fetch given fetchParams.
@@ -649,22 +649,22 @@ async function mainFetch (fetchParams, recursive = false) {
   // 13. If response is not a network error and response is not a filtered
   // response, then:
   if (response.status !== 0 && !response.internalResponse) {
-    // If request’s response tainting is "cors", then:
+    // If request's response tainting is "cors", then:
     if (request.responseTainting === 'cors') {
       // 1. Let headerNames be the result of extracting header list values
-      // given `Access-Control-Expose-Headers` and response’s header list.
+      // given `Access-Control-Expose-Headers` and response's header list.
       // TODO
-      // 2. If request’s credentials mode is not "include" and headerNames
-      // contains `*`, then set response’s CORS-exposed header-name list to
-      // all unique header names in response’s header list.
+      // 2. If request's credentials mode is not "include" and headerNames
+      // contains `*`, then set response's CORS-exposed header-name list to
+      // all unique header names in response's header list.
       // TODO
       // 3. Otherwise, if headerNames is not null or failure, then set
-      // response’s CORS-exposed header-name list to headerNames.
+      // response's CORS-exposed header-name list to headerNames.
       // TODO
     }
 
     // Set response to the following filtered response with response as its
-    // internal response, depending on request’s response tainting:
+    // internal response, depending on request's response tainting:
     if (request.responseTainting === 'basic') {
       response = filterResponse(response, 'basic')
     } else if (request.responseTainting === 'cors') {
@@ -677,18 +677,18 @@ async function mainFetch (fetchParams, recursive = false) {
   }
 
   // 14. Let internalResponse be response, if response is a network error,
-  // and response’s internal response otherwise.
+  // and response's internal response otherwise.
   let internalResponse =
     response.status === 0 ? response : response.internalResponse
 
-  // 15. If internalResponse’s URL list is empty, then set it to a clone of
-  // request’s URL list.
+  // 15. If internalResponse's URL list is empty, then set it to a clone of
+  // request's URL list.
   if (internalResponse.urlList.length === 0) {
     internalResponse.urlList.push(...request.urlList)
   }
 
-  // 16. If request’s timing allow failed flag is unset, then set
-  // internalResponse’s timing allow passed flag.
+  // 16. If request's timing allow failed flag is unset, then set
+  // internalResponse's timing allow passed flag.
   if (!request.timingAllowFailed) {
     response.timingAllowPassed = true
   }
@@ -701,8 +701,8 @@ async function mainFetch (fetchParams, recursive = false) {
   // - should internalResponse to request be blocked due to nosniff
   // TODO
 
-  // 18. If response’s type is "opaque", internalResponse’s status is 206,
-  // internalResponse’s range-requested flag is set, and request’s header
+  // 18. If response's type is "opaque", internalResponse's status is 206,
+  // internalResponse's range-requested flag is set, and request's header
   // list does not contain `Range`, then set response and internalResponse
   // to a network error.
   if (
@@ -714,9 +714,9 @@ async function mainFetch (fetchParams, recursive = false) {
     response = internalResponse = makeNetworkError()
   }
 
-  // 19. If response is not a network error and either request’s method is
-  // `HEAD` or `CONNECT`, or internalResponse’s status is a null body status,
-  // set internalResponse’s body to null and disregard any enqueuing toward
+  // 19. If response is not a network error and either request's method is
+  // `HEAD` or `CONNECT`, or internalResponse's status is a null body status,
+  // set internalResponse's body to null and disregard any enqueuing toward
   // it (if any).
   if (
     response.status !== 0 &&
@@ -728,14 +728,14 @@ async function mainFetch (fetchParams, recursive = false) {
     fetchParams.controller.dump = true
   }
 
-  // 20. If request’s integrity metadata is not the empty string, then:
+  // 20. If request's integrity metadata is not the empty string, then:
   if (request.integrity) {
     // 1. Let processBodyError be this step: run fetch finale given fetchParams
     // and a network error.
     const processBodyError = (reason) =>
       fetchFinale(fetchParams, makeNetworkError(reason))
 
-    // 2. If request’s response tainting is "opaque", or response’s body is null,
+    // 2. If request's response tainting is "opaque", or response's body is null,
     // then run processBodyError and abort these steps.
     if (request.responseTainting === 'opaque' || response.body == null) {
       processBodyError(response.error)
@@ -744,21 +744,21 @@ async function mainFetch (fetchParams, recursive = false) {
 
     // 3. Let processBody given bytes be these steps:
     const processBody = (bytes) => {
-      // 1. If bytes do not match request’s integrity metadata,
+      // 1. If bytes do not match request's integrity metadata,
       // then run processBodyError and abort these steps. [SRI]
       if (!bytesMatch(bytes, request.integrity)) {
         processBodyError('integrity mismatch')
         return
       }
 
-      // 2. Set response’s body to bytes as a body.
+      // 2. Set response's body to bytes as a body.
       response.body = safelyExtractBody(bytes)[0]
 
       // 3. Run fetch finale given fetchParams and response.
       fetchFinale(fetchParams, response)
     }
 
-    // 4. Fully read response’s body given processBody and processBodyError.
+    // 4. Fully read response's body given processBody and processBodyError.
     await fullyReadBody(response.body, processBody, processBodyError)
   } else {
     // 21. Otherwise, run fetch finale given fetchParams and response.
@@ -777,15 +777,15 @@ function schemeFetch (fetchParams) {
     return Promise.resolve(makeAppropriateNetworkError(fetchParams))
   }
 
-  // 2. Let request be fetchParams’s request.
+  // 2. Let request be fetchParams's request.
   const { request } = fetchParams
 
   const { protocol: scheme } = requestCurrentURL(request)
 
-  // 3. Switch on request’s current URL’s scheme and run the associated steps:
+  // 3. Switch on request's current URL's scheme and run the associated steps:
   switch (scheme) {
     case 'about:': {
-      // If request’s current URL’s path is the string "blank", then return a new response
+      // If request's current URL's path is the string "blank", then return a new response
       // whose status message is `OK`, header list is « (`Content-Type`, `text/html;charset=utf-8`) »,
       // and body is the empty byte sequence as a body.
 
@@ -797,7 +797,7 @@ function schemeFetch (fetchParams) {
         resolveObjectURL = require('node:buffer').resolveObjectURL
       }
 
-      // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
+      // 1. Let blobURLEntry be request's current URL's blob URL entry.
       const blobURLEntry = requestCurrentURL(request)
 
       // https://github.com/web-platform-tests/wpt/blob/7b0ebaccc62b566a1965396e5be7bb2bc06f841f/FileAPI/url/resources/fetch-tests.js#L52-L56
@@ -808,28 +808,28 @@ function schemeFetch (fetchParams) {
 
       const blob = resolveObjectURL(blobURLEntry.toString())
 
-      // 2. If request’s method is not `GET`, blobURLEntry is null, or blobURLEntry’s
+      // 2. If request's method is not `GET`, blobURLEntry is null, or blobURLEntry's
       //    object is not a Blob object, then return a network error.
       if (request.method !== 'GET' || !isBlobLike(blob)) {
         return Promise.resolve(makeNetworkError('invalid method'))
       }
 
-      // 3. Let blob be blobURLEntry’s object.
+      // 3. Let blob be blobURLEntry's object.
       // Note: done above
 
       // 4. Let response be a new response.
       const response = makeResponse()
 
-      // 5. Let fullLength be blob’s size.
+      // 5. Let fullLength be blob's size.
       const fullLength = blob.size
 
       // 6. Let serializedFullLength be fullLength, serialized and isomorphic encoded.
       const serializedFullLength = isomorphicEncode(`${fullLength}`)
 
-      // 7. Let type be blob’s type.
+      // 7. Let type be blob's type.
       const type = blob.type
 
-      // 8. If request’s header list does not contain `Range`:
+      // 8. If request's header list does not contain `Range`:
       // 9. Otherwise:
       if (!request.headersList.contains('range', true)) {
         // 1. Let bodyWithType be the result of safely extracting blob.
@@ -838,20 +838,20 @@ function schemeFetch (fetchParams) {
         // use extractBody directly.
         const bodyWithType = extractBody(blob)
 
-        // 2. Set response’s status message to `OK`.
+        // 2. Set response's status message to `OK`.
         response.statusText = 'OK'
 
-        // 3. Set response’s body to bodyWithType’s body.
+        // 3. Set response's body to bodyWithType's body.
         response.body = bodyWithType[0]
 
-        // 4. Set response’s header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
+        // 4. Set response's header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
         response.headersList.set('content-length', serializedFullLength, true)
         response.headersList.set('content-type', type, true)
       } else {
-        // 1. Set response’s range-requested flag.
+        // 1. Set response's range-requested flag.
         response.rangeRequested = true
 
-        // 2. Let rangeHeader be the result of getting `Range` from request’s header list.
+        // 2. Let rangeHeader be the result of getting `Range` from request's header list.
         const rangeHeader = request.headersList.get('range', true)
 
         // 3. Let rangeValue be the result of parsing a single range header value given rangeHeader and true.
@@ -894,23 +894,23 @@ function schemeFetch (fetchParams) {
         // Note: same reason as mentioned above as to why we use extractBody
         const slicedBodyWithType = extractBody(slicedBlob)
 
-        // 10. Set response’s body to slicedBodyWithType’s body.
+        // 10. Set response's body to slicedBodyWithType's body.
         response.body = slicedBodyWithType[0]
 
-        // 11. Let serializedSlicedLength be slicedBlob’s size, serialized and isomorphic encoded.
+        // 11. Let serializedSlicedLength be slicedBlob's size, serialized and isomorphic encoded.
         const serializedSlicedLength = isomorphicEncode(`${slicedBlob.size}`)
 
         // 12. Let contentRange be the result of invoking build a content range given rangeStart,
         //     rangeEnd, and fullLength.
         const contentRange = buildContentRange(rangeStart, rangeEnd, fullLength)
 
-        // 13. Set response’s status to 206.
+        // 13. Set response's status to 206.
         response.status = 206
 
-        // 14. Set response’s status message to `Partial Content`.
+        // 14. Set response's status message to `Partial Content`.
         response.statusText = 'Partial Content'
 
-        // 15. Set response’s header list to « (`Content-Length`, serializedSlicedLength),
+        // 15. Set response's header list to « (`Content-Length`, serializedSlicedLength),
         //     (`Content-Type`, type), (`Content-Range`, contentRange) ».
         response.headersList.set('content-length', serializedSlicedLength, true)
         response.headersList.set('content-type', type, true)
@@ -922,7 +922,7 @@ function schemeFetch (fetchParams) {
     }
     case 'data:': {
       // 1. Let dataURLStruct be the result of running the
-      //    data: URL processor on request’s current URL.
+      //    data: URL processor on request's current URL.
       const currentURL = requestCurrentURL(request)
       const dataURLStruct = dataURLProcessor(currentURL)
 
@@ -932,12 +932,12 @@ function schemeFetch (fetchParams) {
         return Promise.resolve(makeNetworkError('failed to fetch the data URL'))
       }
 
-      // 3. Let mimeType be dataURLStruct’s MIME type, serialized.
+      // 3. Let mimeType be dataURLStruct's MIME type, serialized.
       const mimeType = serializeAMimeType(dataURLStruct.mimeType)
 
       // 4. Return a response whose status message is `OK`,
       //    header list is « (`Content-Type`, mimeType) »,
-      //    and body is dataURLStruct’s body as a body.
+      //    and body is dataURLStruct's body as a body.
       return Promise.resolve(makeResponse({
         statusText: 'OK',
         headersList: [
@@ -966,12 +966,12 @@ function schemeFetch (fetchParams) {
 
 // https://fetch.spec.whatwg.org/#finalize-response
 function finalizeResponse (fetchParams, response) {
-  // 1. Set fetchParams’s request’s done flag.
+  // 1. Set fetchParams's request's done flag.
   fetchParams.request.done = true
 
-  // 2, If fetchParams’s process response done is not null, then queue a fetch
-  // task to run fetchParams’s process response done given response, with
-  // fetchParams’s task destination.
+  // 2, If fetchParams's process response done is not null, then queue a fetch
+  // task to run fetchParams's process response done given response, with
+  // fetchParams's task destination.
   if (fetchParams.processResponseDone != null) {
     queueMicrotask(() => fetchParams.processResponseDone(response))
   }
@@ -979,12 +979,12 @@ function finalizeResponse (fetchParams, response) {
 
 // https://fetch.spec.whatwg.org/#fetch-finale
 function fetchFinale (fetchParams, response) {
-  // 1. Let timingInfo be fetchParams’s timing info.
+  // 1. Let timingInfo be fetchParams's timing info.
   let timingInfo = fetchParams.timingInfo
 
-  // 2. If response is not a network error and fetchParams’s request’s client is a secure context,
-  //    then set timingInfo’s server-timing headers to the result of getting, decoding, and splitting
-  //    `Server-Timing` from response’s internal response’s header list.
+  // 2. If response is not a network error and fetchParams's request's client is a secure context,
+  //    then set timingInfo's server-timing headers to the result of getting, decoding, and splitting
+  //    `Server-Timing` from response's internal response's header list.
   // TODO
 
   // 3. Let processResponseEndOfBody be the following steps:
@@ -992,29 +992,29 @@ function fetchFinale (fetchParams, response) {
     // 1. Let unsafeEndTime be the unsafe shared current time.
     const unsafeEndTime = Date.now() // ?
 
-    // 2. If fetchParams’s request’s destination is "document", then set fetchParams’s controller’s
-    //    full timing info to fetchParams’s timing info.
+    // 2. If fetchParams's request's destination is "document", then set fetchParams's controller's
+    //    full timing info to fetchParams's timing info.
     if (fetchParams.request.destination === 'document') {
       fetchParams.controller.fullTimingInfo = timingInfo
     }
 
-    // 3. Set fetchParams’s controller’s report timing steps to the following steps given a global object global:
+    // 3. Set fetchParams's controller's report timing steps to the following steps given a global object global:
     fetchParams.controller.reportTimingSteps = () => {
-      // 1. If fetchParams’s request’s URL’s scheme is not an HTTP(S) scheme, then return.
+      // 1. If fetchParams's request's URL's scheme is not an HTTP(S) scheme, then return.
       if (fetchParams.request.url.protocol !== 'https:') {
         return
       }
 
-      // 2. Set timingInfo’s end time to the relative high resolution time given unsafeEndTime and global.
+      // 2. Set timingInfo's end time to the relative high resolution time given unsafeEndTime and global.
       timingInfo.endTime = unsafeEndTime
 
-      // 3. Let cacheState be response’s cache state.
+      // 3. Let cacheState be response's cache state.
       let cacheState = response.cacheState
 
-      // 4. Let bodyInfo be response’s body info.
+      // 4. Let bodyInfo be response's body info.
       const bodyInfo = response.bodyInfo
 
-      // 5. If response’s timing allow passed flag is not set, then set timingInfo to the result of creating an
+      // 5. If response's timing allow passed flag is not set, then set timingInfo to the result of creating an
       //    opaque timing info for timingInfo and set cacheState to the empty string.
       if (!response.timingAllowPassed) {
         timingInfo = createOpaqueTimingInfo(timingInfo)
@@ -1025,22 +1025,22 @@ function fetchFinale (fetchParams, response) {
       // 6. Let responseStatus be 0.
       let responseStatus = 0
 
-      // 7. If fetchParams’s request’s mode is not "navigate" or response’s has-cross-origin-redirects is false:
+      // 7. If fetchParams's request's mode is not "navigate" or response's has-cross-origin-redirects is false:
       if (fetchParams.request.mode !== 'navigator' || !response.hasCrossOriginRedirects) {
-        // 1. Set responseStatus to response’s status.
+        // 1. Set responseStatus to response's status.
         responseStatus = response.status
 
-        // 2. Let mimeType be the result of extracting a MIME type from response’s header list.
+        // 2. Let mimeType be the result of extracting a MIME type from response's header list.
         const mimeType = parseMIMEType(response.headersList.get('content-type', true)) // TODO: fix
 
-        // 3. If mimeType is not failure, then set bodyInfo’s content type to the result of minimizing a supported MIME type given mimeType.
+        // 3. If mimeType is not failure, then set bodyInfo's content type to the result of minimizing a supported MIME type given mimeType.
         if (mimeType !== 'failure') {
           // TODO
         }
       }
 
-      // 8. If fetchParams’s request’s initiator type is non-null, then mark resource timing given timingInfo,
-      //    fetchParams’s request’s URL, fetchParams’s request’s initiator type, global, cacheState, bodyInfo,
+      // 8. If fetchParams's request's initiator type is non-null, then mark resource timing given timingInfo,
+      //    fetchParams's request's URL, fetchParams's request's initiator type, global, cacheState, bodyInfo,
       //    and responseStatus.
       if (fetchParams.request.initiatorType != null) {
         // TODO: update markresourcetiming
@@ -1050,37 +1050,37 @@ function fetchFinale (fetchParams, response) {
 
     // 4. Let processResponseEndOfBodyTask be the following steps:
     const processResponseEndOfBodyTask = () => {
-      // 1. Set fetchParams’s request’s done flag.
+      // 1. Set fetchParams's request's done flag.
       fetchParams.request.done = true
 
-      // 2. If fetchParams’s process response end-of-body is non-null, then run fetchParams’s process
+      // 2. If fetchParams's process response end-of-body is non-null, then run fetchParams's process
       //    response end-of-body given response.
       if (fetchParams.processResponseEndOfBody != null) {
         queueMicrotask(() => fetchParams.processResponseEndOfBody(response))
       }
 
-      // 3. If fetchParams’s request’s initiator type is non-null and fetchParams’s request’s client’s
-      //    global object is fetchParams’s task destination, then run fetchParams’s controller’s report
-      //    timing steps given fetchParams’s request’s client’s global object.
+      // 3. If fetchParams's request's initiator type is non-null and fetchParams's request's client's
+      //    global object is fetchParams's task destination, then run fetchParams's controller's report
+      //    timing steps given fetchParams's request's client's global object.
       if (fetchParams.request.initiatorType != null) {
         fetchParams.controller.reportTimingSteps()
       }
     }
 
-    // 5. Queue a fetch task to run processResponseEndOfBodyTask with fetchParams’s task destination
+    // 5. Queue a fetch task to run processResponseEndOfBodyTask with fetchParams's task destination
     queueMicrotask(() => processResponseEndOfBodyTask())
   }
 
-  // 4. If fetchParams’s process response is non-null, then queue a fetch task to run fetchParams’s
-  //    process response given response, with fetchParams’s task destination.
+  // 4. If fetchParams's process response is non-null, then queue a fetch task to run fetchParams's
+  //    process response given response, with fetchParams's task destination.
   if (fetchParams.processResponse != null) {
     queueMicrotask(() => fetchParams.processResponse(response))
   }
 
-  // 5. Let internalResponse be response, if response is a network error; otherwise response’s internal response.
+  // 5. Let internalResponse be response, if response is a network error; otherwise response's internal response.
   const internalResponse = response.type === 'error' ? response : (response.internalResponse ?? response)
 
-  // 6. If internalResponse’s body is null, then run processResponseEndOfBody.
+  // 6. If internalResponse's body is null, then run processResponseEndOfBody.
   // 7. Otherwise:
   if (internalResponse.body == null) {
     processResponseEndOfBody()
@@ -1097,7 +1097,7 @@ function fetchFinale (fetchParams, response) {
       flush: processResponseEndOfBody
     })
 
-    // 4. Set internalResponse’s body’s stream to the result of internalResponse’s body’s stream piped through transformStream.
+    // 4. Set internalResponse's body's stream to the result of internalResponse's body's stream piped through transformStream.
     internalResponse.body.stream.pipeThrough(transformStream)
 
     const byteStream = new ReadableStream({
@@ -1125,7 +1125,7 @@ function fetchFinale (fetchParams, response) {
 
 // https://fetch.spec.whatwg.org/#http-fetch
 async function httpFetch (fetchParams) {
-  // 1. Let request be fetchParams’s request.
+  // 1. Let request be fetchParams's request.
   const request = fetchParams.request
 
   // 2. Let response be null.
@@ -1134,10 +1134,10 @@ async function httpFetch (fetchParams) {
   // 3. Let actualResponse be null.
   let actualResponse = null
 
-  // 4. Let timingInfo be fetchParams’s timing info.
+  // 4. Let timingInfo be fetchParams's timing info.
   const timingInfo = fetchParams.timingInfo
 
-  // 5. If request’s service-workers mode is "all", then:
+  // 5. If request's service-workers mode is "all", then:
   if (request.serviceWorkers === 'all') {
     // TODO
   }
@@ -1147,7 +1147,7 @@ async function httpFetch (fetchParams) {
     // 1. If makeCORSPreflight is true and one of these conditions is true:
     // TODO
 
-    // 2. If request’s redirect mode is "follow", then set request’s
+    // 2. If request's redirect mode is "follow", then set request's
     // service-workers mode to "none".
     if (request.redirect === 'follow') {
       request.serviceWorkers = 'none'
@@ -1157,7 +1157,7 @@ async function httpFetch (fetchParams) {
     // HTTP-network-or-cache fetch given fetchParams.
     actualResponse = response = await httpNetworkOrCacheFetch(fetchParams)
 
-    // 4. If request’s response tainting is "cors" and a CORS check
+    // 4. If request's response tainting is "cors" and a CORS check
     // for request and response returns failure, then return a network error.
     if (
       request.responseTainting === 'cors' &&
@@ -1167,15 +1167,15 @@ async function httpFetch (fetchParams) {
     }
 
     // 5. If the TAO check for request and response returns failure, then set
-    // request’s timing allow failed flag.
+    // request's timing allow failed flag.
     if (TAOCheck(request, response) === 'failure') {
       request.timingAllowFailed = true
     }
   }
 
-  // 7. If either request’s response tainting or response’s type
+  // 7. If either request's response tainting or response's type
   // is "opaque", and the cross-origin resource policy check with
-  // request’s origin, request’s client, request’s destination,
+  // request's origin, request's client, request's destination,
   // and actualResponse returns blocked, then return a network error.
   if (
     (request.responseTainting === 'opaque' || response.type === 'opaque') &&
@@ -1189,9 +1189,9 @@ async function httpFetch (fetchParams) {
     return makeNetworkError('blocked')
   }
 
-  // 8. If actualResponse’s status is a redirect status, then:
+  // 8. If actualResponse's status is a redirect status, then:
   if (redirectStatusSet.has(actualResponse.status)) {
-    // 1. If actualResponse’s status is not 303, request’s body is not null,
+    // 1. If actualResponse's status is not 303, request's body is not null,
     // and the connection uses HTTP/2, then user agents may, and are even
     // encouraged to, transmit an RST_STREAM frame.
     // See, https://github.com/whatwg/fetch/issues/1288
@@ -1199,7 +1199,7 @@ async function httpFetch (fetchParams) {
       fetchParams.controller.connection.destroy(undefined, false)
     }
 
-    // 2. Switch on request’s redirect mode:
+    // 2. Switch on request's redirect mode:
     if (request.redirect === 'error') {
       // Set response to a network error.
       response = makeNetworkError('unexpected redirect')
@@ -1219,7 +1219,7 @@ async function httpFetch (fetchParams) {
     }
   }
 
-  // 9. Set response’s timing info to timingInfo.
+  // 9. Set response's timing info to timingInfo.
   response.timingInfo = timingInfo
 
   // 10. Return response.
@@ -1228,17 +1228,17 @@ async function httpFetch (fetchParams) {
 
 // https://fetch.spec.whatwg.org/#http-redirect-fetch
 function httpRedirectFetch (fetchParams, response) {
-  // 1. Let request be fetchParams’s request.
+  // 1. Let request be fetchParams's request.
   const request = fetchParams.request
 
   // 2. Let actualResponse be response, if response is not a filtered response,
-  // and response’s internal response otherwise.
+  // and response's internal response otherwise.
   const actualResponse = response.internalResponse
     ? response.internalResponse
     : response
 
-  // 3. Let locationURL be actualResponse’s location URL given request’s current
-  // URL’s fragment.
+  // 3. Let locationURL be actualResponse's location URL given request's current
+  // URL's fragment.
   let locationURL
 
   try {
@@ -1256,22 +1256,22 @@ function httpRedirectFetch (fetchParams, response) {
     return Promise.resolve(makeNetworkError(err))
   }
 
-  // 6. If locationURL’s scheme is not an HTTP(S) scheme, then return a network
+  // 6. If locationURL's scheme is not an HTTP(S) scheme, then return a network
   // error.
   if (!urlIsHttpHttpsScheme(locationURL)) {
     return Promise.resolve(makeNetworkError('URL scheme must be a HTTP(S) scheme'))
   }
 
-  // 7. If request’s redirect count is 20, then return a network error.
+  // 7. If request's redirect count is 20, then return a network error.
   if (request.redirectCount === 20) {
     return Promise.resolve(makeNetworkError('redirect count exceeded'))
   }
 
-  // 8. Increase request’s redirect count by 1.
+  // 8. Increase request's redirect count by 1.
   request.redirectCount += 1
 
-  // 9. If request’s mode is "cors", locationURL includes credentials, and
-  // request’s origin is not same origin with locationURL’s origin, then return
+  // 9. If request's mode is "cors", locationURL includes credentials, and
+  // request's origin is not same origin with locationURL's origin, then return
   //  a network error.
   if (
     request.mode === 'cors' &&
@@ -1281,7 +1281,7 @@ function httpRedirectFetch (fetchParams, response) {
     return Promise.resolve(makeNetworkError('cross origin not allowed for request mode "cors"'))
   }
 
-  // 10. If request’s response tainting is "cors" and locationURL includes
+  // 10. If request's response tainting is "cors" and locationURL includes
   // credentials, then return a network error.
   if (
     request.responseTainting === 'cors' &&
@@ -1292,8 +1292,8 @@ function httpRedirectFetch (fetchParams, response) {
     ))
   }
 
-  // 11. If actualResponse’s status is not 303, request’s body is non-null,
-  // and request’s body’s source is null, then return a network error.
+  // 11. If actualResponse's status is not 303, request's body is non-null,
+  // and request's body's source is null, then return a network error.
   if (
     actualResponse.status !== 303 &&
     request.body != null &&
@@ -1303,28 +1303,28 @@ function httpRedirectFetch (fetchParams, response) {
   }
 
   // 12. If one of the following is true
-  // - actualResponse’s status is 301 or 302 and request’s method is `POST`
-  // - actualResponse’s status is 303 and request’s method is not `GET` or `HEAD`
+  // - actualResponse's status is 301 or 302 and request's method is `POST`
+  // - actualResponse's status is 303 and request's method is not `GET` or `HEAD`
   if (
     ([301, 302].includes(actualResponse.status) && request.method === 'POST') ||
     (actualResponse.status === 303 &&
       !GET_OR_HEAD.includes(request.method))
   ) {
     // then:
-    // 1. Set request’s method to `GET` and request’s body to null.
+    // 1. Set request's method to `GET` and request's body to null.
     request.method = 'GET'
     request.body = null
 
     // 2. For each headerName of request-body-header name, delete headerName from
-    // request’s header list.
+    // request's header list.
     for (const headerName of requestBodyHeader) {
       request.headersList.delete(headerName)
     }
   }
 
-  // 13. If request’s current URL’s origin is not same origin with locationURL’s
+  // 13. If request's current URL's origin is not same origin with locationURL's
   //     origin, then for each headerName of CORS non-wildcard request-header name,
-  //     delete headerName from request’s header list.
+  //     delete headerName from request's header list.
   if (!sameOrigin(requestCurrentURL(request), locationURL)) {
     // https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name
     request.headersList.delete('authorization', true)
@@ -1334,32 +1334,32 @@ function httpRedirectFetch (fetchParams, response) {
     request.headersList.delete('host', true)
   }
 
-  // 14. If request’s body is non-null, then set request’s body to the first return
-  // value of safely extracting request’s body’s source.
+  // 14. If request's body is non-null, then set request's body to the first return
+  // value of safely extracting request's body's source.
   if (request.body != null) {
     assert(request.body.source != null)
     request.body = safelyExtractBody(request.body.source)[0]
   }
 
-  // 15. Let timingInfo be fetchParams’s timing info.
+  // 15. Let timingInfo be fetchParams's timing info.
   const timingInfo = fetchParams.timingInfo
 
-  // 16. Set timingInfo’s redirect end time and post-redirect start time to the
-  // coarsened shared current time given fetchParams’s cross-origin isolated
+  // 16. Set timingInfo's redirect end time and post-redirect start time to the
+  // coarsened shared current time given fetchParams's cross-origin isolated
   // capability.
   timingInfo.redirectEndTime = timingInfo.postRedirectStartTime =
     coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
 
-  // 17. If timingInfo’s redirect start time is 0, then set timingInfo’s
-  //  redirect start time to timingInfo’s start time.
+  // 17. If timingInfo's redirect start time is 0, then set timingInfo's
+  //  redirect start time to timingInfo's start time.
   if (timingInfo.redirectStartTime === 0) {
     timingInfo.redirectStartTime = timingInfo.startTime
   }
 
-  // 18. Append locationURL to request’s URL list.
+  // 18. Append locationURL to request's URL list.
   request.urlList.push(locationURL)
 
-  // 19. Invoke set request’s referrer policy on redirect on request and
+  // 19. Invoke set request's referrer policy on redirect on request and
   // actualResponse.
   setRequestReferrerPolicyOnRedirect(request, actualResponse)
 
@@ -1373,7 +1373,7 @@ async function httpNetworkOrCacheFetch (
   isAuthenticationFetch = false,
   isNewConnectionFetch = false
 ) {
-  // 1. Let request be fetchParams’s request.
+  // 1. Let request be fetchParams's request.
   const request = fetchParams.request
 
   // 2. Let httpFetchParams be null.
@@ -1396,7 +1396,7 @@ async function httpNetworkOrCacheFetch (
 
   // 8. Run these steps, but abort when the ongoing fetch is terminated:
 
-  //    1. If request’s window is "no-window" and request’s redirect mode is
+  //    1. If request's window is "no-window" and request's redirect mode is
   //    "error", then set httpFetchParams to fetchParams and httpRequest to
   //    request.
   if (request.window === 'no-window' && request.redirect === 'error') {
@@ -1411,7 +1411,7 @@ async function httpNetworkOrCacheFetch (
     // 2. Set httpFetchParams to a copy of fetchParams.
     httpFetchParams = { ...fetchParams }
 
-    // 3. Set httpFetchParams’s request to httpRequest.
+    // 3. Set httpFetchParams's request to httpRequest.
     httpFetchParams.request = httpRequest
   }
 
@@ -1421,14 +1421,14 @@ async function httpNetworkOrCacheFetch (
     (request.credentials === 'same-origin' &&
       request.responseTainting === 'basic')
 
-  //    4. Let contentLength be httpRequest’s body’s length, if httpRequest’s
+  //    4. Let contentLength be httpRequest's body's length, if httpRequest's
   //    body is non-null; otherwise null.
   const contentLength = httpRequest.body ? httpRequest.body.length : null
 
   //    5. Let contentLengthHeaderValue be null.
   let contentLengthHeaderValue = null
 
-  //    6. If httpRequest’s body is null and httpRequest’s method is `POST` or
+  //    6. If httpRequest's body is null and httpRequest's method is `POST` or
   //    `PUT`, then set contentLengthHeaderValue to `0`.
   if (
     httpRequest.body == null &&
@@ -1444,24 +1444,24 @@ async function httpNetworkOrCacheFetch (
   }
 
   //    8. If contentLengthHeaderValue is non-null, then append
-  //    `Content-Length`/contentLengthHeaderValue to httpRequest’s header
+  //    `Content-Length`/contentLengthHeaderValue to httpRequest's header
   //    list.
   if (contentLengthHeaderValue != null) {
     httpRequest.headersList.append('content-length', contentLengthHeaderValue, true)
   }
 
   //    9. If contentLengthHeaderValue is non-null, then append (`Content-Length`,
-  //    contentLengthHeaderValue) to httpRequest’s header list.
+  //    contentLengthHeaderValue) to httpRequest's header list.
 
-  //    10. If contentLength is non-null and httpRequest’s keepalive is true,
+  //    10. If contentLength is non-null and httpRequest's keepalive is true,
   //    then:
   if (contentLength != null && httpRequest.keepalive) {
     // NOTE: keepalive is a noop outside of browser context.
   }
 
-  //    11. If httpRequest’s referrer is a URL, then append
-  //    `Referer`/httpRequest’s referrer, serialized and isomorphic encoded,
-  //     to httpRequest’s header list.
+  //    11. If httpRequest's referrer is a URL, then append
+  //    `Referer`/httpRequest's referrer, serialized and isomorphic encoded,
+  //     to httpRequest's header list.
   if (httpRequest.referrer instanceof URL) {
     httpRequest.headersList.append('referer', isomorphicEncode(httpRequest.referrer.href), true)
   }
@@ -1472,17 +1472,17 @@ async function httpNetworkOrCacheFetch (
   //    13. Append the Fetch metadata headers for httpRequest. [FETCH-METADATA]
   appendFetchMetadata(httpRequest)
 
-  //    14. If httpRequest’s header list does not contain `User-Agent`, then
+  //    14. If httpRequest's header list does not contain `User-Agent`, then
   //    user agents should append `User-Agent`/default `User-Agent` value to
-  //    httpRequest’s header list.
+  //    httpRequest's header list.
   if (!httpRequest.headersList.contains('user-agent', true)) {
     httpRequest.headersList.append('user-agent', typeof esbuildDetection === 'undefined' ? 'undici' : 'node', true)
   }
 
-  //    15. If httpRequest’s cache mode is "default" and httpRequest’s header
+  //    15. If httpRequest's cache mode is "default" and httpRequest's header
   //    list contains `If-Modified-Since`, `If-None-Match`,
   //    `If-Unmodified-Since`, `If-Match`, or `If-Range`, then set
-  //    httpRequest’s cache mode to "no-store".
+  //    httpRequest's cache mode to "no-store".
   if (
     httpRequest.cache === 'default' &&
     (httpRequest.headersList.contains('if-modified-since', true) ||
@@ -1494,10 +1494,10 @@ async function httpNetworkOrCacheFetch (
     httpRequest.cache = 'no-store'
   }
 
-  //    16. If httpRequest’s cache mode is "no-cache", httpRequest’s prevent
+  //    16. If httpRequest's cache mode is "no-cache", httpRequest's prevent
   //    no-cache cache-control header modification flag is unset, and
-  //    httpRequest’s header list does not contain `Cache-Control`, then append
-  //    `Cache-Control`/`max-age=0` to httpRequest’s header list.
+  //    httpRequest's header list does not contain `Cache-Control`, then append
+  //    `Cache-Control`/`max-age=0` to httpRequest's header list.
   if (
     httpRequest.cache === 'no-cache' &&
     !httpRequest.preventNoCacheCacheControlHeaderModification &&
@@ -1506,29 +1506,29 @@ async function httpNetworkOrCacheFetch (
     httpRequest.headersList.append('cache-control', 'max-age=0', true)
   }
 
-  //    17. If httpRequest’s cache mode is "no-store" or "reload", then:
+  //    17. If httpRequest's cache mode is "no-store" or "reload", then:
   if (httpRequest.cache === 'no-store' || httpRequest.cache === 'reload') {
-    // 1. If httpRequest’s header list does not contain `Pragma`, then append
-    // `Pragma`/`no-cache` to httpRequest’s header list.
+    // 1. If httpRequest's header list does not contain `Pragma`, then append
+    // `Pragma`/`no-cache` to httpRequest's header list.
     if (!httpRequest.headersList.contains('pragma', true)) {
       httpRequest.headersList.append('pragma', 'no-cache', true)
     }
 
-    // 2. If httpRequest’s header list does not contain `Cache-Control`,
-    // then append `Cache-Control`/`no-cache` to httpRequest’s header list.
+    // 2. If httpRequest's header list does not contain `Cache-Control`,
+    // then append `Cache-Control`/`no-cache` to httpRequest's header list.
     if (!httpRequest.headersList.contains('cache-control', true)) {
       httpRequest.headersList.append('cache-control', 'no-cache', true)
     }
   }
 
-  //    18. If httpRequest’s header list contains `Range`, then append
-  //    `Accept-Encoding`/`identity` to httpRequest’s header list.
+  //    18. If httpRequest's header list contains `Range`, then append
+  //    `Accept-Encoding`/`identity` to httpRequest's header list.
   if (httpRequest.headersList.contains('range', true)) {
     httpRequest.headersList.append('accept-encoding', 'identity', true)
   }
 
-  //    19. Modify httpRequest’s header list per HTTP. Do not append a given
-  //    header if httpRequest’s header list contains that header’s name.
+  //    19. Modify httpRequest's header list per HTTP. Do not append a given
+  //    header if httpRequest's header list contains that header's name.
   //    TODO: https://github.com/whatwg/fetch/issues/1285#issuecomment-896560129
   if (!httpRequest.headersList.contains('accept-encoding', true)) {
     if (urlHasHttpsScheme(requestCurrentURL(httpRequest))) {
@@ -1545,24 +1545,24 @@ async function httpNetworkOrCacheFetch (
     // 1. If the user agent is not configured to block cookies for httpRequest
     // (see section 7 of [COOKIES]), then:
     // TODO: credentials
-    // 2. If httpRequest’s header list does not contain `Authorization`, then:
+    // 2. If httpRequest's header list does not contain `Authorization`, then:
     // TODO: credentials
   }
 
-  //    21. If there’s a proxy-authentication entry, use it as appropriate.
+  //    21. If there's a proxy-authentication entry, use it as appropriate.
   //    TODO: proxy-authentication
 
   //    22. Set httpCache to the result of determining the HTTP cache
   //    partition, given httpRequest.
   //    TODO: cache
 
-  //    23. If httpCache is null, then set httpRequest’s cache mode to
+  //    23. If httpCache is null, then set httpRequest's cache mode to
   //    "no-store".
   if (httpCache == null) {
     httpRequest.cache = 'no-store'
   }
 
-  //    24. If httpRequest’s cache mode is neither "no-store" nor "reload",
+  //    24. If httpRequest's cache mode is neither "no-store" nor "reload",
   //    then:
   if (httpRequest.mode !== 'no-store' && httpRequest.mode !== 'reload') {
     // TODO: cache
@@ -1573,7 +1573,7 @@ async function httpNetworkOrCacheFetch (
 
   // 10. If response is null, then:
   if (response == null) {
-    // 1. If httpRequest’s cache mode is "only-if-cached", then return a
+    // 1. If httpRequest's cache mode is "only-if-cached", then return a
     // network error.
     if (httpRequest.mode === 'only-if-cached') {
       return makeNetworkError('only if cached')
@@ -1587,7 +1587,7 @@ async function httpNetworkOrCacheFetch (
       isNewConnectionFetch
     )
 
-    // 3. If httpRequest’s method is unsafe and forwardResponse’s status is
+    // 3. If httpRequest's method is unsafe and forwardResponse's status is
     // in the range 200 to 399, inclusive, invalidate appropriate stored
     // responses in httpCache, as per the "Invalidation" chapter of HTTP
     // Caching, and set storedResponse to null. [HTTP-CACHING]
@@ -1599,7 +1599,7 @@ async function httpNetworkOrCacheFetch (
       // TODO: cache
     }
 
-    // 4. If the revalidatingFlag is set and forwardResponse’s status is 304,
+    // 4. If the revalidatingFlag is set and forwardResponse's status is 304,
     // then:
     if (revalidatingFlag && forwardResponse.status === 304) {
       // TODO: cache
@@ -1616,26 +1616,26 @@ async function httpNetworkOrCacheFetch (
     }
   }
 
-  // 11. Set response’s URL list to a clone of httpRequest’s URL list.
+  // 11. Set response's URL list to a clone of httpRequest's URL list.
   response.urlList = [...httpRequest.urlList]
 
-  // 12. If httpRequest’s header list contains `Range`, then set response’s
+  // 12. If httpRequest's header list contains `Range`, then set response's
   // range-requested flag.
   if (httpRequest.headersList.contains('range', true)) {
     response.rangeRequested = true
   }
 
-  // 13. Set response’s request-includes-credentials to includeCredentials.
+  // 13. Set response's request-includes-credentials to includeCredentials.
   response.requestIncludesCredentials = includeCredentials
 
-  // 14. If response’s status is 401, httpRequest’s response tainting is not
-  // "cors", includeCredentials is true, and request’s window is an environment
+  // 14. If response's status is 401, httpRequest's response tainting is not
+  // "cors", includeCredentials is true, and request's window is an environment
   // settings object, then:
   // TODO
 
-  // 15. If response’s status is 407, then:
+  // 15. If response's status is 407, then:
   if (response.status === 407) {
-    // 1. If request’s window is "no-window", then return a network error.
+    // 1. If request's window is "no-window", then return a network error.
     if (request.window === 'no-window') {
       return makeNetworkError()
     }
@@ -1647,7 +1647,7 @@ async function httpNetworkOrCacheFetch (
       return makeAppropriateNetworkError(fetchParams)
     }
 
-    // 4. Prompt the end user as appropriate in request’s window and store
+    // 4. Prompt the end user as appropriate in request's window and store
     // the result as a proxy-authentication entry. [HTTP-AUTH]
     // TODO: Invoke some kind of callback?
 
@@ -1659,11 +1659,11 @@ async function httpNetworkOrCacheFetch (
 
   // 16. If all of the following are true
   if (
-    // response’s status is 421
+    // response's status is 421
     response.status === 421 &&
     // isNewConnectionFetch is false
     !isNewConnectionFetch &&
-    // request’s body is null, or request’s body is non-null and request’s body’s source is non-null
+    // request's body is null, or request's body is non-null and request's body's source is non-null
     (request.body == null || request.body.source != null)
   ) {
     // then:
@@ -1718,13 +1718,13 @@ async function httpNetworkFetch (
     }
   }
 
-  // 1. Let request be fetchParams’s request.
+  // 1. Let request be fetchParams's request.
   const request = fetchParams.request
 
   // 2. Let response be null.
   let response = null
 
-  // 3. Let timingInfo be fetchParams’s timing info.
+  // 3. Let timingInfo be fetchParams's timing info.
   const timingInfo = fetchParams.timingInfo
 
   // 4. Let httpCache be the result of determining the HTTP cache partition,
@@ -1732,7 +1732,7 @@ async function httpNetworkFetch (
   // TODO: cache
   const httpCache = null
 
-  // 5. If httpCache is null, then set request’s cache mode to "no-store".
+  // 5. If httpCache is null, then set request's cache mode to "no-store".
   if (httpCache == null) {
     request.cache = 'no-store'
   }
@@ -1745,14 +1745,14 @@ async function httpNetworkFetch (
   // "no".
   const newConnection = forceNewConnection ? 'yes' : 'no' // eslint-disable-line no-unused-vars
 
-  // 8. Switch on request’s mode:
+  // 8. Switch on request's mode:
   if (request.mode === 'websocket') {
     // Let connection be the result of obtaining a WebSocket connection,
-    // given request’s current URL.
+    // given request's current URL.
     // TODO
   } else {
     // Let connection be the result of obtaining a connection, given
-    // networkPartitionKey, request’s current URL’s origin,
+    // networkPartitionKey, request's current URL's origin,
     // includeCredentials, and forceNewConnection.
     // TODO
   }
@@ -1761,17 +1761,17 @@ async function httpNetworkFetch (
 
   //    1. If connection is failure, then return a network error.
 
-  //    2. Set timingInfo’s final connection timing info to the result of
-  //    calling clamp and coarsen connection timing info with connection’s
-  //    timing info, timingInfo’s post-redirect start time, and fetchParams’s
+  //    2. Set timingInfo's final connection timing info to the result of
+  //    calling clamp and coarsen connection timing info with connection's
+  //    timing info, timingInfo's post-redirect start time, and fetchParams's
   //    cross-origin isolated capability.
 
-  //    3. If connection is not an HTTP/2 connection, request’s body is non-null,
-  //    and request’s body’s source is null, then append (`Transfer-Encoding`,
-  //    `chunked`) to request’s header list.
+  //    3. If connection is not an HTTP/2 connection, request's body is non-null,
+  //    and request's body's source is null, then append (`Transfer-Encoding`,
+  //    `chunked`) to request's header list.
 
-  //    4. Set timingInfo’s final network-request start time to the coarsened
-  //    shared current time given fetchParams’s cross-origin isolated
+  //    4. Set timingInfo's final network-request start time to the coarsened
+  //    shared current time given fetchParams's cross-origin isolated
   //    capability.
 
   //    5. Set response to the result of making an HTTP request over connection
@@ -1780,15 +1780,15 @@ async function httpNetworkFetch (
   //        - Follow the relevant requirements from HTTP. [HTTP] [HTTP-SEMANTICS]
   //        [HTTP-COND] [HTTP-CACHING] [HTTP-AUTH]
 
-  //        - If request’s body is non-null, and request’s body’s source is null,
+  //        - If request's body is non-null, and request's body's source is null,
   //        then the user agent may have a buffer of up to 64 kibibytes and store
-  //        a part of request’s body in that buffer. If the user agent reads from
-  //        request’s body beyond that buffer’s size and the user agent needs to
+  //        a part of request's body in that buffer. If the user agent reads from
+  //        request's body beyond that buffer's size and the user agent needs to
   //        resend request, then instead return a network error.
 
-  //        - Set timingInfo’s final network-response start time to the coarsened
-  //        shared current time given fetchParams’s cross-origin isolated capability,
-  //        immediately after the user agent’s HTTP parser receives the first byte
+  //        - Set timingInfo's final network-response start time to the coarsened
+  //        shared current time given fetchParams's cross-origin isolated capability,
+  //        immediately after the user agent's HTTP parser receives the first byte
   //        of the response (e.g., frame header bytes for HTTP/2 or response status
   //        line for HTTP/1.x).
 
@@ -1796,24 +1796,24 @@ async function httpNetworkFetch (
 
   //        - Any responses whose status is in the range 100 to 199, inclusive,
   //        and is not 101, are to be ignored, except for the purposes of setting
-  //        timingInfo’s final network-response start time above.
+  //        timingInfo's final network-response start time above.
 
-  //    - If request’s header list contains `Transfer-Encoding`/`chunked` and
+  //    - If request's header list contains `Transfer-Encoding`/`chunked` and
   //    response is transferred via HTTP/1.0 or older, then return a network
   //    error.
 
   //    - If the HTTP request results in a TLS client certificate dialog, then:
 
-  //        1. If request’s window is an environment settings object, make the
-  //        dialog available in request’s window.
+  //        1. If request's window is an environment settings object, make the
+  //        dialog available in request's window.
 
   //        2. Otherwise, return a network error.
 
-  // To transmit request’s body body, run these steps:
+  // To transmit request's body body, run these steps:
   let requestBody = null
-  // 1. If body is null and fetchParams’s process request end-of-body is
-  // non-null, then queue a fetch task given fetchParams’s process request
-  // end-of-body and fetchParams’s task destination.
+  // 1. If body is null and fetchParams's process request end-of-body is
+  // non-null, then queue a fetch task given fetchParams's process request
+  // end-of-body and fetchParams's task destination.
   if (request.body == null && fetchParams.processRequestEndOfBody) {
     queueMicrotask(() => fetchParams.processRequestEndOfBody())
   } else if (request.body != null) {
@@ -1829,8 +1829,8 @@ async function httpNetworkFetch (
       // 2. Run this step in parallel: transmit bytes.
       yield bytes
 
-      // 3. If fetchParams’s process request body is non-null, then run
-      // fetchParams’s process request body given bytes’s length.
+      // 3. If fetchParams's process request body is non-null, then run
+      // fetchParams's process request body given bytes's length.
       fetchParams.processRequestBodyChunkLength?.(bytes.byteLength)
     }
 
@@ -1841,8 +1841,8 @@ async function httpNetworkFetch (
         return
       }
 
-      // 2. If fetchParams’s process request end-of-body is non-null,
-      // then run fetchParams’s process request end-of-body.
+      // 2. If fetchParams's process request end-of-body is non-null,
+      // then run fetchParams's process request end-of-body.
       if (fetchParams.processRequestEndOfBody) {
         fetchParams.processRequestEndOfBody()
       }
@@ -1855,7 +1855,7 @@ async function httpNetworkFetch (
         return
       }
 
-      // 2. If e is an "AbortError" DOMException, then abort fetchParams’s controller.
+      // 2. If e is an "AbortError" DOMException, then abort fetchParams's controller.
       if (e.name === 'AbortError') {
         fetchParams.controller.abort()
       } else {
@@ -1863,8 +1863,8 @@ async function httpNetworkFetch (
       }
     }
 
-    // 4. Incrementally read request’s body given processBodyChunk, processEndOfBody,
-    // processBodyError, and fetchParams’s task destination.
+    // 4. Incrementally read request's body given processBodyChunk, processEndOfBody,
+    // processBodyError, and fetchParams's task destination.
     requestBody = (async function * () {
       try {
         for await (const bytes of request.body.stream) {
@@ -1908,7 +1908,7 @@ async function httpNetworkFetch (
     fetchParams.controller.resume()
   }
 
-  // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams’s
+  // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams's
   // controller with reason, given reason.
   const cancelAlgorithm = (reason) => {
     fetchParams.controller.abort(reason)
@@ -1942,10 +1942,10 @@ async function httpNetworkFetch (
 
   // 17. Run these steps, but abort when the ongoing fetch is terminated:
 
-  //    1. Set response’s body to a new body whose stream is stream.
+  //    1. Set response's body to a new body whose stream is stream.
   response.body = { stream }
 
-  //    2. If response is not a network error and request’s cache mode is
+  //    2. If response is not a network error and request's cache mode is
   //    not "no-store", then update response in httpCache for request.
   //    TODO
 
@@ -1953,7 +1953,7 @@ async function httpNetworkFetch (
   //    to block cookies for request (see section 7 of [COOKIES]), then run the
   //    "set-cookie-string" parsing algorithm (see section 5.2 of [COOKIES]) on
   //    the value of each header whose name is a byte-case-insensitive match for
-  //    `Set-Cookie` in response’s header list, if any, and request’s current URL.
+  //    `Set-Cookie` in response's header list, if any, and request's current URL.
   //    TODO
 
   // 18. If aborted, then:
@@ -1994,7 +1994,7 @@ async function httpNetworkFetch (
       }
 
       if (bytes === undefined) {
-        // 2. Otherwise, if the bytes transmission for response’s message
+        // 2. Otherwise, if the bytes transmission for response's message
         // body is done normally and stream is readable, then close
         // stream, finalize response for fetchParams and response, and
         // abort these in-parallel steps.
@@ -2005,10 +2005,10 @@ async function httpNetworkFetch (
         return
       }
 
-      // 5. Increase timingInfo’s decoded body size by bytes’s length.
+      // 5. Increase timingInfo's decoded body size by bytes's length.
       timingInfo.decodedBodySize += bytes?.byteLength ?? 0
 
-      // 6. If bytes is failure, then terminate fetchParams’s controller.
+      // 6. If bytes is failure, then terminate fetchParams's controller.
       if (isFailure) {
         fetchParams.controller.terminate(bytes)
         return
@@ -2027,7 +2027,7 @@ async function httpNetworkFetch (
         return
       }
 
-      // 9. If stream doesn’t need more data ask the user agent to suspend
+      // 9. If stream doesn't need more data ask the user agent to suspend
       // the ongoing fetch.
       if (!fetchParams.controller.controller.desiredSize) {
         return
@@ -2039,12 +2039,12 @@ async function httpNetworkFetch (
   function onAborted (reason) {
     // 2. If fetchParams is aborted, then:
     if (isAborted(fetchParams)) {
-      // 1. Set response’s aborted flag.
+      // 1. Set response's aborted flag.
       response.aborted = true
 
       // 2. If stream is readable, then error stream with the result of
-      //    deserialize a serialized abort reason given fetchParams’s
-      //    controller’s serialized abort reason and an
+      //    deserialize a serialized abort reason given fetchParams's
+      //    controller's serialized abort reason and an
       //    implementation-defined realm.
       if (isReadable(stream)) {
         fetchParams.controller.controller.error(
@@ -2091,9 +2091,9 @@ async function httpNetworkFetch (
           // TODO (fix): Do we need connection here?
           const { connection } = fetchParams.controller
 
-          // Set timingInfo’s final connection timing info to the result of calling clamp and coarsen
-          // connection timing info with connection’s timing info, timingInfo’s post-redirect start
-          // time, and fetchParams’s cross-origin isolated capability.
+          // Set timingInfo's final connection timing info to the result of calling clamp and coarsen
+          // connection timing info with connection's timing info, timingInfo's post-redirect start
+          // time, and fetchParams's cross-origin isolated capability.
           // TODO: implement connection timing
           timingInfo.finalConnectionTimingInfo = clampAndCoarsenConnectionTimingInfo(undefined, timingInfo.postRedirectStartTime, fetchParams.crossOriginIsolatedCapability)
 
@@ -2104,15 +2104,15 @@ async function httpNetworkFetch (
             this.abort = connection.abort = abort
           }
 
-          // Set timingInfo’s final network-request start time to the coarsened shared current time given
-          // fetchParams’s cross-origin isolated capability.
+          // Set timingInfo's final network-request start time to the coarsened shared current time given
+          // fetchParams's cross-origin isolated capability.
           timingInfo.finalNetworkRequestStartTime = coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
         },
 
         onResponseStarted () {
-          // Set timingInfo’s final network-response start time to the coarsened shared current
-          // time given fetchParams’s cross-origin isolated capability, immediately after the
-          // user agent’s HTTP parser receives the first byte of the response (e.g., frame header
+          // Set timingInfo's final network-response start time to the coarsened shared current
+          // time given fetchParams's cross-origin isolated capability, immediately after the
+          // user agent's HTTP parser receives the first byte of the response (e.g., frame header
           // bytes for HTTP/2 or response status line for HTTP/1.x).
           timingInfo.finalNetworkResponseStartTime = coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
         },
@@ -2207,17 +2207,17 @@ async function httpNetworkFetch (
             return
           }
 
-          // 1. If one or more bytes have been transmitted from response’s
+          // 1. If one or more bytes have been transmitted from response's
           // message body, then:
 
           //  1. Let bytes be the transmitted bytes.
           const bytes = chunk
 
           //  2. Let codings be the result of extracting header list values
-          //  given `Content-Encoding` and response’s header list.
+          //  given `Content-Encoding` and response's header list.
           //  See pullAlgorithm.
 
-          //  3. Increase timingInfo’s encoded body size by bytes’s length.
+          //  3. Increase timingInfo's encoded body size by bytes's length.
           timingInfo.encodedBodySize += bytes.byteLength
 
           //  4. See pullAlgorithm...

--- a/lib/fetch/request.js
+++ b/lib/fetch/request.js
@@ -70,7 +70,7 @@ class Request {
     // 2. Let fallbackMode be null.
     let fallbackMode = null
 
-    // 3. Let baseURL be this’s relevant settings object’s API base URL.
+    // 3. Let baseURL be this's relevant settings object's API base URL.
     const baseUrl = this[kRealm].settingsObject.baseUrl
 
     // 4. Let signal be null.
@@ -106,21 +106,21 @@ class Request {
       // 7. Assert: input is a Request object.
       assert(input instanceof Request)
 
-      // 8. Set request to input’s request.
+      // 8. Set request to input's request.
       request = input[kState]
 
-      // 9. Set signal to input’s signal.
+      // 9. Set signal to input's signal.
       signal = input[kSignal]
     }
 
-    // 7. Let origin be this’s relevant settings object’s origin.
+    // 7. Let origin be this's relevant settings object's origin.
     const origin = this[kRealm].settingsObject.origin
 
     // 8. Let window be "client".
     let window = 'client'
 
-    // 9. If request’s window is an environment settings object and its origin
-    // is same origin with origin, then set window to request’s window.
+    // 9. If request's window is an environment settings object and its origin
+    // is same origin with origin, then set window to request's window.
     if (
       request.window?.constructor?.name === 'EnvironmentSettingsObject' &&
       sameOrigin(request.window, origin)
@@ -140,46 +140,46 @@ class Request {
 
     // 12. Set request to a new request with the following properties:
     request = makeRequest({
-      // URL request’s URL.
+      // URL request's URL.
       // undici implementation note: this is set as the first item in request's urlList in makeRequest
-      // method request’s method.
+      // method request's method.
       method: request.method,
-      // header list A copy of request’s header list.
+      // header list A copy of request's header list.
       // undici implementation note: headersList is cloned in makeRequest
       headersList: request.headersList,
       // unsafe-request flag Set.
       unsafeRequest: request.unsafeRequest,
-      // client This’s relevant settings object.
+      // client This's relevant settings object.
       client: this[kRealm].settingsObject,
       // window window.
       window,
-      // priority request’s priority.
+      // priority request's priority.
       priority: request.priority,
-      // origin request’s origin. The propagation of the origin is only significant for navigation requests
+      // origin request's origin. The propagation of the origin is only significant for navigation requests
       // being handled by a service worker. In this scenario a request can have an origin that is different
       // from the current client.
       origin: request.origin,
-      // referrer request’s referrer.
+      // referrer request's referrer.
       referrer: request.referrer,
-      // referrer policy request’s referrer policy.
+      // referrer policy request's referrer policy.
       referrerPolicy: request.referrerPolicy,
-      // mode request’s mode.
+      // mode request's mode.
       mode: request.mode,
-      // credentials mode request’s credentials mode.
+      // credentials mode request's credentials mode.
       credentials: request.credentials,
-      // cache mode request’s cache mode.
+      // cache mode request's cache mode.
       cache: request.cache,
-      // redirect mode request’s redirect mode.
+      // redirect mode request's redirect mode.
       redirect: request.redirect,
-      // integrity metadata request’s integrity metadata.
+      // integrity metadata request's integrity metadata.
       integrity: request.integrity,
-      // keepalive request’s keepalive.
+      // keepalive request's keepalive.
       keepalive: request.keepalive,
-      // reload-navigation flag request’s reload-navigation flag.
+      // reload-navigation flag request's reload-navigation flag.
       reloadNavigation: request.reloadNavigation,
-      // history-navigation flag request’s history-navigation flag.
+      // history-navigation flag request's history-navigation flag.
       historyNavigation: request.historyNavigation,
-      // URL list A clone of request’s URL list.
+      // URL list A clone of request's URL list.
       urlList: [...request.urlList]
     })
 
@@ -187,30 +187,30 @@ class Request {
 
     // 13. If init is not empty, then:
     if (initHasKey) {
-      // 1. If request’s mode is "navigate", then set it to "same-origin".
+      // 1. If request's mode is "navigate", then set it to "same-origin".
       if (request.mode === 'navigate') {
         request.mode = 'same-origin'
       }
 
-      // 2. Unset request’s reload-navigation flag.
+      // 2. Unset request's reload-navigation flag.
       request.reloadNavigation = false
 
-      // 3. Unset request’s history-navigation flag.
+      // 3. Unset request's history-navigation flag.
       request.historyNavigation = false
 
-      // 4. Set request’s origin to "client".
+      // 4. Set request's origin to "client".
       request.origin = 'client'
 
-      // 5. Set request’s referrer to "client"
+      // 5. Set request's referrer to "client"
       request.referrer = 'client'
 
-      // 6. Set request’s referrer policy to the empty string.
+      // 6. Set request's referrer policy to the empty string.
       request.referrerPolicy = ''
 
-      // 7. Set request’s URL to request’s current URL.
+      // 7. Set request's URL to request's current URL.
       request.url = request.urlList[request.urlList.length - 1]
 
-      // 8. Set request’s URL list to « request’s URL ».
+      // 8. Set request's URL list to « request's URL ».
       request.urlList = [request.url]
     }
 
@@ -219,7 +219,7 @@ class Request {
       // 1. Let referrer be init["referrer"].
       const referrer = init.referrer
 
-      // 2. If referrer is the empty string, then set request’s referrer to "no-referrer".
+      // 2. If referrer is the empty string, then set request's referrer to "no-referrer".
       if (referrer === '') {
         request.referrer = 'no-referrer'
       } else {
@@ -234,22 +234,22 @@ class Request {
         }
 
         // 3. If one of the following is true
-        // - parsedReferrer’s scheme is "about" and path is the string "client"
-        // - parsedReferrer’s origin is not same origin with origin
-        // then set request’s referrer to "client".
+        // - parsedReferrer's scheme is "about" and path is the string "client"
+        // - parsedReferrer's origin is not same origin with origin
+        // then set request's referrer to "client".
         if (
           (parsedReferrer.protocol === 'about:' && parsedReferrer.hostname === 'client') ||
           (origin && !sameOrigin(parsedReferrer, this[kRealm].settingsObject.baseUrl))
         ) {
           request.referrer = 'client'
         } else {
-          // 4. Otherwise, set request’s referrer to parsedReferrer.
+          // 4. Otherwise, set request's referrer to parsedReferrer.
           request.referrer = parsedReferrer
         }
       }
     }
 
-    // 15. If init["referrerPolicy"] exists, then set request’s referrer policy
+    // 15. If init["referrerPolicy"] exists, then set request's referrer policy
     // to it.
     if (init.referrerPolicy !== undefined) {
       request.referrerPolicy = init.referrerPolicy
@@ -271,23 +271,23 @@ class Request {
       })
     }
 
-    // 18. If mode is non-null, set request’s mode to mode.
+    // 18. If mode is non-null, set request's mode to mode.
     if (mode != null) {
       request.mode = mode
     }
 
-    // 19. If init["credentials"] exists, then set request’s credentials mode
+    // 19. If init["credentials"] exists, then set request's credentials mode
     // to it.
     if (init.credentials !== undefined) {
       request.credentials = init.credentials
     }
 
-    // 18. If init["cache"] exists, then set request’s cache mode to it.
+    // 18. If init["cache"] exists, then set request's cache mode to it.
     if (init.cache !== undefined) {
       request.cache = init.cache
     }
 
-    // 21. If request’s cache mode is "only-if-cached" and request’s mode is
+    // 21. If request's cache mode is "only-if-cached" and request's mode is
     // not "same-origin", then throw a TypeError.
     if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
       throw new TypeError(
@@ -295,17 +295,17 @@ class Request {
       )
     }
 
-    // 22. If init["redirect"] exists, then set request’s redirect mode to it.
+    // 22. If init["redirect"] exists, then set request's redirect mode to it.
     if (init.redirect !== undefined) {
       request.redirect = init.redirect
     }
 
-    // 23. If init["integrity"] exists, then set request’s integrity metadata to it.
+    // 23. If init["integrity"] exists, then set request's integrity metadata to it.
     if (init.integrity != null) {
       request.integrity = String(init.integrity)
     }
 
-    // 24. If init["keepalive"] exists, then set request’s keepalive to it.
+    // 24. If init["keepalive"] exists, then set request's keepalive to it.
     if (init.keepalive !== undefined) {
       request.keepalive = Boolean(init.keepalive)
     }
@@ -334,7 +334,7 @@ class Request {
         // 3. Normalize method.
         method = normalizeMethod(method)
 
-        // 4. Set request’s method to method.
+        // 4. Set request's method to method.
         request.method = method
       }
 
@@ -352,10 +352,10 @@ class Request {
       signal = init.signal
     }
 
-    // 27. Set this’s request to request.
+    // 27. Set this's request to request.
     this[kState] = request
 
-    // 28. Set this’s signal to a new AbortSignal object with this’s relevant
+    // 28. Set this's signal to a new AbortSignal object with this's relevant
     // Realm.
     // TODO: could this be simplified with AbortSignal.any
     // (https://dom.spec.whatwg.org/#dom-abortsignal-any)
@@ -363,7 +363,7 @@ class Request {
     this[kSignal] = ac.signal
     this[kSignal][kRealm] = this[kRealm]
 
-    // 29. If signal is not null, then make this’s signal follow signal.
+    // 29. If signal is not null, then make this's signal follow signal.
     if (signal != null) {
       if (
         !signal ||
@@ -425,17 +425,17 @@ class Request {
       }
     }
 
-    // 30. Set this’s headers to a new Headers object with this’s relevant
-    // Realm, whose header list is request’s header list and guard is
+    // 30. Set this's headers to a new Headers object with this's relevant
+    // Realm, whose header list is request's header list and guard is
     // "request".
     this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kGuard] = 'request'
     this[kHeaders][kRealm] = this[kRealm]
 
-    // 31. If this’s request’s mode is "no-cors", then:
+    // 31. If this's request's mode is "no-cors", then:
     if (mode === 'no-cors') {
-      // 1. If this’s request’s method is not a CORS-safelisted method,
+      // 1. If this's request's method is not a CORS-safelisted method,
       // then throw a TypeError.
       if (!corsSafeListedMethodsSet.has(request.method)) {
         throw new TypeError(
@@ -443,7 +443,7 @@ class Request {
         )
       }
 
-      // 2. Set this’s headers’s guard to "request-no-cors".
+      // 2. Set this's headers's guard to "request-no-cors".
       this[kHeaders][kGuard] = 'request-no-cors'
     }
 
@@ -451,16 +451,16 @@ class Request {
     if (initHasKey) {
       /** @type {HeadersList} */
       const headersList = this[kHeaders][kHeadersList]
-      // 1. Let headers be a copy of this’s headers and its associated header
+      // 1. Let headers be a copy of this's headers and its associated header
       // list.
       // 2. If init["headers"] exists, then set headers to init["headers"].
       const headers = init.headers !== undefined ? init.headers : new HeadersList(headersList)
 
-      // 3. Empty this’s headers’s header list.
+      // 3. Empty this's headers's header list.
       headersList.clear()
 
       // 4. If headers is a Headers object, then for each header in its header
-      // list, append header’s name/header’s value to this’s headers.
+      // list, append header's name/header's value to this's headers.
       if (headers instanceof HeadersList) {
         for (const [key, val] of headers) {
           headersList.append(key, val)
@@ -468,17 +468,17 @@ class Request {
         // Note: Copy the `set-cookie` meta-data.
         headersList.cookies = headers.cookies
       } else {
-        // 5. Otherwise, fill this’s headers with headers.
+        // 5. Otherwise, fill this's headers with headers.
         fillHeaders(this[kHeaders], headers)
       }
     }
 
-    // 33. Let inputBody be input’s request’s body if input is a Request
+    // 33. Let inputBody be input's request's body if input is a Request
     // object; otherwise null.
     const inputBody = input instanceof Request ? input[kState].body : null
 
     // 34. If either init["body"] exists and is non-null or inputBody is
-    // non-null, and request’s method is `GET` or `HEAD`, then throw a
+    // non-null, and request's method is `GET` or `HEAD`, then throw a
     // TypeError.
     if (
       (init.body != null || inputBody != null) &&
@@ -494,16 +494,16 @@ class Request {
     if (init.body != null) {
       // 1. Let Content-Type be null.
       // 2. Set initBody and Content-Type to the result of extracting
-      // init["body"], with keepalive set to request’s keepalive.
+      // init["body"], with keepalive set to request's keepalive.
       const [extractedBody, contentType] = extractBody(
         init.body,
         request.keepalive
       )
       initBody = extractedBody
 
-      // 3, If Content-Type is non-null and this’s headers’s header list does
+      // 3, If Content-Type is non-null and this's headers's header list does
       // not contain `Content-Type`, then append `Content-Type`/Content-Type to
-      // this’s headers.
+      // this's headers.
       if (contentType && !this[kHeaders][kHeadersList].contains('content-type', true)) {
         this[kHeaders].append('content-type', contentType)
       }
@@ -513,7 +513,7 @@ class Request {
     // inputBody.
     const inputOrInitBody = initBody ?? inputBody
 
-    // 38. If inputOrInitBody is non-null and inputOrInitBody’s source is
+    // 38. If inputOrInitBody is non-null and inputOrInitBody's source is
     // null, then:
     if (inputOrInitBody != null && inputOrInitBody.source == null) {
       // 1. If initBody is non-null and init["duplex"] does not exist,
@@ -522,7 +522,7 @@ class Request {
         throw new TypeError('RequestInit: duplex option is required when sending a body.')
       }
 
-      // 2. If this’s request’s mode is neither "same-origin" nor "cors",
+      // 2. If this's request's mode is neither "same-origin" nor "cors",
       // then throw a TypeError.
       if (request.mode !== 'same-origin' && request.mode !== 'cors') {
         throw new TypeError(
@@ -530,7 +530,7 @@ class Request {
         )
       }
 
-      // 3. Set this’s request’s use-CORS-preflight flag.
+      // 3. Set this's request's use-CORS-preflight flag.
       request.useCORSPreflightFlag = true
     }
 
@@ -557,15 +557,15 @@ class Request {
       }
     }
 
-    // 41. Set this’s request’s body to finalBody.
+    // 41. Set this's request's body to finalBody.
     this[kState].body = finalBody
   }
 
-  // Returns request’s HTTP method, which is "GET" by default.
+  // Returns request's HTTP method, which is "GET" by default.
   get method () {
     webidl.brandCheck(this, Request)
 
-    // The method getter steps are to return this’s request’s method.
+    // The method getter steps are to return this's request's method.
     return this[kState].method
   }
 
@@ -573,7 +573,7 @@ class Request {
   get url () {
     webidl.brandCheck(this, Request)
 
-    // The url getter steps are to return this’s request’s URL, serialized.
+    // The url getter steps are to return this's request's URL, serialized.
     return URLSerializer(this[kState].url)
   }
 
@@ -583,7 +583,7 @@ class Request {
   get headers () {
     webidl.brandCheck(this, Request)
 
-    // The headers getter steps are to return this’s headers.
+    // The headers getter steps are to return this's headers.
     return this[kHeaders]
   }
 
@@ -592,41 +592,41 @@ class Request {
   get destination () {
     webidl.brandCheck(this, Request)
 
-    // The destination getter are to return this’s request’s destination.
+    // The destination getter are to return this's request's destination.
     return this[kState].destination
   }
 
   // Returns the referrer of request. Its value can be a same-origin URL if
   // explicitly set in init, the empty string to indicate no referrer, and
-  // "about:client" when defaulting to the global’s default. This is used
+  // "about:client" when defaulting to the global's default. This is used
   // during fetching to determine the value of the `Referer` header of the
   // request being made.
   get referrer () {
     webidl.brandCheck(this, Request)
 
-    // 1. If this’s request’s referrer is "no-referrer", then return the
+    // 1. If this's request's referrer is "no-referrer", then return the
     // empty string.
     if (this[kState].referrer === 'no-referrer') {
       return ''
     }
 
-    // 2. If this’s request’s referrer is "client", then return
+    // 2. If this's request's referrer is "client", then return
     // "about:client".
     if (this[kState].referrer === 'client') {
       return 'about:client'
     }
 
-    // Return this’s request’s referrer, serialized.
+    // Return this's request's referrer, serialized.
     return this[kState].referrer.toString()
   }
 
   // Returns the referrer policy associated with request.
-  // This is used during fetching to compute the value of the request’s
+  // This is used during fetching to compute the value of the request's
   // referrer.
   get referrerPolicy () {
     webidl.brandCheck(this, Request)
 
-    // The referrerPolicy getter steps are to return this’s request’s referrer policy.
+    // The referrerPolicy getter steps are to return this's request's referrer policy.
     return this[kState].referrerPolicy
   }
 
@@ -636,7 +636,7 @@ class Request {
   get mode () {
     webidl.brandCheck(this, Request)
 
-    // The mode getter steps are to return this’s request’s mode.
+    // The mode getter steps are to return this's request's mode.
     return this[kState].mode
   }
 
@@ -644,17 +644,17 @@ class Request {
   // which is a string indicating whether credentials will be sent with the
   // request always, never, or only when sent to a same-origin URL.
   get credentials () {
-    // The credentials getter steps are to return this’s request’s credentials mode.
+    // The credentials getter steps are to return this's request's credentials mode.
     return this[kState].credentials
   }
 
   // Returns the cache mode associated with request,
   // which is a string indicating how the request will
-  // interact with the browser’s cache when fetching.
+  // interact with the browser's cache when fetching.
   get cache () {
     webidl.brandCheck(this, Request)
 
-    // The cache getter steps are to return this’s request’s cache mode.
+    // The cache getter steps are to return this's request's cache mode.
     return this[kState].cache
   }
 
@@ -665,17 +665,17 @@ class Request {
   get redirect () {
     webidl.brandCheck(this, Request)
 
-    // The redirect getter steps are to return this’s request’s redirect mode.
+    // The redirect getter steps are to return this's request's redirect mode.
     return this[kState].redirect
   }
 
-  // Returns request’s subresource integrity metadata, which is a
+  // Returns request's subresource integrity metadata, which is a
   // cryptographic hash of the resource being fetched. Its value
   // consists of multiple hashes separated by whitespace. [SRI]
   get integrity () {
     webidl.brandCheck(this, Request)
 
-    // The integrity getter steps are to return this’s request’s integrity
+    // The integrity getter steps are to return this's request's integrity
     // metadata.
     return this[kState].integrity
   }
@@ -685,7 +685,7 @@ class Request {
   get keepalive () {
     webidl.brandCheck(this, Request)
 
-    // The keepalive getter steps are to return this’s request’s keepalive.
+    // The keepalive getter steps are to return this's request's keepalive.
     return this[kState].keepalive
   }
 
@@ -694,8 +694,8 @@ class Request {
   get isReloadNavigation () {
     webidl.brandCheck(this, Request)
 
-    // The isReloadNavigation getter steps are to return true if this’s
-    // request’s reload-navigation flag is set; otherwise false.
+    // The isReloadNavigation getter steps are to return true if this's
+    // request's reload-navigation flag is set; otherwise false.
     return this[kState].reloadNavigation
   }
 
@@ -704,7 +704,7 @@ class Request {
   get isHistoryNavigation () {
     webidl.brandCheck(this, Request)
 
-    // The isHistoryNavigation getter steps are to return true if this’s request’s
+    // The isHistoryNavigation getter steps are to return true if this's request's
     // history-navigation flag is set; otherwise false.
     return this[kState].historyNavigation
   }
@@ -715,7 +715,7 @@ class Request {
   get signal () {
     webidl.brandCheck(this, Request)
 
-    // The signal getter steps are to return this’s signal.
+    // The signal getter steps are to return this's signal.
     return this[kSignal]
   }
 
@@ -746,12 +746,12 @@ class Request {
       throw new TypeError('unusable')
     }
 
-    // 2. Let clonedRequest be the result of cloning this’s request.
+    // 2. Let clonedRequest be the result of cloning this's request.
     const clonedRequest = cloneRequest(this[kState])
 
     // 3. Let clonedRequestObject be the result of creating a Request object,
-    // given clonedRequest, this’s headers’s guard, and this’s relevant Realm.
-    // 4. Make clonedRequestObject’s signal follow this’s signal.
+    // given clonedRequest, this's headers's guard, and this's relevant Realm.
+    // 4. Make clonedRequestObject's signal follow this's signal.
     const ac = new AbortController()
     if (this.signal.aborted) {
       ac.abort(this.signal.reason)
@@ -825,8 +825,8 @@ function cloneRequest (request) {
   // 1. Let newRequest be a copy of request, except for its body.
   const newRequest = makeRequest({ ...request, body: null })
 
-  // 2. If request’s body is non-null, set newRequest’s body to the
-  // result of cloning request’s body.
+  // 2. If request's body is non-null, set newRequest's body to the
+  // result of cloning request's body.
   if (request.body != null) {
     newRequest.body = cloneBody(request.body)
   }

--- a/lib/fetch/response.js
+++ b/lib/fetch/response.js
@@ -36,7 +36,7 @@ class Response {
     const relevantRealm = { settingsObject: {} }
 
     // The static error() method steps are to return the result of creating a
-    // Response object, given a new network error, "immutable", and this’s
+    // Response object, given a new network error, "immutable", and this's
     // relevant Realm.
     const responseObject = fromInnerResponse(makeNetworkError(), 'immutable', relevantRealm)
 
@@ -60,7 +60,7 @@ class Response {
     const body = extractBody(bytes)
 
     // 3. Let responseObject be the result of creating a Response object, given a new response,
-    //    "response", and this’s relevant Realm.
+    //    "response", and this's relevant Realm.
     const relevantRealm = { settingsObject: {} }
     const responseObject = fromInnerResponse(makeResponse({}), 'response', relevantRealm)
 
@@ -81,7 +81,7 @@ class Response {
     status = webidl.converters['unsigned short'](status)
 
     // 1. Let parsedURL be the result of parsing url with current settings
-    // object’s API base URL.
+    // object's API base URL.
     // 2. If parsedURL is failure, then throw a TypeError.
     // TODO: base-URL?
     let parsedURL
@@ -99,16 +99,16 @@ class Response {
     }
 
     // 4. Let responseObject be the result of creating a Response object,
-    // given a new response, "immutable", and this’s relevant Realm.
+    // given a new response, "immutable", and this's relevant Realm.
     const responseObject = fromInnerResponse(makeResponse({}), 'immutable', relevantRealm)
 
-    // 5. Set responseObject’s response’s status to status.
+    // 5. Set responseObject's response's status to status.
     responseObject[kState].status = status
 
     // 6. Let value be parsedURL, serialized and isomorphic encoded.
     const value = isomorphicEncode(URLSerializer(parsedURL))
 
-    // 7. Append `Location`/value to responseObject’s response’s header list.
+    // 7. Append `Location`/value to responseObject's response's header list.
     responseObject[kState].headersList.append('location', value, true)
 
     // 8. Return responseObject.
@@ -130,11 +130,11 @@ class Response {
     // TODO
     this[kRealm] = { settingsObject: {} }
 
-    // 1. Set this’s response to a new response.
+    // 1. Set this's response to a new response.
     this[kState] = makeResponse({})
 
-    // 2. Set this’s headers to a new Headers object with this’s relevant
-    // Realm, whose header list is this’s response’s header list and guard
+    // 2. Set this's headers to a new Headers object with this's relevant
+    // Realm, whose header list is this's response's header list and guard
     // is "response".
     this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kGuard] = 'response'
@@ -154,22 +154,22 @@ class Response {
     initializeResponse(this, init, bodyWithType)
   }
 
-  // Returns response’s type, e.g., "cors".
+  // Returns response's type, e.g., "cors".
   get type () {
     webidl.brandCheck(this, Response)
 
-    // The type getter steps are to return this’s response’s type.
+    // The type getter steps are to return this's response's type.
     return this[kState].type
   }
 
-  // Returns response’s URL, if it has one; otherwise the empty string.
+  // Returns response's URL, if it has one; otherwise the empty string.
   get url () {
     webidl.brandCheck(this, Response)
 
     const urlList = this[kState].urlList
 
-    // The url getter steps are to return the empty string if this’s
-    // response’s URL is null; otherwise this’s response’s URL,
+    // The url getter steps are to return the empty string if this's
+    // response's URL is null; otherwise this's response's URL,
     // serialized with exclude fragment set to true.
     const url = urlList[urlList.length - 1] ?? null
 
@@ -184,42 +184,42 @@ class Response {
   get redirected () {
     webidl.brandCheck(this, Response)
 
-    // The redirected getter steps are to return true if this’s response’s URL
+    // The redirected getter steps are to return true if this's response's URL
     // list has more than one item; otherwise false.
     return this[kState].urlList.length > 1
   }
 
-  // Returns response’s status.
+  // Returns response's status.
   get status () {
     webidl.brandCheck(this, Response)
 
-    // The status getter steps are to return this’s response’s status.
+    // The status getter steps are to return this's response's status.
     return this[kState].status
   }
 
-  // Returns whether response’s status is an ok status.
+  // Returns whether response's status is an ok status.
   get ok () {
     webidl.brandCheck(this, Response)
 
-    // The ok getter steps are to return true if this’s response’s status is an
+    // The ok getter steps are to return true if this's response's status is an
     // ok status; otherwise false.
     return this[kState].status >= 200 && this[kState].status <= 299
   }
 
-  // Returns response’s status message.
+  // Returns response's status message.
   get statusText () {
     webidl.brandCheck(this, Response)
 
-    // The statusText getter steps are to return this’s response’s status
+    // The statusText getter steps are to return this's response's status
     // message.
     return this[kState].statusText
   }
 
-  // Returns response’s headers as Headers.
+  // Returns response's headers as Headers.
   get headers () {
     webidl.brandCheck(this, Response)
 
-    // The headers getter steps are to return this’s headers.
+    // The headers getter steps are to return this's headers.
     return this[kHeaders]
   }
 
@@ -247,11 +247,11 @@ class Response {
       })
     }
 
-    // 2. Let clonedResponse be the result of cloning this’s response.
+    // 2. Let clonedResponse be the result of cloning this's response.
     const clonedResponse = cloneResponse(this[kState])
 
     // 3. Return the result of creating a Response object, given
-    // clonedResponse, this’s headers’s guard, and this’s relevant Realm.
+    // clonedResponse, this's headers's guard, and this's relevant Realm.
     return fromInnerResponse(clonedResponse, this[kHeaders][kGuard], this[kRealm])
   }
 }
@@ -286,7 +286,7 @@ function cloneResponse (response) {
   // To clone a response response, run these steps:
 
   // 1. If response is a filtered response, then return a new identical
-  // filtered response whose internal response is a clone of response’s
+  // filtered response whose internal response is a clone of response's
   // internal response.
   if (response.internalResponse) {
     return filterResponse(
@@ -298,8 +298,8 @@ function cloneResponse (response) {
   // 2. Let newResponse be a copy of response, except for its body.
   const newResponse = makeResponse({ ...response, body: null })
 
-  // 3. If response’s body is non-null, then set newResponse’s body to the
-  // result of cloning response’s body.
+  // 3. If response's body is non-null, then set newResponse's body to the
+  // result of cloning response's body.
   if (response.body != null) {
     newResponse.body = cloneBody(response.body)
   }
@@ -370,10 +370,10 @@ function makeFilteredResponse (response, state) {
 // https://fetch.spec.whatwg.org/#concept-filtered-response
 function filterResponse (response, type) {
   // Set response to the following filtered response with response as its
-  // internal response, depending on request’s response tainting:
+  // internal response, depending on request's response tainting:
   if (type === 'basic') {
     // A basic filtered response is a filtered response whose type is "basic"
-    // and header list excludes any headers in internal response’s header list
+    // and header list excludes any headers in internal response's header list
     // whose name is a forbidden response-header name.
 
     // Note: undici does not implement forbidden response-header names
@@ -383,9 +383,9 @@ function filterResponse (response, type) {
     })
   } else if (type === 'cors') {
     // A CORS filtered response is a filtered response whose type is "cors"
-    // and header list excludes any headers in internal response’s header
+    // and header list excludes any headers in internal response's header
     // list whose name is not a CORS-safelisted response-header name, given
-    // internal response’s CORS-exposed header-name list.
+    // internal response's CORS-exposed header-name list.
 
     // Note: undici does not implement CORS-safelisted response-header names
     return makeFilteredResponse(response, {
@@ -451,17 +451,17 @@ function initializeResponse (response, init, body) {
     }
   }
 
-  // 3. Set response’s response’s status to init["status"].
+  // 3. Set response's response's status to init["status"].
   if ('status' in init && init.status != null) {
     response[kState].status = init.status
   }
 
-  // 4. Set response’s response’s status message to init["statusText"].
+  // 4. Set response's response's status message to init["statusText"].
   if ('statusText' in init && init.statusText != null) {
     response[kState].statusText = init.statusText
   }
 
-  // 5. If init["headers"] exists, then fill response’s headers with init["headers"].
+  // 5. If init["headers"] exists, then fill response's headers with init["headers"].
   if ('headers' in init && init.headers != null) {
     fill(response[kHeaders], init.headers)
   }

--- a/lib/fetch/util.js
+++ b/lib/fetch/util.js
@@ -22,7 +22,7 @@ try {
 function responseURL (response) {
   // https://fetch.spec.whatwg.org/#responses
   // A response has an associated URL. It is a pointer to the last URL
-  // in response’s URL list and null if response’s URL list is empty.
+  // in response's URL list and null if response's URL list is empty.
   const urlList = response.urlList
   const length = urlList.length
   return length === 0 ? null : urlList[length - 1].toString()
@@ -30,22 +30,22 @@ function responseURL (response) {
 
 // https://fetch.spec.whatwg.org/#concept-response-location-url
 function responseLocationURL (response, requestFragment) {
-  // 1. If response’s status is not a redirect status, then return null.
+  // 1. If response's status is not a redirect status, then return null.
   if (!redirectStatusSet.has(response.status)) {
     return null
   }
 
   // 2. Let location be the result of extracting header list values given
-  // `Location` and response’s header list.
+  // `Location` and response's header list.
   let location = response.headersList.get('location', true)
 
   // 3. If location is a header value, then set location to the result of
-  //    parsing location with response’s URL.
+  //    parsing location with response's URL.
   if (location !== null && isValidHeaderValue(location)) {
     location = new URL(location, responseURL(response))
   }
 
-  // 4. If location is a URL whose fragment is null, then set location’s
+  // 4. If location is a URL whose fragment is null, then set location's
   // fragment to requestFragment.
   if (location && !location.hash) {
     location.hash = requestFragment
@@ -61,10 +61,10 @@ function requestCurrentURL (request) {
 }
 
 function requestBadPort (request) {
-  // 1. Let url be request’s current URL.
+  // 1. Let url be request's current URL.
   const url = requestCurrentURL(request)
 
-  // 2. If url’s scheme is an HTTP(S) scheme and url’s port is a bad port,
+  // 2. If url's scheme is an HTTP(S) scheme and url's port is a bad port,
   // then return blocked.
   if (urlIsHttpHttpsScheme(url) && badPortsSet.has(url.port)) {
     return 'blocked'
@@ -143,14 +143,14 @@ function isValidHeaderValue (potentialValue) {
 // https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect
 function setRequestReferrerPolicyOnRedirect (request, actualResponse) {
   //  Given a request request and a response actualResponse, this algorithm
-  //  updates request’s referrer policy according to the Referrer-Policy
+  //  updates request's referrer policy according to the Referrer-Policy
   //  header (if any) in actualResponse.
 
   // 1. Let policy be the result of executing § 8.1 Parse a referrer policy
   // from a Referrer-Policy header on actualResponse.
 
   // 8.1 Parse a referrer policy from a Referrer-Policy header
-  // 1. Let policy-tokens be the result of extracting header list values given `Referrer-Policy` and response’s header list.
+  // 1. Let policy-tokens be the result of extracting header list values given `Referrer-Policy` and response's header list.
   const { headersList } = actualResponse
   // 2. Let policy be the empty string.
   // 3. For each token in policy-tokens, if token is a referrer policy and token is not the empty string, then set policy to token.
@@ -174,7 +174,7 @@ function setRequestReferrerPolicyOnRedirect (request, actualResponse) {
     }
   }
 
-  // 2. If policy is not the empty string, then set request’s referrer policy to policy.
+  // 2. If policy is not the empty string, then set request's referrer policy to policy.
   if (policy !== '') {
     request.referrerPolicy = policy
   }
@@ -204,16 +204,16 @@ function appendFetchMetadata (httpRequest) {
 
   //  https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-mode-header
 
-  //  1. Assert: r’s url is a potentially trustworthy URL.
+  //  1. Assert: r's url is a potentially trustworthy URL.
   //  TODO
 
   //  2. Let header be a Structured Header whose value is a token.
   let header = null
 
-  //  3. Set header’s value to r’s mode.
+  //  3. Set header's value to r's mode.
   header = httpRequest.mode
 
-  //  4. Set a structured field value `Sec-Fetch-Mode`/header in r’s header list.
+  //  4. Set a structured field value `Sec-Fetch-Mode`/header in r's header list.
   httpRequest.headersList.set('sec-fetch-mode', header, true)
 
   //  https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header
@@ -228,15 +228,15 @@ function appendRequestOriginHeader (request) {
   // 1. Let serializedOrigin be the result of byte-serializing a request origin with request.
   let serializedOrigin = request.origin
 
-  // 2. If request’s response tainting is "cors" or request’s mode is "websocket", then append (`Origin`, serializedOrigin) to request’s header list.
+  // 2. If request's response tainting is "cors" or request's mode is "websocket", then append (`Origin`, serializedOrigin) to request's header list.
   if (request.responseTainting === 'cors' || request.mode === 'websocket') {
     if (serializedOrigin) {
       request.headersList.append('origin', serializedOrigin, true)
     }
 
-  // 3. Otherwise, if request’s method is neither `GET` nor `HEAD`, then:
+  // 3. Otherwise, if request's method is neither `GET` nor `HEAD`, then:
   } else if (request.method !== 'GET' && request.method !== 'HEAD') {
-    // 1. Switch on request’s referrer policy:
+    // 1. Switch on request's referrer policy:
     switch (request.referrerPolicy) {
       case 'no-referrer':
         // Set serializedOrigin to `null`.
@@ -245,13 +245,13 @@ function appendRequestOriginHeader (request) {
       case 'no-referrer-when-downgrade':
       case 'strict-origin':
       case 'strict-origin-when-cross-origin':
-        // If request’s origin is a tuple origin, its scheme is "https", and request’s current URL’s scheme is not "https", then set serializedOrigin to `null`.
+        // If request's origin is a tuple origin, its scheme is "https", and request's current URL's scheme is not "https", then set serializedOrigin to `null`.
         if (request.origin && urlHasHttpsScheme(request.origin) && !urlHasHttpsScheme(requestCurrentURL(request))) {
           serializedOrigin = null
         }
         break
       case 'same-origin':
-        // If request’s origin is not same origin with request’s current URL’s origin, then set serializedOrigin to `null`.
+        // If request's origin is not same origin with request's current URL's origin, then set serializedOrigin to `null`.
         if (!sameOrigin(request, requestCurrentURL(request))) {
           serializedOrigin = null
         }
@@ -261,7 +261,7 @@ function appendRequestOriginHeader (request) {
     }
 
     if (serializedOrigin) {
-      // 2. Append (`Origin`, serializedOrigin) to request’s header list.
+      // 2. Append (`Origin`, serializedOrigin) to request's header list.
       request.headersList.append('origin', serializedOrigin, true)
     }
   }
@@ -341,11 +341,11 @@ function determineRequestsReferrer (request) {
   // Note: policy cannot (shouldn't) be null or an empty string.
   assert(policy)
 
-  // 2. Let environment be request’s client.
+  // 2. Let environment be request's client.
 
   let referrerSource = null
 
-  // 3. Switch on request’s referrer:
+  // 3. Switch on request's referrer:
   if (request.referrer === 'client') {
     // Note: node isn't a browser and doesn't implement document/iframes,
     // so we bypass this step and replace it with our own.
@@ -359,11 +359,11 @@ function determineRequestsReferrer (request) {
     // note: we need to clone it as it's mutated
     referrerSource = new URL(globalOrigin)
   } else if (request.referrer instanceof URL) {
-    // Let referrerSource be request’s referrer.
+    // Let referrerSource be request's referrer.
     referrerSource = request.referrer
   }
 
-  // 4. Let request’s referrerURL be the result of stripping referrerSource for
+  // 4. Let request's referrerURL be the result of stripping referrerSource for
   //    use as a referrer.
   let referrerURL = stripURLForReferrer(referrerSource)
 
@@ -392,13 +392,13 @@ function determineRequestsReferrer (request) {
     case 'strict-origin-when-cross-origin': {
       const currentURL = requestCurrentURL(request)
 
-      // 1. If the origin of referrerURL and the origin of request’s current
+      // 1. If the origin of referrerURL and the origin of request's current
       //    URL are the same, then return referrerURL.
       if (sameOrigin(referrerURL, currentURL)) {
         return referrerURL
       }
 
-      // 2. If referrerURL is a potentially trustworthy URL and request’s
+      // 2. If referrerURL is a potentially trustworthy URL and request's
       //    current URL is not a potentially trustworthy URL, then return no
       //    referrer.
       if (isURLPotentiallyTrustworthy(referrerURL) && !isURLPotentiallyTrustworthy(currentURL)) {
@@ -411,14 +411,14 @@ function determineRequestsReferrer (request) {
     case 'strict-origin': // eslint-disable-line
       /**
          * 1. If referrerURL is a potentially trustworthy URL and
-         * request’s current URL is not a potentially trustworthy URL,
+         * request's current URL is not a potentially trustworthy URL,
          * then return no referrer.
          * 2. Return referrerOrigin
         */
     case 'no-referrer-when-downgrade': // eslint-disable-line
       /**
        * 1. If referrerURL is a potentially trustworthy URL and
-       * request’s current URL is not a potentially trustworthy URL,
+       * request's current URL is not a potentially trustworthy URL,
        * then return no referrer.
        * 2. Return referrerOrigin
       */
@@ -437,26 +437,26 @@ function stripURLForReferrer (url, originOnly) {
   // 1. Assert: url is a URL.
   assert(url instanceof URL)
 
-  // 2. If url’s scheme is a local scheme, then return no referrer.
+  // 2. If url's scheme is a local scheme, then return no referrer.
   if (url.protocol === 'file:' || url.protocol === 'about:' || url.protocol === 'blank:') {
     return 'no-referrer'
   }
 
-  // 3. Set url’s username to the empty string.
+  // 3. Set url's username to the empty string.
   url.username = ''
 
-  // 4. Set url’s password to the empty string.
+  // 4. Set url's password to the empty string.
   url.password = ''
 
-  // 5. Set url’s fragment to null.
+  // 5. Set url's fragment to null.
   url.hash = ''
 
   // 6. If the origin-only flag is true, then:
   if (originOnly) {
-    // 1. Set url’s path to « the empty string ».
+    // 1. Set url's path to « the empty string ».
     url.pathname = ''
 
-    // 2. Set url’s query to null.
+    // 2. Set url's query to null.
     url.search = ''
   }
 
@@ -768,9 +768,9 @@ function makeIterator (iterator, name, kind) {
         )
       }
 
-      // 6. Let index be object’s index.
-      // 7. Let kind be object’s kind.
-      // 8. Let values be object’s target's value pairs to iterate over.
+      // 6. Let index be object's index.
+      // 7. Let kind be object's kind.
+      // 8. Let values be object's target's value pairs to iterate over.
       const { index, kind, target } = object
       const values = target()
 
@@ -786,7 +786,7 @@ function makeIterator (iterator, name, kind) {
       // 11. Let pair be the entry in values at index index.
       const pair = values[index]
 
-      // 12. Set object’s index to index + 1.
+      // 12. Set object's index to index + 1.
       object.index = index + 1
 
       // 13. Return the iterator result for pair and kind.
@@ -811,7 +811,7 @@ function iteratorResult (pair, kind) {
   // 1. Let result be a value determined by the value of kind:
   switch (kind) {
     case 'key': {
-      // 1. Let idlKey be pair’s key.
+      // 1. Let idlKey be pair's key.
       // 2. Let key be the result of converting idlKey to an
       //    ECMAScript value.
       // 3. result is key.
@@ -819,7 +819,7 @@ function iteratorResult (pair, kind) {
       break
     }
     case 'value': {
-      // 1. Let idlValue be pair’s value.
+      // 1. Let idlValue be pair's value.
       // 2. Let value be the result of converting idlValue to
       //    an ECMAScript value.
       // 3. result is value.
@@ -827,8 +827,8 @@ function iteratorResult (pair, kind) {
       break
     }
     case 'key+value': {
-      // 1. Let idlKey be pair’s key.
-      // 2. Let idlValue be pair’s value.
+      // 1. Let idlKey be pair's key.
+      // 2. Let idlValue be pair's value.
       // 3. Let key be the result of converting idlKey to an
       //    ECMAScript value.
       // 4. Let value be the result of converting idlValue to
@@ -861,7 +861,7 @@ async function fullyReadBody (body, processBody, processBodyError) {
   //    with taskDestination.
   const errorSteps = processBodyError
 
-  // 4. Let reader be the result of getting a reader for body’s stream.
+  // 4. Let reader be the result of getting a reader for body's stream.
   //    If that threw an exception, then run errorSteps with that
   //    exception and return.
   let reader
@@ -895,8 +895,8 @@ function isReadableStreamLike (stream) {
  */
 function isomorphicDecode (input) {
   // 1. To isomorphic decode a byte sequence input, return a string whose code point
-  //    length is equal to input’s length and whose code points have the same values
-  //    as the values of input’s bytes, in the same order.
+  //    length is equal to input's length and whose code points have the same values
+  //    as the values of input's bytes, in the same order.
   const length = input.length
   if ((2 << 15) - 1 > length) {
     return String.fromCharCode.apply(null, input)
@@ -937,9 +937,9 @@ function isomorphicEncode (input) {
     assert(input.charCodeAt(i) <= 0xFF)
   }
 
-  // 2. Return a byte sequence whose length is equal to input’s code
+  // 2. Return a byte sequence whose length is equal to input's code
   //    point length and whose bytes have the same values as the
-  //    values of input’s code points, in the same order
+  //    values of input's code points, in the same order
   return input
 }
 

--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -544,7 +544,7 @@ webidl.converters.TypedArray = function (V, T, opts = {}) {
 
   // 2. If Type(V) is not Object, or V does not have a
   //    [[TypedArrayName]] internal slot with a value
-  //    equal to T’s name, then throw a TypeError.
+  //    equal to T's name, then throw a TypeError.
   if (
     webidl.util.Type(V) !== 'Object' ||
     !types.isTypedArray(V) ||

--- a/lib/fileapi/filereader.js
+++ b/lib/fileapi/filereader.js
@@ -157,7 +157,7 @@ class FileReader extends EventTarget {
   get result () {
     webidl.brandCheck(this, FileReader)
 
-    // The result attribute’s getter, when invoked, must return
+    // The result attribute's getter, when invoked, must return
     // this's result.
     return this[kResult]
   }
@@ -168,7 +168,7 @@ class FileReader extends EventTarget {
   get error () {
     webidl.brandCheck(this, FileReader)
 
-    // The error attribute’s getter, when invoked, must return
+    // The error attribute's getter, when invoked, must return
     // this's error.
     return this[kError]
   }

--- a/lib/fileapi/util.js
+++ b/lib/fileapi/util.js
@@ -29,19 +29,19 @@ const staticPropertyDescriptors = {
  * @param {string?} encodingName
  */
 function readOperation (fr, blob, type, encodingName) {
-  // 1. If fr’s state is "loading", throw an InvalidStateError
+  // 1. If fr's state is "loading", throw an InvalidStateError
   //    DOMException.
   if (fr[kState] === 'loading') {
     throw new DOMException('Invalid state', 'InvalidStateError')
   }
 
-  // 2. Set fr’s state to "loading".
+  // 2. Set fr's state to "loading".
   fr[kState] = 'loading'
 
-  // 3. Set fr’s result to null.
+  // 3. Set fr's result to null.
   fr[kResult] = null
 
-  // 4. Set fr’s error to null.
+  // 4. Set fr's error to null.
   fr[kError] = null
 
   // 5. Let stream be the result of calling get stream on blob.
@@ -119,11 +119,11 @@ function readOperation (fr, blob, type, encodingName) {
           //    object whose done property is true, queue a task
           //    to run the following steps and abort this algorithm:
           queueMicrotask(() => {
-            // 1. Set fr’s state to "done".
+            // 1. Set fr's state to "done".
             fr[kState] = 'done'
 
             // 2. Let result be the result of package data given
-            //    bytes, type, blob’s type, and encodingName.
+            //    bytes, type, blob's type, and encodingName.
             try {
               const result = packageData(bytes, type, blob.type, encodingName)
 
@@ -133,7 +133,7 @@ function readOperation (fr, blob, type, encodingName) {
                 return
               }
 
-              // 1. Set fr’s result to result.
+              // 1. Set fr's result to result.
               fr[kResult] = result
 
               // 2. Fire a progress event called load at the fr.
@@ -141,14 +141,14 @@ function readOperation (fr, blob, type, encodingName) {
             } catch (error) {
               // 3. If package data threw an exception error:
 
-              // 1. Set fr’s error to error.
+              // 1. Set fr's error to error.
               fr[kError] = error
 
               // 2. Fire a progress event called error at fr.
               fireAProgressEvent('error', fr)
             }
 
-            // 5. If fr’s state is not "loading", fire a progress
+            // 5. If fr's state is not "loading", fire a progress
             //    event called loadend at the fr.
             if (fr[kState] !== 'loading') {
               fireAProgressEvent('loadend', fr)
@@ -166,16 +166,16 @@ function readOperation (fr, blob, type, encodingName) {
         //    error error, queue a task to run the following
         //    steps and abort this algorithm:
         queueMicrotask(() => {
-          // 1. Set fr’s state to "done".
+          // 1. Set fr's state to "done".
           fr[kState] = 'done'
 
-          // 2. Set fr’s error to error.
+          // 2. Set fr's error to error.
           fr[kError] = error
 
           // 3. Fire a progress event called error at fr.
           fireAProgressEvent('error', fr)
 
-          // 4. If fr’s state is not "loading", fire a progress
+          // 4. If fr's state is not "loading", fire a progress
           //    event called loadend at fr.
           if (fr[kState] !== 'loading') {
             fireAProgressEvent('loadend', fr)
@@ -270,7 +270,7 @@ function packageData (bytes, type, mimeType, encodingName) {
         const type = parseMIMEType(mimeType)
 
         // 2. If type is not failure, set encoding to the result
-        //    of getting an encoding from type’s parameters["charset"].
+        //    of getting an encoding from type's parameters["charset"].
         if (type !== 'failure') {
           encoding = getEncoding(type.parameters.get('charset'))
         }
@@ -333,7 +333,7 @@ function decode (ioQueue, encoding) {
     slice = BOMEncoding === 'UTF-8' ? 3 : 2
   }
 
-  // 3. Process a queue with an instance of encoding’s
+  // 3. Process a queue with an instance of encoding's
   //    decoder, ioQueue, output, and "replacement".
 
   // 4. Return output.

--- a/lib/websocket/connection.js
+++ b/lib/websocket/connection.js
@@ -33,7 +33,7 @@ try {
  * @param {Partial<import('../../types/websocket').WebSocketInit>} options
  */
 function establishWebSocketConnection (url, protocols, ws, onEstablish, options) {
-  // 1. Let requestURL be a copy of url, with its scheme set to "http", if url’s
+  // 1. Let requestURL be a copy of url, with its scheme set to "http", if url's
   //    scheme is "ws", and to "https" otherwise.
   const requestURL = url
 
@@ -60,8 +60,8 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
     request.headersList = headersList
   }
 
-  // 3. Append (`Upgrade`, `websocket`) to request’s header list.
-  // 4. Append (`Connection`, `Upgrade`) to request’s header list.
+  // 3. Append (`Upgrade`, `websocket`) to request's header list.
+  // 4. Append (`Connection`, `Upgrade`) to request's header list.
   // Note: both of these are handled by undici currently.
   // https://github.com/nodejs/undici/blob/68c269c4144c446f3f1220951338daef4a6b5ec4/lib/client.js#L1397
 
@@ -70,16 +70,16 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
   //    isomorphic encoded.
   const keyValue = crypto.randomBytes(16).toString('base64')
 
-  // 6. Append (`Sec-WebSocket-Key`, keyValue) to request’s
+  // 6. Append (`Sec-WebSocket-Key`, keyValue) to request's
   //    header list.
   request.headersList.append('sec-websocket-key', keyValue)
 
-  // 7. Append (`Sec-WebSocket-Version`, `13`) to request’s
+  // 7. Append (`Sec-WebSocket-Version`, `13`) to request's
   //    header list.
   request.headersList.append('sec-websocket-version', '13')
 
   // 8. For each protocol in protocols, combine
-  //    (`Sec-WebSocket-Protocol`, protocol) in request’s header
+  //    (`Sec-WebSocket-Protocol`, protocol) in request's header
   //    list.
   for (const protocol of protocols) {
     request.headersList.append('sec-websocket-protocol', protocol)
@@ -92,7 +92,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
   const permessageDeflate = '' // 'permessage-deflate; 15'
 
   // 10. Append (`Sec-WebSocket-Extensions`, permessageDeflate) to
-  //     request’s header list.
+  //     request's header list.
   // request.headersList.append('sec-websocket-extensions', permessageDeflate)
 
   // 11. Fetch request with useParallelQueue set to true, and
@@ -110,7 +110,7 @@ function establishWebSocketConnection (url, protocols, ws, onEstablish, options)
       }
 
       // 2. If protocols is not the empty list and extracting header
-      //    list values given `Sec-WebSocket-Protocol` and response’s
+      //    list values given `Sec-WebSocket-Protocol` and response's
       //    header list results in null, failure, or the empty byte
       //    sequence, then fail the WebSocket connection.
       if (protocols.length !== 0 && !response.headersList.get('Sec-WebSocket-Protocol')) {

--- a/lib/websocket/util.js
+++ b/lib/websocket/util.js
@@ -44,7 +44,7 @@ function fireEvent (e, target, eventConstructor = Event, eventInitDict) {
 
   // 2. Let event be the result of creating an event given eventConstructor,
   //    in the relevant realm of target.
-  // 3. Initialize event’s type attribute to e.
+  // 3. Initialize event's type attribute to e.
   const event = new eventConstructor(e, eventInitDict) // eslint-disable-line new-cap
 
   // 4. Initialize any other IDL attributes of event as described in the
@@ -95,7 +95,7 @@ function websocketMessageReceived (ws, type, data) {
 
   // 3. Fire an event named message at the WebSocket object, using MessageEvent,
   //    with the origin attribute initialized to the serialization of the WebSocket
-  //    object’s url's origin, and the data attribute initialized to dataForEvent.
+  //    object's url's origin, and the data attribute initialized to dataForEvent.
   fireEvent('message', ws, MessageEvent, {
     origin: ws[kWebSocketURL].origin,
     data: dataForEvent

--- a/lib/websocket/websocket.js
+++ b/lib/websocket/websocket.js
@@ -70,15 +70,15 @@ class WebSocket extends EventTarget {
       throw new DOMException(e, 'SyntaxError')
     }
 
-    // 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
+    // 4. If urlRecord's scheme is "http", then set urlRecord's scheme to "ws".
     if (urlRecord.protocol === 'http:') {
       urlRecord.protocol = 'ws:'
     } else if (urlRecord.protocol === 'https:') {
-      // 5. Otherwise, if urlRecord’s scheme is "https", set urlRecord’s scheme to "wss".
+      // 5. Otherwise, if urlRecord's scheme is "https", set urlRecord's scheme to "wss".
       urlRecord.protocol = 'wss:'
     }
 
-    // 6. If urlRecord’s scheme is not "ws" or "wss", then throw a "SyntaxError" DOMException.
+    // 6. If urlRecord's scheme is not "ws" or "wss", then throw a "SyntaxError" DOMException.
     if (urlRecord.protocol !== 'ws:' && urlRecord.protocol !== 'wss:') {
       throw new DOMException(
         `Expected a ws: or wss: protocol, got ${urlRecord.protocol}`,
@@ -86,7 +86,7 @@ class WebSocket extends EventTarget {
       )
     }
 
-    // 7. If urlRecord’s fragment is non-null, then throw a "SyntaxError"
+    // 7. If urlRecord's fragment is non-null, then throw a "SyntaxError"
     //    DOMException.
     if (urlRecord.hash || urlRecord.href.endsWith('#')) {
       throw new DOMException('Got fragment', 'SyntaxError')
@@ -326,7 +326,7 @@ class WebSocket extends EventTarget {
       // described by the ArrayBuffer object that data references. Any
       // invocation of this method with this kind of argument that does
       // not throw an exception must increase the bufferedAmount attribute
-      // by the length of data’s buffer in bytes.
+      // by the length of data's buffer in bytes.
 
       const ab = Buffer.from(data, data.byteOffset, data.byteLength)
 
@@ -347,7 +347,7 @@ class WebSocket extends EventTarget {
       // to be sent is the raw data represented by the Blob object. Any
       // invocation of this method with a Blob argument that does not throw
       // an exception must increase the bufferedAmount attribute by the size
-      // of the Blob object’s raw data, in bytes.
+      // of the Blob object's raw data, in bytes.
 
       const frame = new WebsocketFrameSend()
 
@@ -500,7 +500,7 @@ class WebSocket extends EventTarget {
    * @see https://websockets.spec.whatwg.org/#feedback-from-the-protocol
    */
   #onConnectionEstablished (response) {
-    // processResponse is called when the "response’s header list has been received and initialized."
+    // processResponse is called when the "response's header list has been received and initialized."
     // once this happens, the connection is open
     this[kResponse] = response
 
@@ -515,7 +515,7 @@ class WebSocket extends EventTarget {
     // 1. Change the ready state to OPEN (1).
     this[kReadyState] = states.OPEN
 
-    // 2. Change the extensions attribute’s value to the extensions in use, if
+    // 2. Change the extensions attribute's value to the extensions in use, if
     //    it is not the null value.
     // https://datatracker.ietf.org/doc/html/rfc6455#section-9.1
     const extensions = response.headersList.get('sec-websocket-extensions')
@@ -524,7 +524,7 @@ class WebSocket extends EventTarget {
       this.#extensions = extensions
     }
 
-    // 3. Change the protocol attribute’s value to the subprotocol in use, if
+    // 3. Change the protocol attribute's value to the subprotocol in use, if
     //    it is not the null value.
     // https://datatracker.ietf.org/doc/html/rfc6455#section-1.9
     const protocol = response.headersList.get('sec-websocket-protocol')

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "docs"
   ],
   "scripts": {
-    "build:node": "npx esbuild@0.20.0 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1",
+    "build:node": "npx esbuild@0.20.0 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1 --keep-names",
     "prebuild:wasm": "node build/wasm.js --prebuild",
     "build:wasm": "node build/wasm.js --docker",
     "lint": "standard | snazzy",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "docs"
   ],
   "scripts": {
-    "build:node": "npx esbuild@0.19.4 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1 --keep-names",
+    "build:node": "npx esbuild@0.20.0 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1",
     "prebuild:wasm": "node build/wasm.js --prebuild",
     "build:wasm": "node build/wasm.js --docker",
     "lint": "standard | snazzy",


### PR DESCRIPTION
Related to: https://github.com/nodejs/node/pull/51605

this replaces all `’` with `'` and the `ä` with `a` in a licensing comment.

Based on my research, the licensing comment change does not impact its validity. It would actually be more appropriate to have a complete License file along with the code instead of having it inlined.  

I also tried out the `--minify-whitespace` flag for esbuild. This would remove comments from `node:build`, but also remove all other whitespace. There does not seem to be an esbuild configuration option that only removes comments. We could consider another tool for that so we can retain other whitespace. 