### PR TITLE
perf: remove redundant operation in FormData

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -438,13 +438,7 @@ const hasToWellFormed = !!String.prototype.toWellFormed
  * @param {string} val
  */
 function toUSVString (val) {
-  if (hasToWellFormed) {
-    return `${val}`.toWellFormed()
-  } else if (nodeUtil.toUSVString) {
-    return nodeUtil.toUSVString(val)
-  }
-
-  return `${val}`
+  return hasToWellFormed ? `${val}`.toWellFormed() : nodeUtil.toUSVString(val)
 }
 
 /**

--- a/lib/fetch/formdata.js
+++ b/lib/fetch/formdata.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isBlobLike, toUSVString, makeIterator } = require('./util')
+const { isBlobLike, makeIterator } = require('./util')
 const { kState } = require('./symbols')
 const { kEnumerableProperty } = require('../core/util')
 const { File: UndiciFile, FileLike, isFileLike } = require('./file')
@@ -133,7 +133,7 @@ class FormData {
       ? webidl.converters.Blob(value, { strict: false })
       : webidl.converters.USVString(value)
     filename = arguments.length === 3
-      ? toUSVString(filename)
+      ? webidl.converters.USVString(filename)
       : undefined
 
     // 2. Let entry be the result of creating an entry with name, value, and
@@ -238,15 +238,12 @@ Object.defineProperties(FormData.prototype, {
  */
 function makeEntry (name, value, filename) {
   // 1. Set name to the result of converting name into a scalar value string.
-  // "To convert a string into a scalar value string, replace any surrogates
-  //  with U+FFFD."
-  // see: https://nodejs.org/dist/latest-v20.x/docs/api/buffer.html#buftostringencoding-start-end
-  name = Buffer.from(name).toString('utf8')
+  // Note: This operation was done by the webidl converter USVString.
 
   // 2. If value is a string, then set value to the result of converting
   //    value into a scalar value string.
   if (typeof value === 'string') {
-    value = Buffer.from(value).toString('utf8')
+    // Note: This operation was done by the webidl converter USVString.
   } else {
     // 3. Otherwise:
 


### PR DESCRIPTION
This step is duplicated because the webidl converter USVString has already converted it to a scalar value string.

Since we are doing the same thing, we will remove it and improve performance.

### Benchmark

Script from #2560

```
Benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
• append FormData
------------------------------------------------- -----------------------------
current     7,743 ns/iter   (5,500 ns … 1,875 µs)  7,000 ns   27.9 µs  158.7 µs
new        545.65 ns/iter  (457.76 ns … 1,452 ns) 553.71 ns  1,006 ns  1,452 ns

summary for append FormData
  new
   14.19x faster than current

• set FormData
------------------------------------------------- -----------------------------
current     7,594 ns/iter   (5,900 ns … 464.4 µs)  7,100 ns   21.8 µs  143.5 µs
new        785.77 ns/iter  (658.84 ns … 2,248 ns) 788.23 ns  1,475 ns  2,248 ns

summary for set FormData
  new
   9.66x faster than current

• set FormData (already append)
------------------------------------------------- -----------------------------
current     9,848 ns/iter   (7,500 ns … 1,137 µs)  9,200 ns   26.9 µs  186.7 µs
new         3,109 ns/iter   (2,100 ns … 1,809 µs)  2,900 ns  8,700 ns     97 µs

summary for set FormData (already append)
  new
   3.17x faster than current
```