### PR TITLE
chore: improve usage of skip in tests

### DIFF
--- a/test/cookie/global-headers.js
+++ b/test/cookie/global-headers.js
@@ -10,11 +10,8 @@ const {
 } = require('../..')
 const { getHeadersList } = require('../../lib/cookies/util')
 
-/* global Headers */
-const skip = !globalThis.Headers
-
 describe('Using global Headers', async () => {
-  test('deleteCookies', { skip }, () => {
+  test('deleteCookies', () => {
     const headers = new Headers()
 
     assert.equal(headers.get('set-cookie'), null)
@@ -22,7 +19,7 @@ describe('Using global Headers', async () => {
     assert.equal(headers.get('set-cookie'), 'undici=; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
   })
 
-  test('getCookies', { skip }, () => {
+  test('getCookies', () => {
     const headers = new Headers({
       cookie: 'get=cookies; and=attributes'
     })
@@ -30,7 +27,7 @@ describe('Using global Headers', async () => {
     assert.deepEqual(getCookies(headers), { get: 'cookies', and: 'attributes' })
   })
 
-  test('getSetCookies', { skip }, () => {
+  test('getSetCookies', () => {
     const headers = new Headers({
       'set-cookie': 'undici=getSetCookies; Secure'
     })
@@ -50,7 +47,7 @@ describe('Using global Headers', async () => {
     }
   })
 
-  test('setCookie', { skip }, () => {
+  test('setCookie', () => {
     const headers = new Headers()
 
     setCookie(headers, { name: 'undici', value: 'setCookie' })

--- a/test/cookie/global-headers.js
+++ b/test/cookie/global-headers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, skip } = require('node:test')
+const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const {
   deleteCookie,
@@ -11,14 +11,10 @@ const {
 const { getHeadersList } = require('../../lib/cookies/util')
 
 /* global Headers */
+const skip = !globalThis.Headers
 
-if (!globalThis.Headers) {
-  skip('No global Headers to test')
-  process.exit(0)
-}
-
-test('Using global Headers', async (t) => {
-  await t.test('deleteCookies', () => {
+describe('Using global Headers', async () => {
+  test('deleteCookies', { skip }, () => {
     const headers = new Headers()
 
     assert.equal(headers.get('set-cookie'), null)
@@ -26,7 +22,7 @@ test('Using global Headers', async (t) => {
     assert.equal(headers.get('set-cookie'), 'undici=; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
   })
 
-  await t.test('getCookies', () => {
+  test('getCookies', { skip }, () => {
     const headers = new Headers({
       cookie: 'get=cookies; and=attributes'
     })
@@ -34,7 +30,7 @@ test('Using global Headers', async (t) => {
     assert.deepEqual(getCookies(headers), { get: 'cookies', and: 'attributes' })
   })
 
-  await t.test('getSetCookies', () => {
+  test('getSetCookies', { skip }, () => {
     const headers = new Headers({
       'set-cookie': 'undici=getSetCookies; Secure'
     })
@@ -54,7 +50,7 @@ test('Using global Headers', async (t) => {
     }
   })
 
-  await t.test('setCookie', () => {
+  test('setCookie', { skip }, () => {
     const headers = new Headers()
 
     setCookie(headers, { name: 'undici', value: 'setCookie' })

--- a/test/fetch/http2.js
+++ b/test/fetch/http2.js
@@ -14,8 +14,6 @@ const { Client, fetch, Headers } = require('../..')
 
 const { closeClientAndServerAsPromise } = require('../utils/node-http')
 
-const nodeVersion = Number(process.version.split('v')[1].split('.')[0])
-
 test('[Fetch] Issue#2311', async (t) => {
   const expectedBody = 'hello from client!'
 
@@ -180,7 +178,6 @@ test('[Fetch] Should handle h2 request with body (string or buffer)', async (t) 
 // Skipping for now, there is something odd in the way the body is handled
 test(
   '[Fetch] Should handle h2 request with body (stream)',
-  { skip: nodeVersion === 16 },
   async (t) => {
     const server = createSecureServer(pem)
     const expectedBody = readFileSync(__filename, 'utf-8')

--- a/test/gc.js
+++ b/test/gc.js
@@ -6,11 +6,7 @@ const { test, after } = require('node:test')
 const { createServer } = require('node:net')
 const { Client, Pool } = require('..')
 
-const skip = (
-  typeof WeakRef === 'undefined' ||
-  typeof FinalizationRegistry === 'undefined' ||
-  typeof global.gc === 'undefined'
-)
+const skip = typeof global.gc === 'undefined'
 
 setInterval(() => {
   global.gc()

--- a/test/gc.js
+++ b/test/gc.js
@@ -6,7 +6,7 @@ const { test, after } = require('node:test')
 const { createServer } = require('node:net')
 const { Client, Pool } = require('..')
 
-const SKIP = (
+const skip = (
   typeof WeakRef === 'undefined' ||
   typeof FinalizationRegistry === 'undefined' ||
   typeof global.gc === 'undefined'
@@ -16,7 +16,7 @@ setInterval(() => {
   global.gc()
 }, 100).unref()
 
-test('gc should collect the client if, and only if, there are no active sockets', { skip: SKIP }, async t => {
+test('gc should collect the client if, and only if, there are no active sockets', { skip }, async t => {
   t = tspl(t, { plan: 4 })
 
   const server = createServer((socket) => {
@@ -60,7 +60,7 @@ test('gc should collect the client if, and only if, there are no active sockets'
   await t.completed
 })
 
-test('gc should collect the pool if, and only if, there are no active sockets', { skip: SKIP }, async t => {
+test('gc should collect the pool if, and only if, there are no active sockets', { skip }, async t => {
   t = tspl(t, { plan: 4 })
 
   const server = createServer((socket) => {

--- a/test/node-test/autoselectfamily.js
+++ b/test/node-test/autoselectfamily.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, skip } = require('node:test')
+const { test } = require('node:test')
 const dgram = require('node:dgram')
 const { Resolver } = require('node:dns')
 const dnsPacket = require('dns-packet')
@@ -16,11 +16,7 @@ const { tspl } = require('@matteo.collina/tspl')
  * explicitly passed in tests in this file to avoid compatibility problems across release lines.
  *
  */
-
-if (!nodeHasAutoSelectFamily) {
-  skip('autoSelectFamily is not supportee')
-  process.exit()
-}
+const skip = !nodeHasAutoSelectFamily
 
 function _lookup (resolver, hostname, options, cb) {
   resolver.resolve(hostname, 'ANY', (err, replies) => {
@@ -68,7 +64,7 @@ function createDnsServer (ipv6Addr, ipv4Addr, cb) {
   })
 }
 
-test('with autoSelectFamily enable the request succeeds when using request', async (t) => {
+test('with autoSelectFamily enable the request succeeds when using request', { skip }, async (t) => {
   const p = tspl(t, { plan: 3 })
 
   createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
@@ -108,7 +104,7 @@ test('with autoSelectFamily enable the request succeeds when using request', asy
   await p.completed
 })
 
-test('with autoSelectFamily enable the request succeeds when using a client', async (t) => {
+test('with autoSelectFamily enable the request succeeds when using a client', { skip }, async (t) => {
   const p = tspl(t, { plan: 3 })
 
   createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
@@ -149,7 +145,7 @@ test('with autoSelectFamily enable the request succeeds when using a client', as
   await p.completed
 })
 
-test('with autoSelectFamily disabled the request fails when using request', async (t) => {
+test('with autoSelectFamily disabled the request fails when using request', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
   createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
@@ -177,7 +173,7 @@ test('with autoSelectFamily disabled the request fails when using request', asyn
   await p.completed
 })
 
-test('with autoSelectFamily disabled the request fails when using a client', async (t) => {
+test('with autoSelectFamily disabled the request fails when using a client', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
   createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {

--- a/test/node-test/diagnostics-channel/connect-error.js
+++ b/test/node-test/diagnostics-channel/connect-error.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const { test, skip } = require('node:test')
+const { test } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
 let diagnosticsChannel
+let skip = false
 
 try {
   diagnosticsChannel = require('node:diagnostics_channel')
 } catch {
-  skip('missing diagnostics_channel')
-  process.exit(0)
+  skip = true
 }
 
 const { Client } = require('../../..')
 
-test('Diagnostics channel - connect error', (t) => {
+test('Diagnostics channel - connect error', { skip }, (t) => {
   const connectError = new Error('custom error')
   const assert = tspl(t, { plan: 16 })
 

--- a/test/node-test/diagnostics-channel/connect-error.js
+++ b/test/node-test/diagnostics-channel/connect-error.js
@@ -2,19 +2,10 @@
 
 const { test } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
-
-let diagnosticsChannel
-let skip = false
-
-try {
-  diagnosticsChannel = require('node:diagnostics_channel')
-} catch {
-  skip = true
-}
-
+const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client } = require('../../..')
 
-test('Diagnostics channel - connect error', { skip }, (t) => {
+test('Diagnostics channel - connect error', (t) => {
   const connectError = new Error('custom error')
   const assert = tspl(t, { plan: 16 })
 

--- a/test/node-test/diagnostics-channel/error.js
+++ b/test/node-test/diagnostics-channel/error.js
@@ -1,21 +1,21 @@
 'use strict'
 
-const { test, skip, after } = require('node:test')
+const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
 let diagnosticsChannel
+let skip = false
 
 try {
   diagnosticsChannel = require('node:diagnostics_channel')
 } catch {
-  skip('missing diagnostics_channel')
-  process.exit(0)
+  skip = true
 }
 
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - error', (t) => {
+test('Diagnostics channel - error', { skip }, (t) => {
   const assert = tspl(t, { plan: 3 })
   const server = createServer((req, res) => {
     res.destroy()

--- a/test/node-test/diagnostics-channel/error.js
+++ b/test/node-test/diagnostics-channel/error.js
@@ -2,20 +2,11 @@
 
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
-
-let diagnosticsChannel
-let skip = false
-
-try {
-  diagnosticsChannel = require('node:diagnostics_channel')
-} catch {
-  skip = true
-}
-
+const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - error', { skip }, (t) => {
+test('Diagnostics channel - error', (t) => {
   const assert = tspl(t, { plan: 3 })
   const server = createServer((req, res) => {
     res.destroy()

--- a/test/node-test/diagnostics-channel/get.js
+++ b/test/node-test/diagnostics-channel/get.js
@@ -1,21 +1,21 @@
 'use strict'
 
-const { test, skip, after } = require('node:test')
+const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
 let diagnosticsChannel
+let skip = false
 
 try {
   diagnosticsChannel = require('node:diagnostics_channel')
 } catch {
-  skip('missing diagnostics_channel')
-  process.exit(0)
+  skip = true
 }
 
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - get', (t) => {
+test('Diagnostics channel - get', { skip }, (t) => {
   const assert = tspl(t, { plan: 32 })
   const server = createServer((req, res) => {
     res.setHeader('Content-Type', 'text/plain')

--- a/test/node-test/diagnostics-channel/get.js
+++ b/test/node-test/diagnostics-channel/get.js
@@ -2,20 +2,11 @@
 
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
-
-let diagnosticsChannel
-let skip = false
-
-try {
-  diagnosticsChannel = require('node:diagnostics_channel')
-} catch {
-  skip = true
-}
-
+const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - get', { skip }, (t) => {
+test('Diagnostics channel - get', (t) => {
   const assert = tspl(t, { plan: 32 })
   const server = createServer((req, res) => {
     res.setHeader('Content-Type', 'text/plain')

--- a/test/node-test/diagnostics-channel/post-stream.js
+++ b/test/node-test/diagnostics-channel/post-stream.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const { test, skip, after } = require('node:test')
+const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const { Readable } = require('node:stream')
 
 let diagnosticsChannel
+let skip = false
 
 try {
   diagnosticsChannel = require('node:diagnostics_channel')
 } catch {
-  skip('missing diagnostics_channel')
-  process.exit(0)
+  skip = true
 }
 
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - post stream', (t) => {
+test('Diagnostics channel - post stream', { skip }, (t) => {
   const assert = tspl(t, { plan: 33 })
   const server = createServer((req, res) => {
     req.resume()

--- a/test/node-test/diagnostics-channel/post-stream.js
+++ b/test/node-test/diagnostics-channel/post-stream.js
@@ -3,20 +3,11 @@
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const { Readable } = require('node:stream')
-
-let diagnosticsChannel
-let skip = false
-
-try {
-  diagnosticsChannel = require('node:diagnostics_channel')
-} catch {
-  skip = true
-}
-
+const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - post stream', { skip }, (t) => {
+test('Diagnostics channel - post stream', (t) => {
   const assert = tspl(t, { plan: 33 })
   const server = createServer((req, res) => {
     req.resume()

--- a/test/node-test/diagnostics-channel/post.js
+++ b/test/node-test/diagnostics-channel/post.js
@@ -1,21 +1,21 @@
 'use strict'
 
-const { test, skip, after } = require('node:test')
+const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 
 let diagnosticsChannel
+let skip = false
 
 try {
   diagnosticsChannel = require('node:diagnostics_channel')
 } catch {
-  skip('missing diagnostics_channel')
-  process.exit(0)
+  skip = true
 }
 
 const { Client } = require('../../../')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - post', (t) => {
+test('Diagnostics channel - post', { skip }, (t) => {
   const assert = tspl(t, { plan: 33 })
   const server = createServer((req, res) => {
     req.resume()

--- a/test/node-test/diagnostics-channel/post.js
+++ b/test/node-test/diagnostics-channel/post.js
@@ -2,20 +2,11 @@
 
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
-
-let diagnosticsChannel
-let skip = false
-
-try {
-  diagnosticsChannel = require('node:diagnostics_channel')
-} catch {
-  skip = true
-}
-
+const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client } = require('../../../')
 const { createServer } = require('node:http')
 
-test('Diagnostics channel - post', { skip }, (t) => {
+test('Diagnostics channel - post', (t) => {
   const assert = tspl(t, { plan: 33 })
   const server = createServer((req, res) => {
     req.resume()


### PR DESCRIPTION
This is an opinionated change. I like to see in the test runner output if a test was skipped or not. So it is possible to see how many of the tests were skipped. If we just call skip and then process.exit() it does not show that we skipped 1 or 10 tests.

Also removed version check for node 16.