### PR TITLE
perf: reuse TextDecoder instance

### DIFF
--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -12,6 +12,8 @@ const { WebsocketFrameSend } = require('./frame')
 // Copyright (c) 2013 Arnout Kazemier and contributors
 // Copyright (c) 2016 Luigi Pinca and contributors
 
+const textDecoder = new TextDecoder('utf-8', { fatal: true })
+
 class ByteParser extends Writable {
   #buffers = []
   #byteOffset = 0
@@ -322,8 +324,7 @@ class ByteParser extends Writable {
     }
 
     try {
-      // TODO: optimize this
-      reason = new TextDecoder('utf-8', { fatal: true }).decode(reason)
+      reason = textDecoder.decode(reason)
     } catch {
       return null
     }

--- a/lib/web/websocket/util.js
+++ b/lib/web/websocket/util.js
@@ -55,6 +55,8 @@ function fireEvent (e, target, eventConstructor = Event, eventInitDict = {}) {
   target.dispatchEvent(event)
 }
 
+const textDecoder = new TextDecoder('utf-8', { fatal: true })
+
 /**
  * @see https://websockets.spec.whatwg.org/#feedback-from-the-protocol
  * @param {import('./websocket').WebSocket} ws
@@ -74,7 +76,7 @@ function websocketMessageReceived (ws, type, data) {
     // -> type indicates that the data is Text
     //      a new DOMString containing data
     try {
-      dataForEvent = new TextDecoder('utf-8', { fatal: true }).decode(data)
+      dataForEvent = textDecoder.decode(data)
     } catch {
       failWebsocketConnection(ws, 'Received invalid UTF-8 in text frame.')
       return


### PR DESCRIPTION
Was there a reason not to reuse the textdecoder instance?