### PR TITLE
fix(fetch): prevent crash when `fetch` is aborted with `null` as the `AbortSignal's` `reason`

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -4,7 +4,7 @@ const fetchImpl = require('./lib/web/fetch').fetch
 
 module.exports.fetch = function fetch (resource, init = undefined) {
   return fetchImpl(resource, init).catch((err) => {
-    if (typeof err === 'object') {
+    if (err && typeof err === 'object') {
       Error.captureStackTrace(err, this)
     }
     throw err

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports.fetch = async function fetch (init, options = undefined) {
   try {
     return await fetchImpl(init, options)
   } catch (err) {
-    if (typeof err === 'object') {
+    if (err && typeof err === 'object') {
       Error.captureStackTrace(err, this)
     }
 

--- a/test/fetch/issue-2242.js
+++ b/test/fetch/issue-2242.js
@@ -1,24 +1,54 @@
 'use strict'
 
-const { test } = require('node:test')
+const { beforeEach, describe, it } = require('node:test')
 const assert = require('node:assert')
 const { fetch } = require('../..')
 const nodeFetch = require('../../index-fetch')
 
-test('fetch with signal already aborted', async () => {
-  await assert.rejects(
-    fetch('http://localhost', {
-      signal: AbortSignal.abort('Already aborted')
-    }),
-    /Already aborted/
+describe('Issue #2242', () => {
+  ['Already aborted', null, false, true, 123, Symbol('Some reason')].forEach(
+    (reason) =>
+      describe(`when an already-aborted signal's reason is \`${String(
+        reason
+      )}\``, () => {
+        let signal
+        beforeEach(() => {
+          signal = AbortSignal.abort(reason)
+        })
+        it('rejects with that reason ', async () => {
+          await assert.rejects(fetch('http://localhost', { signal }), (err) => {
+            assert.strictEqual(err, reason)
+            return true
+          })
+        })
+        it('rejects with that reason (from index-fetch)', async () => {
+          await assert.rejects(
+            nodeFetch.fetch('http://localhost', { signal }),
+            (err) => {
+              assert.strictEqual(err, reason)
+              return true
+            }
+          )
+        })
+      })
   )
-})
 
-test('fetch with signal already aborted (from index-fetch)', async () => {
-  await assert.rejects(
-    nodeFetch.fetch('http://localhost', {
-      signal: AbortSignal.abort('Already aborted')
-    }),
-    /Already aborted/
-  )
+  describe("when an already-aborted signal's reason is `undefined`", () => {
+    let signal
+    beforeEach(() => {
+      signal = AbortSignal.abort(undefined)
+    })
+    it('rejects with an `AbortError`', async () => {
+      await assert.rejects(
+        fetch('http://localhost', { signal }),
+        new DOMException('This operation was aborted', 'AbortError')
+      )
+    })
+    it('rejects with an `AbortError` (from index-fetch)', async () => {
+      await assert.rejects(
+        nodeFetch.fetch('http://localhost', { signal }),
+        new DOMException('This operation was aborted', 'AbortError')
+      )
+    })
+  })
 })


### PR DESCRIPTION
The aim of #2243 was to prevent the use of `Error.captureStackTrace` with non-objects, but unfortunately `null` is an object.

# Repro

```shell
$ node
Welcome to Node.js v18.19.1.
Type ".help" for more information.
> const { fetch } = require('undici');
undefined
>  await fetch('http://localhost', { signal: AbortSignal.abort(null) });
Uncaught TypeError: invalid_argument
    at Function.captureStackTrace (<anonymous>)
    at fetch (/home/sol/src/solana-web3.js-git/node_modules/.pnpm/undici@6.6.2/node_modules/undici/index.js:103:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async REPL3:1:34
```

# Solution

This PR prevents the use of `Error.captureStackTrace` with `null` as well.

Further fixes #2242.