### PR TITLE
feat: draft: adds a onMissedRequest hook for seeing missed mocks

### DIFF
--- a/docs/api/MockAgent.md
+++ b/docs/api/MockAgent.md
@@ -38,6 +38,14 @@ const agent = new Agent()
 const mockAgent = new MockAgent({ agent })
 ```
 
+### Example - MockAgent instantiation with missed request callback
+
+```js
+import { MockAgent } from 'undici'
+
+const mockAgent = new MockAgent({ onMissedRequest: (error) => console.log(`A request wasn't handled: ${error.message}`) })
+```
+
 ## Instance Methods
 
 ### `MockAgent.get(origin)`

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -11,7 +11,8 @@ const {
   kNetConnect,
   kGetNetConnect,
   kOptions,
-  kFactory
+  kFactory,
+  kOnMissedRequest
 } = require('./mock-symbols')
 const MockClient = require('./mock-client')
 const MockPool = require('./mock-pool')
@@ -35,6 +36,11 @@ class MockAgent extends Dispatcher {
     const agent = opts?.agent ? opts.agent : new Agent(opts)
     this[kAgent] = agent
 
+    if (opts?.onMissedRequest && typeof opts.onMissedRequest !== 'function') {
+      throw new InvalidArgumentError('Argument opts.onMissedRequest must be a callback')
+    }
+
+    this[kOnMissedRequest] = opts?.onMissedRequest
     this[kClients] = agent[kClients]
     this[kOptions] = buildMockOptions(opts)
   }

--- a/lib/mock/mock-symbols.js
+++ b/lib/mock/mock-symbols.js
@@ -19,5 +19,6 @@ module.exports = {
   kIsMockActive: Symbol('is mock active'),
   kNetConnect: Symbol('net connect'),
   kGetNetConnect: Symbol('get net connect'),
-  kConnected: Symbol('connected')
+  kConnected: Symbol('connected'),
+  kOnMissedRequest: Symbol('onMissedRequest')
 }

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -6,7 +6,8 @@ const {
   kMockAgent,
   kOriginalDispatch,
   kOrigin,
-  kGetNetConnect
+  kGetNetConnect,
+  kOnMissedRequest
 } = require('./mock-symbols')
 const { buildURL, nop } = require('../core/util')
 const { STATUS_CODES } = require('node:http')
@@ -307,6 +308,10 @@ function buildMockDispatch () {
         mockDispatch.call(this, opts, handler)
       } catch (error) {
         if (error instanceof MockNotMatchedError) {
+          if (agent[kOnMissedRequest]) {
+            agent[kOnMissedRequest](error)
+          }
+
           const netConnect = agent[kGetNetConnect]()
           if (netConnect === false) {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`)

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -3,6 +3,7 @@
 const { test } = require('tap')
 const { createServer } = require('node:http')
 const { promisify } = require('node:util')
+const { stub } = require('sinon')
 const { request, setGlobalDispatcher, MockAgent, Agent } = require('..')
 const { getResponse } = require('../lib/mock/mock-utils')
 const { kClients, kConnected } = require('../lib/core/symbols')
@@ -383,6 +384,44 @@ test('MockAgent - basic intercept with request', async (t) => {
   t.same(jsonResponse, {
     foo: 'bar'
   })
+})
+
+test('MockAgent - basic missed request', async (t) => {
+  t.plan(5)
+
+  const server = createServer((req, res) => {
+    res.setHeader('content-type', 'text/plain')
+    res.end('hello from the other side')
+  })
+  t.teardown(server.close.bind(server))
+
+  await promisify(server.listen.bind(server))(0)
+
+  const baseUrl = `http://localhost:${server.address().port}`
+  const onMissedRequest = stub()
+  const mockAgent = new MockAgent({ onMissedRequest })
+
+  setGlobalDispatcher(mockAgent)
+  t.teardown(mockAgent.close.bind(mockAgent))
+  const mockPool = mockAgent.get(baseUrl)
+
+  mockPool.intercept({
+    path: '/justatest?hello=there&see=ya',
+    method: 'GET'
+  }).reply(200, { wont: 'match' }, {
+    headers: { 'content-type': 'application/json' }
+  })
+
+  const { statusCode, headers, body } = await request(`${baseUrl}/justatest?hello=there&another=one`, {
+    method: 'GET'
+  })
+
+  t.equal(statusCode, 200, 'Status code is 200')
+  t.equal(headers['content-type'], 'text/plain', 'Content type is text/plain')
+  const responseBody = await getResponse(body)
+  t.equal(responseBody, 'hello from the other side', 'Body is from the local server')
+  t.equal(onMissedRequest.calledOnce, true, 'onMissedRequest calledOnce')
+  t.ok(onMissedRequest.firstCall.args[0].message.includes('Mock dispatch not matched for path \'/justatest?another=one&hello=there\''), 'Error message matches')
 })
 
 test('MockAgent - should support local agents', async (t) => {


### PR DESCRIPTION
## This relates to...
#2681
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
To enable easier debugging of the mockagent, as discussed in #1600 

## Changes
- docs: added an example of mockAgent onMissedRequest option
- test: added a basic test for onMissedRequest
- feat: added onMissedRequest
  - Added mock symbol for callback
  - Added logic in mock-utils dispatch to emit the hook

### Features
- added onMissedRequest hook for debugging mismatched requests

### Bug Fixes
No bugs fixed

### Breaking Changes and Deprecations
No breaking changes or deprecations

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [ ] Documented (will add specific option documentation in case spec changes)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
