### PR TITLE
ci: add macos-latest to test-matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -64,6 +64,7 @@ jobs:
         runs-on: 
           - ubuntu-latest
           - windows-latest
+          - macos-latest
     
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
CITGM is having macos-latet, but we dont.

https://github.com/nodejs/citgm/issues/1051#issuecomment-1993803240