### PR TITLE
test: replace t.pass with t.ok

### DIFF
--- a/test/client-keep-alive.js
+++ b/test/client-keep-alive.js
@@ -34,7 +34,7 @@ test('keep-alive header', (t) => {
           t.fail()
         }, 4e3)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -76,7 +76,7 @@ test('keep-alive header 0', (t) => {
       t.error(err)
       body.on('end', () => {
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
         clock.tick(600)
       }).resume()
@@ -110,7 +110,7 @@ test('keep-alive header 1', (t) => {
           t.fail()
         }, 0)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -144,7 +144,7 @@ test('keep-alive header no postfix', (t) => {
           t.fail()
         }, 4e3)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -180,7 +180,7 @@ test('keep-alive not timeout', (t) => {
           t.fail()
         }, 3e3)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -217,7 +217,7 @@ test('keep-alive threshold', (t) => {
           t.fail()
         }, 5e3)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -254,7 +254,7 @@ test('keep-alive max keepalive', (t) => {
           t.fail()
         }, 3e3)
         client.on('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
           clearTimeout(timeout)
         })
       }).resume()
@@ -296,7 +296,7 @@ test('connection close', (t) => {
           }, 3e3)
           client.once('disconnect', () => {
             close = false
-            t.pass()
+            t.ok(true, 'pass')
             clearTimeout(timeout)
           })
         }).resume()
@@ -312,7 +312,7 @@ test('connection close', (t) => {
             t.fail()
           }, 3e3)
           client.once('disconnect', () => {
-            t.pass()
+            t.ok(true, 'pass')
             clearTimeout(timeout)
           })
         }).resume()
@@ -350,7 +350,7 @@ test('Disable keep alive', (t) => {
         }, (err, { body }) => {
           t.error(err)
           body.on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           }).resume()
         })
       }).resume()

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -201,7 +201,7 @@ test('pipeline invalid handler return after destroy should not error', (t) => {
         t.equal(err.message, 'asd')
       })
       .on('close', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
       .end()
   })
@@ -315,7 +315,7 @@ test('pipeline backpressure', (t) => {
         duplex.resume()
       })
     }).on('end', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })
@@ -412,7 +412,7 @@ test('pipeline destroy and throw handler', (t) => {
         t.type(err, errors.RequestAbortedError)
       })
       .on('close', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
   })
 })
@@ -443,7 +443,7 @@ test('pipeline abort res', (t) => {
         }, 100)
         client.on('disconnect', () => {
           clearTimeout(timeout)
-          t.pass()
+          t.ok(true, 'pass')
         })
       })
       return body
@@ -789,7 +789,7 @@ test('pipeline legacy stream', (t) => {
       })
       .resume()
       .on('end', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
       .end()
   })
@@ -896,7 +896,7 @@ test('pipeline body without destroy', (t) => {
     })
       .end()
       .on('end', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
       .resume()
   })

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -355,7 +355,7 @@ function errordInflightPost (bodyType) {
             serverRes.end()
           })
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
     })
@@ -391,7 +391,7 @@ test('pipelining non-idempotent', (t) => {
       data.body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
           ended = true
         })
     })
@@ -449,7 +449,7 @@ function pipeliningNonIdempotentWithBody (bodyType) {
         data.body
           .resume()
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
 
@@ -504,7 +504,7 @@ function pipeliningHeadBusy (bodyType) {
             data.body
               .resume()
               .on('end', () => {
-                t.pass()
+                t.ok(true, 'pass')
               })
           })
           body.push(null)
@@ -525,7 +525,7 @@ function pipeliningHeadBusy (bodyType) {
               .resume()
               .on('end', () => {
                 ended = true
-                t.pass()
+                t.ok(true, 'pass')
               })
           })
           body.push(null)
@@ -575,7 +575,7 @@ test('pipelining empty pipeline before reset', (t) => {
         data.body
           .resume()
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
       t.equal(client[kBusy], false)
@@ -590,7 +590,7 @@ test('pipelining empty pipeline before reset', (t) => {
           .resume()
           .on('end', () => {
             ended = true
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
       t.equal(client[kBusy], true)
@@ -628,7 +628,7 @@ function pipeliningIdempotentBusy (bodyType) {
           data.body
             .resume()
             .on('end', () => {
-              t.pass()
+              t.ok(true, 'pass')
             })
         })
         body.push(null)
@@ -649,7 +649,7 @@ function pipeliningIdempotentBusy (bodyType) {
             data.body
               .resume()
               .on('end', () => {
-                t.pass()
+                t.ok(true, 'pass')
               })
           })
           body.push(null)
@@ -688,7 +688,7 @@ function pipeliningIdempotentBusy (bodyType) {
             data.body
               .resume()
               .on('end', () => {
-                t.pass()
+                t.ok(true, 'pass')
               })
           })
           body.push(null)
@@ -734,7 +734,7 @@ test('pipelining blocked', (t) => {
       data.body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
     client.request({
@@ -745,7 +745,7 @@ test('pipelining blocked', (t) => {
       data.body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })

--- a/test/client-post.js
+++ b/test/client-post.js
@@ -32,7 +32,7 @@ test('request post blob', { skip: !Blob }, (t) => {
     }, (err, data) => {
       t.error(err)
       data.body.resume().on('end', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })
@@ -66,7 +66,7 @@ test('request post arrayBuffer', { skip: !Blob }, (t) => {
     }, (err, data) => {
       t.error(err)
       data.body.resume().on('end', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })

--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -38,13 +38,13 @@ test('multiple reconnect', (t) => {
       data.body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
 
     client.on('disconnect', () => {
       if (++n === 1) {
-        t.pass()
+        t.ok(true, 'pass')
       }
       process.nextTick(() => {
         clock.tick(1000)

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -36,7 +36,7 @@ test('request dump', (t) => {
       t.error(err)
       body.dump().then(() => {
         dumped = true
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })
@@ -270,7 +270,7 @@ test('destroy socket abruptly with keep-alive', { skip: true }, async (t) => {
     /* eslint-enable */
     t.fail('no error')
   } catch (err) {
-    t.pass('error happened')
+    t.ok(true, 'error happened')
   }
 })
 
@@ -490,7 +490,7 @@ test('request post body no missing data', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -527,7 +527,7 @@ test('request post body no extra data handler', (t) => {
       maxRedirections: 0
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -552,7 +552,7 @@ test('request with onInfo callback', (t) => {
     })
     t.equal(infos.length, 1)
     t.equal(infos[0].statusCode, 102)
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -585,7 +585,7 @@ test('request with onInfo callback but socket is destroyed before end of respons
     }
     t.equal(infos.length, 1)
     t.equal(infos[0].statusCode, 102)
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -622,7 +622,7 @@ test('request onInfo callback headers parsing', async (t) => {
   t.equal(infos.length, 1)
   t.equal(infos[0].statusCode, 103)
   t.same(infos[0].headers, { link: '</style.css>; rel=preload; as=style' })
-  t.pass()
+  t.ok(true, 'pass')
 })
 
 test('request raw responseHeaders', async (t) => {
@@ -659,7 +659,7 @@ test('request raw responseHeaders', async (t) => {
   t.equal(infos.length, 1)
   t.same(infos[0].headers, ['Link', '</style.css>; rel=preload; as=style'])
   t.same(headers, ['Date', 'Sat, 09 Oct 2010 14:28:02 GMT', 'Connection', 'close'])
-  t.pass()
+  t.ok(true, 'pass')
 })
 
 test('request formData', (t) => {
@@ -793,7 +793,7 @@ test('request post body Buffer from string', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -823,7 +823,7 @@ test('request post body Buffer from buffer', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -853,7 +853,7 @@ test('request post body Uint8Array', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -883,7 +883,7 @@ test('request post body Uint32Array', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -913,7 +913,7 @@ test('request post body Float64Array', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -943,7 +943,7 @@ test('request post body BigUint64Array', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })
 
@@ -973,6 +973,6 @@ test('request post body DataView', (t) => {
       maxRedirections: 2
     })
     await body.text()
-    t.pass()
+    t.ok(true, 'pass')
   })
 })

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -729,7 +729,7 @@ test('stream needDrain', (t) => {
     })
 
     p.then(() => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })
@@ -782,7 +782,7 @@ test('stream legacy needDrain', (t) => {
     })
 
     p.then(() => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -187,7 +187,7 @@ test('parser resume with no body timeout', (t) => {
 
       },
       onComplete () {
-        t.pass()
+        t.ok(true, 'pass')
       },
       onError (err) {
         t.error(err)

--- a/test/client-upgrade.js
+++ b/test/client-upgrade.js
@@ -316,7 +316,7 @@ test('upgrade aborted', (t) => {
     signal.emit('abort')
 
     client.close(() => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })

--- a/test/client-write-max-listeners.js
+++ b/test/client-write-max-listeners.js
@@ -27,7 +27,7 @@ test('socket close listener does not leak', (t) => {
 
   const onRequest = (err, data) => {
     t.error(err)
-    data.body.on('end', () => t.pass()).resume()
+    data.body.on('end', () => t.ok(true, 'pass')).resume()
   }
 
   function onWarning (warning) {

--- a/test/client.js
+++ b/test/client.js
@@ -469,7 +469,7 @@ test('basic head', (t) => {
       body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
 
@@ -480,7 +480,7 @@ test('basic head', (t) => {
       body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })
@@ -509,7 +509,7 @@ test('basic head (IPv6)', { skip: !hasIPv6 }, (t) => {
       body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
 
@@ -520,7 +520,7 @@ test('basic head (IPv6)', { skip: !hasIPv6 }, (t) => {
       body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })
@@ -611,7 +611,7 @@ test('head with host header', (t) => {
       body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })
@@ -1061,7 +1061,7 @@ test('basic POST with empty stream', (t) => {
           t.fail()
         })
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })
@@ -1124,7 +1124,7 @@ test('10 times HEAD', (t) => {
         body
           .resume()
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
     }
@@ -1256,7 +1256,7 @@ test('multiple destroy callback', (t) => {
       data.body
         .resume()
         .on('error', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
       client.destroy(new Error(), (err) => {
         t.error(err)
@@ -1316,7 +1316,7 @@ test('only one streaming req at a time', (t) => {
         data.body
           .resume()
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
       t.equal(client[kBusy], true)
@@ -1370,7 +1370,7 @@ test('only one async iterating req at a time', (t) => {
         data.body
           .resume()
           .on('end', () => {
-            t.pass()
+            t.ok(true, 'pass')
           })
       })
       t.equal(client[kBusy], true)
@@ -1399,7 +1399,7 @@ test('300 requests succeed', (t) => {
         data.body.on('data', (chunk) => {
           t.equal(chunk.toString(), 'asd')
         }).on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
       })
     }
@@ -1650,7 +1650,7 @@ test('emit disconnect after destroy', t => {
       let disconnected = false
       client.on('disconnect', () => {
         disconnected = true
-        t.pass()
+        t.ok(true, 'pass')
       })
       client.destroy(() => {
         t.equal(disconnected, true)
@@ -1684,7 +1684,7 @@ test('end response before request', t => {
         t.fail()
       })
       .on('end', () => {
-        t.pass()
+        t.ok(true, 'pass')
       })
       .resume()
     client.on('disconnect', (url, targets, err) => {
@@ -1808,7 +1808,7 @@ test('async iterator error from server destroys early', (t) => {
         yield 'inner-value'
         t.fail('should not get here, iterator should be destroyed')
       } finally {
-        t.ok(true)
+        t.ok(true, 'pass')
       }
     })()
     client.request({ path: '/', method: 'POST', body }, (err, { statusCode, body }) => {
@@ -1848,7 +1848,7 @@ test('regular iterator error from server closes early', (t) => {
         t.fail('should not get here, iterator should be destroyed')
         yield 'zzz'
       } finally {
-        t.ok(true)
+        t.ok(true, 'pass')
       }
     })()
     client.request({ path: '/', method: 'POST', body }, (err, { statusCode, body }) => {
@@ -1885,7 +1885,7 @@ test('async iterator early return closes early', (t) => {
         yield 'inner-value'
         t.fail('should not get here, iterator should be destroyed')
       } finally {
-        t.ok(true)
+        t.ok(true, 'pass')
       }
     })()
     client.request({ path: '/', method: 'POST', body }, (err, { statusCode, body }) => {
@@ -1916,7 +1916,7 @@ test('async iterator yield unsupported TypedArray', (t) => {
         yield new Int32Array([1])
         t.fail('should not get here, iterator should be destroyed')
       } finally {
-        t.ok(true)
+        t.ok(true, 'pass')
       }
     })()
     client.request({ path: '/', method: 'POST', body }, (err) => {
@@ -1946,7 +1946,7 @@ test('async iterator yield object error', (t) => {
         yield {}
         t.fail('should not get here, iterator should be destroyed')
       } finally {
-        t.ok(true)
+        t.ok(true, 'pass')
       }
     })()
     client.request({ path: '/', method: 'POST', body }, (err) => {

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -11,7 +11,7 @@ test('close waits for queued requests to finish', (t) => {
   const server = createServer()
 
   server.on('request', (req, res) => {
-    t.pass('request received')
+    t.ok(true, 'request received')
     res.end('hello')
   })
   t.teardown(server.close.bind(server))

--- a/test/connect-errconnect.js
+++ b/test/connect-errconnect.js
@@ -11,7 +11,7 @@ test('connect-connectionError', t => {
   t.teardown(client.close.bind(client))
 
   client.once('connectionError', () => {
-    t.pass()
+    t.ok(true, 'pass')
   })
 
   const _err = new Error('kaboom')

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -109,9 +109,9 @@ function invalidContentLength (bodyType) {
       t.teardown(client.destroy.bind(client))
 
       client.once('disconnect', () => {
-        t.pass()
+        t.ok(true, 'pass')
         client.once('disconnect', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
       })
 
@@ -217,7 +217,7 @@ test('request streaming no body data when content-length=0', (t) => {
           t.fail()
         })
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })
@@ -282,7 +282,7 @@ test('request streaming with Readable.from(buf)', (t) => {
         })
         .on('end', () => {
           t.equal(Buffer.concat(chunks).toString(), 'hello')
-          t.pass()
+          t.ok(true, 'pass')
           t.end()
         })
     })
@@ -330,7 +330,7 @@ test('request DELETE, content-length=0, with body', (t) => {
     })
 
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })
@@ -439,7 +439,7 @@ test('content-length shouldSendContentLength=false', (t) => {
     })
 
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })

--- a/test/get-head-body.js
+++ b/test/get-head-body.js
@@ -21,7 +21,7 @@ test('GET and HEAD with body should reset connection', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
 
     client.request({
@@ -145,7 +145,7 @@ test('HEAD should reset connection', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.once('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
 
     client.request({
@@ -172,7 +172,7 @@ test('HEAD should reset connection', (t) => {
             t.error(err)
             data.body.resume()
             data.body.on('end', () => {
-              t.pass()
+              t.ok(true, 'pass')
             })
           })
           t.equal(client[kBusy], true)

--- a/test/http-100.js
+++ b/test/http-100.js
@@ -55,7 +55,7 @@ test('error 103 body', (t) => {
       t.equal(err.code, 'HPE_INVALID_CONSTANT')
     })
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })
@@ -79,7 +79,7 @@ test('error 100 body', (t) => {
       t.equal(err.message, 'bad response')
     })
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })
@@ -103,7 +103,7 @@ test('error 101 upgrade', (t) => {
       t.equal(err.message, 'bad upgrade')
     })
     client.on('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 })

--- a/test/http2.js
+++ b/test/http2.js
@@ -829,7 +829,7 @@ test('Should handle h2 request with body (string or buffer) - dispatch', t => {
       },
       {
         onConnect () {
-          t.ok(true)
+          t.ok(true, 'pass')
         },
         onError (err) {
           t.error(err)

--- a/test/inflight-and-close.js
+++ b/test/inflight-and-close.js
@@ -12,14 +12,14 @@ const server = http.createServer((req, res) => {
   const url = `http://127.0.0.1:${this.address().port}`
   request(url)
     .then(({ statusCode, headers, body }) => {
-      t.pass('first response')
+      t.ok(true, 'first response')
       body.resume()
       body.on('close', function () {
-        t.pass('first body closed')
+        t.ok(true, 'first body closed')
       })
       return request(url)
         .then(({ statusCode, headers, body }) => {
-          t.pass('second response')
+          t.ok(true, 'second response')
           body.resume()
           body.on('close', function () {
             server.close()

--- a/test/issue-810.js
+++ b/test/issue-810.js
@@ -32,7 +32,7 @@ test('https://github.com/mcollina/undici/issues/810', (t) => {
       t.error(err)
       data.body.resume().on('end', () => {
         // t.fail() FIX: Should fail.
-        t.pass()
+        t.ok(true, 'pass')
       }).on('error', err => (
         t.type(err, errors.HTTPParserError)
       ))
@@ -66,7 +66,7 @@ test('https://github.com/mcollina/undici/issues/810 no pipelining', (t) => {
       t.error(err)
       data.body.resume().on('end', () => {
         // t.fail() FIX: Should fail.
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })
@@ -93,7 +93,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining', (t) => {
       t.error(err)
       data.body.resume().on('end', () => {
         // t.fail() FIX: Should fail.
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })
@@ -120,7 +120,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining 2', (t) => {
       t.error(err)
       data.body.resume().on('end', () => {
         // t.fail() FIX: Should fail.
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
 

--- a/test/max-headers.js
+++ b/test/max-headers.js
@@ -34,7 +34,7 @@ test('handle a lot of headers', (t) => {
       data.body
         .resume()
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })

--- a/test/node-test/client-dispatch.js
+++ b/test/node-test/client-dispatch.js
@@ -387,7 +387,7 @@ test('connect call onUpgrade once', async (t) => {
       onConnect () {
       },
       onHeaders (statusCode, headers) {
-        t.pass('should not throw')
+        t.ok(true, 'should not throw')
       },
       onUpgrade (statusCode, headers, socket) {
         p.strictEqual(count++, 0)
@@ -435,13 +435,13 @@ test('dispatch onConnect missing', async (t) => {
       method: 'GET'
     }, {
       onHeaders (statusCode, headers) {
-        t.pass('should not throw')
+        t.ok(true, 'should not throw')
       },
       onData (buf) {
-        t.pass('should not throw')
+        t.ok(true, 'should not throw')
       },
       onComplete (trailers) {
-        t.pass('should not throw')
+        t.ok(true, 'should not throw')
       },
       onError (err) {
         p.strictEqual(err.code, 'UND_ERR_INVALID_ARG')

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -32,7 +32,7 @@ test('https://github.com/mcollina/undici/issues/268', (t) => {
       data.body
         .resume()
       setTimeout(() => {
-        t.pass()
+        t.ok(true, 'pass')
         data.body.on('error', () => {})
       }, 2e3)
     })

--- a/test/pipeline-pipelining.js
+++ b/test/pipeline-pipelining.js
@@ -65,7 +65,7 @@ test('pipeline pipelining retry', (t) => {
     t.teardown(client.destroy.bind(client))
 
     client.once('disconnect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
 
     client[kConnect](() => {
@@ -101,7 +101,7 @@ test('pipeline pipelining retry', (t) => {
       })
 
       client.close(() => {
-        t.pass()
+        t.ok(true, 'pass')
       })
     })
   })

--- a/test/pool.js
+++ b/test/pool.js
@@ -423,10 +423,10 @@ test('busy', (t) => {
       pipelining: 2
     })
     client.on('drain', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
     client.on('connect', () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
     t.teardown(client.destroy.bind(client))
 
@@ -623,7 +623,7 @@ test('300 requests succeed', (t) => {
         data.body.on('data', (chunk) => {
           t.equal(chunk.toString(), 'asd')
         }).on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
       })
     }
@@ -716,7 +716,7 @@ test('pool dispatch error', (t) => {
       onData (chunk) {
       },
       onComplete () {
-        t.pass()
+        t.ok(true, 'pass')
       },
       onError () {
       }
@@ -772,7 +772,7 @@ test('pool request abort in queue', (t) => {
       onData (chunk) {
       },
       onComplete () {
-        t.pass()
+        t.ok(true, 'pass')
       },
       onError () {
       }
@@ -817,7 +817,7 @@ test('pool stream abort in queue', (t) => {
       onData (chunk) {
       },
       onComplete () {
-        t.pass()
+        t.ok(true, 'pass')
       },
       onError () {
       }
@@ -862,7 +862,7 @@ test('pool pipeline abort in queue', (t) => {
       onData (chunk) {
       },
       onComplete () {
-        t.pass()
+        t.ok(true, 'pass')
       },
       onError () {
       }
@@ -1014,11 +1014,11 @@ test('pool close waits for all requests', (t) => {
     })
 
     client.close(() => {
-      t.pass()
+      t.ok(true, 'pass')
     })
 
     client.close(() => {
-      t.pass()
+      t.ok(true, 'pass')
     })
 
     client.request({
@@ -1087,7 +1087,7 @@ test('pool destroy fails queued requests', (t) => {
 
     t.equal(client.destroyed, false)
     client.destroy(_err, () => {
-      t.pass()
+      t.ok(true, 'pass')
     })
     t.equal(client.destroyed, true)
 

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -46,7 +46,7 @@ test('use proxy-agent to connect through proxy', async (t) => {
   const parsedOrigin = new URL(serverUrl)
 
   proxy.on('connect', () => {
-    t.pass('should connect to proxy')
+    t.ok(true, 'should connect to proxy')
   })
 
   server.on('request', (req, res) => {
@@ -81,7 +81,7 @@ test('use proxy agent to connect through proxy using Pool', async (t) => {
 
   proxy.authenticate = async function (req, fn) {
     if (++connectCount === 2) {
-      t.pass('second connect should arrive while first is still inflight')
+      t.ok(true, 'second connect should arrive while first is still inflight')
       resolveFirstConnect()
       fn(null, true)
     } else {
@@ -122,7 +122,7 @@ test('use proxy-agent to connect through proxy using path with params', async (t
   const parsedOrigin = new URL(serverUrl)
 
   proxy.on('connect', () => {
-    t.pass('should call proxy')
+    t.ok(true, 'should call proxy')
   })
   server.on('request', (req, res) => {
     t.equal(req.url, '/hello?foo=bar')
@@ -161,11 +161,11 @@ test('use proxy-agent with auth', async (t) => {
   const parsedOrigin = new URL(serverUrl)
 
   proxy.authenticate = function (req, fn) {
-    t.pass('authentication should be called')
+    t.ok(true, 'authentication should be called')
     fn(null, req.headers['proxy-authorization'] === `Basic ${Buffer.from('user:pass').toString('base64')}`)
   }
   proxy.on('connect', () => {
-    t.pass('proxy should be called')
+    t.ok(true, 'proxy should be called')
   })
 
   server.on('request', (req, res) => {
@@ -205,11 +205,11 @@ test('use proxy-agent with token', async (t) => {
   const parsedOrigin = new URL(serverUrl)
 
   proxy.authenticate = function (req, fn) {
-    t.pass('authentication should be called')
+    t.ok(true, 'authentication should be called')
     fn(null, req.headers['proxy-authorization'] === `Bearer ${Buffer.from('user:pass').toString('base64')}`)
   }
   proxy.on('connect', () => {
-    t.pass('proxy should be called')
+    t.ok(true, 'proxy should be called')
   })
 
   server.on('request', (req, res) => {
@@ -341,7 +341,7 @@ test('use proxy-agent with setGlobalDispatcher', async (t) => {
   t.teardown(() => setGlobalDispatcher(defaultDispatcher))
 
   proxy.on('connect', () => {
-    t.pass('should call proxy')
+    t.ok(true, 'should call proxy')
   })
   server.on('request', (req, res) => {
     t.equal(req.url, '/hello?foo=bar')
@@ -432,7 +432,7 @@ test('should throw when proxy does not return 200', async (t) => {
     await request(serverUrl, { dispatcher: proxyAgent })
     t.fail()
   } catch (e) {
-    t.pass()
+    t.ok(true, 'pass')
     t.ok(e)
   }
 
@@ -492,7 +492,7 @@ test('Proxy via HTTP to HTTPS endpoint', async (t) => {
   })
 
   server.on('secureConnection', () => {
-    t.pass('server should be connected secured')
+    t.ok(true, 'server should be connected secured')
   })
 
   proxy.on('secureConnection', () => {
@@ -500,7 +500,7 @@ test('Proxy via HTTP to HTTPS endpoint', async (t) => {
   })
 
   proxy.on('connect', function () {
-    t.pass('proxy should be connected')
+    t.ok(true, 'proxy should be connected')
   })
 
   proxy.on('request', function () {
@@ -553,15 +553,15 @@ test('Proxy via HTTPS to HTTPS endpoint', async (t) => {
   })
 
   server.on('secureConnection', () => {
-    t.pass('server should be connected secured')
+    t.ok(true, 'server should be connected secured')
   })
 
   proxy.on('secureConnection', () => {
-    t.pass('proxy over http should call secureConnection')
+    t.ok(true, 'proxy over http should call secureConnection')
   })
 
   proxy.on('connect', function () {
-    t.pass('proxy should be connected')
+    t.ok(true, 'proxy should be connected')
   })
 
   proxy.on('request', function () {
@@ -610,7 +610,7 @@ test('Proxy via HTTPS to HTTP endpoint', async (t) => {
   })
 
   proxy.on('secureConnection', () => {
-    t.pass('proxy over http should call secureConnection')
+    t.ok(true, 'proxy over http should call secureConnection')
   })
 
   proxy.on('request', function () {
@@ -652,7 +652,7 @@ test('Proxy via HTTP to HTTP endpoint', async (t) => {
   })
 
   proxy.on('connect', () => {
-    t.pass('connect to proxy')
+    t.ok(true, 'connect to proxy')
   })
 
   proxy.on('request', function () {

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -284,7 +284,7 @@ for (const factory of [
       t.equal(body.length, 0)
     } catch (error) {
       if (error.message.startsWith('max redirects')) {
-        t.pass('Max redirects handled correctly')
+        t.ok(true, 'Max redirects handled correctly')
       } else {
         t.fail(`Unexpected error: ${error.message}`)
       }

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -60,10 +60,10 @@ tap.test('Should retry status code', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
@@ -145,10 +145,10 @@ tap.test('Should use retry-after header for retries', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
@@ -231,10 +231,10 @@ tap.test('Should use retry-after header for retries (date)', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
@@ -314,10 +314,10 @@ tap.test('Should retry with defaults', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
@@ -364,7 +364,7 @@ tap.test('Should handle 206 partial content', t => {
   let x = 0
   const server = createServer((req, res) => {
     if (x === 0) {
-      t.pass()
+      t.ok(true, 'pass')
       res.setHeader('etag', 'asd')
       res.write('abc')
       setTimeout(() => {
@@ -411,13 +411,13 @@ tap.test('Should handle 206 partial content', t => {
       },
       handler: {
         onRequestSent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
@@ -464,7 +464,7 @@ tap.test('Should handle 206 partial content - bad-etag', t => {
   let x = 0
   const server = createServer((req, res) => {
     if (x === 0) {
-      t.pass()
+      t.ok(true, 'pass')
       res.setHeader('etag', 'asd')
       res.write('abc')
       setTimeout(() => {
@@ -500,13 +500,13 @@ tap.test('Should handle 206 partial content - bad-etag', t => {
         },
         handler: {
           onConnect () {
-            t.pass()
+            t.ok(true, 'pass')
           },
           onBodySent () {
-            t.pass()
+            t.ok(true, 'pass')
           },
           onHeaders (status, _rawHeaders, resume, _statusMessage) {
-            t.pass()
+            t.ok(true, 'pass')
             return true
           },
           onData (chunk) {
@@ -647,10 +647,10 @@ tap.test('should not error if request is not meant to be retried', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onBodySent () {
-          t.pass()
+          t.ok(true, 'pass')
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 400)

--- a/test/socket-back-pressure.js
+++ b/test/socket-back-pressure.js
@@ -47,7 +47,7 @@ test('socket back-pressure', (t) => {
           }, 1e3)
         })
         .on('end', () => {
-          t.pass()
+          t.ok(true, 'pass')
         })
     })
   })

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -12,7 +12,7 @@ test('timeout with pipelining 1', (t) => {
   const server = createServer()
 
   server.once('request', (req, res) => {
-    t.pass('first request received, we are letting this timeout on the client')
+    t.ok(true, 'first request received, we are letting this timeout on the client')
 
     server.once('request', (req, res) => {
       t.equal('/', req.url)

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -70,7 +70,7 @@ test('A client should disable session caching', t => {
             if (queue.length !== 0) {
               return request()
             }
-            t.pass()
+            t.ok(true, 'pass')
           })
         })
       }
@@ -170,7 +170,7 @@ test('A pool should be able to reuse TLS sessions between clients', t => {
 
       t.equal(numSessions, 2)
       t.equal(serverRequests, 2 + REQ_COUNT * 2)
-      t.pass()
+      t.ok(true, 'pass')
     })
   })
 

--- a/test/tls.js
+++ b/test/tls.js
@@ -22,7 +22,7 @@
 //     data.body
 //       .resume()
 //       .on('end', () => {
-//         t.pass()
+//         t.ok(true, 'pass')
 //       })
 //   })
 // })
@@ -45,7 +45,7 @@
 //     data.body
 //       .resume()
 //       .on('end', () => {
-//         t.pass()
+//         t.ok(true, 'pass')
 //       })
 //   })
 // })
@@ -71,10 +71,10 @@
 //     data.body
 //       .resume()
 //       .on('end', () => {
-//         t.pass()
+//         t.ok(true, 'pass')
 //       })
 //     client.once('disconnect', () => {
-//       t.pass()
+//       t.ok(true, 'pass')
 //       didDisconnect = true
 //     })
 //   })
@@ -133,14 +133,14 @@
 //       data.body
 //         .resume()
 //         .on('end', () => {
-//           t.pass()
+//           t.ok(true, 'pass')
 //         })
 //     })
 
 //     data.body
 //       .resume()
 //       .on('end', () => {
-//         t.pass()
+//         t.ok(true, 'pass')
 //       })
 //   })
 // })
@@ -166,10 +166,10 @@
 //     data.body
 //       .resume()
 //       .on('end', () => {
-//         t.pass()
+//         t.ok(true, 'pass')
 //       })
 //     client.once('disconnect', () => {
-//       t.pass()
+//       t.ok(true, 'pass')
 //       didDisconnect = true
 //     })
 //   })


### PR DESCRIPTION
This PR replaces t.pass() with a corresponding t.ok call as node:assert and tspl do not provide a pass function.