### PR TITLE
perf: improve getResolveErrorBodyCallback

### DIFF
--- a/benchmarks/api/util.mjs
+++ b/benchmarks/api/util.mjs
@@ -1,0 +1,37 @@
+import { bench, group, run } from 'mitata'
+import { isContentTypeText, isContentTypeApplicationJson } from '../../lib/api/util.js'
+
+const html = 'text/html'
+const json = 'application/json; charset=UTF-8'
+
+group('isContentTypeText', () => {
+  bench(`isContentTypeText('${html}')`, () => {
+    return isContentTypeText(html)
+  })
+  bench(`isContentTypeText('${json}')`, () => {
+    return isContentTypeText(json)
+  })
+  bench('html.startsWith(\'text/\')', () => {
+    return html.startsWith('text/')
+  })
+  bench('json.startsWith(\'text/\')', () => {
+    return json.startsWith('text/')
+  })
+})
+
+group('isContentTypeApplicationJson', () => {
+  bench(`isContentTypeApplicationJson('${html}')`, () => {
+    return isContentTypeApplicationJson(html)
+  })
+  bench(`isContentTypeApplicationJson('${json}')`, () => {
+    return isContentTypeApplicationJson(json)
+  })
+  bench('html.startsWith(\'application/json\')', () => {
+    return html.startsWith('application/json')
+  })
+  bench('json.startsWith(\'application/json\')', () => {
+    return json.startsWith('application/json')
+  })
+})
+
+await run()

--- a/lib/api/util.js
+++ b/lib/api/util.js
@@ -21,28 +21,66 @@ async function getResolveErrorBodyCallback ({ callback, body, contentType, statu
     }
   }
 
+  const message = `Response status code ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`
+
   if (statusCode === 204 || !contentType || !chunks) {
-    process.nextTick(callback, new ResponseStatusCodeError(`Response status code ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`, statusCode, headers))
+    queueMicrotask(() => callback(new ResponseStatusCodeError(message, statusCode, headers)))
     return
   }
 
+  const stackTraceLimit = Error.stackTraceLimit
+  Error.stackTraceLimit = 0
+  let payload
+
   try {
-    if (contentType.startsWith('application/json')) {
-      const payload = JSON.parse(chunksDecode(chunks, length))
-      process.nextTick(callback, new ResponseStatusCodeError(`Response status code ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`, statusCode, headers, payload))
-      return
+    if (isContentTypeApplicationJson(contentType)) {
+      payload = JSON.parse(chunksDecode(chunks, length))
+    } else if (isContentTypeText(contentType)) {
+      payload = chunksDecode(chunks, length)
     }
-
-    if (contentType.startsWith('text/')) {
-      const payload = chunksDecode(chunks, length)
-      process.nextTick(callback, new ResponseStatusCodeError(`Response status code ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`, statusCode, headers, payload))
-      return
-    }
-  } catch (err) {
-    // Process in a fallback if error
+  } catch {
+    // process in a callback to avoid throwing in the microtask queue
+  } finally {
+    Error.stackTraceLimit = stackTraceLimit
   }
-
-  process.nextTick(callback, new ResponseStatusCodeError(`Response status code ${statusCode}${statusMessage ? `: ${statusMessage}` : ''}`, statusCode, headers))
+  queueMicrotask(() => callback(new ResponseStatusCodeError(message, statusCode, headers, payload)))
 }
 
-module.exports = { getResolveErrorBodyCallback }
+const isContentTypeApplicationJson = (contentType) => {
+  return (
+    contentType.length > 15 &&
+    contentType[11] === '/' &&
+    contentType[0] === 'a' &&
+    contentType[1] === 'p' &&
+    contentType[2] === 'p' &&
+    contentType[3] === 'l' &&
+    contentType[4] === 'i' &&
+    contentType[5] === 'c' &&
+    contentType[6] === 'a' &&
+    contentType[7] === 't' &&
+    contentType[8] === 'i' &&
+    contentType[9] === 'o' &&
+    contentType[10] === 'n' &&
+    contentType[12] === 'j' &&
+    contentType[13] === 's' &&
+    contentType[14] === 'o' &&
+    contentType[15] === 'n'
+  )
+}
+
+const isContentTypeText = (contentType) => {
+  return (
+    contentType.length > 4 &&
+    contentType[4] === '/' &&
+    contentType[0] === 't' &&
+    contentType[1] === 'e' &&
+    contentType[2] === 'x' &&
+    contentType[3] === 't'
+  )
+}
+
+module.exports = {
+  getResolveErrorBodyCallback,
+  isContentTypeApplicationJson,
+  isContentTypeText
+}


### PR DESCRIPTION
I dont know how i can bench this in a meaningfull way. 

- Using queueMicrotask instead of process.nextTick
- avoid stacktrace generation if processing the payload throws an error (which would get ignored anyway)
- avoid use of `.startsWith()` as it is slower than provided fns

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/api/util.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark                                                            time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------------------------------------- -----------------------------
• isContentTypeText
------------------------------------------------------------------------------------------------------- -----------------------------
isContentTypeText('text/html')                                      744 ps/iter       (409 ps … 150 ns)    716 ps   1.16 ns   5.39 ns
isContentTypeText('application/json; charset=UTF-8')                728 ps/iter       (409 ps … 126 ns)    716 ps    955 ps   5.29 ns
html.startsWith('text/')                                          15.86 ns/iter   (13.91 ns … 43.58 ns)  15.62 ns  25.17 ns  34.89 ns
json.startsWith('text/')                                           1.25 ns/iter      (443 ps … 63.5 ns)   1.36 ns   1.84 ns  10.09 ns

summary for isContentTypeText
  isContentTypeText('application/json; charset=UTF-8')
   1.02x faster than isContentTypeText('text/html')
   1.71x faster than json.startsWith('text/')
   21.79x faster than html.startsWith('text/')

• isContentTypeApplicationJson
------------------------------------------------------------------------------------------------------- -----------------------------
isContentTypeApplicationJson('text/html')                          1.98 ns/iter    (1.19 ns … 75.77 ns)   2.08 ns   2.76 ns  10.54 ns
isContentTypeApplicationJson('application/json; charset=UTF-8')    1.95 ns/iter      (1.19 ns … 169 ns)   2.08 ns   2.39 ns    5.8 ns
html.startsWith('application/json')                                 659 ps/iter       (409 ps … 142 ns)    716 ps    955 ps   5.05 ns
json.startsWith('application/json')                               54.82 ns/iter     (37.27 ns … 101 ns)  55.21 ns  64.32 ns   87.2 ns

summary for isContentTypeApplicationJson
  html.startsWith('application/json')
   2.96x faster than isContentTypeApplicationJson('application/json; charset=UTF-8')
   3.01x faster than isContentTypeApplicationJson('text/html')
   83.18x faster than json.startsWith('application/json')
```