### PR TITLE
types: align with lib.dom.d.ts by removing [Symbol.toStringTag] from File/FormData

### DIFF
--- a/types/file.d.ts
+++ b/types/file.d.ts
@@ -34,6 +34,4 @@ export declare class File extends Blob {
    * The last modified date of the file as the number of milliseconds since the Unix epoch (January 1, 1970 at midnight). Files without a known last modified date return the current date.
    */
   readonly lastModified: number
-
-  readonly [Symbol.toStringTag]: string
 }

--- a/types/formdata.d.ts
+++ b/types/formdata.d.ts
@@ -103,6 +103,4 @@ export declare class FormData {
    * An alias for FormData#entries()
    */
   [Symbol.iterator]: () => SpecIterableIterator<[string, FormDataEntryValue]>
-
-  readonly [Symbol.toStringTag]: string
 }


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/issues/1172

## Rationale
In TypeScript `lib.dom.d.ts`, the interfaces `File` and `FormData` do not include the `[Symbol.toStringTag]` instance method.

By aligning types, can avoid type errors such as the following when combining undici in a JSDom environment or other Browser like environments.

```
.../tests/utils/fetch.ts:99:3 - error TS2322: Type 'Mock<(resource: RequestInfo | URL, options?: RequestInit | undefined) => Promise<Response>>' is not assignable to type '{ (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>; (input: string | Request | URL, init?: RequestInit | undefined): Promise<...>; }'.
  Types of parameters 'options' and 'init' are incompatible.
    Type 'RequestInit | undefined' is not assignable to type 'import(".../node_modules/undici/types/fetch").RequestInit | undefined'.
      Type 'RequestInit' is not assignable to type 'import(".../node_modules/undici/types/fetch").RequestInit'.
        Types of property 'body' are incompatible.
          Type 'BodyInit | null | undefined' is not assignable to type 'BodyInit | undefined'.
            Type 'FormData' is not assignable to type 'BodyInit | undefined'.
              Property '[Symbol.toStringTag]' is missing in type 'FormData' but required in type 'import(".../node_modules/undici/types/formdata").FormData'.

99   globalThis.fetch = jest.fn(fetch);
     ~~~~~~~~~~~~~~~~

  node_modules/undici/types/formdata.d.ts:107:12
    107   readonly [Symbol.toStringTag]: string
                   ~~~~~~~~~~~~~~~~~~~~
    '[Symbol.toStringTag]' is declared here.
```

```
.../tests/utils/fetch.ts:99:3 - error TS2322: Type 'Mock<(resource: URL | RequestInfo, options?: RequestInit | undefined) => Promise<Response>>' is not assignable to type '{ (input: URL | RequestInfo, init?: RequestInit | undefined): Promise<Response>; (input: string | URL | Request, init?: RequestInit | undefined): Promise<...>; }'.
  Types of parameters 'options' and 'init' are incompatible.
    Type 'RequestInit | undefined' is not assignable to type 'import(".../node_modules/undici/types/fetch").RequestInit | undefined'.
      Type 'RequestInit' is not assignable to type 'import(".../node_modules/undici/types/fetch").RequestInit'.
        Types of property 'body' are incompatible.
          Type 'BodyInit | null | undefined' is not assignable to type 'BodyInit | undefined'.
            Type 'FormData' is not assignable to type 'BodyInit | undefined'.
              Type 'FormData' is not assignable to type 'import(".../node_modules/undici/types/formdata").FormData'.
                The types returned by 'get(...)' are incompatible between these types.
                  Type 'FormDataEntryValue | null' is not assignable to type 'import(".../node_modules/undici/types/formdata").FormDataEntryValue | null'.
                    Type 'File' is not assignable to type 'FormDataEntryValue | null'.
                      Property '[Symbol.toStringTag]' is missing in type 'File' but required in type 'import(".../node_modules/undici/types/file").File'.

99   globalThis.fetch = jest.fn(fetch);
     ~~~~~~~~~~~~~~~~

  node_modules/undici/types/file.d.ts:38:12
    38   readonly [Symbol.toStringTag]: string
                  ~~~~~~~~~~~~~~~~~~~~
    '[Symbol.toStringTag]' is declared here.
```

These types were both originally added in 5425b77c503cb5af47419255778181c254f17089 adnd then modified slightly in 609d89b070f75d5f4d9f6d15f830f9cf4d3f6dfb.

The `[Symbol.toStringTag]` instance method is not something we expect users to call directly.

## Changes

Removed the `[Symbol.toStringTag]` instance method from the File and FormData interfaces in the files `file.d.ts` and `formdata.d.ts`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [s] Benchmarked (**optional**)
- [s] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
