### PR TITLE
mock: improve validateReplyParameters

### DIFF
--- a/lib/mock/mock-interceptor.js
+++ b/lib/mock/mock-interceptor.js
@@ -106,7 +106,7 @@ class MockInterceptor {
     if (typeof data === 'undefined') {
       throw new InvalidArgumentError('data must be defined')
     }
-    if (typeof responseOptions !== 'object') {
+    if (typeof responseOptions !== 'object' || responseOptions === null) {
       throw new InvalidArgumentError('responseOptions must be an object')
     }
   }

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -53,7 +53,7 @@ describe('MockInterceptor - reply callback', () => {
   })
 
   test('should error if passed options invalid', t => {
-    t = tspl(t, { plan: 2 })
+    t = tspl(t, { plan: 3 })
 
     const mockInterceptor = new MockInterceptor({
       path: '',
@@ -61,6 +61,7 @@ describe('MockInterceptor - reply callback', () => {
     }, [])
     t.throws(() => mockInterceptor.reply(), new InvalidArgumentError('statusCode must be defined'))
     t.throws(() => mockInterceptor.reply(200, () => { }, 'hello'), new InvalidArgumentError('responseOptions must be an object'))
+    t.throws(() => mockInterceptor.reply(200, () => { }, null), new InvalidArgumentError('responseOptions must be an object'))
   })
 })
 


### PR DESCRIPTION
if you would set responseOptions to null, it would pass but then it would throw an error in createMockScopeDispatchData because it would try to read headers attribute from null.

https://github.com/nodejs/undici/blob/fedae35f1b71999d2327ef6a28538f5845a71515/lib/mock/mock-interceptor.js#L96