### PR TITLE
test: always exit with 0 when running in Node's Daily WPT Report CI job

### DIFF
--- a/test/wpt/runner/runner.mjs
+++ b/test/wpt/runner/runner.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url'
 import { Worker } from 'node:worker_threads'
 import { colors, handlePipes, normalizeName, parseMeta, resolveStatusPath } from './util.mjs'
 
+const alwaysExit0 = process.env.GITHUB_WORKFLOW === 'Daily WPT report'
+
 const basePath = fileURLToPath(join(import.meta.url, '../..'))
 const testPath = join(basePath, 'tests')
 const statusPath = join(basePath, 'status')
@@ -343,7 +345,11 @@ export class WPTRunner extends EventEmitter {
       `unexpected failures: ${failedTests - expectedFailures}`
     )
 
-    process.exit(failedTests - expectedFailures ? 1 : process.exitCode)
+    if (alwaysExit0) {
+      process.exit(0)
+    } else {
+      process.exit(failedTests - expectedFailures ? 1 : process.exitCode)
+    }
   }
 
   addInitScript (code) {


### PR DESCRIPTION
Updates the WPTRunner to always exit with 0 when running in https://github.com/nodejs/node/blob/main/.github/workflows/daily-wpt-fyi.yml

This is so that WPT failures don't block subsequent suites from running and being included in the WPT Report submitted to wpt.fyi.

Example of missing suites: https://wpt.fyi/results/?run_id=5181229028081664&run_id=5071266792341504&run_id=5183242763763712&run_id=5108285182574592