### PR TITLE
unite webidl stringification

### DIFF
--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -339,7 +339,7 @@ webidl.interfaceConverter = function (i) {
     if (opts.strict !== false && !(V instanceof i)) {
       throw webidl.errors.exception({
         header: i.name,
-        message: `Expected ${JSON.stringify(V)} to be an instance of ${i.name}.`
+        message: `Expected ${webidl.util.Stringify(V)} to be an instance of ${i.name}.`
       })
     }
 

--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -224,6 +224,8 @@ webidl.util.Stringify = function (V) {
       return `Symbol(${V.description})`
     case 'Object':
       return JSON.stringify(V)
+    case 'String':
+      return V.length ? V : '""'
     default:
       return `${V}`
   }

--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { types } = require('node:util')
+const { types, inspect } = require('node:util')
 const { toUSVString } = require('../../core/util')
 
 /** @type {import('../../../types/webidl').Webidl} */
@@ -223,9 +223,9 @@ webidl.util.Stringify = function (V) {
     case 'Symbol':
       return `Symbol(${V.description})`
     case 'Object':
-      return JSON.stringify(V)
+      return inspect(V)
     case 'String':
-      return V.length ? V : '""'
+      return `"${V}"`
     default:
       return `${V}`
   }

--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -221,7 +221,7 @@ webidl.util.Stringify = function (V) {
 
   switch (type) {
     case 'Symbol':
-      return V.description
+      return `Symbol(${V.description})`
     case 'Object':
       return JSON.stringify(V)
     default:

--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -136,7 +136,7 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, opts = {}) {
     ) {
       throw webidl.errors.exception({
         header: 'Integer conversion',
-        message: `Could not convert ${V} to an integer.`
+        message: `Could not convert ${webidl.util.Stringify(V)} to an integer.`
       })
     }
 
@@ -214,6 +214,19 @@ webidl.util.IntegerPart = function (n) {
 
   // 3. Otherwise, return r.
   return r
+}
+
+webidl.util.Stringify = function (V) {
+  const type = webidl.util.Type(V)
+
+  switch (type) {
+    case 'Symbol':
+      return V.description
+    case 'Object':
+      return JSON.stringify(V)
+    default:
+      return `${V}`
+  }
 }
 
 // https://webidl.spec.whatwg.org/#es-sequence
@@ -324,7 +337,7 @@ webidl.interfaceConverter = function (i) {
     if (opts.strict !== false && !(V instanceof i)) {
       throw webidl.errors.exception({
         header: i.name,
-        message: `Expected ${V} to be an instance of ${i.name}.`
+        message: `Expected ${JSON.stringify(V)} to be an instance of ${i.name}.`
       })
     }
 
@@ -515,8 +528,8 @@ webidl.converters.ArrayBuffer = function (V, opts = {}) {
     !types.isAnyArrayBuffer(V)
   ) {
     throw webidl.errors.conversionFailed({
-      prefix: `${V}`,
-      argument: `${V}`,
+      prefix: webidl.util.Stringify(V),
+      argument: webidl.util.Stringify(V),
       types: ['ArrayBuffer']
     })
   }
@@ -556,7 +569,7 @@ webidl.converters.TypedArray = function (V, T, opts = {}) {
   ) {
     throw webidl.errors.conversionFailed({
       prefix: `${T.name}`,
-      argument: `${V}`,
+      argument: webidl.util.Stringify(V),
       types: [T.name]
     })
   }
@@ -629,7 +642,7 @@ webidl.converters.BufferSource = function (V, opts = {}) {
     return webidl.converters.DataView(V, opts, { ...opts, allowShared: false })
   }
 
-  throw new TypeError(`Could not convert ${V} to a BufferSource.`)
+  throw new TypeError(`Could not convert ${webidl.util.Stringify(V)} to a BufferSource.`)
 }
 
 webidl.converters['sequence<ByteString>'] = webidl.sequenceConverter(

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -193,6 +193,7 @@ test('webidl.util.Stringify', (t) => {
     [true, 'true'],
     [0, '0'],
     ['hello', 'hello'],
+    ['', '""'],
     [null, 'null'],
     [undefined, 'undefined']
   ]

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -188,8 +188,8 @@ test('webidl.util.Stringify', (t) => {
   const pairs = [
     [Object.create(null), '{}'],
     [{ a: 'b' }, '{"a":"b"}'],
-    [Symbol('sym'), 'sym'],
-    [Symbol.iterator, 'Symbol.iterator'], // well-known symbol
+    [Symbol('sym'), 'Symbol(sym)'],
+    [Symbol.iterator, 'Symbol(Symbol.iterator)'], // well-known symbol
     [true, 'true'],
     [0, '0'],
     ['hello', 'hello'],

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -185,17 +185,21 @@ test('ByteString', () => {
 })
 
 test('webidl.util.Stringify', (t) => {
+  const circular = {}
+  circular.circular = circular
+
   const pairs = [
-    [Object.create(null), '{}'],
-    [{ a: 'b' }, '{"a":"b"}'],
+    [Object.create(null), '[Object: null prototype] {}'],
+    [{ a: 'b' }, "{ a: 'b' }"],
     [Symbol('sym'), 'Symbol(sym)'],
     [Symbol.iterator, 'Symbol(Symbol.iterator)'], // well-known symbol
     [true, 'true'],
     [0, '0'],
-    ['hello', 'hello'],
+    ['hello', '"hello"'],
     ['', '""'],
     [null, 'null'],
-    [undefined, 'undefined']
+    [undefined, 'undefined'],
+    [circular, '<ref *1> { circular: [Circular *1] }']
   ]
 
   for (const [value, expected] of pairs) {

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -183,3 +183,21 @@ test('ByteString', () => {
              'index 7 has a value of 256 which is greater than 255.'
   })
 })
+
+test('webidl.util.Stringify', (t) => {
+  const pairs = [
+    [Object.create(null), '{}'],
+    [{ a: 'b' }, '{"a":"b"}'],
+    [Symbol('sym'), 'sym'],
+    [Symbol.iterator, 'Symbol.iterator'], // well-known symbol
+    [true, 'true'],
+    [0, '0'],
+    ['hello', 'hello'],
+    [null, 'null'],
+    [undefined, 'undefined']
+  ]
+
+  for (const [value, expected] of pairs) {
+    assert.deepStrictEqual(webidl.util.Stringify(value), expected)
+  }
+})

--- a/test/websocket/messageevent.js
+++ b/test/websocket/messageevent.js
@@ -103,7 +103,7 @@ test('test/parallel/test-worker-message-port.js', () => {
   })
   assert.throws(() => new MessageEvent('message', { source: {} }), {
     constructor: TypeError,
-    message: 'MessagePort: Expected [object Object] to be an instance of MessagePort.'
+    message: 'MessagePort: Expected {} to be an instance of MessagePort.'
   })
   assert.throws(() => new MessageEvent('message', { ports: 0 }), {
     constructor: TypeError,
@@ -117,7 +117,7 @@ test('test/parallel/test-worker-message-port.js', () => {
     new MessageEvent('message', { ports: [{}] })
   , {
     constructor: TypeError,
-    message: 'MessagePort: Expected [object Object] to be an instance of MessagePort.'
+    message: 'MessagePort: Expected {} to be an instance of MessagePort.'
   })
 
   assert(new MessageEvent('message') instanceof Event)

--- a/types/webidl.d.ts
+++ b/types/webidl.d.ts
@@ -62,6 +62,11 @@ interface WebidlUtil {
    * @see https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
    */
   IntegerPart (N: number): number
+
+  /**
+   * Stringifies {@param V}
+   */
+  Stringify (V: any): string
 }
 
 interface WebidlConverters {


### PR DESCRIPTION
Before:
```js

webidl.converters.BufferSource(Object.create(null))
// TypeError: Cannot convert object to primitive value

webidl.converters.BufferSource(Symbol('t'))
// TypeError: Cannot convert a Symbol value to a string

webidl.converters.BufferSource('')
// TypeError: Could not convert  to a BufferSource.
// convert what?

```

After:
```js

webidl.converters.BufferSource(Object.create(null))
// TypeError: Could not convert {} to a BufferSource.

webidl.converters.BufferSource(Symbol('t'))
// TypeError: Could not convert Symbol(t) to a BufferSource.

webidl.converters.BufferSource('')
// TypeError: Could not convert "" to a BufferSource.
