### PR TITLE
remove useless options in web streams

### DIFF
--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -1114,7 +1114,6 @@ function fetchFinale (fetchParams, response) {
           controller.enqueue(value)
         }
       },
-      queuingStrategy: new ByteLengthQueuingStrategy({ highWaterMark: 16384 }),
       type: 'bytes'
     })
 
@@ -1929,7 +1928,6 @@ async function httpNetworkFetch (
   //     cancelAlgorithm set to cancelAlgorithm.
   const stream = new ReadableStream(
     {
-      highWaterMark: 16384,
       async start (controller) {
         fetchParams.controller.controller = controller
       },
@@ -1939,8 +1937,7 @@ async function httpNetworkFetch (
       async cancel (reason) {
         await cancelAlgorithm(reason)
       },
-      type: 'bytes',
-      queuingStrategy: new ByteLengthQueuingStrategy({ highWaterMark: 16384 })
+      type: 'bytes'
     }
   )
 


### PR DESCRIPTION
ref: https://github.com/nodejs/undici/commit/87a48113f1f68f60aa09abb07276d7c35467c663#r138446550

If we set the strategy correctly as the second parameter, the test starts to fail.