### PR TITLE
tests: ignore catch block when requiring crypto module

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -12,11 +12,11 @@ const { isUint8Array } = require('node:util/types')
 const { webidl } = require('./webidl')
 
 // https://nodejs.org/api/crypto.html#determining-if-crypto-support-is-unavailable
-/** @type {import('crypto')|undefined} */
+/** @type {import('crypto')} */
 let crypto
-
 try {
   crypto = require('node:crypto')
+/* c8 ignore next 3 */
 } catch {
 
 }

--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -20,6 +20,7 @@ const { kHeadersList } = require('../../core/symbols')
 let crypto
 try {
   crypto = require('node:crypto')
+/* c8 ignore next 3 */
 } catch {
 
 }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -6,6 +6,7 @@ const { maxUnsigned16Bit } = require('./constants')
 let crypto
 try {
   crypto = require('node:crypto')
+/* c8 ignore next 3 */
 } catch {
 
 }


### PR DESCRIPTION
Just ignore the catch block to improve test coverage