### PR TITLE
feat: improve mock error breadcrumbs

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -138,19 +138,20 @@ function getMockDispatch (mockDispatches, key) {
   // Match method
   matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
   if (matchedMockDispatches.length === 0) {
-    throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}'`)
+    throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}' on path '${resolvedPath}'`)
   }
 
   // Match body
   matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
   if (matchedMockDispatches.length === 0) {
-    throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}'`)
+    throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}' on path '${resolvedPath}'`)
   }
 
   // Match headers
   matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
   if (matchedMockDispatches.length === 0) {
-    throw new MockNotMatchedError(`Mock dispatch not matched for headers '${typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers}'`)
+    const headers = typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers
+    throw new MockNotMatchedError(`Mock dispatch not matched for headers '${headers}' on path '${resolvedPath}'`)
   }
 
   return matchedMockDispatches[0]

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -2176,7 +2176,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for meth
 
   await t.rejects(request(`${baseUrl}/foo`, {
     method: 'WRONG'
-  }), new MockNotMatchedError(`Mock dispatch not matched for method 'WRONG': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for method 'WRONG' on path '/foo': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
 test('MockAgent - enableNetConnect should throw if dispatch not matched for body and the origin was not allowed by net connect', async (t) => {
@@ -2209,7 +2209,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for body
   await t.rejects(request(`${baseUrl}/foo`, {
     method: 'GET',
     body: 'wrong'
-  }), new MockNotMatchedError(`Mock dispatch not matched for body 'wrong': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for body 'wrong' on path '/foo': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
 test('MockAgent - enableNetConnect should throw if dispatch not matched for headers and the origin was not allowed by net connect', async (t) => {
@@ -2246,7 +2246,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for head
     headers: {
       'User-Agent': 'wrong'
     }
-  }), new MockNotMatchedError(`Mock dispatch not matched for headers '{"User-Agent":"wrong"}': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for headers '{"User-Agent":"wrong"}' on path '/foo': subsequent request to origin ${baseUrl} was not allowed (net.connect is not enabled for this origin)`))
 })
 
 test('MockAgent - disableNetConnect should throw if dispatch not found by net connect', async (t) => {
@@ -2317,7 +2317,7 @@ test('MockAgent - headers function interceptor', async (t) => {
     headers: {
       Authorization: 'Bearer foo'
     }
-  }), new MockNotMatchedError(`Mock dispatch not matched for headers '{"Authorization":"Bearer foo"}': subsequent request to origin ${baseUrl} was not allowed (net.connect disabled)`))
+  }), new MockNotMatchedError(`Mock dispatch not matched for headers '{"Authorization":"Bearer foo"}' on path '/foo': subsequent request to origin ${baseUrl} was not allowed (net.connect disabled)`))
 
   {
     const { statusCode } = await request(`${baseUrl}/foo`, {

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -87,6 +87,60 @@ describe('getMockDispatch', () => {
       method: 'wrong'
     }), new MockNotMatchedError('Mock dispatch not matched for path \'wrong\''))
   })
+
+  test('it should throw if no dispatch matches method', (t) => {
+    t = tspl(t, { plan: 1 })
+    const dispatches = [
+      {
+        path: 'path',
+        method: 'method',
+        consumed: false
+      }
+    ]
+
+    t.throws(() => getMockDispatch(dispatches, {
+      path: 'path',
+      method: 'wrong'
+    }), new MockNotMatchedError('Mock dispatch not matched for method \'wrong\' on path \'path\''))
+  })
+
+  test('it should throw if no dispatch matches body', (t) => {
+    t = tspl(t, { plan: 1 })
+    const dispatches = [
+      {
+        path: 'path',
+        method: 'method',
+        body: 'body',
+        consumed: false
+      }
+    ]
+
+    t.throws(() => getMockDispatch(dispatches, {
+      path: 'path',
+      method: 'method',
+      body: 'wrong'
+    }), new MockNotMatchedError('Mock dispatch not matched for body \'wrong\' on path \'path\''))
+  })
+
+  test('it should throw if no dispatch matches headers', (t) => {
+    t = tspl(t, { plan: 1 })
+    const dispatches = [
+      {
+        path: 'path',
+        method: 'method',
+        body: 'body',
+        headers: { key: 'value' },
+        consumed: false
+      }
+    ]
+
+    t.throws(() => getMockDispatch(dispatches, {
+      path: 'path',
+      method: 'method',
+      body: 'body',
+      headers: { key: 'wrong' }
+    }), new MockNotMatchedError('Mock dispatch not matched for headers \'{"key":"wrong"}\' on path \'path\''))
+  })
 })
 
 describe('getResponseData', () => {


### PR DESCRIPTION
## This relates to...
#1999

## Changes
- Add information on `resolvedPath` to `getMockDispatch` error messages 
- Update `mock-utils.js` unit tests with the new `getMockDispatch` error messages
- Update `mock-agent.js` unit tests with the new `getMockDispatch` error messages

### Features
In `mock-utils.js>getMockDispatch`, there are a series of `matchedMockDispatches` checks. If the first check passes, we know we've matched `resolvedPath`. 

This PR adds `resolvedPath` to the `MockNotMatchedErrormessages` in subsequent checks so that it's easier to track down the `MockNotMatchedError` source.


## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
