### PR TITLE
perf(headers): a single set-cookie

### DIFF
--- a/benchmarks/fetch/headers-length32.mjs
+++ b/benchmarks/fetch/headers-length32.mjs
@@ -19,7 +19,7 @@ const headers = new Headers(
     'Width',
     'Accept-CH',
     'Via',
-    'Refresh',
+    'Set-Cookie',
     'Server',
     'Sec-Fetch-Dest',
     'Sec-CH-UA-Model',

--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -536,7 +536,7 @@ class Headers {
     const cookies = this[kHeadersList].cookies
 
     // fast-path
-    if (cookies === null) {
+    if (cookies === null || cookies.length === 1) {
       // Note: The non-null assertion of value has already been done by `HeadersList#toSortedArray`
       return (this[kHeadersList][kHeadersSortedMap] = names)
     }

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -694,7 +694,7 @@ test('Headers.prototype.getSetCookie', async (t) => {
   })
 
   // https://github.com/nodejs/undici/issues/1935
-  await t.test('When Headers are cloned, so are the cookies', async (t) => {
+  await t.test('When Headers are cloned, so are the cookies (single entry)', async (t) => {
     const server = createServer((req, res) => {
       res.setHeader('Set-Cookie', 'test=onetwo')
       res.end('Hello World!')
@@ -707,6 +707,22 @@ test('Headers.prototype.getSetCookie', async (t) => {
     const entries = Object.fromEntries(res.headers.entries())
 
     assert.deepStrictEqual(res.headers.getSetCookie(), ['test=onetwo'])
+    assert.ok('set-cookie' in entries)
+  })
+
+  await t.test('When Headers are cloned, so are the cookies (multiple entries)', async (t) => {
+    const server = createServer((req, res) => {
+      res.setHeader('Set-Cookie', ['test=onetwo', 'test=onetwothree'])
+      res.end('Hello World!')
+    }).listen(0)
+
+    await once(server, 'listening')
+    t.after(closeServerAsPromise(server))
+
+    const res = await fetch(`http://localhost:${server.address().port}`)
+    const entries = Object.fromEntries(res.headers.entries())
+
+    assert.deepStrictEqual(res.headers.getSetCookie(), ['test=onetwo', 'test=onetwothree'])
     assert.ok('set-cookie' in entries)
   })
 })


### PR DESCRIPTION
**benchmarks/fetch/headers-length32.mjs**
- main
```
benchmark              time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------- -----------------------------
Headers@@iterator   5'731 ns/iter     (4'300 ns … 516 µs)  5'300 ns 11'600 ns    115 µs
```

- this patch
```
benchmark              time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------- -----------------------------
Headers@@iterator   5'151 ns/iter     (4'100 ns … 689 µs)  4'800 ns 11'100 ns    109 µs
```