### PR TITLE
Chore: run tests daily against node nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,62 @@
+name: Nightly tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  test:
+    if: github.repository == 'nodejs/undici'
+    strategy:
+      fail-fast: false
+      max-parallel: 0
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: 22-nightly
+      runs-on: ${{ matrix.runs-on }}
+    secrets: inherit
+
+  report-failure:
+    if: failure()
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const ISSUE_TITLE = "Nightly tests are failing"
+
+            const actionRunUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+            const issueContext = {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }
+
+            let issue = (await github.rest.issues.listForRepo({
+              state: "open",
+              creator: "github-actions[bot]",
+              ...issueContext
+            })).data.find((issue) => issue.title === ISSUE_TITLE)
+
+            if(!issue) {
+              issue = (await github.rest.issues.create({
+                title: ISSUE_TITLE,
+                ...issueContext
+              })).data
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: issue.number,
+              body: `Tests against nightly failed, see: ${actionRunUrl}`,
+              ...issueContext
+            });

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -51,8 +51,6 @@ jobs:
         run: npm run lint
 
   test:
-    name: Test with Node.js ${{ matrix.node-version }} on ${{ matrix.runs-on }}
-    timeout-minutes: 15
     strategy:
       fail-fast: false
       max-parallel: 0
@@ -61,48 +59,15 @@ jobs:
           - 18
           - 20
           - 21
-        runs-on: 
+        runs-on:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-    
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false          
-
-      - name: Setup Node.js@${{ matrix.node-version }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version: ${{ matrix.node-version }}
-      
-      - name: Print version information
-        run: |
-          echo OS: $(node -p "os.version()")
-          echo Node.js: $(node --version)
-          echo npm: $(npm --version)
-          echo git: $(git --version)
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Print installed dependencies
-        run: npm ls --all
-        continue-on-error: true
-  
-      - name: Run tests
-        run: npm run coverage:ci
-        env:
-          CI: true
-          NODE_V8_COVERAGE: ./coverage/tmp
-
-      - name: Coverage Report
-        if: matrix.runs-on == 'ubuntu-latest' && matrix.node-version == 20
-        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: ${{ matrix.node-version }}
+      runs-on: ${{ matrix.runs-on }}
+    secrets: inherit
 
   test-types:
     name: Test TypeScript types

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: Run tests
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test with Node.js ${{ inputs.node-version }} on ${{ inputs.runs-on }}
+    timeout-minutes: 15
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js@${{ inputs.node-version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Print version information
+        run: |
+          echo OS: $(node -p "os.version()")
+          echo Node.js: $(node --version)
+          echo npm: $(npm --version)
+          echo git: $(git --version)
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Print installed dependencies
+        run: npm ls --all
+        continue-on-error: true
+
+      - name: Run tests
+        run: npm run coverage:ci
+        env:
+          CI: true
+          NODE_V8_COVERAGE: ./coverage/tmp
+
+      - name: Coverage Report
+        if: inputs.runs-on == 'ubuntu-latest' && inputs.node-version == 20
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/issues/2932

## Rationale
In order to catch regressions either caused by or a result of upstream Node changes, add a workflow that is invoked on a daily basis to run the `main` branch's unit tests utilizing the most recent daily build.

In the event of test failure, create a new issue if needed, otherwise comment the most recent open "Nightly tests are failing" issue with the most recent failure.


## Changes

1. Factor tests out of existing `Node CI` workflow
2. Add new `nightly` workflow, triggered on a daily schedule (or alternative, manually via workflow_dispatch to test changes in main without waiting for the next day's scheduled run.)

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
