### PR TITLE
chore: use lts for pubish types workflow

### DIFF
--- a/.github/workflows/publish-undici-types.yml
+++ b/.github/workflows/publish-undici-types.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '16.x'
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: node scripts/generate-undici-types-package-json.js


### PR DESCRIPTION
Use node lts instead of EOL node16

