### PR TITLE
Add support for passing iterable objects as headers

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -174,7 +174,7 @@ class Request {
         }
       } else {
         const keys = Object.keys(headers)
-        for (let i = 0; i < keys.length; i++) {
+        for (const key of keys) {
           const key = keys[i]
           processHeader(this, key, headers[key])
         }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -169,13 +169,12 @@ class Request {
           if (!Array.isArray(header) || header.length !== 2) {
             throw new InvalidArgumentError('headers must be in key-value pair format')
           }
-   const [key, value] = header;
+          const [key, value] = header
           processHeader(this, key, value)
         }
       } else {
         const keys = Object.keys(headers)
         for (const key of keys) {
-          const key = keys[i]
           processHeader(this, key, headers[key])
         }
       }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -166,6 +166,9 @@ class Request {
     } else if (headers && typeof headers === 'object') {
       if (headers[Symbol.iterator]) {
         for (const header of headers) {
+          if (!Array.isArray(header) || header.length !== 2) {
+            throw new InvalidArgumentError('headers must be in key-value pair format')
+          }
           const key = header[0]
           const value = header[1]
           processHeader(this, key, value)

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -169,8 +169,7 @@ class Request {
           if (!Array.isArray(header) || header.length !== 2) {
             throw new InvalidArgumentError('headers must be in key-value pair format')
           }
-          const key = header[0]
-          const value = header[1]
+   const [key, value] = header;
           processHeader(this, key, value)
         }
       } else {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -164,10 +164,18 @@ class Request {
         processHeader(this, headers[i], headers[i + 1])
       }
     } else if (headers && typeof headers === 'object') {
-      const keys = Object.keys(headers)
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i]
-        processHeader(this, key, headers[key])
+      if (headers[Symbol.iterator]) {
+        for (const header of headers) {
+          const key = header[0]
+          const value = header[1]
+          processHeader(this, key, value)
+        }
+      } else {
+        const keys = Object.keys(headers)
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i]
+          processHeader(this, key, headers[key])
+        }
       }
     } else if (headers != null) {
       throw new InvalidArgumentError('headers must be an object or an array')

--- a/test/request.js
+++ b/test/request.js
@@ -246,3 +246,103 @@ test('DispatchOptions#reset', scope => {
     })
   })
 })
+
+test('Should include headers from iterable objects', scope => {
+  scope.plan(3)
+
+  scope.test('Should include headers built with Headers global object', async t => {
+    const server = createServer((req, res) => {
+      t.equal('GET', req.method)
+      t.equal(`localhost:${server.address().port}`, req.headers.host)
+      t.equal(req.headers.hello, 'world')
+      res.statusCode = 200
+      res.end('hello')
+    })
+
+    const headers = new Headers()
+    headers.set('hello', 'world')
+
+    t.plan(3)
+
+    t.teardown(server.close.bind(server))
+
+    await new Promise((resolve, reject) => {
+      server.listen(0, (err) => {
+        if (err != null) reject(err)
+        else resolve()
+      })
+    })
+
+    await request({
+      method: 'GET',
+      origin: `http://localhost:${server.address().port}`,
+      reset: true,
+      headers
+    })
+  })
+
+  scope.test('Should include headers built with Map', async t => {
+    const server = createServer((req, res) => {
+      t.equal('GET', req.method)
+      t.equal(`localhost:${server.address().port}`, req.headers.host)
+      t.equal(req.headers.hello, 'world')
+      res.statusCode = 200
+      res.end('hello')
+    })
+
+    const headers = new Map()
+    headers.set('hello', 'world')
+
+    t.plan(3)
+
+    t.teardown(server.close.bind(server))
+
+    await new Promise((resolve, reject) => {
+      server.listen(0, (err) => {
+        if (err != null) reject(err)
+        else resolve()
+      })
+    })
+
+    await request({
+      method: 'GET',
+      origin: `http://localhost:${server.address().port}`,
+      reset: true,
+      headers
+    })
+  })
+
+  scope.test('Should include headers built with custom iterable object', async t => {
+    const server = createServer((req, res) => {
+      t.equal('GET', req.method)
+      t.equal(`localhost:${server.address().port}`, req.headers.host)
+      t.equal(req.headers.hello, 'world')
+      res.statusCode = 200
+      res.end('hello')
+    })
+
+    const headers = {
+      * [Symbol.iterator] () {
+        yield ['hello', 'world']
+      }
+    }
+
+    t.plan(3)
+
+    t.teardown(server.close.bind(server))
+
+    await new Promise((resolve, reject) => {
+      server.listen(0, (err) => {
+        if (err != null) reject(err)
+        else resolve()
+      })
+    })
+
+    await request({
+      method: 'GET',
+      origin: `http://localhost:${server.address().port}`,
+      reset: true,
+      headers
+    })
+  })
+})


### PR DESCRIPTION
## This relates to 

Resolves #2700 

## Rationale

Improve flexibility and user expirience by allowing directly passing iterable objects as headers to `undici.request`.  
It will add support for [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers), [Maps](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and custom objects with [Symbol.iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator) that yields the key-value pairs.

## Changes

 * add for..of iterating in core/request.js

### Features

 * Support for iterable object headers

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
