### PR TITLE
cookies: improve validateCookieName

### DIFF
--- a/benchmarks/cookies/validate-cookie-name.mjs
+++ b/benchmarks/cookies/validate-cookie-name.mjs
@@ -1,0 +1,12 @@
+import { bench, group, run } from 'mitata'
+import { validateCookieName } from '../../lib/web/cookies/util.js'
+
+const valid = 'Cat'
+
+group('validateCookieName', () => {
+  bench(`valid: ${valid}`, () => {
+    return validateCookieName(valid)
+  })
+})
+
+await run()

--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -32,28 +32,29 @@ function isCTLExcludingHtab (value) {
  * @param {string} name
  */
 function validateCookieName (name) {
-  for (const char of name) {
-    const code = char.charCodeAt(0)
+  for (let i = 0; i < name.length; ++i) {
+    const code = name.charCodeAt(i)
 
     if (
-      (code <= 0x20 || code > 0x7F) ||
-      char === '(' ||
-      char === ')' ||
-      char === '>' ||
-      char === '<' ||
-      char === '@' ||
-      char === ',' ||
-      char === ';' ||
-      char === ':' ||
-      char === '\\' ||
-      char === '"' ||
-      char === '/' ||
-      char === '[' ||
-      char === ']' ||
-      char === '?' ||
-      char === '=' ||
-      char === '{' ||
-      char === '}'
+      code < 0x21 || // exclude CTLs (0-31), SP and HT
+      code > 0x7E || // exclude non-ascii and DEL
+      code === 0x22 || // "
+      code === 0x28 || // (
+      code === 0x29 || // )
+      code === 0x3C || // <
+      code === 0x3E || // >
+      code === 0x40 || // @
+      code === 0x2C || // ,
+      code === 0x3B || // ;
+      code === 0x3A || // :
+      code === 0x5C || // \
+      code === 0x2F || // /
+      code === 0x5B || // [
+      code === 0x5D || // ]
+      code === 0x3F || // ?
+      code === 0x3D || // =
+      code === 0x7B || // {
+      code === 0x7D // }
     ) {
       throw new Error('Invalid cookie name')
     }
@@ -285,6 +286,7 @@ function getHeadersList (headers) {
 
 module.exports = {
   isCTLExcludingHtab,
+  validateCookieName,
   validateCookiePath,
   toIMFDate,
   stringify,

--- a/test/cookie/validate-cookie-name.js
+++ b/test/cookie/validate-cookie-name.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const { throws, strictEqual } = require('node:assert')
+
+const {
+  validateCookieName
+} = require('../../lib/web/cookies/util')
+
+describe('validateCookieName', () => {
+  test('should throw for CTLs', () => {
+    throws(() => validateCookieName('\x00'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x01'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x02'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x03'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x04'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x05'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x06'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x07'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x08'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x09'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0A'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0B'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0C'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0D'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0E'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x0F'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x10'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x11'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x12'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x13'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x14'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x15'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x16'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x17'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x18'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x19'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1A'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1B'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1C'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1D'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1E'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x1F'), new Error('Invalid cookie name'))
+    throws(() => validateCookieName('\x7F'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for " " character', () => {
+    throws(() => validateCookieName(' '), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for Horizontal Tab character', () => {
+    throws(() => validateCookieName('\t'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for ; character', () => {
+    throws(() => validateCookieName(';'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for " character', () => {
+    throws(() => validateCookieName('"'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for , character', () => {
+    throws(() => validateCookieName(','), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for \\ character', () => {
+    throws(() => validateCookieName('\\'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for ( character', () => {
+    throws(() => validateCookieName('('), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for ) character', () => {
+    throws(() => validateCookieName(')'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for < character', () => {
+    throws(() => validateCookieName('<'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for > character', () => {
+    throws(() => validateCookieName('>'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for @ character', () => {
+    throws(() => validateCookieName('@'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for : character', () => {
+    throws(() => validateCookieName(':'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for / character', () => {
+    throws(() => validateCookieName('/'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for [ character', () => {
+    throws(() => validateCookieName('['), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for ] character', () => {
+    throws(() => validateCookieName(']'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for ? character', () => {
+    throws(() => validateCookieName('?'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for = character', () => {
+    throws(() => validateCookieName('='), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for { character', () => {
+    throws(() => validateCookieName('{'), new Error('Invalid cookie name'))
+  })
+
+  test('should throw for } character', () => {
+    throws(() => validateCookieName('}'), new Error('Invalid cookie name'))
+  })
+
+  test('should pass for a printable character', t => {
+    strictEqual(validateCookieName('A'), undefined)
+    strictEqual(validateCookieName('Z'), undefined)
+    strictEqual(validateCookieName('a'), undefined)
+    strictEqual(validateCookieName('z'), undefined)
+    strictEqual(validateCookieName('!'), undefined)
+  })
+})


### PR DESCRIPTION
- improve performance
- write tests

before:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/cookies/validate-cookie-name.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark       time (avg)             (min … max)       p75       p99      p999
-------------------------------------------------- -----------------------------
• validateCookieName
-------------------------------------------------- -----------------------------
valid: Cat   29.24 ns/iter     (25.81 ns … 854 ns)  26.67 ns  82.46 ns    107 ns

summary for validateCookieName
  valid: Cat
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/cookies/validate-cookie-name.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.6.2 (x64-linux)

benchmark       time (avg)             (min … max)       p75       p99      p999
-------------------------------------------------- -----------------------------
• validateCookieName
-------------------------------------------------- -----------------------------
valid: Cat    9.95 ns/iter       (8.8 ns … 305 ns)   9.96 ns  13.27 ns  18.21 ns

summary for validateCookieName
  valid: Cat
```