### PR TITLE
perf: improve performance of isValidSubprotocol

### DIFF
--- a/benchmarks/websocketIsValidSubprotocol.mjs
+++ b/benchmarks/websocketIsValidSubprotocol.mjs
@@ -1,0 +1,17 @@
+import { bench, group, run } from 'mitata'
+import { isValidSubprotocol } from '../lib/web/websocket/util.js'
+
+const valid = 'valid'
+const invalid = 'invalid '
+
+group('isValidSubprotocol', () => {
+  bench(`valid: ${valid}`, () => {
+    return isValidSubprotocol(valid)
+  })
+
+  bench(`invalid: ${invalid}`, () => {
+    return isValidSubprotocol(invalid)
+  })
+})
+
+await run()

--- a/lib/web/websocket/util.js
+++ b/lib/web/websocket/util.js
@@ -119,31 +119,29 @@ function isValidSubprotocol (protocol) {
     return false
   }
 
-  for (const char of protocol) {
-    const code = char.charCodeAt(0)
+  for (let i = 0; i < protocol.length; ++i) {
+    const code = protocol.charCodeAt(i)
 
     if (
-      code < 0x21 ||
+      code < 0x21 || // CTL, contains SP (0x20) and HT (0x09)
       code > 0x7E ||
-      char === '(' ||
-      char === ')' ||
-      char === '<' ||
-      char === '>' ||
-      char === '@' ||
-      char === ',' ||
-      char === ';' ||
-      char === ':' ||
-      char === '\\' ||
-      char === '"' ||
-      char === '/' ||
-      char === '[' ||
-      char === ']' ||
-      char === '?' ||
-      char === '=' ||
-      char === '{' ||
-      char === '}' ||
-      code === 32 || // SP
-      code === 9 // HT
+      code === 0x22 || // "
+      code === 0x28 || // (
+      code === 0x29 || // )
+      code === 0x2C || // ,
+      code === 0x2F || // /
+      code === 0x3A || // :
+      code === 0x3B || // ;
+      code === 0x3C || // <
+      code === 0x3D || // =
+      code === 0x3E || // >
+      code === 0x3F || // ?
+      code === 0x40 || // @
+      code === 0x5B || // [
+      code === 0x5C || // \
+      code === 0x5D || // ]
+      code === 0x7B || // {
+      code === 0x7D // }
     ) {
       return false
     }

--- a/test/websocket/util.js
+++ b/test/websocket/util.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { describe, test } = require('node:test')
+const { isValidSubprotocol } = require('../../lib/web/websocket/util')
+
+describe('isValidSubprotocol', () => {
+  test('empty string returns false', t => {
+    t = tspl(t, { plan: 1 })
+    t.strictEqual(isValidSubprotocol(''), false)
+  })
+
+  test('simple valid value returns false', t => {
+    t = tspl(t, { plan: 1 })
+    t.strictEqual(isValidSubprotocol('chat'), true)
+  })
+
+  test('empty string returns false', t => {
+    t = tspl(t, { plan: 1 })
+    t.strictEqual(isValidSubprotocol(''), false)
+  })
+
+  test('value with "(),/:;<=>?@[\\]{} returns false', t => {
+    const chars = '"(),/:;<=>?@[\\]{}'
+    t = tspl(t, { plan: 17 })
+
+    for (let i = 0; i < chars.length; ++i) {
+      t.strictEqual(isValidSubprotocol('valid' + chars[i]), false)
+    }
+  })
+})


### PR DESCRIPTION
before:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/websocketIsValidSubprotocol.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark              time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------- -----------------------------
• isValidSubprotocol
--------------------------------------------------------- -----------------------------
valid: valid        47.78 ns/iter     (42.32 ns … 279 ns)  44.95 ns    153 ns    231 ns
invalid: invalid     64.4 ns/iter   (61.08 ns … 1'276 ns)  64.08 ns  79.02 ns    141 ns
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/websocketIsValidSubprotocol.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark              time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------- -----------------------------
• isValidSubprotocol
--------------------------------------------------------- -----------------------------
valid: valid        15.08 ns/iter     (12.48 ns … 102 ns)  14.87 ns  40.31 ns  82.84 ns
invalid: invalid    19.86 ns/iter    (18.38 ns … 50.3 ns)  19.54 ns  32.71 ns  37.24 ns

summary for isValidSubprotocol
  valid: valid
   1.32x faster than invalid: invalid 
```