### PR TITLE
perf: optimize check invalid field-vchar

### DIFF
--- a/benchmarks/core/is-valid-header-char.mjs
+++ b/benchmarks/core/is-valid-header-char.mjs
@@ -39,7 +39,7 @@ group(`isValidHeaderChar# ${html}`, () => {
   })
 })
 
-group(`isValidHeaderChar ${json}`, () => {
+group(`isValidHeaderChar# ${json}`, () => {
   bench('regexp.test', () => {
     return !headerCharRegex.test(json)
   })

--- a/benchmarks/core/is-valid-header-char.mjs
+++ b/benchmarks/core/is-valid-header-char.mjs
@@ -1,0 +1,57 @@
+import { bench, group, run } from 'mitata'
+import { isValidHeaderChar } from '../../lib/core/util.js'
+
+const html = 'text/html'
+const json = 'application/json; charset=UTF-8'
+
+const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/
+
+/**
+ * @param {string} characters
+ */
+function charCodeAtApproach (characters) {
+  // Validate if characters is a valid field-vchar.
+  //  field-value    = *( field-content / obs-fold )
+  //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+  //  field-vchar    = VCHAR / obs-text
+  for (let i = 0; i < characters.length; ++i) {
+    const code = characters.charCodeAt(i)
+    // not \x20-\x7e, \t and \x80-\xff
+    if ((code < 0x20 && code !== 0x09) || code === 0x7f || code > 0xff) {
+      return false
+    }
+  }
+  return true
+}
+
+group(`isValidHeaderChar# ${html}`, () => {
+  bench('regexp.test', () => {
+    return !headerCharRegex.test(html)
+  })
+  bench('regexp.exec', () => {
+    return headerCharRegex.exec(html) === null
+  })
+  bench('charCodeAt', () => {
+    return charCodeAtApproach(html) === true
+  })
+  bench('isValidHeaderChar', () => {
+    return isValidHeaderChar(html) === true
+  })
+})
+
+group(`isValidHeaderChar ${json}`, () => {
+  bench('regexp.test', () => {
+    return !headerCharRegex.test(json)
+  })
+  bench('regexp.exec', () => {
+    return headerCharRegex.exec(json) === null
+  })
+  bench('charCodeAt', () => {
+    return charCodeAtApproach(json)
+  })
+  bench('isValidHeaderChar', () => {
+    return isValidHeaderChar(json)
+  })
+})
+
+await run()

--- a/benchmarks/core/is-valid-header-char.mjs
+++ b/benchmarks/core/is-valid-header-char.mjs
@@ -32,10 +32,10 @@ group(`isValidHeaderChar# ${html}`, () => {
     return headerCharRegex.exec(html) === null
   })
   bench('charCodeAt', () => {
-    return charCodeAtApproach(html) === true
+    return charCodeAtApproach(html)
   })
   bench('isValidHeaderChar', () => {
-    return isValidHeaderChar(html) === true
+    return isValidHeaderChar(html)
   })
 })
 

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -5,7 +5,19 @@ const {
   NotSupportedError
 } = require('./errors')
 const assert = require('node:assert')
-const util = require('./util')
+const {
+  isValidHTTPToken,
+  isValidHeaderChar,
+  isStream,
+  destroy,
+  isBuffer,
+  isFormDataLike,
+  isIterable,
+  isBlobLike,
+  buildURL,
+  validateHandler,
+  getServerName
+} = require('./util')
 const { channels } = require('./diagnostics.js')
 const { headerNameLowerCasedRecord } = require('./constants')
 
@@ -44,7 +56,7 @@ class Request {
 
     if (typeof method !== 'string') {
       throw new InvalidArgumentError('method must be a string')
-    } else if (!util.isValidHTTPToken(method)) {
+    } else if (!isValidHTTPToken(method)) {
       throw new InvalidArgumentError('invalid request method')
     }
 
@@ -80,13 +92,13 @@ class Request {
 
     if (body == null) {
       this.body = null
-    } else if (util.isStream(body)) {
+    } else if (isStream(body)) {
       this.body = body
 
       const rState = this.body._readableState
       if (!rState || !rState.autoDestroy) {
         this.endHandler = function autoDestroy () {
-          util.destroy(this)
+          destroy(this)
         }
         this.body.on('end', this.endHandler)
       }
@@ -99,7 +111,7 @@ class Request {
         }
       }
       this.body.on('error', this.errorHandler)
-    } else if (util.isBuffer(body)) {
+    } else if (isBuffer(body)) {
       this.body = body.byteLength ? body : null
     } else if (ArrayBuffer.isView(body)) {
       this.body = body.buffer.byteLength ? Buffer.from(body.buffer, body.byteOffset, body.byteLength) : null
@@ -107,7 +119,7 @@ class Request {
       this.body = body.byteLength ? Buffer.from(body) : null
     } else if (typeof body === 'string') {
       this.body = body.length ? Buffer.from(body) : null
-    } else if (util.isFormDataLike(body) || util.isIterable(body) || util.isBlobLike(body)) {
+    } else if (isFormDataLike(body) || isIterable(body) || isBlobLike(body)) {
       this.body = body
     } else {
       throw new InvalidArgumentError('body must be a string, a Buffer, a Readable stream, an iterable, or an async iterable')
@@ -119,7 +131,7 @@ class Request {
 
     this.upgrade = upgrade || null
 
-    this.path = query ? util.buildURL(path, query) : path
+    this.path = query ? buildURL(path, query) : path
 
     this.origin = origin
 
@@ -167,9 +179,9 @@ class Request {
       throw new InvalidArgumentError('headers must be an object or an array')
     }
 
-    util.validateHandler(handler, method, upgrade)
+    validateHandler(handler, method, upgrade)
 
-    this.servername = util.getServerName(this.host)
+    this.servername = getServerName(this.host)
 
     this[kHandler] = handler
 
@@ -314,7 +326,7 @@ function processHeader (request, key, val) {
 
   if (headerName === undefined) {
     headerName = key.toLowerCase()
-    if (headerNameLowerCasedRecord[headerName] === undefined && !util.isValidHTTPToken(headerName)) {
+    if (headerNameLowerCasedRecord[headerName] === undefined && !isValidHTTPToken(headerName)) {
       throw new InvalidArgumentError('invalid header key')
     }
   }
@@ -323,7 +335,7 @@ function processHeader (request, key, val) {
     const arr = []
     for (let i = 0; i < val.length; i++) {
       if (typeof val[i] === 'string') {
-        if (!util.isValidHeaderChar(val[i])) {
+        if (!isValidHeaderChar(val[i])) {
           throw new InvalidArgumentError(`invalid ${key} header`)
         }
         arr.push(val[i])
@@ -337,7 +349,7 @@ function processHeader (request, key, val) {
     }
     val = arr
   } else if (typeof val === 'string') {
-    if (!util.isValidHeaderChar(val)) {
+    if (!isValidHeaderChar(val)) {
       throw new InvalidArgumentError(`invalid ${key} header`)
     }
   } else if (val === null) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -9,17 +9,6 @@ const util = require('./util')
 const { channels } = require('./diagnostics.js')
 const { headerNameLowerCasedRecord } = require('./constants')
 
-// headerCharRegex have been lifted from
-// https://github.com/nodejs/node/blob/main/lib/_http_common.js
-
-/**
- * Matches if val contains an invalid field-vchar
- *  field-value    = *( field-content / obs-fold )
- *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
- *  field-vchar    = VCHAR / obs-text
- */
-const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/
-
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
 
@@ -166,13 +155,12 @@ class Request {
           if (!Array.isArray(header) || header.length !== 2) {
             throw new InvalidArgumentError('headers must be in key-value pair format')
           }
-          const [key, value] = header
-          processHeader(this, key, value)
+          processHeader(this, header[0], header[1])
         }
       } else {
         const keys = Object.keys(headers)
-        for (const key of keys) {
-          processHeader(this, key, headers[key])
+        for (let i = 0; i < keys.length; ++i) {
+          processHeader(this, keys[i], headers[keys[i]])
         }
       }
     } else if (headers != null) {
@@ -315,7 +303,7 @@ class Request {
   }
 }
 
-function processHeader (request, key, val, skipAppend = false) {
+function processHeader (request, key, val) {
   if (val && (typeof val === 'object' && !Array.isArray(val))) {
     throw new InvalidArgumentError(`invalid ${key} header`)
   } else if (val === undefined) {
@@ -335,7 +323,7 @@ function processHeader (request, key, val, skipAppend = false) {
     const arr = []
     for (let i = 0; i < val.length; i++) {
       if (typeof val[i] === 'string') {
-        if (headerCharRegex.exec(val[i]) !== null) {
+        if (!util.isValidHeaderChar(val[i])) {
           throw new InvalidArgumentError(`invalid ${key} header`)
         }
         arr.push(val[i])
@@ -349,7 +337,7 @@ function processHeader (request, key, val, skipAppend = false) {
     }
     val = arr
   } else if (typeof val === 'string') {
-    if (headerCharRegex.exec(val) !== null) {
+    if (!util.isValidHeaderChar(val)) {
       throw new InvalidArgumentError(`invalid ${key} header`)
     }
   } else if (val === null) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -495,6 +495,24 @@ function isValidHTTPToken (characters) {
   return true
 }
 
+/**
+ * @param {string} characters
+ */
+function isValidHeaderChar (characters) {
+  // Validate if val is a valid field-vchar.
+  //  field-value    = *( field-content / obs-fold )
+  //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+  //  field-vchar    = VCHAR / obs-text
+  for (let i = 0; i < characters.length; ++i) {
+    const code = characters.charCodeAt(i)
+    // not \x20-\x7e, \t and \x80-\xff
+    if ((code < 0x20 && code !== 0x09) || code === 0x7f || code > 0xff) {
+      return false
+    }
+  }
+  return true
+}
+
 // Parsed accordingly to RFC 9110
 // https://www.rfc-editor.org/rfc/rfc9110#field.content-range
 function parseRangeHeader (range) {
@@ -516,7 +534,6 @@ kEnumerableProperty.enumerable = true
 module.exports = {
   kEnumerableProperty,
   nop,
-
   isDisturbed,
   isErrored,
   isReadable,
@@ -546,6 +563,7 @@ module.exports = {
   buildURL,
   addAbortListener,
   isValidHTTPToken,
+  isValidHeaderChar,
   isTokenCharCode,
   parseRangeHeader,
   nodeMajor,

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -495,22 +495,22 @@ function isValidHTTPToken (characters) {
   return true
 }
 
+// headerCharRegex have been lifted from
+// https://github.com/nodejs/node/blob/main/lib/_http_common.js
+
+/**
+ * Matches if val contains an invalid field-vchar
+ *  field-value    = *( field-content / obs-fold )
+ *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ */
+const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/
+
 /**
  * @param {string} characters
  */
 function isValidHeaderChar (characters) {
-  // Validate if val is a valid field-vchar.
-  //  field-value    = *( field-content / obs-fold )
-  //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
-  //  field-vchar    = VCHAR / obs-text
-  for (let i = 0; i < characters.length; ++i) {
-    const code = characters.charCodeAt(i)
-    // not \x20-\x7e, \t and \x80-\xff
-    if ((code < 0x20 && code !== 0x09) || code === 0x7f || code > 0xff) {
-      return false
-    }
-  }
-  return true
+  return !headerCharRegex.test(characters)
 }
 
 // Parsed accordingly to RFC 9110


### PR DESCRIPTION
```
benchmark              time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------- -----------------------------
• isValidHeaderChar# text/html
--------------------------------------------------------- -----------------------------
regexp.test            34 ns/iter     (28.27 ns … 303 ns)  32.71 ns  72.85 ns    133 ns
regexp.exec         40.45 ns/iter     (34.18 ns … 218 ns)  41.16 ns  83.69 ns    135 ns
charCodeAt          30.31 ns/iter     (26.07 ns … 217 ns)   29.1 ns  61.91 ns    123 ns
isValidHeaderChar   35.55 ns/iter      (29.3 ns … 236 ns)  35.45 ns  86.28 ns    126 ns

summary for isValidHeaderChar# text/html
  charCodeAt
   1.12x faster than regexp.test
   1.17x faster than isValidHeaderChar
   1.33x faster than regexp.exec

• isValidHeaderChar application/json; charset=UTF-8
--------------------------------------------------------- -----------------------------
regexp.test         65.64 ns/iter     (56.88 ns … 426 ns)  63.33 ns    152 ns    237 ns
regexp.exec         73.79 ns/iter     (63.48 ns … 283 ns)  72.61 ns    153 ns    208 ns
charCodeAt            108 ns/iter     (95.21 ns … 416 ns)    102 ns    238 ns    353 ns
isValidHeaderChar   66.89 ns/iter     (57.03 ns … 254 ns)  63.48 ns    156 ns    207 ns

summary for isValidHeaderChar application/json; charset=UTF-8
  regexp.test
   1.02x faster than isValidHeaderChar
   1.12x faster than regexp.exec
   1.64x faster than charCodeAt
```