### PR TITLE
test: remove t.diagnostics() calls in push-dont-push.js test

### DIFF
--- a/test/fetch/pull-dont-push.js
+++ b/test/fetch/pull-dont-push.js
@@ -36,9 +36,7 @@ test('pull dont\'t push', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  t.diagnostic('server listening on port %d', server.address().port)
   const res = await fetch(`http://localhost:${server.address().port}`)
-  t.diagnostic('fetched')
 
   // Some time is needed to fill the buffer
   await sleep(1000)


### PR DESCRIPTION
Because of the use of t.diagnostics the github overview for affected files in PRs is containing annotations. See screenshot

![image](https://github.com/nodejs/undici/assets/5059100/5e8bf23a-cd5a-4b71-bb13-e459aac8bdd1)
