### PR TITLE
ci: pin versions of github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Coverage Report
         if: matrix.runs-on == 'ubuntu-latest' && matrix.node-version == 20
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/security-wg/issues/1247
Note: I will work on `npmCommand not pinned ` in a separate PR, for [context](https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/nodejs/undici)