### PR TITLE
perf: improve perf of parseRawHeaders

### DIFF
--- a/benchmarks/parseRawHeaders.mjs
+++ b/benchmarks/parseRawHeaders.mjs
@@ -1,0 +1,24 @@
+import { bench, group, run } from 'mitata'
+import { parseRawHeaders } from '../lib/core/util.js'
+
+const rawHeadersMixed = ['key', 'value', Buffer.from('key'), Buffer.from('value')]
+const rawHeadersOnlyStrings = ['key', 'value', 'key', 'value']
+const rawHeadersOnlyBuffers = [Buffer.from('key'), Buffer.from('value'), Buffer.from('key'), Buffer.from('value')]
+const rawHeadersContent = ['content-length', 'value', 'content-disposition', 'form-data; name="fieldName"']
+
+group('parseRawHeaders', () => {
+  bench('only strings', () => {
+    parseRawHeaders(rawHeadersOnlyStrings)
+  })
+  bench('only buffers', () => {
+    parseRawHeaders(rawHeadersOnlyBuffers)
+  })
+  bench('mixed', () => {
+    parseRawHeaders(rawHeadersMixed)
+  })
+  bench('content-disposition special case', () => {
+    parseRawHeaders(rawHeadersContent)
+  })
+})
+
+await run()

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -279,22 +279,30 @@ function parseHeaders (headers, obj) {
 }
 
 function parseRawHeaders (headers) {
-  const ret = []
+  const len = headers.length
+  const ret = new Array(len)
+
   let hasContentLength = false
   let contentDispositionIdx = -1
+  let key
+  let val
+  let kLen = 0
 
   for (let n = 0; n < headers.length; n += 2) {
-    const key = headers[n + 0].toString()
-    const val = headers[n + 1].toString('utf8')
+    key = headers[n]
+    val = headers[n + 1]
 
-    if (key.length === 14 && (key === 'content-length' || key.toLowerCase() === 'content-length')) {
-      ret.push(key, val)
+    typeof key !== 'string' && (key = key.toString())
+    typeof val !== 'string' && (val = val.toString('utf8'))
+
+    kLen = key.length
+    if (kLen === 14 && key[7] === '-' && (key === 'content-length' || key.toLowerCase() === 'content-length')) {
       hasContentLength = true
-    } else if (key.length === 19 && (key === 'content-disposition' || key.toLowerCase() === 'content-disposition')) {
-      contentDispositionIdx = ret.push(key, val) - 1
-    } else {
-      ret.push(key, val)
+    } else if (kLen === 19 && key[7] === '-' && (key === 'content-disposition' || key.toLowerCase() === 'content-disposition')) {
+      contentDispositionIdx = n + 1
     }
+    ret[n] = key
+    ret[n + 1] = val
   }
 
   // See https://github.com/nodejs/node/pull/46528

--- a/test/node-test/util.js
+++ b/test/node-test/util.js
@@ -89,6 +89,7 @@ test('parseHeaders', () => {
 
 test('parseRawHeaders', () => {
   assert.deepEqual(util.parseRawHeaders(['key', 'value', Buffer.from('key'), Buffer.from('value')]), ['key', 'value', 'key', 'value'])
+  assert.deepEqual(util.parseRawHeaders(['content-length', 'value', 'content-disposition', 'form-data; name="fieldName"']), ['content-length', 'value', 'content-disposition', 'form-data; name="fieldName"'])
 })
 
 test('buildURL', () => {


### PR DESCRIPTION
before:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/parseRawHeaders.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark                             time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------ -----------------------------
• parseRawHeaders
------------------------------------------------------------------------ -----------------------------
only strings                      43'233 ps/iter    (29'089 ps … 505 ns) 36'933 ps    150 ns    237 ns
only buffers                         536 ns/iter     (483 ns … 1'204 ns)    567 ns    773 ns  1'204 ns
mixed                                312 ns/iter       (280 ns … 384 ns)    325 ns    371 ns    384 ns
content-disposition special case     408 ns/iter     (373 ns … 1'291 ns)    435 ns    463 ns  1'291 ns

summary for parseRawHeaders
  only strings
   7.21x faster than mixed
   9.43x faster than content-disposition special case
   12.4x faster than only buffers
```


after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/parseRawHeaders.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark                             time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------ -----------------------------
• parseRawHeaders
------------------------------------------------------------------------ -----------------------------
only strings                      13'686 ps/iter     (9'787 ps … 257 ns) 11'151 ps 63'976 ps 90'201 ps
only buffers                         423 ns/iter       (370 ns … 981 ns)    426 ns    529 ns    981 ns
mixed                                214 ns/iter       (194 ns … 357 ns)    211 ns    282 ns    345 ns
content-disposition special case     331 ns/iter     (302 ns … 1'160 ns)    326 ns    464 ns  1'160 ns

summary for parseRawHeaders
  only strings
   15.67x faster than mixed
   24.17x faster than content-disposition special case
   30.92x faster than only buffers
```