### PR TITLE
perf: optimize one element splice operation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1463,7 +1463,7 @@ function _resume (client, sync) {
     if (!request.aborted && write(client, request)) {
       client[kPendingIdx]++
     } else {
-      client[kQueue].splice(client[kPendingIdx], 1)
+      util.spliceOneUnordered(client[kQueue], client[kPendingIdx])
     }
   }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1463,7 +1463,7 @@ function _resume (client, sync) {
     if (!request.aborted && write(client, request)) {
       client[kPendingIdx]++
     } else {
-      util.spliceOneUnordered(client[kQueue], client[kPendingIdx])
+      client[kQueue].splice(client[kPendingIdx], 1)
     }
   }
 }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -513,6 +513,14 @@ function parseRangeHeader (range) {
 const kEnumerableProperty = Object.create(null)
 kEnumerableProperty.enumerable = true
 
+function spliceOneUnordered (list, index) {
+  if (index === list.length - 1) {
+    list.pop()
+    return
+  }
+  list[index] = list.pop()
+}
+
 module.exports = {
   kEnumerableProperty,
   nop,
@@ -547,6 +555,7 @@ module.exports = {
   isValidHTTPToken,
   isTokenCharCode,
   parseRangeHeader,
+  spliceOneUnordered,
   nodeMajor,
   nodeMinor,
   nodeHasAutoSelectFamily: nodeMajor > 18 || (nodeMajor === 18 && nodeMinor >= 13),

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -8,7 +8,7 @@ const {
   kOrigin,
   kGetNetConnect
 } = require('./mock-symbols')
-const { buildURL, nop } = require('../core/util')
+const { buildURL, nop, spliceOneUnordered } = require('../core/util')
 const { STATUS_CODES } = require('node:http')
 const {
   types: {
@@ -173,7 +173,7 @@ function deleteMockDispatch (mockDispatches, key) {
     return matchKey(dispatch, key)
   })
   if (index !== -1) {
-    mockDispatches.splice(index, 1)
+    spliceOneUnordered(mockDispatches, index)
   }
 }
 

--- a/lib/pool-base.js
+++ b/lib/pool-base.js
@@ -4,6 +4,7 @@ const DispatcherBase = require('./dispatcher-base')
 const FixedQueue = require('./node/fixed-queue')
 const { kConnected, kSize, kRunning, kPending, kQueued, kBusy, kFree, kUrl, kClose, kDestroy, kDispatch } = require('./core/symbols')
 const PoolStats = require('./pool-stats')
+const { spliceOneUnordered } = require('./core/util')
 
 const kClients = Symbol('clients')
 const kNeedDrain = Symbol('needDrain')
@@ -172,7 +173,7 @@ class PoolBase extends DispatcherBase {
     client.close(() => {
       const idx = this[kClients].indexOf(client)
       if (idx !== -1) {
-        this[kClients].splice(idx, 1)
+        spliceOneUnordered(this[kClients], idx)
       }
     })
 


### PR DESCRIPTION
based on #2809 by @tsctx 

While slice keeps the order, sliceOneUnordered doesnt care about the order and can so improve the performance by a factor of 10. 

I think it is a low hanging fruit and not a micro optimization. 