### PR TITLE
remove anti-pattern dispatcher hooks

### DIFF
--- a/docs/api/DiagnosticsChannel.md
+++ b/docs/api/DiagnosticsChannel.md
@@ -27,17 +27,6 @@ diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
 
 Note: a request is only loosely completed to a given socket.
 
-
-## `undici:request:bodySent`
-
-```js
-import diagnosticsChannel from 'diagnostics_channel'
-
-diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) => {
-  // request is the same object undici:request:create
-})
-```
-
 ## `undici:request:headers`
 
 This message is published after the response headers have been received, i.e. the response has been completed.

--- a/docs/api/Dispatcher.md
+++ b/docs/api/Dispatcher.md
@@ -209,11 +209,9 @@ Returns: `Boolean` - `false` if dispatcher is busy and further dispatch calls wo
 * **onConnect** `(abort: () => void, context: object) => void` - Invoked before request is dispatched on socket. May be invoked multiple times when a request is retried when the request at the head of the pipeline fails.
 * **onError** `(error: Error) => void` - Invoked when an error has occurred. May not throw.
 * **onUpgrade** `(statusCode: number, headers: Buffer[], socket: Duplex) => void` (optional) - Invoked when request is upgraded. Required if `DispatchOptions.upgrade` is defined or `DispatchOptions.method === 'CONNECT'`.
-* **onResponseStarted** `() => void` (optional) - Invoked when response is received, before headers have been read.
 * **onHeaders** `(statusCode: number, headers: Buffer[], resume: () => void, statusText: string) => boolean` - Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. Not required for `upgrade` requests.
 * **onData** `(chunk: Buffer) => boolean` - Invoked when response payload data is received. Not required for `upgrade` requests.
 * **onComplete** `(trailers: Buffer[]) => void` - Invoked when response payload and trailers have been received and the request has completed. Not required for `upgrade` requests.
-* **onBodySent** `(chunk: string | Buffer | Uint8Array) => void` - Invoked when a body chunk is sent to the server. Not required. For a stream or iterable body this will be invoked for every chunk. For other body types, it will be invoked once after the body is sent.
 
 #### Example 1 - Dispatch GET request
 

--- a/docs/api/RedirectHandler.md
+++ b/docs/api/RedirectHandler.md
@@ -86,11 +86,3 @@ Called when the request is complete.
 Parameters:
 
 - **trailers** `object` - The trailers received.
-
-#### `onBodySent(chunk)`
-
-Called when the request body is sent.
-
-Parameters:
-
-- **chunk** `Buffer` - The chunk of the request body sent.

--- a/docs/api/RetryHandler.md
+++ b/docs/api/RetryHandler.md
@@ -73,7 +73,6 @@ const handler = new RetryHandler(
     },
     handler: {
       onConnect() {},
-      onBodySent() {},
       onHeaders(status, _rawHeaders, resume, _statusMessage) {
         // do something with headers
       },
@@ -98,7 +97,6 @@ const handler = new RetryHandler(dispatchOptions, {
   dispatch: client.dispatch.bind(client),
   handler: {
     onConnect() {},
-    onBodySent() {},
     onHeaders(status, _rawHeaders, resume, _statusMessage) {},
     onData(chunk) {},
     onComplete() {},

--- a/lib/client.js
+++ b/lib/client.js
@@ -726,7 +726,6 @@ class Parser {
     if (!request) {
       return -1
     }
-    request.onResponseStarted()
   }
 
   onHeaderField (buf) {
@@ -1606,7 +1605,6 @@ function write (client, request) {
       assert(contentLength === null, 'no body must not have content length')
       socket.write(`${header}\r\n`, 'latin1')
     }
-    request.onRequestSent()
   } else if (util.isBuffer(body)) {
     assert(contentLength === body.byteLength, 'buffer body must have content length')
 
@@ -1614,8 +1612,6 @@ function write (client, request) {
     socket.write(`${header}content-length: ${contentLength}\r\n\r\n`, 'latin1')
     socket.write(body)
     socket.uncork()
-    request.onBodySent(body)
-    request.onRequestSent()
     if (!expectsPayload) {
       socket[kReset] = true
     }
@@ -1789,7 +1785,6 @@ function writeH2 (client, session, request) {
 
   stream.once('response', headers => {
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
-    request.onResponseStarted()
 
     if (request.onHeaders(Number(statusCode), realHeaders, stream.resume.bind(stream), '') === false) {
       stream.pause()
@@ -1870,15 +1865,13 @@ function writeH2 (client, session, request) {
   function writeBodyH2 () {
     /* istanbul ignore else: assertion */
     if (!body) {
-      request.onRequestSent()
+      // Do nothing...
     } else if (util.isBuffer(body)) {
       assert(contentLength === body.byteLength, 'buffer body must have content length')
       stream.cork()
       stream.write(body)
       stream.uncork()
       stream.end()
-      request.onBodySent(body)
-      request.onRequestSent()
     } else if (util.isBlobLike(body)) {
       if (typeof body.stream === 'function') {
         writeIterable({
@@ -1943,21 +1936,13 @@ function writeStream ({ h2stream, body, client, request, socket, contentLength, 
         if (err) {
           util.destroy(body, err)
           util.destroy(h2stream, err)
-        } else {
-          request.onRequestSent()
         }
       }
     )
 
-    pipe.on('data', onPipeData)
     pipe.once('end', () => {
-      pipe.removeListener('data', onPipeData)
       util.destroy(pipe)
     })
-
-    function onPipeData (chunk) {
-      request.onBodySent(chunk)
-    }
 
     return
   }
@@ -2074,9 +2059,6 @@ async function writeBlob ({ h2stream, body, client, request, socket, contentLeng
       socket.uncork()
     }
 
-    request.onBodySent(buffer)
-    request.onRequestSent()
-
     if (!expectsPayload) {
       socket[kReset] = true
     }
@@ -2122,7 +2104,6 @@ async function writeIterable ({ h2stream, body, client, request, socket, content
         }
 
         const res = h2stream.write(chunk)
-        request.onBodySent(chunk)
         if (!res) {
           await waitForDrain()
         }
@@ -2130,7 +2111,6 @@ async function writeIterable ({ h2stream, body, client, request, socket, content
     } catch (err) {
       h2stream.destroy(err)
     } finally {
-      request.onRequestSent()
       h2stream.end()
       h2stream
         .off('close', onDrain)
@@ -2181,7 +2161,7 @@ class AsyncWriter {
   }
 
   write (chunk) {
-    const { socket, request, contentLength, client, bytesWritten, expectsPayload, header } = this
+    const { socket, contentLength, client, bytesWritten, expectsPayload, header } = this
 
     if (socket[kError]) {
       throw socket[kError]
@@ -2229,8 +2209,6 @@ class AsyncWriter {
 
     socket.uncork()
 
-    request.onBodySent(chunk)
-
     if (!ret) {
       if (socket[kParser].timeout && socket[kParser].timeoutType === TIMEOUT_HEADERS) {
         // istanbul ignore else: only for jest
@@ -2244,8 +2222,7 @@ class AsyncWriter {
   }
 
   end () {
-    const { socket, contentLength, client, bytesWritten, expectsPayload, header, request } = this
-    request.onRequestSent()
+    const { socket, contentLength, client, bytesWritten, expectsPayload, header } = this
 
     socket[kWriting] = false
 

--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -14,7 +14,6 @@ const channels = {
   sendHeaders: diagnosticsChannel.channel('undici:client:sendHeaders'),
   // Request
   create: diagnosticsChannel.channel('undici:request:create'),
-  bodySent: diagnosticsChannel.channel('undici:request:bodySent'),
   headers: diagnosticsChannel.channel('undici:request:headers'),
   trailers: diagnosticsChannel.channel('undici:request:trailers'),
   error: diagnosticsChannel.channel('undici:request:error'),

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -201,30 +201,6 @@ class Request {
     }
   }
 
-  onBodySent (chunk) {
-    if (this[kHandler].onBodySent) {
-      try {
-        return this[kHandler].onBodySent(chunk)
-      } catch (err) {
-        this.abort(err)
-      }
-    }
-  }
-
-  onRequestSent () {
-    if (channels.bodySent.hasSubscribers) {
-      channels.bodySent.publish({ request: this })
-    }
-
-    if (this[kHandler].onRequestSent) {
-      try {
-        return this[kHandler].onRequestSent()
-      } catch (err) {
-        this.abort(err)
-      }
-    }
-  }
-
   onConnect (abort) {
     assert(!this.aborted)
     assert(!this.completed)
@@ -235,10 +211,6 @@ class Request {
       this.abort = abort
       return this[kHandler].onConnect(abort)
     }
-  }
-
-  onResponseStarted () {
-    return this[kHandler].onResponseStarted?.()
   }
 
   onHeaders (statusCode, headers, resume, statusText) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -323,10 +323,6 @@ function validateHandler (handler, method, upgrade) {
     throw new InvalidArgumentError('invalid onError method')
   }
 
-  if (typeof handler.onBodySent !== 'function' && handler.onBodySent !== undefined) {
-    throw new InvalidArgumentError('invalid onBodySent method')
-  }
-
   if (upgrade || method === 'CONNECT') {
     if (typeof handler.onUpgrade !== 'function') {
       throw new InvalidArgumentError('invalid onUpgrade method')

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -2113,15 +2113,13 @@ async function httpNetworkFetch (
           timingInfo.finalNetworkRequestStartTime = coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
         },
 
-        onResponseStarted () {
+        onHeaders (status, rawHeaders, resume, statusText) {
           // Set timingInfo’s final network-response start time to the coarsened shared current
           // time given fetchParams’s cross-origin isolated capability, immediately after the
           // user agent’s HTTP parser receives the first byte of the response (e.g., frame header
           // bytes for HTTP/2 or response status line for HTTP/1.x).
           timingInfo.finalNetworkResponseStartTime = coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
-        },
 
-        onHeaders (status, rawHeaders, resume, statusText) {
           if (status < 200) {
             return
           }

--- a/lib/handler/DecoratorHandler.js
+++ b/lib/handler/DecoratorHandler.js
@@ -28,8 +28,4 @@ module.exports = class DecoratorHandler {
   onComplete (...args) {
     return this.handler.onComplete(...args)
   }
-
-  onBodySent (...args) {
-    return this.handler.onBodySent(...args)
-  }
 }

--- a/lib/handler/RedirectHandler.js
+++ b/lib/handler/RedirectHandler.js
@@ -173,12 +173,6 @@ class RedirectHandler {
       this.handler.onComplete(trailers)
     }
   }
-
-  onBodySent (chunk) {
-    if (this.handler.onBodySent) {
-      this.handler.onBodySent(chunk)
-    }
-  }
 }
 
 function parseLocation (statusCode, headers) {

--- a/lib/handler/RetryHandler.js
+++ b/lib/handler/RetryHandler.js
@@ -74,12 +74,6 @@ class RetryHandler {
     })
   }
 
-  onRequestSent () {
-    if (this.handler.onRequestSent) {
-      this.handler.onRequestSent()
-    }
-  }
-
   onUpgrade (statusCode, headers, socket) {
     if (this.handler.onUpgrade) {
       this.handler.onUpgrade(statusCode, headers, socket)
@@ -92,10 +86,6 @@ class RetryHandler {
     } else {
       this.abort = abort
     }
-  }
-
-  onBodySent (chunk) {
-    if (this.handler.onBodySent) return this.handler.onBodySent(chunk)
   }
 
   static [kRetryHandlerDefaultRetry] (err, { state, opts }, cb) {

--- a/test/http2.js
+++ b/test/http2.js
@@ -804,7 +804,7 @@ test('Should handle h2 request with body (string or buffer) - dispatch', t => {
     stream.end('hello h2!')
   })
 
-  t.plan(7)
+  t.plan(6)
 
   server.listen(0, () => {
     const client = new Client(`https://localhost:${server.address().port}`, {
@@ -841,9 +841,6 @@ test('Should handle h2 request with body (string or buffer) - dispatch', t => {
         },
         onData (chunk) {
           response.push(chunk)
-        },
-        onBodySent (body) {
-          t.equal(body.toString('utf-8'), expectedBody)
         },
         onComplete () {
           t.equal(Buffer.concat(response).toString('utf-8'), 'hello h2!')

--- a/test/jest/interceptor.test.js
+++ b/test/jest/interceptor.test.js
@@ -143,14 +143,6 @@ describe('interceptors with NtlmRequestHandler', () => {
         return this.handler.onComplete(...args)
       }
     }
-
-    onBodySent (...args) {
-      if (this.requestCount < 2) {
-        // Do nothing
-      } else {
-        return this.handler.onBodySent(...args)
-      }
-    }
   }
   let server
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -149,7 +149,7 @@ test('MockAgent - dispatch', t => {
   })
 
   t.test('should throw if handler is not valid on redirect', (t) => {
-    t.plan(7)
+    t.plan(6)
 
     const baseUrl = 'http://localhost:9999'
 
@@ -176,21 +176,10 @@ test('MockAgent - dispatch', t => {
     t.throws(() => mockAgent.dispatch({
       origin: baseUrl,
       path: '/foo',
-      method: 'GET'
-    }, {
-      onError: (err) => { throw err },
-      onConnect: () => {},
-      onBodySent: 'INVALID'
-    }), new InvalidArgumentError('invalid onBodySent method'))
-
-    t.throws(() => mockAgent.dispatch({
-      origin: baseUrl,
-      path: '/foo',
       method: 'CONNECT'
     }, {
       onError: (err) => { throw err },
       onConnect: () => {},
-      onBodySent: () => {},
       onUpgrade: 'INVALID'
     }), new InvalidArgumentError('invalid onUpgrade method'))
 
@@ -201,7 +190,6 @@ test('MockAgent - dispatch', t => {
     }, {
       onError: (err) => { throw err },
       onConnect: () => {},
-      onBodySent: () => {},
       onHeaders: 'INVALID'
     }), new InvalidArgumentError('invalid onHeaders method'))
 
@@ -212,7 +200,6 @@ test('MockAgent - dispatch', t => {
     }, {
       onError: (err) => { throw err },
       onConnect: () => {},
-      onBodySent: () => {},
       onHeaders: () => {},
       onData: 'INVALID'
     }), new InvalidArgumentError('invalid onData method'))
@@ -224,7 +211,6 @@ test('MockAgent - dispatch', t => {
     }, {
       onError: (err) => { throw err },
       onConnect: () => {},
-      onBodySent: () => {},
       onHeaders: () => {},
       onData: () => {},
       onComplete: 'INVALID'
@@ -797,7 +783,7 @@ test('MockAgent - handle delays to simulate work', async (t) => {
   const response = await getResponse(body)
   t.equal(response, 'hello')
   const elapsedInMs = process.hrtime(start)[1] / 1e6
-  t.ok(elapsedInMs >= 50, `Elapsed time is not greater than 50ms: ${elapsedInMs}`)
+  t.ok(elapsedInMs >= 49, `Elapsed time is not greater than 50ms: ${elapsedInMs}`)
 })
 
 test('MockAgent - should persist requests', async (t) => {

--- a/test/node-test/diagnostics-channel/post-stream.js
+++ b/test/node-test/diagnostics-channel/post-stream.js
@@ -17,7 +17,7 @@ const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
 test('Diagnostics channel - post stream', (t) => {
-  const assert = tspl(t, { plan: 33 })
+  const assert = tspl(t, { plan: 32 })
   const server = createServer((req, res) => {
     req.resume()
     res.setHeader('Content-Type', 'text/plain')
@@ -114,10 +114,6 @@ test('Diagnostics channel - post stream', (t) => {
     ]
     assert.deepStrictEqual(response.headers, expectedHeaders)
     assert.equal(response.statusText, 'OK')
-  })
-
-  diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) => {
-    assert.equal(_req, request)
   })
 
   let endEmitted = false

--- a/test/node-test/diagnostics-channel/post.js
+++ b/test/node-test/diagnostics-channel/post.js
@@ -16,7 +16,7 @@ const { Client } = require('../../../')
 const { createServer } = require('node:http')
 
 test('Diagnostics channel - post', (t) => {
-  const assert = tspl(t, { plan: 33 })
+  const assert = tspl(t, { plan: 32 })
   const server = createServer((req, res) => {
     req.resume()
     res.setHeader('Content-Type', 'text/plain')
@@ -112,10 +112,6 @@ test('Diagnostics channel - post', (t) => {
     ]
     assert.deepStrictEqual(response.headers, expectedHeaders)
     assert.equal(response.statusText, 'OK')
-  })
-
-  diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) => {
-    assert.equal(_req, request)
   })
 
   let endEmitted = false

--- a/test/node-test/util.js
+++ b/test/node-test/util.js
@@ -41,25 +41,17 @@ test('validateHandler', () => {
   assert.throws(() => util.validateHandler({
     onConnect: () => {},
     onError: () => {},
-    onBodySent: null
-  }), InvalidArgumentError, 'invalid onBodySent method')
-  assert.throws(() => util.validateHandler({
-    onConnect: () => {},
-    onError: () => {},
-    onBodySent: () => {},
     onHeaders: null
   }), InvalidArgumentError, 'invalid onHeaders method')
   assert.throws(() => util.validateHandler({
     onConnect: () => {},
     onError: () => {},
-    onBodySent: () => {},
     onHeaders: () => {},
     onData: null
   }), InvalidArgumentError, 'invalid onData method')
   assert.throws(() => util.validateHandler({
     onConnect: () => {},
     onError: () => {},
-    onBodySent: () => {},
     onHeaders: () => {},
     onData: () => {},
     onComplete: null
@@ -67,13 +59,11 @@ test('validateHandler', () => {
   assert.throws(() => util.validateHandler({
     onConnect: () => {},
     onError: () => {},
-    onBodySent: () => {},
     onUpgrade: 'null'
   }, 'CONNECT'), InvalidArgumentError, 'invalid onUpgrade method')
   assert.throws(() => util.validateHandler({
     onConnect: () => {},
     onError: () => {},
-    onBodySent: () => {},
     onUpgrade: 'null'
   }, 'CONNECT', () => {}), InvalidArgumentError, 'invalid onUpgrade method')
 })

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -62,9 +62,6 @@ tap.test('Should retry status code', t => {
         onConnect () {
           t.pass()
         },
-        onBodySent () {
-          t.pass()
-        },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
           return true
@@ -145,9 +142,6 @@ tap.test('Should use retry-after header for retries', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
-        },
-        onBodySent () {
           t.pass()
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
@@ -233,9 +227,6 @@ tap.test('Should use retry-after header for retries (date)', t => {
         onConnect () {
           t.pass()
         },
-        onBodySent () {
-          t.pass()
-        },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
           t.equal(status, 200)
           return true
@@ -314,9 +305,6 @@ tap.test('Should retry with defaults', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
-        },
-        onBodySent () {
           t.pass()
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
@@ -401,7 +389,7 @@ tap.test('Should handle 206 partial content', t => {
     }
   }
 
-  t.plan(8)
+  t.plan(6)
 
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
@@ -410,13 +398,7 @@ tap.test('Should handle 206 partial content', t => {
         return client.dispatch(...args)
       },
       handler: {
-        onRequestSent () {
-          t.pass()
-        },
         onConnect () {
-          t.pass()
-        },
-        onBodySent () {
           t.pass()
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {
@@ -500,9 +482,6 @@ tap.test('Should handle 206 partial content - bad-etag', t => {
         },
         handler: {
           onConnect () {
-            t.pass()
-          },
-          onBodySent () {
             t.pass()
           },
           onHeaders (status, _rawHeaders, resume, _statusMessage) {
@@ -647,9 +626,6 @@ tap.test('should not error if request is not meant to be retried', t => {
       dispatch: client.dispatch.bind(client),
       handler: {
         onConnect () {
-          t.pass()
-        },
-        onBodySent () {
           t.pass()
         },
         onHeaders (status, _rawHeaders, resume, _statusMessage) {

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -217,16 +217,12 @@ declare namespace Dispatcher {
     onError?(err: Error): void;
     /** Invoked when request is upgraded either due to a `Upgrade` header or `CONNECT` method. */
     onUpgrade?(statusCode: number, headers: Buffer[] | string[] | null, socket: Duplex): void;
-    /** Invoked when response is received, before headers have been read. **/
-    onResponseStarted?(): void;
     /** Invoked when statusCode and headers have been received. May be invoked multiple times due to 1xx informational headers. */
     onHeaders?(statusCode: number, headers: Buffer[] | string[] | null, resume: () => void, statusText: string): boolean;
     /** Invoked when response payload data is received. */
     onData?(chunk: Buffer): boolean;
     /** Invoked when response payload and trailers have been received and the request has completed. */
     onComplete?(trailers: string[] | null): void;
-    /** Invoked when a body chunk is sent to the server. May be invoked multiple times for chunked requests */
-    onBodySent?(chunkSize: number, totalBytesSent: number): void;
   }
   export type PipelineHandler = (data: PipelineHandlerData) => Readable;
   export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';


### PR DESCRIPTION
onBodySent on onRequestSent are footguns that easily cause bugs
when implementing logic will send multiple requests, e.g. redirect
and retry.

To achieve similar functionality wrap body into a stream and listen
to 'data' and 'end' events.

Refs: https://github.com/nodejs/undici/issues/2722