### PR TITLE
perf(tree): reduce overhead of build TernarySearchTree

### DIFF
--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -17,7 +17,7 @@ class TstNode {
   /** @type {number} */
   code
   /**
-   * @param {Uint8Array} key
+   * @param {string} key
    * @param {any} value
    * @param {number} index
    */
@@ -25,7 +25,11 @@ class TstNode {
     if (index === undefined || index >= key.length) {
       throw new TypeError('Unreachable')
     }
-    this.code = key[index]
+    const code = this.code = key.charCodeAt(index)
+    // check code is ascii string
+    if (code > 0x7F) {
+      throw new TypeError('key must be ascii string')
+    }
     if (key.length !== ++index) {
       this.middle = new TstNode(key, value, index)
     } else {
@@ -34,7 +38,7 @@ class TstNode {
   }
 
   /**
-   * @param {Uint8Array} key
+   * @param {string} key
    * @param {any} value
    */
   add (key, value) {
@@ -45,7 +49,11 @@ class TstNode {
     let index = 0
     let node = this
     while (true) {
-      const code = key[index]
+      const code = key.charCodeAt(index)
+      // check code is ascii string
+      if (code > 0x7F) {
+        throw new TypeError('key must be ascii string')
+      }
       if (node.code === code) {
         if (length === ++index) {
           node.value = value
@@ -111,7 +119,7 @@ class TernarySearchTree {
   node = null
 
   /**
-   * @param {Uint8Array} key
+   * @param {string} key
    * @param {any} value
    * */
   insert (key, value) {
@@ -135,7 +143,7 @@ const tree = new TernarySearchTree()
 
 for (let i = 0; i < wellknownHeaderNames.length; ++i) {
   const key = headerNameLowerCasedRecord[wellknownHeaderNames[i]]
-  tree.insert(Buffer.from(key), key)
+  tree.insert(key, key)
 }
 
 module.exports = {

--- a/test/node-test/tree.js
+++ b/test/node-test/tree.js
@@ -24,7 +24,7 @@ describe('Ternary Search Tree', () => {
     const tst = new TernarySearchTree()
     tst.insert('a', 'a')
     // throw on TstNode
-    assert.throws(() => tst.insert('a\x80', 'a'))
+    assert.throws(() => tst.insert('\x80', 'a'))
   })
 
   test('duplicate key', () => {

--- a/test/node-test/tree.js
+++ b/test/node-test/tree.js
@@ -7,26 +7,34 @@ const assert = require('node:assert')
 
 describe('Ternary Search Tree', () => {
   test('The empty key cannot be added.', () => {
-    assert.throws(() => new TernarySearchTree().insert(Buffer.from(''), ''))
+    assert.throws(() => new TernarySearchTree().insert('', ''))
     const tst = new TernarySearchTree()
-    tst.insert(Buffer.from('a'), 'a')
-    assert.throws(() => tst.insert(Buffer.from(''), ''))
+    tst.insert('a', 'a')
+    assert.throws(() => tst.insert('', ''))
   })
 
   test('looking up not inserted key returns null', () => {
-    assert.throws(() => new TernarySearchTree().insert(Buffer.from(''), ''))
     const tst = new TernarySearchTree()
-    tst.insert(Buffer.from('a'), 'a')
+    tst.insert('a', 'a')
     assert.strictEqual(tst.lookup(Buffer.from('non-existant')), null)
+  })
+
+  test('not ascii string', () => {
+    assert.throws(() => new TernarySearchTree().insert('\x80', 'a'))
+    const tst = new TernarySearchTree()
+    tst.insert('a', 'a')
+    // throw on TstNode
+    assert.throws(() => tst.insert('a\x80', 'a'))
   })
 
   test('duplicate key', () => {
     const tst = new TernarySearchTree()
-    const key = Buffer.from('a')
+    const key = 'a'
+    const lookupKey = Buffer.from(key)
     tst.insert(key, 'a')
-    assert.strictEqual(tst.lookup(key), 'a')
+    assert.strictEqual(tst.lookup(lookupKey), 'a')
     tst.insert(key, 'b')
-    assert.strictEqual(tst.lookup(key), 'b')
+    assert.strictEqual(tst.lookup(lookupKey), 'b')
   })
 
   test('tree', () => {
@@ -59,7 +67,7 @@ describe('Ternary Search Tree', () => {
       const key = generateAsciiString((Math.random() * 100 + 5) | 0)
       const lowerCasedKey = random[i] = key.toLowerCase()
       randomBuffer[i] = Buffer.from(key)
-      tst.insert(Buffer.from(lowerCasedKey), lowerCasedKey)
+      tst.insert(lowerCasedKey, lowerCasedKey)
     }
 
     for (let i = 0; i < LENGTH; ++i) {


### PR DESCRIPTION
Reduce tree build time and improve module loading time.

<details>

<summary>Benchmark Script</summary>

```js
import { bench, group, run } from 'mitata'
import {
  wellknownHeaderNames,
  headerNameLowerCasedRecord
} from '../lib/core/constants.js'
import { TernarySearchTree } from '../lib/core/tree.js'
// copy new implementation
import { TernarySearchTree2 } from '../lib/core/tree2.js'

group('built', () => {
  bench('current', () => {
    const tst = new TernarySearchTree()
    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
      const key = wellknownHeaderNames[i].toLowerCase()
      tst.insert(Buffer.from(key), key)
    }
  })
  bench('new', () => {
    const tst = new TernarySearchTree2()
    for (let i = 0; i < wellknownHeaderNames.length; ++i) {
      const key = headerNameLowerCasedRecord[wellknownHeaderNames[i]]
      tst.insert(key, key)
    }
  })
})

await run()
```

</details>

```
benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
• built
------------------------------------------------- -----------------------------
current    65'261 ns/iter    (50'800 ns … 650 µs) 61'600 ns    230 µs    482 µs
new        38'100 ns/iter    (29'900 ns … 482 µs) 37'100 ns 94'300 ns    287 µs

summary for built
  new
   1.71x faster than current
```