### PR TITLE
cookies: fix validateMaxAge allow negative numbers

### DIFF
--- a/benchmarks/cookies/validate-max-age.mjs
+++ b/benchmarks/cookies/validate-max-age.mjs
@@ -1,0 +1,12 @@
+import { bench, group, run } from 'mitata'
+import { validateCookieMaxAge } from '../../lib/web/cookies/util.js'
+
+const valid = 2000
+
+group('validateCookieMaxAge', () => {
+  bench(`valid: ${valid}`, () => {
+    return validateCookieMaxAge(valid)
+  })
+})
+
+await run()

--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -197,10 +197,21 @@ function toIMFDate (date) {
                        ; In practice, both expires-av and max-age-av
                        ; are limited to dates representable by the
                        ; user agent.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
+ *
+ * but:
+ * If delta-seconds is less than or equal to zero (0), let expiry-time be the
+ * earliest representable date and time. Otherwise, let the expiry-time be the
+ * current date and time plus delta-seconds seconds.
+ * @see https://www.rfc-editor.org/rfc/rfc6265#section-5.2.2
+ *
+ * Any integer value is valid.
+ *
  * @param {number} maxAge
  */
 function validateCookieMaxAge (maxAge) {
-  if (maxAge < 0) {
+  if (Number.isInteger(maxAge) === false) {
     throw new Error('Invalid cookie max-age')
   }
 }
@@ -301,6 +312,7 @@ module.exports = {
   validateCookieName,
   validateCookiePath,
   validateCookieValue,
+  validateCookieMaxAge,
   toIMFDate,
   stringify,
   getHeadersList

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -255,7 +255,11 @@ test('Cookie Set', () => {
   } catch {
     error = true
   }
-  assert.ok(error)
+  assert.strictEqual(error, false)
+  assert.equal(
+    headers.get('Set-Cookie'),
+    'Space=Cat; Secure; HttpOnly; Max-Age=-1'
+  )
 
   headers = new Headers()
   setCookie(headers, {

--- a/test/cookie/validate-cookie-max-age.js
+++ b/test/cookie/validate-cookie-max-age.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const { throws, strictEqual } = require('node:assert')
+
+const {
+  validateCookieMaxAge
+} = require('../../lib/web/cookies/util')
+
+describe('validateCookieMaxAge', () => {
+  test('0', () => {
+    strictEqual(validateCookieMaxAge(0), undefined)
+    strictEqual(validateCookieMaxAge(+0), undefined)
+    strictEqual(validateCookieMaxAge(-0), undefined)
+  })
+
+  test('float', () => {
+    throws(() => validateCookieMaxAge(3.15), Error('Invalid cookie max-age'))
+  })
+
+  test('integer value', () => {
+    strictEqual(validateCookieMaxAge(2), undefined)
+    strictEqual(validateCookieMaxAge(-2), undefined)
+  })
+
+  test('-Infinity', () => {
+    throws(() => validateCookieMaxAge(-Infinity), Error('Invalid cookie max-age'))
+  })
+
+  test('Infinity', () => {
+    throws(() => validateCookieMaxAge(Infinity), Error('Invalid cookie max-age'))
+  })
+
+  test('NaN', () => {
+    throws(() => validateCookieMaxAge(NaN), Error('Invalid cookie max-age'))
+  })
+})


### PR DESCRIPTION
Imho the spec rfc 6265 is not correctly implemented. 

Either only positive integers excluding 0 are allowed (which the current implementation does not match) for MaxAge or all integer values are allowed (this PR)

I think the problem arises because imho https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1 talks about how the data in the useragent is stored while https://www.rfc-editor.org/rfc/rfc6265#section-5.2.2 talks about the data which the useragent receives and how it should be processed.

So a server can send negative values for max-age, while a client has to drop all cookies with negative values immediatly. If the maxage is set to 0, then it would actually mean to drop the cookie according to the rfc, but it seems most useragents keep the cookie till the end of the session.

Anyhow, this means that we must allow negative integers for validateMaxAge.
