### PR TITLE
chore: restructure benchmarks, use kebab-case

### DIFF
--- a/benchmarks/cache/get-field-values.mjs
+++ b/benchmarks/cache/get-field-values.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { getFieldValues } from '../lib/web/cache/util.js'
+import { getFieldValues } from '../../lib/web/cache/util.js'
 
 const values = [
   '',

--- a/benchmarks/cookies/Is-ctl-excluding-htab.mjs
+++ b/benchmarks/cookies/Is-ctl-excluding-htab.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { isCTLExcludingHtab } from '../lib/web/cookies/util.js'
+import { isCTLExcludingHtab } from '../../lib/web/cookies/util.js'
 
 const valid = 'Space=Cat; Secure; HttpOnly; Max-Age=2'
 const invalid = 'Space=Cat; Secure; HttpOnly; Max-Age=2\x7F'

--- a/benchmarks/core/parse-headers.mjs
+++ b/benchmarks/core/parse-headers.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { parseHeaders } from '../lib/core/util.js'
+import { parseHeaders } from '../../lib/core/util.js'
 
 const target = [
   {

--- a/benchmarks/core/parse-raw-headers.mjs
+++ b/benchmarks/core/parse-raw-headers.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { parseRawHeaders } from '../lib/core/util.js'
+import { parseRawHeaders } from '../../lib/core/util.js'
 
 const rawHeadersMixed = ['key', 'value', Buffer.from('key'), Buffer.from('value')]
 const rawHeadersOnlyStrings = ['key', 'value', 'key', 'value']

--- a/benchmarks/core/tree.mjs
+++ b/benchmarks/core/tree.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { tree } from '../lib/core/tree.js'
+import { tree } from '../../lib/core/tree.js'
 
 const contentLength = Buffer.from('Content-Length')
 const contentLengthUpperCase = Buffer.from('Content-Length'.toUpperCase())

--- a/benchmarks/fetch/headers-length32.mjs
+++ b/benchmarks/fetch/headers-length32.mjs
@@ -1,5 +1,5 @@
 import { bench, run } from 'mitata'
-import { Headers } from '../lib/web/fetch/headers.js'
+import { Headers } from '../../lib/web/fetch/headers.js'
 
 const headers = new Headers(
   [

--- a/benchmarks/fetch/headers.mjs
+++ b/benchmarks/fetch/headers.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { Headers } from '../lib/web/fetch/headers.js'
+import { Headers } from '../../lib/web/fetch/headers.js'
 
 const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 const charactersLength = characters.length

--- a/benchmarks/websocket/is-valid-subprotocol.mjs
+++ b/benchmarks/websocket/is-valid-subprotocol.mjs
@@ -1,5 +1,5 @@
 import { bench, group, run } from 'mitata'
-import { isValidSubprotocol } from '../lib/web/websocket/util.js'
+import { isValidSubprotocol } from '../../lib/web/websocket/util.js'
 
 const valid = 'valid'
 const invalid = 'invalid '


### PR DESCRIPTION
this is just about restructuring the benchmarks folder, also use kebab-case for the file names