### PR TITLE
perf(tree): avoid recursive calls

### DIFF
--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -36,31 +36,39 @@ class TstNode {
   /**
    * @param {Uint8Array} key
    * @param {any} value
-   * @param {number} index
    */
-  add (key, value, index) {
-    if (index === undefined || index >= key.length) {
+  add (key, value) {
+    const length = key.length
+    if (length === 0) {
       throw new TypeError('Unreachable')
     }
-    const code = key[index]
-    if (this.code === code) {
-      if (key.length === ++index) {
-        this.value = value
-      } else if (this.middle !== null) {
-        this.middle.add(key, value, index)
+    let index = 0
+    let node = this
+    while (true) {
+      const code = key[index]
+      if (node.code === code) {
+        if (length === ++index) {
+          node.value = value
+          break
+        } else if (node.middle !== null) {
+          node = node.middle
+        } else {
+          node.middle = new TstNode(key, value, index)
+          break
+        }
+      } else if (node.code < code) {
+        if (node.left !== null) {
+          node = node.left
+        } else {
+          node.left = new TstNode(key, value, index)
+          break
+        }
+      } else if (node.right !== null) {
+        node = node.right
       } else {
-        this.middle = new TstNode(key, value, index)
+        node.right = new TstNode(key, value, index)
+        break
       }
-    } else if (this.code < code) {
-      if (this.left !== null) {
-        this.left.add(key, value, index)
-      } else {
-        this.left = new TstNode(key, value, index)
-      }
-    } else if (this.right !== null) {
-      this.right.add(key, value, index)
-    } else {
-      this.right = new TstNode(key, value, index)
     }
   }
 
@@ -107,7 +115,7 @@ class TernarySearchTree {
     if (this.node === null) {
       this.node = new TstNode(key, value, 0)
     } else {
-      this.node.add(key, value, 0)
+      this.node.add(key, value)
     }
   }
 


### PR DESCRIPTION
Reduce tree build time and improve module loading time.

Script from #2517

```
benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
• built
------------------------------------------------- -----------------------------
current     76.94 µs/iter    (58.1 µs … 1,168 µs)   73.3 µs    279 µs  503.4 µs
new         59.77 µs/iter    (48.8 µs … 570.2 µs)   56.9 µs  197.8 µs    384 µs

summary for built
  new
   1.29x faster than current
```