### PR TITLE
override request dispatcher from init

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -103,7 +103,7 @@ class Request {
       // 5. Set fallbackMode to "cors".
       fallbackMode = 'cors'
     } else {
-      this[kDispatcher] = input[kDispatcher]
+      this[kDispatcher] = init.dispatcher || input[kDispatcher]
 
       // 6. Otherwise:
 

--- a/test/fetch/issue-2898-comment.js
+++ b/test/fetch/issue-2898-comment.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const { test } = require('node:test')
+const { Agent, Request, fetch } = require('../..')
+const { tspl } = require('@matteo.collina/tspl')
+
+test('issue #2828, RequestInit dispatcher options overrides Request input dispatcher', async (t) => {
+  const { strictEqual } = tspl(t, { plan: 2 })
+
+  class CustomAgentA extends Agent {
+    dispatch (options, handler) {
+      options.headers['x-my-header-a'] = 'hello'
+      return super.dispatch(...arguments)
+    }
+  }
+
+  class CustomAgentB extends Agent {
+    dispatch (options, handler) {
+      options.headers['x-my-header-b'] = 'world'
+      return super.dispatch(...arguments)
+    }
+  }
+
+  const server = createServer((req, res) => {
+    strictEqual(req.headers['x-my-header-a'], undefined)
+    strictEqual(req.headers['x-my-header-b'], 'world')
+    res.end()
+  }).listen(0)
+
+  t.after(server.close.bind(server))
+  await once(server, 'listening')
+
+  const request = new Request(`http://localhost:${server.address().port}`, {
+    dispatcher: new CustomAgentA()
+  })
+
+  await fetch(request, {
+    dispatcher: new CustomAgentB()
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

The following comment: https://github.com/nodejs/undici/pull/2831/files#r1501662661

The following logic should result in `CustomAgentB` agent being used. It is currently not the case.

```ts
  const request = new Request(`http://localhost`, {
    dispatcher: new CustomAgentA()
  })

  await fetch(request, {
    dispatcher: new CustomAgentB()
  })
```

## Rationale

in both `Request` and `fetch()`, `init` is meant to override the values from the input. This is currently true for most fields but gets ignored in case of the `dispacher` field when `input` is a request instance.

## Changes

`init.dispatcher` takes precedence over `input[kDispatcher]` when creating a request from a request.

### Features

N/A

### Bug Fixes

- https://github.com/nodejs/undici/pull/2831/files#r1501662661

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

- If an implementation relied on the wrong dispatcher being used, this change might cause an issue.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
