### PR TITLE
expose MessageEvent in fetch bundle

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -16,5 +16,6 @@ module.exports.Response = require('./lib/fetch/response').Response
 module.exports.Request = require('./lib/fetch/request').Request
 
 module.exports.WebSocket = require('./lib/websocket/websocket').WebSocket
+module.exports.MessageEvent = require('./lib/websocket/events').MessageEvent
 
 module.exports.EventSource = require('./lib/eventsource/eventsource').EventSource

--- a/index.js
+++ b/index.js
@@ -137,7 +137,11 @@ const { parseMIMEType, serializeAMimeType } = require('./lib/fetch/dataURL')
 module.exports.parseMIMEType = parseMIMEType
 module.exports.serializeAMimeType = serializeAMimeType
 
+const { CloseEvent, ErrorEvent, MessageEvent } = require('./lib/websocket/events')
 module.exports.WebSocket = require('./lib/websocket/websocket').WebSocket
+module.exports.CloseEvent = CloseEvent
+module.exports.ErrorEvent = ErrorEvent
+module.exports.MessageEvent = MessageEvent
 
 module.exports.request = makeDispatcher(api.request)
 module.exports.stream = makeDispatcher(api.stream)

--- a/test/websocket/messageevent.js
+++ b/test/websocket/messageevent.js
@@ -129,3 +129,8 @@ test('test/parallel/test-worker-message-port.js', () => {
   assert(event.cancelable)
   assert(event.defaultPrevented)
 })
+
+test('bug in node core', () => {
+  // In node core, this will throw an error.
+  new MessageEvent('', null) // eslint-disable-line no-new
+})

--- a/test/websocket/messageevent.js
+++ b/test/websocket/messageevent.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('assert')
+const { MessageEvent } = require('../..')
+
+test('test/parallel/test-messageevent-brandcheck.js', () => {
+  [
+    'data',
+    'origin',
+    'lastEventId',
+    'source',
+    'ports'
+  ].forEach((i) => {
+    assert.throws(() => Reflect.get(MessageEvent.prototype, i, {}), {
+      constructor: TypeError,
+      message: 'Illegal invocation'
+    })
+  })
+})
+
+test('test/parallel/test-worker-message-port.js', () => {
+  const dummyPort = new MessageChannel().port1
+
+  for (const [args, expected] of [
+    [
+      ['message'],
+      {
+        type: 'message',
+        data: null,
+        origin: '',
+        lastEventId: '',
+        source: null,
+        ports: []
+      }
+    ],
+    [
+      ['message', { data: undefined, origin: 'foo' }],
+      {
+        type: 'message',
+        data: null,
+        origin: 'foo',
+        lastEventId: '',
+        source: null,
+        ports: []
+      }
+    ],
+    [
+      ['message', { data: 2, origin: 1, lastEventId: 0 }],
+      {
+        type: 'message',
+        data: 2,
+        origin: '1',
+        lastEventId: '0',
+        source: null,
+        ports: []
+      }
+    ],
+    [
+      ['message', { lastEventId: 'foo' }],
+      {
+        type: 'message',
+        data: null,
+        origin: '',
+        lastEventId: 'foo',
+        source: null,
+        ports: []
+      }
+    ],
+    [
+      ['messageerror', { lastEventId: 'foo', source: dummyPort }],
+      {
+        type: 'messageerror',
+        data: null,
+        origin: '',
+        lastEventId: 'foo',
+        source: dummyPort,
+        ports: []
+      }
+    ],
+    [
+      ['message', { ports: [dummyPort], source: null }],
+      {
+        type: 'message',
+        data: null,
+        origin: '',
+        lastEventId: '',
+        source: null,
+        ports: [dummyPort]
+      }
+    ]
+  ]) {
+    const ev = new MessageEvent(...args)
+    const { type, data, origin, lastEventId, source, ports } = ev
+    assert.deepStrictEqual(expected, {
+      type, data, origin, lastEventId, source, ports
+    })
+  }
+
+  assert.throws(() => new MessageEvent('message', { source: 1 }), {
+    constructor: TypeError,
+    message: 'MessagePort: Expected 1 to be an instance of MessagePort.'
+  })
+  assert.throws(() => new MessageEvent('message', { source: {} }), {
+    constructor: TypeError,
+    message: 'MessagePort: Expected [object Object] to be an instance of MessagePort.'
+  })
+  assert.throws(() => new MessageEvent('message', { ports: 0 }), {
+    constructor: TypeError,
+    message: 'Sequence: Value of type Number is not an Object.'
+  })
+  assert.throws(() => new MessageEvent('message', { ports: [null] }), {
+    constructor: TypeError,
+    message: 'MessagePort: Expected null to be an instance of MessagePort.'
+  })
+  assert.throws(() =>
+    new MessageEvent('message', { ports: [{}] })
+  , {
+    constructor: TypeError,
+    message: 'MessagePort: Expected [object Object] to be an instance of MessagePort.'
+  })
+
+  assert(new MessageEvent('message') instanceof Event)
+
+  // https://github.com/nodejs/node/issues/51767
+  const event = new MessageEvent('type', { cancelable: true })
+  event.preventDefault()
+
+  assert(event.cancelable)
+  assert(event.defaultPrevented)
+})


### PR DESCRIPTION
Fixes: #2769 

Tests were added from node core (including one for a bug fix that has not landed, and a bug that hasn't yet been reported) and all pass as expected. Error messages and codes do change, unfortunately, so this will end up being a semver-major change in core.