### PR TITLE
chore: refine esbuild & node detection

### DIFF
--- a/build/wasm.js
+++ b/build/wasm.js
@@ -101,6 +101,8 @@ if (EXTERNAL_PATH) {
   writeFileSync(join(ROOT, 'loader.js'), `
 'use strict'
 
+globalThis.__UNDICI_IS_NODE__ = true
 module.exports = require('node:module').createRequire('${EXTERNAL_PATH}/loader.js')('./index-fetch.js')
+delete globalThis.__UNDICI_IS_NODE__
 `)
 }

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -66,6 +66,10 @@ const { webidl } = require('./webidl')
 const { STATUS_CODES } = require('node:http')
 const GET_OR_HEAD = ['GET', 'HEAD']
 
+const defaultUserAgent = typeof __UNDICI_IS_NODE__ !== 'undefined' || typeof esbuildDetection !== 'undefined'
+  ? 'node'
+  : 'undici'
+
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
 
@@ -1473,7 +1477,7 @@ async function httpNetworkOrCacheFetch (
   //    user agents should append `User-Agent`/default `User-Agent` value to
   //    httpRequest’s header list.
   if (!httpRequest.headersList.contains('user-agent', true)) {
-    httpRequest.headersList.append('user-agent', typeof esbuildDetection === 'undefined' ? 'undici' : 'node', true)
+    httpRequest.headersList.append('user-agent', defaultUserAgent)
   }
 
   //    15. If httpRequest’s cache mode is "default" and httpRequest’s header


### PR DESCRIPTION
When using the loader for external builtins, `esbuildDetection` is undefined. This commit defines `__UNDICI_IS_NODE__` on `globalThis` in the loader and deletes it after loading Undici. `esbuildDetection` has also been extracted as a variable at the top level of the module, to support deleting `__UNDICI_IS_NODE__` on `globalThis` to avoid polluting the global namespace.

Follow up of #2643.