### PR TITLE
cookies: improve perf of toIMFDate

### DIFF
--- a/benchmarks/cookies/to-imf-date.mjs
+++ b/benchmarks/cookies/to-imf-date.mjs
@@ -1,0 +1,12 @@
+import { bench, group, run } from 'mitata'
+import { toIMFDate } from '../../lib/web/cookies/util.js'
+
+const date = new Date()
+
+group('toIMFDate', () => {
+  bench(`toIMFDate: ${date}`, () => {
+    return toIMFDate(date)
+  })
+})
+
+await run()

--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -114,6 +114,18 @@ function validateCookieDomain (domain) {
   }
 }
 
+const IMFDays = [
+  'Sun', 'Mon', 'Tue', 'Wed',
+  'Thu', 'Fri', 'Sat'
+]
+
+const IMFMonths = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+]
+
+const IMFPaddedNumbers = Array(61).fill(0).map((_, i) => i.toString().padStart(2, '0'))
+
 /**
  * @see https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
  * @param {number|Date} date
@@ -160,25 +172,7 @@ function toIMFDate (date) {
     date = new Date(date)
   }
 
-  const days = [
-    'Sun', 'Mon', 'Tue', 'Wed',
-    'Thu', 'Fri', 'Sat'
-  ]
-
-  const months = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-  ]
-
-  const dayName = days[date.getUTCDay()]
-  const day = date.getUTCDate().toString().padStart(2, '0')
-  const month = months[date.getUTCMonth()]
-  const year = date.getUTCFullYear()
-  const hour = date.getUTCHours().toString().padStart(2, '0')
-  const minute = date.getUTCMinutes().toString().padStart(2, '0')
-  const second = date.getUTCSeconds().toString().padStart(2, '0')
-
-  return `${dayName}, ${day} ${month} ${year} ${hour}:${minute}:${second} GMT`
+  return `${IMFDays[date.getUTCDay()]}, ${IMFPaddedNumbers[date.getUTCDate()]} ${IMFMonths[date.getUTCMonth()]} ${date.getUTCFullYear()} ${IMFPaddedNumbers[date.getUTCHours()]}:${IMFPaddedNumbers[date.getUTCMinutes()]}:${IMFPaddedNumbers[date.getUTCSeconds()]} GMT`
 }
 
 /**
@@ -287,6 +281,7 @@ function getHeadersList (headers) {
 
 module.exports = {
   isCTLExcludingHtab,
+  toIMFDate,
   stringify,
   getHeadersList
 }

--- a/test/cookie/to-imf-date.js
+++ b/test/cookie/to-imf-date.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const { strictEqual } = require('node:assert')
+
+const {
+  toIMFDate
+} = require('../../lib/web/cookies/util')
+
+describe('toIMFDate', () => {
+  test('should return the same as Date.prototype.toGMTString()', () => {
+    for (let i = 1; i <= 1e6; i *= 2) {
+      const date = new Date(i)
+      strictEqual(toIMFDate(date), date.toGMTString())
+    }
+    for (let i = 0; i <= 1e6; i++) {
+      const date = new Date(Math.trunc(Math.random() * 8640000000000000))
+      strictEqual(toIMFDate(date), date.toGMTString())
+    }
+  })
+})


### PR DESCRIPTION
before:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/cookies/to-imf-date.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark                                                                          time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------------------------------------------------------------------- -----------------------------
• toIMFDate
--------------------------------------------------------------------------------------------------------------------- -----------------------------
toIMFDate: Wed Feb 28 2024 01:28:41 GMT+0100 (Central European Standard Time)     307 ns/iter     (237 ns … 1'868 ns)    295 ns    854 ns  1'868 ns

summary for toIMFDate
  toIMFDate: Wed Feb 28 2024 01:28:41 GMT+0100 (Central European Standard Time)
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/cookies/to-imf-date.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark                                                                          time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------------------------------------------------------------------- -----------------------------
• toIMFDate
--------------------------------------------------------------------------------------------------------------------- -----------------------------
toIMFDate: Wed Feb 28 2024 01:29:02 GMT+0100 (Central European Standard Time)     216 ns/iter     (158 ns … 1'330 ns)    209 ns    649 ns  1'271 ns

summary for toIMFDate
  toIMFDate: Wed Feb 28 2024 01:29:02 GMT+0100 (Central European Standard Time)
```
