### PR TITLE
fix: MockResponseCallbackOptions type

### DIFF
--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -37,7 +37,12 @@ expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCall
     trailers: { foo: 'bar' }
   }})))
   mockInterceptor.reply((options) => {
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions["path"]>(options.path);
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions["method"]>(options.method);
     expectAssignable<MockInterceptor.MockResponseCallbackOptions['headers']>(options.headers);
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions['origin']>(options.origin);
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions['body']>(options.body);
+    expectAssignable<MockInterceptor.MockResponseCallbackOptions["maxRedirections"]>(options.maxRedirections);
     return { statusCode: 200, data: { foo: 'bar' } }
   })
 

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -71,11 +71,11 @@ declare namespace MockInterceptor {
 
   export interface MockResponseCallbackOptions {
     path: string;
-    origin: string;
     method: string;
-    body?: BodyInit | Dispatcher.DispatchOptions['body'];
-    headers: Headers | Record<string, string>;
-    maxRedirections: number;
+    headers?: Headers | Record<string, string>;
+    origin?: string;
+    body?: BodyInit | Dispatcher.DispatchOptions['body'] | null;
+    maxRedirections?: number;
   }
 
   export type MockResponseDataHandler<TData extends object = object> = (


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
https://github.com/nodejs/undici/issues/1583

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

The issue is self-explanatory. It's kinda complicated to get what the actual types are. So I decided to print the `opts`argument:
https://github.com/nodejs/undici/blob/0b5a4515f3b7c0bbdc873ea172c47a56e515b167/lib/mock/mock-interceptor.js#L124

This is what I got:

![image](https://github.com/nodejs/undici/assets/38768936/17df3dd4-7bde-4ce9-ac97-c7e6bf00d0b5)
![image](https://github.com/nodejs/undici/assets/38768936/2a07d43d-a309-42e6-bcda-9e71633cc310)


From what I understand, only  `path` and `method` are sure to exist.

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
