### PR TITLE
perf: improve TernarySearchTree

### DIFF
--- a/benchmarks/TernarySearchTree.mjs
+++ b/benchmarks/TernarySearchTree.mjs
@@ -1,0 +1,20 @@
+import { bench, group, run } from 'mitata'
+import { tree } from '../lib/core/tree.js'
+
+const contentLength = Buffer.from('Content-Length')
+const contentLengthUpperCase = Buffer.from('Content-Length'.toUpperCase())
+const contentLengthLowerCase = Buffer.from('Content-Length'.toLowerCase())
+
+group('tree.search', () => {
+  bench('content-length', () => {
+    tree.lookup(contentLengthLowerCase)
+  })
+  bench('CONTENT-LENGTH', () => {
+    tree.lookup(contentLengthUpperCase)
+  })
+  bench('Content-Length', () => {
+    tree.lookup(contentLength)
+  })
+})
+
+await run()

--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -83,7 +83,10 @@ class TstNode {
     while (node !== null && index < keylength) {
       let code = key[index]
       // A-Z
-      if (code >= 0x41 && code <= 0x5a) {
+      // First check if it is bigger than 0x5a.
+      // Lowercase letters have higher char codes than uppercase ones.
+      // Also we assume that headers will mostly contain lowercase characters.
+      if (code <= 0x5a && code >= 0x41) {
         // Lowercase for uppercase.
         code |= 32
       }
@@ -109,7 +112,7 @@ class TernarySearchTree {
 
   /**
    * @param {Uint8Array} key
-   * @param {any} value
+   * @param {void}
    * */
   insert (key, value) {
     if (this.node === null) {
@@ -121,6 +124,7 @@ class TernarySearchTree {
 
   /**
    * @param {Uint8Array} key
+   * @return {TstNode | null}
    */
   lookup (key) {
     return this.node?.search(key)?.value ?? null

--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -124,7 +124,7 @@ class TernarySearchTree {
 
   /**
    * @param {Uint8Array} key
-   * @return {TstNode | null}
+   * @return {any}
    */
   lookup (key) {
     return this.node?.search(key)?.value ?? null

--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -112,7 +112,7 @@ class TernarySearchTree {
 
   /**
    * @param {Uint8Array} key
-   * @param {void}
+   * @param {any} value
    * */
   insert (key, value) {
     if (this.node === null) {

--- a/test/node-test/tree.js
+++ b/test/node-test/tree.js
@@ -13,6 +13,13 @@ describe('Ternary Search Tree', () => {
     assert.throws(() => tst.insert(Buffer.from(''), ''))
   })
 
+  test('looking up not inserted key returns null', () => {
+    assert.throws(() => new TernarySearchTree().insert(Buffer.from(''), ''))
+    const tst = new TernarySearchTree()
+    tst.insert(Buffer.from('a'), 'a')
+    assert.strictEqual(tst.lookup(Buffer.from('non-existant')), null)
+  })
+
   test('duplicate key', () => {
     const tst = new TernarySearchTree()
     const key = Buffer.from('a')


### PR DESCRIPTION
before:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/TernarySearchTree.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark           time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------ -----------------------------
• tree.search
------------------------------------------------------ -----------------------------
content-length  35'297 ps/iter    (33'693 ps … 337 ns) 34'613 ps 40'718 ps    109 ns
CONTENT-LENGTH  35'353 ps/iter    (34'034 ps … 368 ns) 34'954 ps 40'991 ps 82'356 ps
Content-Length  34'016 ps/iter (32'977 ps … 71'478 ps) 33'795 ps 39'354 ps 60'906 ps

summary for tree.search
  Content-Length
   1.04x faster than content-length
   1.04x faster than CONTENT-LENGTH
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/TernarySearchTree.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark           time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------ -----------------------------
• tree.search
------------------------------------------------------ -----------------------------
content-length  32'567 ps/iter    (30'964 ps … 379 ns) 31'919 ps 37'205 ps 93'200 ps
CONTENT-LENGTH  35'016 ps/iter    (33'761 ps … 174 ns) 34'716 ps 39'183 ps 89'211 ps
Content-Length  32'719 ps/iter (31'578 ps … 77'070 ps) 32'499 ps 36'625 ps 64'691 ps

summary for tree.search
  content-length
   1x faster than Content-Length
   1.08x faster than CONTENT-LENGTH
```