### PR TITLE
ci: fix broken ci on windows and node v21 because of libuv bug

### DIFF
--- a/test/node-test/debug.js
+++ b/test/node-test/debug.js
@@ -8,10 +8,7 @@ const { tspl } = require('@matteo.collina/tspl')
 // eslint-disable-next-line no-control-regex
 const removeEscapeColorsRE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
 
-// see https://github.com/nodejs/node/issues/51766
-const skip = process.version === 'v21.6.2' && process.platform === 'win32'
-
-test('debug#websocket', { skip }, async t => {
+test('debug#websocket', async t => {
   const assert = tspl(t, { plan: 8 })
   const child = spawn(
     process.execPath,
@@ -48,10 +45,9 @@ test('debug#websocket', { skip }, async t => {
   })
 
   await assert.completed
-  child.kill()
 })
 
-test('debug#fetch', { skip }, async t => {
+test('debug#fetch', async t => {
   const assert = tspl(t, { plan: 7 })
   const child = spawn(
     process.execPath,
@@ -83,10 +79,9 @@ test('debug#fetch', { skip }, async t => {
   })
 
   await assert.completed
-  child.kill()
 })
 
-test('debug#undici', { skip }, async t => {
+test('debug#undici', async t => {
   // Due to Node.js webpage redirect
   const assert = tspl(t, { plan: 7 })
   const child = spawn(
@@ -121,7 +116,6 @@ test('debug#undici', { skip }, async t => {
   })
 
   await assert.completed
-  child.kill()
 })
 
 function extractLines (chunks) {


### PR DESCRIPTION
Actually all the fixtures terminate the servers after the first request. So we just wont call child.kill() and it should not error anymore on windows.

![image](https://github.com/nodejs/undici/assets/5059100/0d57ab4d-69fb-4ca6-bc2a-954f3bb182e6)
