### PR TITLE
ci: remove concurrency

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,5 @@
 name: Node CI
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }} 
-  cancel-in-progress: true
-
 on:
   push:
     branches:


### PR DESCRIPTION
It seems, that codecov needs all commits. So we should remove the concurrency so that github pushes all commits to codecov.