### PR TITLE
fix(benchmark): set body correctly

### DIFF
--- a/benchmarks/post-benchmark.js
+++ b/benchmarks/post-benchmark.js
@@ -245,7 +245,7 @@ const experiments = {
           }
         }),
         (err) => {
-          if (err !== null) {
+          if (err != null) {
             console.log(err)
           }
           resolve()

--- a/benchmarks/post-benchmark.js
+++ b/benchmarks/post-benchmark.js
@@ -234,7 +234,7 @@ const experiments = {
         .pipeline(undiciOptions, data => {
           return data.body
         })
-        .end()
+        .end(data)
         .pipe(
           new Writable({
             write (chunk, encoding, callback) {

--- a/benchmarks/post-benchmark.js
+++ b/benchmarks/post-benchmark.js
@@ -357,7 +357,7 @@ if (process.env.PORT) {
     method: 'POST',
     headers,
     agent: requestAgent,
-    data
+    body: data
   }
   experiments.request = () => {
     return makeParallelRequests(resolve => {

--- a/benchmarks/post-benchmark.js
+++ b/benchmarks/post-benchmark.js
@@ -3,9 +3,8 @@
 const http = require('node:http')
 const os = require('node:os')
 const path = require('node:path')
-const { Writable } = require('node:stream')
+const { Writable, Readable, pipeline } = require('node:stream')
 const { isMainThread } = require('node:worker_threads')
-
 const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
 let nodeFetch
@@ -230,19 +229,28 @@ const experiments = {
   },
   'undici - pipeline' () {
     return makeParallelRequests(resolve => {
-      dispatcher
-        .pipeline(undiciOptions, data => {
+      pipeline(
+        new Readable({
+          read () {
+            this.push(data)
+            this.push(null)
+          }
+        }),
+        dispatcher.pipeline(undiciOptions, data => {
           return data.body
-        })
-        .end(data)
-        .pipe(
-          new Writable({
-            write (chunk, encoding, callback) {
-              callback()
-            }
-          })
-        )
-        .on('finish', resolve)
+        }),
+        new Writable({
+          write (chunk, encoding, callback) {
+            callback()
+          }
+        }),
+        (err) => {
+          if (err !== null) {
+            console.log(err)
+          }
+          resolve()
+        }
+      )
     })
   },
   'undici - request' () {


### PR DESCRIPTION
before:


```

┌─────────┬───────────────────────┬─────────┬───────────────────┬────────────┬─────────────────────────┐
│ (index) │ Tests                 │ Samples │ Result            │ Tolerance  │ Difference with slowest │
├─────────┼───────────────────────┼─────────┼───────────────────┼────────────┼─────────────────────────┤
│ 0       │ 'got'                 │ 55      │ '1797.06 req/sec' │ '± 2.88 %' │ '-'                     │
│ 1       │ 'undici - fetch'      │ 35      │ '1828.63 req/sec' │ '± 2.73 %' │ '+ 1.76 %'              │
│ 2       │ 'node-fetch'          │ 10      │ '2295.80 req/sec' │ '± 2.44 %' │ '+ 27.75 %'             │
│ 3       │ 'http - no keepalive' │ 15      │ '2373.41 req/sec' │ '± 2.95 %' │ '+ 32.07 %'             │
│ 4       │ 'superagent'          │ 40      │ '3152.94 req/sec' │ '± 2.75 %' │ '+ 75.45 %'             │
│ 5       │ 'http - keepalive'    │ 15      │ '3328.89 req/sec' │ '± 2.58 %' │ '+ 85.24 %'             │
│ 6       │ 'axios'               │ 20      │ '3499.47 req/sec' │ '± 2.91 %' │ '+ 94.73 %'             │
│ 7       │ 'request'             │ 35      │ '4669.86 req/sec' │ '± 2.87 %' │ '+ 159.86 %'            │
│ 8       │ 'undici - request'    │ 10      │ '5779.17 req/sec' │ '± 1.44 %' │ '+ 221.59 %'            │
│ 9       │ 'undici - stream'     │ 10      │ '6139.74 req/sec' │ '± 1.44 %' │ '+ 241.65 %'            │
│ 10      │ 'undici - dispatch'   │ 10      │ '6304.52 req/sec' │ '± 1.81 %' │ '+ 250.82 %'            │
│ 11      │ 'undici - pipeline'   │ 100     │ '8885.32 req/sec' │ '± 2.98 %' │ '+ 394.44 %'            │
└─────────┴───────────────────────┴─────────┴───────────────────┴────────────┴─────────────────────────┘
```

after:

```
┌─────────┬───────────────────────┬─────────┬───────────────────┬────────────┬─────────────────────────┐
│ (index) │ Tests                 │ Samples │ Result            │ Tolerance  │ Difference with slowest │
├─────────┼───────────────────────┼─────────┼───────────────────┼────────────┼─────────────────────────┤
│ 0       │ 'got'                 │ 40      │ '1975.01 req/sec' │ '± 2.87 %' │ '-'                     │
│ 1       │ 'undici - fetch'      │ 20      │ '2026.76 req/sec' │ '± 2.55 %' │ '+ 2.62 %'              │
│ 2       │ 'http - no keepalive' │ 25      │ '2542.56 req/sec' │ '± 2.64 %' │ '+ 28.74 %'             │
│ 3       │ 'node-fetch'          │ 20      │ '2693.04 req/sec' │ '± 2.78 %' │ '+ 36.36 %'             │
│ 4       │ 'request'             │ 30      │ '2812.90 req/sec' │ '± 2.84 %' │ '+ 42.42 %'             │
│ 5       │ 'superagent'          │ 45      │ '3349.51 req/sec' │ '± 2.96 %' │ '+ 69.59 %'             │
│ 6       │ 'axios'               │ 15      │ '3354.35 req/sec' │ '± 2.37 %' │ '+ 69.84 %'             │
│ 7       │ 'http - keepalive'    │ 35      │ '3741.67 req/sec' │ '± 2.84 %' │ '+ 89.45 %'             │
│ 8       │ 'undici - pipeline'   │ 10      │ '4749.89 req/sec' │ '± 1.27 %' │ '+ 140.50 %'            │
│ 9       │ 'undici - request'    │ 10      │ '6281.27 req/sec' │ '± 1.32 %' │ '+ 218.04 %'            │
│ 10      │ 'undici - stream'     │ 10      │ '6692.79 req/sec' │ '± 1.58 %' │ '+ 238.87 %'            │
│ 11      │ 'undici - dispatch'   │ 10      │ '6930.50 req/sec' │ '± 1.04 %' │ '+ 250.91 %'            │
└─────────┴───────────────────────┴─────────┴───────────────────┴────────────┴─────────────────────────┘
```
