### PR TITLE
fetch: improve util.inspect output for web specifications

### DIFF
--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -580,7 +580,7 @@ class Headers {
 
   [util.inspect.custom] (depth, options) {
     const inspected = util.inspect(this[kHeadersList].entries)
-    
+
     return `Headers ${inspected}`
   }
 }

--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -579,12 +579,9 @@ class Headers {
   }
 
   [util.inspect.custom] (depth, options) {
-    const headerString = Array.from(this[kHeadersList])
-      .map(([name, value]) =>
-          `${name.replace(/\b\w/g, (char) =>
-            char.toUpperCase())}: ${value}`)
-      .join('\n')
-    return 'Headers:\n' + headerString
+    const inspected = util.inspect(this[kHeadersList].entries)
+    
+    return `Headers ${inspected}`
   }
 }
 

--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -12,6 +12,7 @@ const {
 } = require('./util')
 const { webidl } = require('./webidl')
 const assert = require('node:assert')
+const util = require('util')
 
 const kHeadersMap = Symbol('headers map')
 const kHeadersSortedMap = Symbol('headers map sorted')
@@ -576,7 +577,20 @@ class Headers {
 
     return this[kHeadersList]
   }
+
+  [util.inspect.custom] (depth, options) {
+    const headerString = Array.from(this[kHeadersList])
+      .map(([name, value]) =>
+          `${name.replace(/\b\w/g, (char) =>
+            char.toUpperCase())}: ${value}`)
+      .join('\n')
+    return 'Headers:\n' + headerString
+  }
 }
+
+Object.defineProperty(Headers.prototype, util.inspect.custom, {
+  enumerable: false
+})
 
 iteratorMixin('Headers', Headers, kHeadersSortedMap, 0, 1)
 

--- a/test/fetch/headers-inspect-custom.js
+++ b/test/fetch/headers-inspect-custom.js
@@ -7,12 +7,11 @@ const util = require('util')
 
 test('Headers class custom inspection', () => {
   const headers = new Headers()
-  headers.set('content-Type', 'application/json')
-  headers.set('authorization', 'Bearer token')
+  headers.set('Content-Type', 'application/json')
+  headers.set('Authorization', 'Bearer token')
 
   const inspectedOutput = util.inspect(headers, { depth: 1 })
 
-  const expectedOutput =
-    'Headers:\nContent-Type: application/json\nAuthorization: Bearer token'
+  const expectedOutput = "Headers { 'Content-Type': 'application/json', Authorization: 'Bearer token' }"
   assert.strictEqual(inspectedOutput, expectedOutput)
 })

--- a/test/fetch/headers-inspect-custom.js
+++ b/test/fetch/headers-inspect-custom.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { Headers } = require('../../lib/web/fetch/headers')
+const { test } = require('node:test')
+const assert = require('node:assert')
+const util = require('util')
+
+test('Headers class custom inspection', () => {
+  const headers = new Headers()
+  headers.set('content-Type', 'application/json')
+  headers.set('authorization', 'Bearer token')
+
+  const inspectedOutput = util.inspect(headers, { depth: 1 })
+
+  const expectedOutput =
+    'Headers:\nContent-Type: application/json\nAuthorization: Bearer token'
+  assert.strictEqual(inspectedOutput, expectedOutput)
+})


### PR DESCRIPTION
Issue: web specs better util.inspect output #2917

Issue Description:
The issue revolves around enhancing the util.inspect output for the Headers class. The current output exposes too many internal implementation details and does not provide much useful information. 

Solution:
I have improved the util.inspect output to better reflect the contents of the Headers object for enhanced clarity.