### PR TITLE
test: replace t.type with t.ok and instanceof

### DIFF
--- a/test/client-connect.js
+++ b/test/client-connect.js
@@ -31,7 +31,7 @@ test('connect aborted after connect', (t) => {
       opaque: 'asd'
     }, (err, { opaque }) => {
       t.equal(opaque, 'asd')
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
     })
     t.equal(client[kBusy], true)
   })

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -340,7 +340,7 @@ test('pipeline invalid handler return', (t) => {
       body.on('error', () => {})
     })
       .on('error', (err) => {
-        t.type(err, errors.InvalidReturnValueError)
+        t.ok(err instanceof errors.InvalidReturnValueError)
       })
       .end()
 
@@ -353,7 +353,7 @@ test('pipeline invalid handler return', (t) => {
       return {}
     })
       .on('error', (err) => {
-        t.type(err, errors.InvalidReturnValueError)
+        t.ok(err instanceof errors.InvalidReturnValueError)
       })
       .end()
   })
@@ -409,7 +409,7 @@ test('pipeline destroy and throw handler', (t) => {
     })
       .end()
       .on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
       .on('close', () => {
         t.pass()
@@ -449,7 +449,7 @@ test('pipeline abort res', (t) => {
       return body
     })
       .on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
       .end()
   })
@@ -474,7 +474,7 @@ test('pipeline abort server res', (t) => {
       t.fail()
     })
       .on('error', (err) => {
-        t.type(err, errors.SocketError)
+        t.ok(err instanceof errors.SocketError)
       })
       .end()
   })
@@ -505,7 +505,7 @@ test('pipeline abort duplex', (t) => {
       }, () => {
         t.fail()
       }).destroy().on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
     })
   })
@@ -558,7 +558,7 @@ test('pipeline abort piped res 2', (t) => {
     }, ({ body }) => {
       const pt = new PassThrough()
       body.on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
       setImmediate(() => {
         pt.destroy()
@@ -567,7 +567,7 @@ test('pipeline abort piped res 2', (t) => {
       return pt
     })
       .on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
       .end()
   })
@@ -628,7 +628,7 @@ test('pipeline abort server res after headers', (t) => {
       return data.body
     })
       .on('error', (err) => {
-        t.type(err, errors.SocketError)
+        t.ok(err instanceof errors.SocketError)
       })
       .end()
   })
@@ -656,7 +656,7 @@ test('pipeline w/ write abort server res after headers', (t) => {
       return data.body
     })
       .on('error', (err) => {
-        t.type(err, errors.SocketError)
+        t.ok(err instanceof errors.SocketError)
       })
       .resume()
       .write('asd')
@@ -713,7 +713,7 @@ test('pipeline args validation', (t) => {
   const ret = client.pipeline(null, () => {})
   ret.on('error', (err) => {
     t.ok(/opts/.test(err.message))
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 })
 
@@ -866,7 +866,7 @@ test('pipeline CONNECT throw', (t) => {
     }, () => {
       t.fail()
     }).on('error', (err) => {
-      t.type(err, errors.InvalidArgumentError)
+      t.ok(err instanceof errors.InvalidArgumentError)
     })
     client.on('disconnect', () => {
       t.fail()
@@ -1030,7 +1030,7 @@ test('pipeline abort after headers', (t) => {
     })
       .end()
       .on('error', (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
       })
   })
 })

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -117,7 +117,7 @@ test('request abort before headers', (t) => {
         method: 'GET',
         signal
       }, (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
         t.equal(signal.listenerCount('abort'), 0)
       })
       t.equal(signal.listenerCount('abort'), 1)
@@ -127,7 +127,7 @@ test('request abort before headers', (t) => {
         method: 'GET',
         signal
       }, (err) => {
-        t.type(err, errors.RequestAbortedError)
+        t.ok(err instanceof errors.RequestAbortedError)
         t.equal(signal.listenerCount('abort'), 0)
       })
       t.equal(signal.listenerCount('abort'), 2)

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -263,17 +263,17 @@ test('stream args validation', (t) => {
     path: '/',
     method: 'GET'
   }, null, (err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.stream(null, null, (err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   try {
     client.stream(null, null, 'asd')
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 })
 
@@ -285,11 +285,11 @@ test('stream args validation promise', (t) => {
     path: '/',
     method: 'GET'
   }, null).catch((err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.stream(null, null).catch((err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 })
 
@@ -337,7 +337,7 @@ test('stream server side destroy', (t) => {
     }, () => {
       t.fail()
     }, (err) => {
-      t.type(err, errors.SocketError)
+      t.ok(err instanceof errors.SocketError)
     })
   })
 })
@@ -360,7 +360,7 @@ test('stream invalid return', (t) => {
     }, () => {
       return {}
     }, (err) => {
-      t.type(err, errors.InvalidReturnValueError)
+      t.ok(err instanceof errors.InvalidReturnValueError)
     })
   })
 })
@@ -413,7 +413,7 @@ test('stream factory abort', (t) => {
       return new PassThrough()
     }, (err) => {
       t.equal(signal.listenerCount('abort'), 0)
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
     })
     t.equal(signal.listenerCount('abort'), 1)
   })
@@ -475,7 +475,7 @@ test('stream CONNECT throw', (t) => {
       method: 'CONNECT'
     }, () => {
     }, (err) => {
-      t.type(err, errors.InvalidArgumentError)
+      t.ok(err instanceof errors.InvalidArgumentError)
     })
   })
 })
@@ -528,7 +528,7 @@ test('stream abort before dispatch', (t) => {
     }, () => {
       return pt
     }, (err) => {
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
     })
     signal.emit('abort')
   })

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -40,7 +40,7 @@ test('refresh timeout on pause', (t) => {
 
       },
       onError (err) {
-        t.type(err, errors.BodyTimeoutError)
+        t.ok(err instanceof errors.BodyTimeoutError)
       }
     })
   })
@@ -96,7 +96,7 @@ test('start headers timeout after request body', (t) => {
       },
       onError (err) {
         t.equal(body.readableEnded, true)
-        t.type(err, errors.HeadersTimeoutError)
+        t.ok(err instanceof errors.HeadersTimeoutError)
       }
     })
   })
@@ -153,7 +153,7 @@ test('start headers timeout after async iterator request body', (t) => {
 
       },
       onError (err) {
-        t.type(err, errors.HeadersTimeoutError)
+        t.ok(err instanceof errors.HeadersTimeoutError)
       }
     })
   })

--- a/test/client-upgrade.js
+++ b/test/client-upgrade.js
@@ -151,7 +151,7 @@ test('upgrade invalid opts', (t) => {
   const client = new Client('http://localhost:5432')
 
   client.upgrade(null, err => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
     t.equal(err.message, 'invalid opts')
   })
 
@@ -159,7 +159,7 @@ test('upgrade invalid opts', (t) => {
     client.upgrade(null, null)
     t.fail()
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
     t.equal(err.message, 'invalid opts')
   }
 
@@ -167,7 +167,7 @@ test('upgrade invalid opts', (t) => {
     client.upgrade({ path: '/' }, null)
     t.fail()
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
     t.equal(err.message, 'invalid callback')
   }
 })
@@ -308,7 +308,7 @@ test('upgrade aborted', (t) => {
       opaque: 'asd'
     }, (err, { opaque }) => {
       t.equal(opaque, 'asd')
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
       t.equal(signal.listenerCount('abort'), 0)
     })
     t.equal(client[kBusy], true)
@@ -351,7 +351,7 @@ test('basic aborted after res', (t) => {
       protocol: 'Websocket',
       signal
     }, (err) => {
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
     })
   })
 })
@@ -408,7 +408,7 @@ test('upgrade disconnect', (t) => {
 
     client.on('disconnect', (origin, [self], error) => {
       t.equal(client, self)
-      t.type(error, Error)
+      t.ok(error instanceof Error)
     })
 
     client
@@ -417,7 +417,7 @@ test('upgrade disconnect', (t) => {
         t.fail()
       })
       .catch(error => {
-        t.type(error, Error)
+        t.ok(error instanceof Error)
       })
   })
 })
@@ -446,7 +446,7 @@ test('upgrade invalid signal', (t) => {
       opaque: 'asd'
     }, (err, { opaque }) => {
       t.equal(opaque, 'asd')
-      t.type(err, errors.InvalidArgumentError)
+      t.ok(err instanceof errors.InvalidArgumentError)
     })
   })
 })

--- a/test/client.js
+++ b/test/client.js
@@ -1412,13 +1412,13 @@ test('request args validation', (t) => {
   const client = new Client('http://localhost:5000')
 
   client.request(null, (err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   try {
     client.request(null, 'asd')
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 })
 
@@ -1428,7 +1428,7 @@ test('request args validation promise', (t) => {
   const client = new Client('http://localhost:5000')
 
   client.request(null).catch((err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 })
 

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -72,10 +72,10 @@ test('destroy invoked all pending callbacks', (t) => {
       client.destroy()
     })
     client.request({ path: '/', method: 'GET' }, (err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
     client.request({ path: '/', method: 'GET' }, (err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
   })
 })
@@ -99,11 +99,11 @@ test('destroy invoked all pending callbacks ticked', (t) => {
     let ticked = false
     client.request({ path: '/', method: 'GET' }, (err) => {
       t.equal(ticked, true)
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
     client.request({ path: '/', method: 'GET' }, (err) => {
       t.equal(ticked, true)
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
     client.destroy()
     ticked = true
@@ -223,10 +223,10 @@ test('closed and destroyed errors', (t) => {
     t.error(err)
   })
   client.request({ path: '/', method: 'GET' }, (err) => {
-    t.type(err, errors.ClientClosedError)
+    t.ok(err instanceof errors.ClientClosedError)
     client.destroy()
     client.request({ path: '/', method: 'GET' }, (err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
   })
 })
@@ -239,10 +239,10 @@ test('close after and destroy should error', (t) => {
 
   client.destroy()
   client.close((err) => {
-    t.type(err, errors.ClientDestroyedError)
+    t.ok(err instanceof errors.ClientDestroyedError)
   })
   client.close().catch((err) => {
-    t.type(err, errors.ClientDestroyedError)
+    t.ok(err instanceof errors.ClientDestroyedError)
   })
 })
 

--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -41,7 +41,7 @@ test('connect-timeout', t => {
     path: '/',
     method: 'GET'
   }, (err) => {
-    t.type(err, errors.ConnectTimeoutError)
+    t.ok(err instanceof errors.ConnectTimeoutError)
     clearTimeout(timeout)
   })
 })
@@ -62,7 +62,7 @@ test('connect-timeout', t => {
     path: '/',
     method: 'GET'
   }, (err) => {
-    t.type(err, errors.ConnectTimeoutError)
+    t.ok(err instanceof errors.ConnectTimeoutError)
     clearTimeout(timeout)
   })
 })

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -25,7 +25,7 @@ test('request invalid content-length', (t) => {
       },
       body: 'asd'
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -36,7 +36,7 @@ test('request invalid content-length', (t) => {
       },
       body: 'asdasdasdasdasdasda'
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -47,7 +47,7 @@ test('request invalid content-length', (t) => {
       },
       body: Buffer.alloc(9)
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -58,7 +58,7 @@ test('request invalid content-length', (t) => {
       },
       body: Buffer.alloc(11)
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -69,7 +69,7 @@ test('request invalid content-length', (t) => {
       },
       body: ['asd']
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -80,7 +80,7 @@ test('request invalid content-length', (t) => {
       },
       body: ['asasdasdasdd']
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({
@@ -91,7 +91,7 @@ test('request invalid content-length', (t) => {
       },
       body: ['asasdasdasdd']
     }, (err, data) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
   })
 })
@@ -130,7 +130,7 @@ function invalidContentLength (bodyType) {
           }
         }), bodyType)
       }, (err, data) => {
-        t.type(err, errors.RequestContentLengthMismatchError)
+        t.ok(err instanceof errors.RequestContentLengthMismatchError)
       })
 
       client.request({
@@ -148,7 +148,7 @@ function invalidContentLength (bodyType) {
           }
         }), bodyType)
       }, (err, data) => {
-        t.type(err, errors.RequestContentLengthMismatchError)
+        t.ok(err instanceof errors.RequestContentLengthMismatchError)
       })
     })
   })
@@ -184,7 +184,7 @@ function zeroContentLength (bodyType) {
           }
         }), bodyType)
       }, (err, data) => {
-        t.type(err, errors.RequestContentLengthMismatchError)
+        t.ok(err instanceof errors.RequestContentLengthMismatchError)
       })
     })
   })
@@ -315,7 +315,7 @@ test('request DELETE, content-length=0, with body', (t) => {
         }
       })
     }, (err) => {
-      t.type(err, errors.RequestContentLengthMismatchError)
+      t.ok(err instanceof errors.RequestContentLengthMismatchError)
     })
 
     client.request({

--- a/test/headers-as-array.js
+++ b/test/headers-as-array.js
@@ -103,7 +103,7 @@ test('fail if headers array is odd', (t) => {
       method: 'GET',
       headers
     }, (err) => {
-      t.type(err, errors.InvalidArgumentError)
+      t.ok(err instanceof errors.InvalidArgumentError)
       t.equal(err.message, 'headers array must be even')
     })
   })

--- a/test/http2.js
+++ b/test/http2.js
@@ -273,7 +273,7 @@ test('Should support H2 GOAWAY (server-side)', async t => {
 
   const [url, disconnectClient, err] = await once(client, 'disconnect')
 
-  t.type(url, URL)
+  t.ok(url instanceof URL)
   t.same(disconnectClient, [client])
   t.equal(err.message, 'HTTP/2: "GOAWAY" frame received with code 204')
 })

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -15,7 +15,7 @@ test('invalid headers', (t) => {
       'content-length': 'asd'
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -23,7 +23,7 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: 1
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -33,7 +33,7 @@ test('invalid headers', (t) => {
       'transfer-encoding': 'chunked'
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -43,7 +43,7 @@ test('invalid headers', (t) => {
       upgrade: 'asd'
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -53,7 +53,7 @@ test('invalid headers', (t) => {
       connection: 'asd'
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -63,7 +63,7 @@ test('invalid headers', (t) => {
       'keep-alive': 'timeout=5'
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -73,7 +73,7 @@ test('invalid headers', (t) => {
       foo: {}
     }
   }, (err, data) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   client.request({
@@ -83,7 +83,7 @@ test('invalid headers', (t) => {
       expect: '100-continue'
     }
   }, (err, data) => {
-    t.type(err, errors.NotSupportedError)
+    t.ok(err instanceof errors.NotSupportedError)
   })
 
   client.request({
@@ -93,7 +93,7 @@ test('invalid headers', (t) => {
       Expect: '100-continue'
     }
   }, (err, data) => {
-    t.type(err, errors.NotSupportedError)
+    t.ok(err instanceof errors.NotSupportedError)
   })
 
   client.request({
@@ -103,6 +103,6 @@ test('invalid headers', (t) => {
       expect: 'asd'
     }
   }, (err, data) => {
-    t.type(err, errors.NotSupportedError)
+    t.ok(err instanceof errors.NotSupportedError)
   })
 })

--- a/test/issue-810.js
+++ b/test/issue-810.js
@@ -34,14 +34,14 @@ test('https://github.com/mcollina/undici/issues/810', (t) => {
         // t.fail() FIX: Should fail.
         t.pass()
       }).on('error', err => (
-        t.type(err, errors.HTTPParserError)
+        t.ok(err instanceof errors.HTTPParserError)
       ))
     })
     client.request({
       path: '/',
       method: 'GET'
     }, (err, data) => {
-      t.type(err, errors.HTTPParserError)
+      t.ok(err instanceof errors.HTTPParserError)
     })
   })
 })
@@ -129,7 +129,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining 2', (t) => {
       method: 'GET'
     }, (err, data) => {
       t.equal(err.code, 'HPE_INVALID_CONSTANT')
-      t.type(err, errors.HTTPParserError)
+      t.ok(err instanceof errors.HTTPParserError)
     })
   })
 })

--- a/test/max-response-size.js
+++ b/test/max-response-size.js
@@ -84,7 +84,7 @@ test('max response size', (t) => {
         t.error(err)
         body.on('error', (err) => {
           t.ok(err)
-          t.type(err, errors.ResponseExceededMaxSizeError)
+          t.ok(err instanceof errors.ResponseExceededMaxSizeError)
         })
       })
     })

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -26,7 +26,7 @@ test('MockAgent - constructor', t => {
     t.plan(1)
 
     const mockAgent = new MockAgent()
-    t.type(mockAgent, Dispatcher)
+    t.ok(mockAgent instanceof Dispatcher)
   })
 
   t.test('sets up mock agent with single connection', t => {
@@ -62,7 +62,7 @@ test('MockAgent - get', t => {
     t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockClient = mockAgent.get(baseUrl)
-    t.type(mockClient, MockClient)
+    t.ok(mockClient instanceof MockClient)
   })
 
   t.test('should return MockPool', (t) => {
@@ -74,7 +74,7 @@ test('MockAgent - get', t => {
     t.teardown(mockAgent.close.bind(mockAgent))
 
     const mockPool = mockAgent.get(baseUrl)
-    t.type(mockPool, MockPool)
+    t.ok(mockPool instanceof MockPool)
   })
 
   t.test('should return the same instance if already created', (t) => {
@@ -241,7 +241,7 @@ test('MockAgent - .close should clean up registered pools', async (t) => {
 
   // Register a pool
   const mockPool = mockAgent.get(baseUrl)
-  t.type(mockPool, MockPool)
+  t.ok(mockPool instanceof MockPool)
 
   t.equal(mockPool[kConnected], 1)
   t.equal(mockAgent[kClients].size, 1)
@@ -259,7 +259,7 @@ test('MockAgent - .close should clean up registered clients', async (t) => {
 
   // Register a pool
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
 
   t.equal(mockClient[kConnected], 1)
   t.equal(mockAgent[kClients].size, 1)
@@ -996,7 +996,7 @@ test('MockAgent - close removes all registered mock clients', async (t) => {
   try {
     await request(`${baseUrl}/foo`, { method: 'GET' })
   } catch (err) {
-    t.type(err, ClientDestroyedError)
+    t.ok(err instanceof ClientDestroyedError)
   }
 })
 
@@ -1030,7 +1030,7 @@ test('MockAgent - close removes all registered mock pools', async (t) => {
   try {
     await request(`${baseUrl}/foo`, { method: 'GET' })
   } catch (err) {
-    t.type(err, ClientDestroyedError)
+    t.ok(err instanceof ClientDestroyedError)
   }
 })
 

--- a/test/mock-client.js
+++ b/test/mock-client.js
@@ -28,7 +28,7 @@ test('MockClient - constructor', t => {
     t.plan(1)
 
     const mockClient = new MockClient('http://localhost:9999', { agent: new MockAgent({ connections: 1 }) })
-    t.type(mockClient, Dispatcher)
+    t.ok(mockClient instanceof Dispatcher)
   })
 })
 
@@ -121,7 +121,7 @@ test('MockClient - intercept should return a MockInterceptor', (t) => {
     method: 'GET'
   })
 
-  t.type(interceptor, MockInterceptor)
+  t.ok(interceptor instanceof MockInterceptor)
 })
 
 test('MockClient - intercept validation', (t) => {
@@ -218,7 +218,7 @@ test('MockClient - should be able to set as globalDispatcher', async (t) => {
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
   setGlobalDispatcher(mockClient)
 
   mockClient.intercept({
@@ -254,7 +254,7 @@ test('MockClient - should support query params', async (t) => {
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
   setGlobalDispatcher(mockClient)
 
   const query = {
@@ -295,7 +295,7 @@ test('MockClient - should intercept query params with hardcoded path', async (t)
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
   setGlobalDispatcher(mockClient)
 
   const query = {
@@ -335,7 +335,7 @@ test('MockClient - should intercept query params regardless of key ordering', as
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
   setGlobalDispatcher(mockClient)
 
   const query = {
@@ -383,7 +383,7 @@ test('MockClient - should be able to use as a local dispatcher', async (t) => {
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
 
   mockClient.intercept({
     path: '/foo',
@@ -418,7 +418,7 @@ test('MockClient - basic intercept with MockClient.request', async (t) => {
   const mockAgent = new MockAgent({ connections: 1 })
   t.teardown(mockAgent.close.bind(mockAgent))
   const mockClient = mockAgent.get(baseUrl)
-  t.type(mockClient, MockClient)
+  t.ok(mockClient instanceof MockClient)
 
   mockClient.intercept({
     path: '/foo?hello=there&see=ya',

--- a/test/mock-errors.js
+++ b/test/mock-errors.js
@@ -13,7 +13,7 @@ test('mockErrors', (t) => {
       t.plan(4)
 
       const mockError = new mockErrors.MockNotMatchedError()
-      t.type(mockError, errors.UndiciError)
+      t.ok(mockError instanceof errors.UndiciError)
       t.same(mockError.name, 'MockNotMatchedError')
       t.same(mockError.code, 'UND_MOCK_ERR_MOCK_NOT_MATCHED')
       t.same(mockError.message, 'The request does not match any registered mock dispatches')
@@ -23,7 +23,7 @@ test('mockErrors', (t) => {
       t.plan(4)
 
       const mockError = new mockErrors.MockNotMatchedError('custom message')
-      t.type(mockError, errors.UndiciError)
+      t.ok(mockError instanceof errors.UndiciError)
       t.same(mockError.name, 'MockNotMatchedError')
       t.same(mockError.code, 'UND_MOCK_ERR_MOCK_NOT_MATCHED')
       t.same(mockError.message, 'custom message')

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -28,7 +28,7 @@ test('MockInterceptor - reply', t => {
       method: ''
     }, [])
     const result = mockInterceptor.reply(200, 'hello')
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -53,7 +53,7 @@ test('MockInterceptor - reply callback', t => {
       method: ''
     }, [])
     const result = mockInterceptor.reply(200, () => 'hello')
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -82,7 +82,7 @@ test('MockInterceptor - reply options callback', t => {
       statusCode: 200,
       data: 'hello'
     }))
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
 
     // Test parameters
 
@@ -181,7 +181,7 @@ test('MockInterceptor - replyWithError', t => {
       method: ''
     }, [])
     const result = mockInterceptor.replyWithError(new Error('kaboom'))
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -205,7 +205,7 @@ test('MockInterceptor - defaultReplyHeaders', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyHeaders({})
-    t.type(result, MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -229,7 +229,7 @@ test('MockInterceptor - defaultReplyTrailers', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyTrailers({})
-    t.type(result, MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -253,6 +253,6 @@ test('MockInterceptor - replyContentLength', t => {
       method: ''
     }, [])
     const result = mockInterceptor.defaultReplyTrailers({})
-    t.type(result, MockInterceptor)
+    t.ok(result instanceof MockInterceptor)
   })
 })

--- a/test/mock-pool.js
+++ b/test/mock-pool.js
@@ -29,7 +29,7 @@ test('MockPool - constructor', t => {
     t.plan(1)
 
     const mockPool = new MockPool('http://localhost:9999', { agent: new MockAgent() })
-    t.type(mockPool, Dispatcher)
+    t.ok(mockPool instanceof Dispatcher)
   })
 })
 
@@ -204,7 +204,7 @@ test('MockPool - should be able to set as globalDispatcher', async (t) => {
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
-  t.type(mockPool, MockPool)
+  t.ok(mockPool instanceof MockPool)
   setGlobalDispatcher(mockPool)
 
   mockPool.intercept({
@@ -240,7 +240,7 @@ test('MockPool - should be able to use as a local dispatcher', async (t) => {
   t.teardown(mockAgent.close.bind(mockAgent))
 
   const mockPool = mockAgent.get(baseUrl)
-  t.type(mockPool, MockPool)
+  t.ok(mockPool instanceof MockPool)
 
   mockPool.intercept({
     path: '/foo',
@@ -275,7 +275,7 @@ test('MockPool - basic intercept with MockPool.request', async (t) => {
   const mockAgent = new MockAgent()
   t.teardown(mockAgent.close.bind(mockAgent))
   const mockPool = mockAgent.get(baseUrl)
-  t.type(mockPool, MockPool)
+  t.ok(mockPool instanceof MockPool)
 
   mockPool.intercept({
     path: '/foo?hello=there&see=ya',

--- a/test/mock-scope.js
+++ b/test/mock-scope.js
@@ -14,7 +14,7 @@ test('MockScope - delay', t => {
       method: ''
     }, [])
     const result = mockScope.delay(200)
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {
@@ -41,7 +41,7 @@ test('MockScope - persist', t => {
       method: ''
     }, [])
     const result = mockScope.persist()
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 })
 
@@ -55,7 +55,7 @@ test('MockScope - times', t => {
       method: ''
     }, [])
     const result = mockScope.times(200)
-    t.type(result, MockScope)
+    t.ok(result instanceof MockScope)
   })
 
   t.test('should error if passed options invalid', t => {

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -56,7 +56,7 @@ test('parser fail', (t) => {
       path: '/'
     }, (err, data) => {
       t.ok(err)
-      t.type(err, errors.HTTPParserError)
+      t.ok(err instanceof errors.HTTPParserError)
     })
   })
 })

--- a/test/pool.js
+++ b/test/pool.js
@@ -30,7 +30,7 @@ test('throws when connection is infinite', (t) => {
   try {
     new Pool(null, { connections: 0 / 0 }) // eslint-disable-line
   } catch (e) {
-    t.type(e, errors.InvalidArgumentError)
+    t.ok(e instanceof errors.InvalidArgumentError)
     t.equal(e.message, 'invalid connections')
   }
 })
@@ -41,7 +41,7 @@ test('throws when connections is negative', (t) => {
   try {
     new Pool(null, { connections: -1 }) // eslint-disable-line no-new
   } catch (e) {
-    t.type(e, errors.InvalidArgumentError)
+    t.ok(e instanceof errors.InvalidArgumentError)
     t.equal(e.message, 'invalid connections')
   }
 })
@@ -52,7 +52,7 @@ test('throws when connection is not number', (t) => {
   try {
     new Pool(null, { connections: true }) // eslint-disable-line no-new
   } catch (e) {
-    t.type(e, errors.InvalidArgumentError)
+    t.ok(e instanceof errors.InvalidArgumentError)
     t.equal(e.message, 'invalid connections')
   }
 })
@@ -63,7 +63,7 @@ test('throws when factory is not a function', (t) => {
   try {
     new Pool(null, { factory: '' }) // eslint-disable-line no-new
   } catch (e) {
-    t.type(e, errors.InvalidArgumentError)
+    t.ok(e instanceof errors.InvalidArgumentError)
     t.equal(e.message, 'factory must be a function.')
   }
 })
@@ -100,7 +100,7 @@ test('connect/disconnect event(s)', (t) => {
     })
     pool.on('disconnect', (origin, [pool, client], error) => {
       t.ok(client instanceof Client)
-      t.type(error, errors.InformationalError)
+      t.ok(error instanceof errors.InformationalError)
       t.equal(error.code, 'UND_ERR_INFO')
       t.equal(error.message, 'socket idle timeout')
     })
@@ -155,7 +155,7 @@ test('basic get', (t) => {
       client.destroy((err) => {
         t.error(err)
         client.close((err) => {
-          t.type(err, errors.ClientDestroyedError)
+          t.ok(err instanceof errors.ClientDestroyedError)
         })
       })
     })
@@ -198,7 +198,7 @@ test('URL as arg', (t) => {
       client.destroy((err) => {
         t.error(err)
         client.close((err) => {
-          t.type(err, errors.ClientDestroyedError)
+          t.ok(err instanceof errors.ClientDestroyedError)
         })
       })
     })
@@ -225,7 +225,7 @@ test('basic get error async/await', (t) => {
     await client.destroy()
 
     await client.close().catch((err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
   })
 })
@@ -596,7 +596,7 @@ test('pool pipeline args validation', (t) => {
   const ret = client.pipeline(null, () => {})
   ret.on('error', (err) => {
     t.ok(/opts/.test(err.message))
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 })
 
@@ -1025,7 +1025,7 @@ test('pool close waits for all requests', (t) => {
       path: '/',
       method: 'GET'
     }, (err) => {
-      t.type(err, errors.ClientClosedError)
+      t.ok(err instanceof errors.ClientClosedError)
     })
   })
 })
@@ -1050,7 +1050,7 @@ test('pool destroyed', (t) => {
       path: '/',
       method: 'GET'
     }, (err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
   })
 })
@@ -1095,7 +1095,7 @@ test('pool destroy fails queued requests', (t) => {
       path: '/',
       method: 'GET'
     }, (err) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
   })
 })

--- a/test/request-crlf.js
+++ b/test/request-crlf.js
@@ -25,7 +25,7 @@ test('should validate content-type CRLF Injection', (t) => {
       })
       t.fail('request should fail')
     } catch (e) {
-      t.type(e, errors.InvalidArgumentError)
+      t.ok(e instanceof errors.InvalidArgumentError)
       t.equal(e.message, 'invalid content-type header')
     }
   })

--- a/test/request-timeout.js
+++ b/test/request-timeout.js
@@ -31,7 +31,7 @@ test('request timeout', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
   })
 })
@@ -53,7 +53,7 @@ test('request timeout with readable body', (t) => {
 
     const body = createReadStream(tempfile)
     client.request({ path: '/', method: 'POST', body }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
   })
 })
@@ -84,7 +84,7 @@ test('body timeout', (t) => {
       body.on('data', () => {
         clock.tick(100)
       }).on('error', (err) => {
-        t.type(err, errors.BodyTimeoutError)
+        t.ok(err instanceof errors.BodyTimeoutError)
       })
     })
 
@@ -117,7 +117,7 @@ test('overridden request timeout', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', headersTimeout: 50 }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     clock.tick(50)
@@ -150,7 +150,7 @@ test('overridden body timeout', (t) => {
       body.on('data', () => {
         clock.tick(100)
       }).on('error', (err) => {
-        t.type(err, errors.BodyTimeoutError)
+        t.ok(err instanceof errors.BodyTimeoutError)
       })
     })
 
@@ -186,7 +186,7 @@ test('With EE signal', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: ee }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     clock.tick(50)
@@ -221,7 +221,7 @@ test('With abort-controller signal', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     clock.tick(50)
@@ -257,7 +257,7 @@ test('Abort before timeout (EE)', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: ee }, (err, response) => {
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
       clock.tick(100)
     })
   })
@@ -292,7 +292,7 @@ test('Abort before timeout (abort-controller)', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
-      t.type(err, errors.RequestAbortedError)
+      t.ok(err instanceof errors.RequestAbortedError)
       clock.tick(100)
     })
   })
@@ -326,15 +326,15 @@ test('Timeout with pipelining', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
   })
 })
@@ -366,7 +366,7 @@ test('Global option', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     clock.tick(50)
@@ -400,7 +400,7 @@ test('Request options overrides global option', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     clock.tick(50)
@@ -421,7 +421,7 @@ test('client.destroy should cancel the timeout', (t) => {
     })
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.ClientDestroyedError)
+      t.ok(err instanceof errors.ClientDestroyedError)
     })
 
     client.destroy(err => {
@@ -453,7 +453,7 @@ test('client.close should wait for the timeout', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
 
     client.close((err) => {
@@ -477,7 +477,7 @@ test('Validation', (t) => {
     })
     t.teardown(client.destroy.bind(client))
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 
   try {
@@ -486,7 +486,7 @@ test('Validation', (t) => {
     })
     t.teardown(client.destroy.bind(client))
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 
   try {
@@ -495,7 +495,7 @@ test('Validation', (t) => {
     })
     t.teardown(client.destroy.bind(client))
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 
   try {
@@ -504,7 +504,7 @@ test('Validation', (t) => {
     })
     t.teardown(client.destroy.bind(client))
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 })
 
@@ -623,7 +623,7 @@ test('stream timeout', (t) => {
     }, (result) => {
       t.fail('Should not be called')
     }, (err) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
   })
 })
@@ -661,7 +661,7 @@ test('stream custom timeout', (t) => {
     }, (result) => {
       t.fail('Should not be called')
     }, (err) => {
-      t.type(err, errors.HeadersTimeoutError)
+      t.ok(err instanceof errors.HeadersTimeoutError)
     })
   })
 })
@@ -715,7 +715,7 @@ test('pipeline timeout', (t) => {
         }
       }),
       (err) => {
-        t.type(err, errors.HeadersTimeoutError)
+        t.ok(err instanceof errors.HeadersTimeoutError)
       }
     )
   })
@@ -772,7 +772,7 @@ test('pipeline timeout', (t) => {
         }
       }),
       (err) => {
-        t.type(err, errors.HeadersTimeoutError)
+        t.ok(err instanceof errors.HeadersTimeoutError)
       }
     )
   })
@@ -806,7 +806,7 @@ test('client.close should not deadlock', (t) => {
         path: '/',
         method: 'GET'
       }, (err, response) => {
-        t.type(err, errors.HeadersTimeoutError)
+        t.ok(err instanceof errors.HeadersTimeoutError)
       })
 
       client.close((err) => {

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -36,7 +36,7 @@ test('timeout with pipelining 1', (t) => {
       method: 'GET',
       opaque: 'asd'
     }, (err, data) => {
-      t.type(err, errors.HeadersTimeoutError) // we are expecting an error
+      t.ok(err instanceof errors.HeadersTimeoutError) // we are expecting an error
       t.equal(data.opaque, 'asd')
     })
 

--- a/test/utils/esm-wrapper.mjs
+++ b/test/utils/esm-wrapper.mjs
@@ -67,13 +67,13 @@ test('imported errors work with request args validation', (t) => {
   const client = new Client('http://localhost:5000')
 
   client.request(null, (err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 
   try {
     client.request(null, 'asd')
   } catch (err) {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   }
 })
 
@@ -83,7 +83,7 @@ test('imported errors work with request args validation promise', (t) => {
   const client = new Client('http://localhost:5000')
 
   client.request(null).catch((err) => {
-    t.type(err, errors.InvalidArgumentError)
+    t.ok(err instanceof errors.InvalidArgumentError)
   })
 })
 

--- a/test/wpt/tests/resources/testharness.js
+++ b/test/wpt/tests/resources/testharness.js
@@ -1247,7 +1247,7 @@
      */
     function is_node(object)
     {
-        // I use duck-typing instead of instanceof, because
+        // I use duck-typing instead of instanceof because
         // instanceof doesn't work if the node is from another window (like an
         // iframe's contentWindow):
         // http://www.w3.org/Bugs/Public/show_bug.cgi?id=12295


### PR DESCRIPTION
This PR replaces t.type with t.ok and instanceof calls, as node:assert and tspl does not have a type() check.