### PR TITLE
fix: dont ship wasm files of llhttp via npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,12 @@
+*
+!lib/**/*
+!index.js
+!index-fetch.js
+
+# The wasm files are stored as base64 strings in the corresponding .js files
 lib/llhttp/llhttp_simd.wasm
 lib/llhttp/llhttp.wasm
+
+!types/**/*
+!index.d.ts
+!docs/**/*

--- a/package.json
+++ b/package.json
@@ -61,15 +61,6 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
-  "files": [
-    "*.d.ts",
-    "index.js",
-    "index-fetch.js",
-    "loader.js",
-    "lib",
-    "types",
-    "docs"
-  ],
   "scripts": {
     "build:node": "npx esbuild@0.19.4 index-fetch.js --bundle --platform=node --outfile=undici-fetch.js --define:esbuildDetection=1 --keep-names && node scripts/strip-comments.js",
     "prebuild:wasm": "node build/wasm.js --prebuild",


### PR DESCRIPTION
.npmignore was useless, because package.json contained files attribute. Now .npmignore is source of truth.

before:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ npm publish --dry-run 
npm notice 
npm notice 📦  undici@6.6.2
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                                   
npm notice 16.7kB README.md                                 
npm notice 2.8kB  docs/api/Agent.md                         
npm notice 8.3kB  docs/api/api-lifecycle.md                 
npm notice 2.8kB  docs/api/BalancedPool.md                  
npm notice 1.1kB  docs/api/CacheStorage.md                  
npm notice 10.8kB docs/api/Client.md                        
npm notice 3.5kB  docs/api/Connector.md                     
npm notice 1.1kB  docs/api/ContentType.md                   
npm notice 2.0kB  docs/api/Cookies.md                       
npm notice 2.3kB  docs/api/Debug.md                         
npm notice 6.3kB  docs/api/DiagnosticsChannel.md            
npm notice 27.6kB docs/api/Dispatcher.md                    
npm notice 1.5kB  docs/api/DispatchInterceptor.md           
npm notice 3.6kB  docs/api/Errors.md                        
npm notice 685B   docs/api/EventSource.md                   
npm notice 1.2kB  docs/api/Fetch.md                         
npm notice 15.2kB docs/api/MockAgent.md                     
npm notice 2.0kB  docs/api/MockClient.md                    
npm notice 595B   docs/api/MockErrors.md                    
npm notice 16.2kB docs/api/MockPool.md                      
npm notice 2.8kB  docs/api/Pool.md                          
npm notice 775B   docs/api/PoolStats.md                     
npm notice 3.8kB  docs/api/ProxyAgent.md                    
npm notice 3.2kB  docs/api/RedirectHandler.md               
npm notice 3.9kB  docs/api/RetryHandler.md                  
npm notice 827B   docs/api/Util.md                          
npm notice 1.5kB  docs/api/WebSocket.md                     
npm notice 47.1kB docs/assets/lifecycle-diagram.png         
npm notice 2.1kB  docs/best-practices/client-certificate.md 
npm notice 3.3kB  docs/best-practices/mocking-request.md    
npm notice 3.3kB  docs/best-practices/proxy.md              
npm notice 648B   docs/best-practices/writing-tests.md      
npm notice 706B   index-fetch.js                            
npm notice 87B    index.d.ts                                
npm notice 5.3kB  index.js                                  
npm notice 4.0kB  lib/agent.js                              
npm notice 1.0kB  lib/api/abort-signal.js                   
npm notice 2.5kB  lib/api/api-connect.js                    
npm notice 5.4kB  lib/api/api-pipeline.js                   
npm notice 4.6kB  lib/api/api-request.js                    
npm notice 5.3kB  lib/api/api-stream.js                     
npm notice 2.6kB  lib/api/api-upgrade.js                    
npm notice 264B   lib/api/index.js                          
npm notice 8.2kB  lib/api/readable.js                       
npm notice 1.6kB  lib/api/util.js                           
npm notice 5.2kB  lib/balanced-pool.js                      
npm notice 20.9kB lib/cache/cache.js                        
npm notice 3.5kB  lib/cache/cachestorage.js                 
npm notice 87B    lib/cache/symbols.js                      
npm notice 1.1kB  lib/cache/util.js                         
npm notice 62.9kB lib/client.js                             
npm notice 953B   lib/compat/dispatcher-weakref.js          
npm notice 306B   lib/cookies/constants.js                  
npm notice 4.3kB  lib/cookies/index.js                      
npm notice 12.4kB lib/cookies/parse.js                      
npm notice 7.4kB  lib/cookies/util.js                       
npm notice 6.0kB  lib/core/connect.js                       
npm notice 2.6kB  lib/core/constants.js                     
npm notice 5.7kB  lib/core/diagnostics.js                   
npm notice 5.7kB  lib/core/errors.js                        
npm notice 13.1kB lib/core/request.js                       
npm notice 2.4kB  lib/core/symbols.js                       
npm notice 2.9kB  lib/core/tree.js                          
npm notice 14.9kB lib/core/util.js                          
npm notice 4.6kB  lib/dispatcher-base.js                    
npm notice 305B   lib/dispatcher.js                         
npm notice 11.6kB lib/eventsource/eventsource-stream.js     
npm notice 13.9kB lib/eventsource/eventsource.js            
npm notice 788B   lib/eventsource/util.js                   
npm notice 19.0kB lib/fetch/body.js                         
npm notice 3.0kB  lib/fetch/constants.js                    
npm notice 21.9kB lib/fetch/dataURL.js                      
npm notice 9.5kB  lib/fetch/file.js                         
npm notice 6.9kB  lib/fetch/formdata.js                     
npm notice 890B   lib/fetch/global.js                       
npm notice 16.4kB lib/fetch/headers.js                      
npm notice 83.0kB lib/fetch/index.js                        
npm notice 1.1kB  lib/fetch/LICENSE                         
npm notice 32.2kB lib/fetch/request.js                      
npm notice 17.9kB lib/fetch/response.js                     
npm notice 198B   lib/fetch/symbols.js                      
npm notice 46.0kB lib/fetch/util.js                         
npm notice 18.7kB lib/fetch/webidl.js                       
npm notice 6.6kB  lib/fileapi/encoding.js                   
npm notice 8.5kB  lib/fileapi/filereader.js                 
npm notice 1.6kB  lib/fileapi/progressevent.js              
npm notice 317B   lib/fileapi/symbols.js                    
npm notice 11.5kB lib/fileapi/util.js                       
npm notice 860B   lib/global.js                             
npm notice 613B   lib/handler/DecoratorHandler.js           
npm notice 7.6kB  lib/handler/RedirectHandler.js            
npm notice 8.5kB  lib/handler/RetryHandler.js               
npm notice 660B   lib/interceptor/redirectInterceptor.js    
npm notice 4.2kB  lib/llhttp/constants.d.ts                 
npm notice 11.0kB lib/llhttp/constants.js                   
npm notice 7.0kB  lib/llhttp/constants.js.map               
npm notice 74.0kB lib/llhttp/llhttp_simd-wasm.js            
npm notice 55.5kB lib/llhttp/llhttp_simd.wasm               
npm notice 74.0kB lib/llhttp/llhttp-wasm.js                 
npm notice 55.5kB lib/llhttp/llhttp.wasm                    
npm notice 112B   lib/llhttp/utils.d.ts                     
npm notice 394B   lib/llhttp/utils.js                       
npm notice 432B   lib/llhttp/utils.js.map                   
npm notice 699B   lib/llhttp/wasm_build_env.txt             
npm notice 4.5kB  lib/mock/mock-agent.js                    
npm notice 1.5kB  lib/mock/mock-client.js                   
npm notice 439B   lib/mock/mock-errors.js                   
npm notice 6.7kB  lib/mock/mock-interceptor.js              
npm notice 1.5kB  lib/mock/mock-pool.js                     
npm notice 769B   lib/mock/mock-symbols.js                  
npm notice 10.5kB lib/mock/mock-utils.js                    
npm notice 1.1kB  lib/mock/pending-interceptors-formatter.js
npm notice 495B   lib/mock/pluralizer.js                    
npm notice 4.2kB  lib/node/fixed-queue.js                   
npm notice 4.6kB  lib/pool-base.js                          
npm notice 552B   lib/pool-stats.js                         
npm notice 2.5kB  lib/pool.js                               
npm notice 5.6kB  lib/proxy-agent.js                        
npm notice 1.9kB  lib/timers.js                             
npm notice 10.7kB lib/websocket/connection.js               
npm notice 881B   lib/websocket/constants.js                
npm notice 6.4kB  lib/websocket/events.js                   
npm notice 1.7kB  lib/websocket/frame.js                    
npm notice 10.7kB lib/websocket/receiver.js                 
npm notice 330B   lib/websocket/symbols.js                  
npm notice 5.9kB  lib/websocket/util.js                     
npm notice 21.0kB lib/websocket/websocket.js                
npm notice 5.1kB  package.json                              
npm notice 1.1kB  types/agent.d.ts                          
npm notice 1.5kB  types/api.d.ts                            
npm notice 961B   types/balanced-pool.d.ts                  
npm notice 1.3kB  types/cache.d.ts                          
npm notice 5.0kB  types/client.d.ts                         
npm notice 1.0kB  types/connector.d.ts                      
npm notice 561B   types/content-type.d.ts                   
npm notice 635B   types/cookies.d.ts                        
npm notice 1.6kB  types/diagnostics-channel.d.ts            
npm notice 13.7kB types/dispatcher.d.ts                     
npm notice 3.7kB  types/errors.d.ts                         
npm notice 1.6kB  types/eventsource.d.ts                    
npm notice 5.5kB  types/fetch.d.ts                          
npm notice 1.7kB  types/file.d.ts                           
npm notice 1.5kB  types/filereader.d.ts                     
npm notice 5.0kB  types/formdata.d.ts                       
npm notice 276B   types/global-dispatcher.d.ts              
npm notice 175B   types/global-origin.d.ts                  
npm notice 447B   types/handlers.d.ts                       
npm notice 133B   types/header.d.ts                         
npm notice 3.1kB  types/index.d.ts                          
npm notice 215B   types/interceptors.d.ts                   
npm notice 2.5kB  types/mock-agent.d.ts                     
npm notice 1.0kB  types/mock-client.d.ts                    
npm notice 338B   types/mock-errors.d.ts                    
npm notice 3.9kB  types/mock-interceptor.d.ts               
npm notice 974B   types/mock-pool.d.ts                      
npm notice 1.7kB  types/patch.d.ts                          
npm notice 669B   types/pool-stats.d.ts                     
npm notice 1.3kB  types/pool.d.ts                           
npm notice 780B   types/proxy-agent.d.ts                    
npm notice 1.6kB  types/readable.d.ts                       
npm notice 455B   types/README.md                           
npm notice 3.0kB  types/retry-handler.d.ts                  
npm notice 1.1kB  types/util.d.ts                           
npm notice 5.6kB  types/webidl.d.ts                         
npm notice 3.9kB  types/websocket.d.ts                      
npm notice === Tarball Details === 
npm notice name:          undici                                  
npm notice version:       6.6.2                                   
npm notice filename:      undici-6.6.2.tgz                        
npm notice package size:  355.6 kB                                
npm notice unpacked size: 1.2 MB                                  
npm notice shasum:        c016578e7a24f1be5a774c74b9e85d946dd80483
npm notice integrity:     sha512-+p+E+nS1jAgVG[...]74VBTK0b3NyOA==
npm notice total files:   166                                     
npm notice 
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ undici@6.6.2
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ npm publish --dry-run 
npm notice 
npm notice 📦  undici@6.6.2
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                                   
npm notice 16.7kB README.md                                 
npm notice 2.8kB  docs/api/Agent.md                         
npm notice 8.3kB  docs/api/api-lifecycle.md                 
npm notice 2.8kB  docs/api/BalancedPool.md                  
npm notice 1.1kB  docs/api/CacheStorage.md                  
npm notice 10.8kB docs/api/Client.md                        
npm notice 3.5kB  docs/api/Connector.md                     
npm notice 1.1kB  docs/api/ContentType.md                   
npm notice 2.0kB  docs/api/Cookies.md                       
npm notice 2.3kB  docs/api/Debug.md                         
npm notice 6.3kB  docs/api/DiagnosticsChannel.md            
npm notice 27.6kB docs/api/Dispatcher.md                    
npm notice 1.5kB  docs/api/DispatchInterceptor.md           
npm notice 3.6kB  docs/api/Errors.md                        
npm notice 685B   docs/api/EventSource.md                   
npm notice 1.2kB  docs/api/Fetch.md                         
npm notice 15.2kB docs/api/MockAgent.md                     
npm notice 2.0kB  docs/api/MockClient.md                    
npm notice 595B   docs/api/MockErrors.md                    
npm notice 16.2kB docs/api/MockPool.md                      
npm notice 2.8kB  docs/api/Pool.md                          
npm notice 775B   docs/api/PoolStats.md                     
npm notice 3.8kB  docs/api/ProxyAgent.md                    
npm notice 3.2kB  docs/api/RedirectHandler.md               
npm notice 3.9kB  docs/api/RetryHandler.md                  
npm notice 827B   docs/api/Util.md                          
npm notice 1.5kB  docs/api/WebSocket.md                     
npm notice 47.1kB docs/assets/lifecycle-diagram.png         
npm notice 2.1kB  docs/best-practices/client-certificate.md 
npm notice 3.3kB  docs/best-practices/mocking-request.md    
npm notice 3.3kB  docs/best-practices/proxy.md              
npm notice 648B   docs/best-practices/writing-tests.md      
npm notice 706B   index-fetch.js                            
npm notice 87B    index.d.ts                                
npm notice 5.3kB  index.js                                  
npm notice 4.0kB  lib/agent.js                              
npm notice 1.0kB  lib/api/abort-signal.js                   
npm notice 2.5kB  lib/api/api-connect.js                    
npm notice 5.4kB  lib/api/api-pipeline.js                   
npm notice 4.6kB  lib/api/api-request.js                    
npm notice 5.3kB  lib/api/api-stream.js                     
npm notice 2.6kB  lib/api/api-upgrade.js                    
npm notice 264B   lib/api/index.js                          
npm notice 8.2kB  lib/api/readable.js                       
npm notice 1.6kB  lib/api/util.js                           
npm notice 5.2kB  lib/balanced-pool.js                      
npm notice 20.9kB lib/cache/cache.js                        
npm notice 3.5kB  lib/cache/cachestorage.js                 
npm notice 87B    lib/cache/symbols.js                      
npm notice 1.1kB  lib/cache/util.js                         
npm notice 62.9kB lib/client.js                             
npm notice 953B   lib/compat/dispatcher-weakref.js          
npm notice 306B   lib/cookies/constants.js                  
npm notice 4.3kB  lib/cookies/index.js                      
npm notice 12.4kB lib/cookies/parse.js                      
npm notice 7.4kB  lib/cookies/util.js                       
npm notice 6.0kB  lib/core/connect.js                       
npm notice 2.6kB  lib/core/constants.js                     
npm notice 5.7kB  lib/core/diagnostics.js                   
npm notice 5.7kB  lib/core/errors.js                        
npm notice 13.1kB lib/core/request.js                       
npm notice 2.4kB  lib/core/symbols.js                       
npm notice 2.9kB  lib/core/tree.js                          
npm notice 14.9kB lib/core/util.js                          
npm notice 4.6kB  lib/dispatcher-base.js                    
npm notice 305B   lib/dispatcher.js                         
npm notice 11.6kB lib/eventsource/eventsource-stream.js     
npm notice 13.9kB lib/eventsource/eventsource.js            
npm notice 788B   lib/eventsource/util.js                   
npm notice 19.0kB lib/fetch/body.js                         
npm notice 3.0kB  lib/fetch/constants.js                    
npm notice 21.9kB lib/fetch/dataURL.js                      
npm notice 9.5kB  lib/fetch/file.js                         
npm notice 6.9kB  lib/fetch/formdata.js                     
npm notice 890B   lib/fetch/global.js                       
npm notice 16.4kB lib/fetch/headers.js                      
npm notice 83.0kB lib/fetch/index.js                        
npm notice 1.1kB  lib/fetch/LICENSE                         
npm notice 32.2kB lib/fetch/request.js                      
npm notice 17.9kB lib/fetch/response.js                     
npm notice 198B   lib/fetch/symbols.js                      
npm notice 46.0kB lib/fetch/util.js                         
npm notice 18.7kB lib/fetch/webidl.js                       
npm notice 6.6kB  lib/fileapi/encoding.js                   
npm notice 8.5kB  lib/fileapi/filereader.js                 
npm notice 1.6kB  lib/fileapi/progressevent.js              
npm notice 317B   lib/fileapi/symbols.js                    
npm notice 11.5kB lib/fileapi/util.js                       
npm notice 860B   lib/global.js                             
npm notice 613B   lib/handler/DecoratorHandler.js           
npm notice 7.6kB  lib/handler/RedirectHandler.js            
npm notice 8.5kB  lib/handler/RetryHandler.js               
npm notice 660B   lib/interceptor/redirectInterceptor.js    
npm notice 4.2kB  lib/llhttp/constants.d.ts                 
npm notice 11.0kB lib/llhttp/constants.js                   
npm notice 7.0kB  lib/llhttp/constants.js.map               
npm notice 74.0kB lib/llhttp/llhttp_simd-wasm.js            
npm notice 74.0kB lib/llhttp/llhttp-wasm.js                 
npm notice 112B   lib/llhttp/utils.d.ts                     
npm notice 394B   lib/llhttp/utils.js                       
npm notice 432B   lib/llhttp/utils.js.map                   
npm notice 699B   lib/llhttp/wasm_build_env.txt             
npm notice 4.5kB  lib/mock/mock-agent.js                    
npm notice 1.5kB  lib/mock/mock-client.js                   
npm notice 439B   lib/mock/mock-errors.js                   
npm notice 6.7kB  lib/mock/mock-interceptor.js              
npm notice 1.5kB  lib/mock/mock-pool.js                     
npm notice 769B   lib/mock/mock-symbols.js                  
npm notice 10.5kB lib/mock/mock-utils.js                    
npm notice 1.1kB  lib/mock/pending-interceptors-formatter.js
npm notice 495B   lib/mock/pluralizer.js                    
npm notice 4.2kB  lib/node/fixed-queue.js                   
npm notice 4.6kB  lib/pool-base.js                          
npm notice 552B   lib/pool-stats.js                         
npm notice 2.5kB  lib/pool.js                               
npm notice 5.6kB  lib/proxy-agent.js                        
npm notice 1.9kB  lib/timers.js                             
npm notice 10.7kB lib/websocket/connection.js               
npm notice 881B   lib/websocket/constants.js                
npm notice 6.4kB  lib/websocket/events.js                   
npm notice 1.7kB  lib/websocket/frame.js                    
npm notice 10.7kB lib/websocket/receiver.js                 
npm notice 330B   lib/websocket/symbols.js                  
npm notice 5.9kB  lib/websocket/util.js                     
npm notice 21.0kB lib/websocket/websocket.js                
npm notice 5.0kB  package.json                              
npm notice 1.1kB  types/agent.d.ts                          
npm notice 1.5kB  types/api.d.ts                            
npm notice 961B   types/balanced-pool.d.ts                  
npm notice 1.3kB  types/cache.d.ts                          
npm notice 5.0kB  types/client.d.ts                         
npm notice 1.0kB  types/connector.d.ts                      
npm notice 561B   types/content-type.d.ts                   
npm notice 635B   types/cookies.d.ts                        
npm notice 1.6kB  types/diagnostics-channel.d.ts            
npm notice 13.7kB types/dispatcher.d.ts                     
npm notice 3.7kB  types/errors.d.ts                         
npm notice 1.6kB  types/eventsource.d.ts                    
npm notice 5.5kB  types/fetch.d.ts                          
npm notice 1.7kB  types/file.d.ts                           
npm notice 1.5kB  types/filereader.d.ts                     
npm notice 5.0kB  types/formdata.d.ts                       
npm notice 276B   types/global-dispatcher.d.ts              
npm notice 175B   types/global-origin.d.ts                  
npm notice 447B   types/handlers.d.ts                       
npm notice 133B   types/header.d.ts                         
npm notice 3.1kB  types/index.d.ts                          
npm notice 215B   types/interceptors.d.ts                   
npm notice 2.5kB  types/mock-agent.d.ts                     
npm notice 1.0kB  types/mock-client.d.ts                    
npm notice 338B   types/mock-errors.d.ts                    
npm notice 3.9kB  types/mock-interceptor.d.ts               
npm notice 974B   types/mock-pool.d.ts                      
npm notice 1.7kB  types/patch.d.ts                          
npm notice 669B   types/pool-stats.d.ts                     
npm notice 1.3kB  types/pool.d.ts                           
npm notice 780B   types/proxy-agent.d.ts                    
npm notice 1.6kB  types/readable.d.ts                       
npm notice 455B   types/README.md                           
npm notice 3.0kB  types/retry-handler.d.ts                  
npm notice 1.1kB  types/util.d.ts                           
npm notice 5.6kB  types/webidl.d.ts                         
npm notice 3.9kB  types/websocket.d.ts                      
npm notice === Tarball Details === 
npm notice name:          undici                                  
npm notice version:       6.6.2                                   
npm notice filename:      undici-6.6.2.tgz                        
npm notice package size:  318.6 kB                                
npm notice unpacked size: 1.1 MB                                  
npm notice shasum:        31d01c11af292c7cfed4cd5c272e7b1491d219bd
npm notice integrity:     sha512-1rU1pXxeWwnln[...]jObvqU5QB0Fdg==
npm notice total files:   164                                     
npm notice 
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ undici@6.6.2
```