### PR TITLE
fix: webidl.brandcheck non strict should throw

### DIFF
--- a/lib/fetch/webidl.js
+++ b/lib/fetch/webidl.js
@@ -34,10 +34,14 @@ webidl.errors.invalidArgument = function (context) {
 
 // https://webidl.spec.whatwg.org/#implements
 webidl.brandCheck = function (V, I, opts = undefined) {
-  if (opts?.strict !== false && !(V instanceof I)) {
-    throw new TypeError('Illegal invocation')
+  if (opts?.strict !== false) {
+    if (!(V instanceof I)) {
+      throw new TypeError('Illegal invocation')
+    }
   } else {
-    return V?.[Symbol.toStringTag] === I.prototype[Symbol.toStringTag]
+    if (V?.[Symbol.toStringTag] !== I.prototype[Symbol.toStringTag]) {
+      throw new TypeError('Illegal invocation')
+    }
   }
 }
 

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -599,3 +599,37 @@ test('Set-Cookie parser', () => {
   headers = new Headers()
   assert.deepEqual(getSetCookies(headers), [])
 })
+
+test('Cookie setCookie throws if headers is not of type Headers', () => {
+  class Headers {
+    [Symbol.toStringTag] = 'CustomHeaders'
+  }
+  const headers = new Headers()
+  assert.throws(
+    () => {
+      setCookie(headers, {
+        name: 'key',
+        value: 'Cat',
+        httpOnly: true,
+        secure: true,
+        maxAge: 3
+      })
+    },
+    new TypeError('Illegal invocation')
+  )
+})
+
+test('Cookie setCookie does not throw if headers is an instance of a custom Headers class', () => {
+  class Headers {
+    [Symbol.toStringTag] = 'Headers'
+    append () { }
+  }
+  const headers = new Headers()
+  setCookie(headers, {
+    name: 'key',
+    value: 'Cat',
+    httpOnly: true,
+    secure: true,
+    maxAge: 3
+  })
+})

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -640,3 +640,72 @@ test('Cookie setCookie does not throw if headers is an instance of the global He
     maxAge: 3
   })
 })
+
+test('Cookie getCookies throws if headers is not of type Headers', () => {
+  class Headers {
+    [Symbol.toStringTag] = 'CustomHeaders'
+  }
+  const headers = new Headers()
+  assert.throws(
+    () => {
+      getCookies(headers)
+    },
+    new TypeError('Illegal invocation')
+  )
+})
+
+test('Cookie getCookies does not throw if headers is an instance of undici owns Headers class', () => {
+  const headers = new Headers()
+  getCookies(headers)
+})
+
+test('Cookie getCookie does not throw if headers is an instance of the global Headers class', () => {
+  const headers = new globalThis.Headers()
+  getCookies(headers)
+})
+
+test('Cookie getSetCookies throws if headers is not of type Headers', () => {
+  class Headers {
+    [Symbol.toStringTag] = 'CustomHeaders'
+  }
+  const headers = new Headers({ 'set-cookie': 'Space=Cat' })
+  assert.throws(
+    () => {
+      getSetCookies(headers)
+    },
+    new TypeError('Illegal invocation')
+  )
+})
+
+test('Cookie getSetCookies does not throw if headers is an instance of undici owns Headers class', () => {
+  const headers = new Headers({ 'set-cookie': 'Space=Cat' })
+  getSetCookies(headers)
+})
+
+test('Cookie setCookie does not throw if headers is an instance of the global Headers class', () => {
+  const headers = new globalThis.Headers({ 'set-cookie': 'Space=Cat' })
+  getSetCookies(headers)
+})
+
+test('Cookie deleteCookie throws if headers is not of type Headers', () => {
+  class Headers {
+    [Symbol.toStringTag] = 'CustomHeaders'
+  }
+  const headers = new Headers()
+  assert.throws(
+    () => {
+      deleteCookie(headers, 'deno')
+    },
+    new TypeError('Illegal invocation')
+  )
+})
+
+test('Cookie deleteCookie does not throw if headers is an instance of undici owns Headers class', () => {
+  const headers = new Headers()
+  deleteCookie(headers, 'deno')
+})
+
+test('Cookie getCookie does not throw if headers is an instance of the global Headers class', () => {
+  const headers = new globalThis.Headers()
+  deleteCookie(headers, 'deno')
+})

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -633,3 +633,14 @@ test('Cookie setCookie does not throw if headers is an instance of a custom Head
     maxAge: 3
   })
 })
+
+test('Cookie setCookie does not throw if headers is an instance of undici owns Headers class', () => {
+  const headers = new Headers()
+  setCookie(headers, {
+    name: 'key',
+    value: 'Cat',
+    httpOnly: true,
+    secure: true,
+    maxAge: 3
+  })
+})

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -644,3 +644,14 @@ test('Cookie setCookie does not throw if headers is an instance of undici owns H
     maxAge: 3
   })
 })
+
+test('Cookie setCookie does not throw if headers is an instance of the global Headers class', () => {
+  const headers = new globalThis.Headers()
+  setCookie(headers, {
+    name: 'key',
+    value: 'Cat',
+    httpOnly: true,
+    secure: true,
+    maxAge: 3
+  })
+})

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -619,21 +619,6 @@ test('Cookie setCookie throws if headers is not of type Headers', () => {
   )
 })
 
-test('Cookie setCookie does not throw if headers is an instance of a custom Headers class', () => {
-  class Headers {
-    [Symbol.toStringTag] = 'Headers'
-    append () { }
-  }
-  const headers = new Headers()
-  setCookie(headers, {
-    name: 'key',
-    value: 'Cat',
-    httpOnly: true,
-    secure: true,
-    maxAge: 3
-  })
-})
-
 test('Cookie setCookie does not throw if headers is an instance of undici owns Headers class', () => {
   const headers = new Headers()
   setCookie(headers, {


### PR DESCRIPTION
It is very strange, that in case of strict: false brandCheck would not throw, but in strict cases it would throw. 

We use the non strict brandCheck e.g.
https://github.com/nodejs/undici/blob/0808a721570baaa10e6386a9e50bd34278814afe/lib/cookies/index.js#L56

The non strict check is basically a no op, as nothing happens with the result. I assume this was just an oversight. 

I would actually recommend for performance reasons to implement a webidl.brandCheckLax (or something like that) and make webidl.brandCheck only handle strict cases.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
