### PR TITLE
fix url referrer wpt

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -437,6 +437,8 @@ function stripURLForReferrer (url, originOnly) {
   // 1. Assert: url is a URL.
   assert(url instanceof URL)
 
+  url = new URL(url)
+
   // 2. If url’s scheme is a local scheme, then return no referrer.
   if (url.protocol === 'file:' || url.protocol === 'about:' || url.protocol === 'blank:') {
     return 'no-referrer'

--- a/test/wpt/status/fetch.status.json
+++ b/test/wpt/status/fetch.status.json
@@ -76,10 +76,8 @@
         "skip": true
       },
       "request-referrer.any.js": {
-        "note": "TODO(@KhafraDev): url referrer test could probably be fixed",
         "fail": [
-          "about:client referrer",
-          "url referrer"
+          "about:client referrer"
         ]
       },
       "request-upload.any.js": {


### PR DESCRIPTION
Number of bugs caused by the spec not realizing that objects might be passed by reference and therefore need to be cloned before modifying: 2