### PR TITLE
types: align RequestInit.body type with lib.dom.ts

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -31,6 +31,7 @@ const requestInit2: RequestInit = {
 const requestInit3: RequestInit = {}
 // Test assignment. See https://github.com/whatwg/fetch/issues/1445
 requestInit3.credentials = 'include'
+const requestInit4: RequestInit = { body: null }
 
 declare const request: Request
 declare const headers: Headers

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -122,7 +122,7 @@ export interface RequestInit {
   method?: string
   keepalive?: boolean
   headers?: HeadersInit
-  body?: BodyInit
+  body?: BodyInit | null
   redirect?: RequestRedirect
   integrity?: string
   signal?: AbortSignal | null


### PR DESCRIPTION
## This relates to...

#1172

## Rationale

The `RequestInit.body` property should allow `null` to match the TypeScript DOM types.

Expected to help avoid typing errors such as:

```
Argument of type 'RequestInit | undefined' is not assignable to parameter of type 'import(".../node_modules/undici/types/fetch").RequestInit | undefined'.
  Type 'RequestInit' is not assignable to type 'import(".../node_modules/undici/types/fetch").RequestInit'.
    Types of property 'body' are incompatible.
      Type 'BodyInit | null | undefined' is not assignable to type 'BodyInit | undefined'.

     const fetchRequest = new Request(fetchUrl, options);
                                                ~~~~~~~
```

## Changes

The `RequestInit.body` property now allows `null` in addition to `undefined`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [s] Benchmarked (**optional**)
- [s] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
