### PR TITLE
fix: fix the linux patch

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1099,16 +1099,12 @@ function fetchFinale (fetchParams, response) {
 
     const byteStream = new ReadableStream({
       readableStream: transformStream.readable,
+      async start () {
+        this._bodyReader = this.readableStream.getReader()
+      },
       async pull (controller) {
-        // TODO(mcollina): removen this block, not sure why pull() is called twice
-        if (this.readableStream.locked) {
-          return
-        }
-
-        const reader = this.readableStream.getReader()
-
         while (controller.desiredSize >= 0) {
-          const { done, value } = await reader.read()
+          const { done, value } = await this._bodyReader.read()
 
           if (done) {
             queueMicrotask(() => readableStreamClose(controller))
@@ -1910,8 +1906,8 @@ async function httpNetworkFetch (
 
   // 11. Let pullAlgorithm be an action that resumes the ongoing fetch
   // if it is suspended.
-  const pullAlgorithm = () => {
-    fetchParams.controller.resume()
+  const pullAlgorithm = async () => {
+    await fetchParams.controller.resume()
   }
 
   // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams’s
@@ -2026,9 +2022,7 @@ async function httpNetworkFetch (
       // into stream.
       const buffer = new Uint8Array(bytes)
       if (buffer.byteLength) {
-        try {
-          fetchParams.controller.controller.enqueue(buffer)
-        } catch {}
+        fetchParams.controller.controller.enqueue(buffer)
       }
 
       // 8. If stream is errored, then terminate the ongoing fetch.
@@ -2039,7 +2033,7 @@ async function httpNetworkFetch (
 
       // 9. If stream doesn’t need more data ask the user agent to suspend
       // the ongoing fetch.
-      if (!fetchParams.controller.controller.desiredSize) {
+      if (fetchParams.controller.controller.desiredSize <= 0) {
         return
       }
     }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/desiredSize

> The value will be null if the stream has errored and 0 if it is closed.

<s>So when the stream was closed we tried to read again from it. </s>

<s>Well... at this point i dont know...</s>

I guess the problem was, that the readable stream can get suspended. So when the readable stream is unsuspended, and pull gets called a second time, than we  try to get again a reader. But you can have only one reader on the stream, thus it breaks. Now it gets the reader only once.