### PR TITLE
websocket: fix close when no closing code is received

### DIFF
--- a/lib/websocket/receiver.js
+++ b/lib/websocket/receiver.js
@@ -107,8 +107,11 @@ class ByteParser extends Writable {
             // Close frame, the endpoint MUST send a Close frame in response.  (When
             // sending a Close frame in response, the endpoint typically echos the
             // status code it received.)
-            const body = Buffer.allocUnsafe(2)
-            body.writeUInt16BE(this.#info.closeInfo.code, 0)
+            let body = emptyBuffer
+            if (this.#info.closeInfo.code) {
+              body = Buffer.allocUnsafe(2)
+              body.writeUInt16BE(this.#info.closeInfo.code, 0)
+            }
             const closeFrame = new WebsocketFrameSend(body)
 
             this.ws[kResponse].socket.write(

--- a/test/websocket/issue-2679.js
+++ b/test/websocket/issue-2679.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+
+test('Close without receiving code does not send an invalid payload', async () => {
+  const server = new WebSocketServer({ port: 0 })
+
+  await once(server, 'listening')
+
+  server.on('connection', (sock, request) => {
+    setTimeout(() => {
+      sock.close()
+    }, 3000)
+  })
+
+  server.on('error', (err) => assert.ifError(err))
+
+  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  await once(client, 'open')
+
+  await once(client, 'close')
+
+  server.close()
+  await once(server, 'close')
+})


### PR DESCRIPTION
Fixes #2679 (an incredibly well-written issue that made this issue infinitely easier to fix, tysm)

The issue is (afaict, I haven't worked on websocket in a while...) is that the closing code is optional, but we would always allocate a 2-byte body, thereby sending a buffer containing (0x0, 0x0) which would then get interpreted as a 0 status code, which is invalid.