### PR TITLE
fix: tests dont need process.exit

### DIFF
--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-const { test, after } = require('node:test')
+const { test } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const { createServer } = require('node:http')
@@ -700,5 +700,3 @@ test('Receiving non-Latin1 headers', async (t) => {
   assert.deepStrictEqual(cdHeaders, ContentDisposition)
   assert.deepStrictEqual(lengths, [30, 34, 94, 104, 90])
 })
-
-after(() => process.exit())

--- a/test/node-test/agent.js
+++ b/test/node-test/agent.js
@@ -808,5 +808,3 @@ test('the dispatcher is truly global', t => {
   const undiciFresh = importFresh('../../index.js')
   assert.strictEqual(agent, undiciFresh.getGlobalDispatcher())
 })
-
-after(() => process.exit())


### PR DESCRIPTION
when working on #2908 I realized that the tests are prematurely stopped because of the deleted lines. The lines were part of the tap to node builtin test runner. It seems that they are not necessary and worse they are disrupting the test flow.

