### PR TITLE
fix(fetch): properly redirect non-ascii location header url

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -44,7 +44,8 @@ function responseLocationURL (response, requestFragment) {
   // 3. If location is a header value, then set location to the result of
   //    parsing location with response’s URL.
   if (location !== null && isValidHeaderValue(location)) {
-    location = new URL(location, responseURL(response))
+    // Make sure location is properly encoded.
+    location = new URL(Buffer.from(location, 'ascii').toString('utf8'), responseURL(response))
   }
 
   // 4. If location is a URL whose fragment is null, then set location’s

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -44,8 +44,10 @@ function responseLocationURL (response, requestFragment) {
   // 3. If location is a header value, then set location to the result of
   //    parsing location with response’s URL.
   if (location !== null && isValidHeaderValue(location)) {
-    // Make sure location is properly encoded.
-    location = new URL(Buffer.from(location, 'ascii').toString('utf8'), responseURL(response))
+    // Some websites respond location header in binary form without encoding them
+    // and major browsers redirect them to correctly UTF-8 encoded addresses.
+    // Here, we handle that behavior in the same way.
+    location = new URL(decodeBinaryStringToUtf8(location), responseURL(response))
   }
 
   // 4. If location is a URL whose fragment is null, then set location’s
@@ -56,6 +58,14 @@ function responseLocationURL (response, requestFragment) {
 
   // 5. Return location.
   return location
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function decodeBinaryStringToUtf8 (value) {
+  return Buffer.from(value, 'binary').toString('utf8')
 }
 
 /** @returns {URL} */

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -47,7 +47,7 @@ function responseLocationURL (response, requestFragment) {
     // Some websites respond location header in binary form without encoding them
     // and major browsers redirect them to correctly UTF-8 encoded addresses.
     // Here, we handle that behavior in the same way.
-    location = new URL(decodeBinaryStringToUtf8(location), responseURL(response))
+    location = new URL(normalizeBinaryStringToUtf8(location), responseURL(response))
   }
 
   // 4. If location is a URL whose fragment is null, then set location’s
@@ -61,10 +61,12 @@ function responseLocationURL (response, requestFragment) {
 }
 
 /**
+ * If string contains non-ASCII characters, assumes it's UTF-8 encoded and decodes it.
+ * Since UTF-8 is a superset of ASCII, this will work for ASCII strings as well.
  * @param {string} value
  * @returns {string}
  */
-function decodeBinaryStringToUtf8 (value) {
+function normalizeBinaryStringToUtf8 (value) {
   return Buffer.from(value, 'binary').toString('utf8')
 }
 

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -45,7 +45,7 @@ function responseLocationURL (response, requestFragment) {
   //    parsing location with response’s URL.
   if (location !== null && isValidHeaderValue(location)) {
     if (!isValidEncodedURL(location)) {
-      // Some websites respond location header in binary form without encoding them
+      // Some websites respond location header in UTF-8 form without encoding them as ASCII
       // and major browsers redirect them to correctly UTF-8 encoded addresses.
       // Here, we handle that behavior in the same way.
       location = normalizeBinaryStringToUtf8(location)

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -72,7 +72,7 @@ function isValidEncodedURL (url) {
   for (const c of url) {
     const code = c.charCodeAt(0)
     // Not used in US-ASCII
-    if (code >= 0x80 && code <= 0xFF) {
+    if (code >= 0x80) {
       return false
     }
     // Control characters

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -44,10 +44,13 @@ function responseLocationURL (response, requestFragment) {
   // 3. If location is a header value, then set location to the result of
   //    parsing location with response’s URL.
   if (location !== null && isValidHeaderValue(location)) {
-    // Some websites respond location header in binary form without encoding them
-    // and major browsers redirect them to correctly UTF-8 encoded addresses.
-    // Here, we handle that behavior in the same way.
-    location = new URL(normalizeBinaryStringToUtf8(location), responseURL(response))
+    if (!isValidEncodedURL(location)) {
+      // Some websites respond location header in binary form without encoding them
+      // and major browsers redirect them to correctly UTF-8 encoded addresses.
+      // Here, we handle that behavior in the same way.
+      location = normalizeBinaryStringToUtf8(location)
+    }
+    location = new URL(location, responseURL(response))
   }
 
   // 4. If location is a URL whose fragment is null, then set location’s
@@ -58,6 +61,26 @@ function responseLocationURL (response, requestFragment) {
 
   // 5. Return location.
   return location
+}
+
+/**
+ * @see https://www.rfc-editor.org/rfc/rfc1738#section-2.2
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isValidEncodedURL (url) {
+  for (const c of url) {
+    const code = c.charCodeAt(0)
+    // Not used in US-ASCII
+    if (code >= 0x80 && code <= 0xFF) {
+      return false
+    }
+    // Control characters
+    if ((code >= 0x00 && code <= 0x1F) || code === 0x7F) {
+      return false
+    }
+  }
+  return true
 }
 
 /**

--- a/test/fetch/fetch-url-after-redirect.js
+++ b/test/fetch/fetch-url-after-redirect.js
@@ -54,7 +54,7 @@ test('location header with non-ASCII character redirects to a properly encoded u
    *         .map(n => parseInt(n, 16))
    *     )
    *     res.writeHead(302, {
-   *       Location: `/${}`
+   *       Location: `/${path}`
    *     })
    *     return res.end()
    *   }

--- a/test/fetch/fetch-url-after-redirect.js
+++ b/test/fetch/fetch-url-after-redirect.js
@@ -40,39 +40,10 @@ test('after redirecting the url of the response is set to the target url', async
 })
 
 test('location header with non-ASCII character redirects to a properly encoded url', async (t) => {
-  /**
-   * @example
-   * ```ts
-   * const server = createServer((req, res) => {
-   *   // redirect -> %EC%95%88%EB%85%95 (안녕), not %C3%AC%C2%95%C2%88%C3%AB%C2%85%C2%95
-   *   if (res.req.url.endsWith('/redirect')) {
-   *     const path = String.fromCharCode.apply(
-   *       null,
-   *       encodeURIComponent('안녕')
-   *         .split('%')
-   *         .slice(1)
-   *         .map(n => parseInt(n, 16))
-   *     )
-   *     res.writeHead(302, {
-   *       Location: `/${path}`
-   *     })
-   *     return res.end()
-   *   }
-   * })
-   * ```
-   */
-  const encodedPath = encodeURIComponent('안녕')
-  const nonEncodedPath = String.fromCharCode.apply(
-    null,
-    encodeURIComponent('안녕')
-      .split('%')
-      .slice(1)
-      .map(n => parseInt(n, 16))
-  )
-
+  // redirect -> %EC%95%88%EB%85%95 (안녕), not %C3%AC%C2%95%C2%88%C3%AB%C2%85%C2%95
   const server = createServer((req, res) => {
     if (res.req.url.endsWith('/redirect')) {
-      res.writeHead(302, undefined, { Location: `/${nonEncodedPath}` })
+      res.writeHead(302, undefined, { Location: `/${Buffer.from('안녕').toString('binary')}` })
       res.end()
     } else {
       res.writeHead(200, 'dummy', { 'Content-Type': 'text/plain' })
@@ -86,5 +57,5 @@ test('location header with non-ASCII character redirects to a properly encoded u
   const { port } = server.address()
   const response = await fetch(`http://127.0.0.1:${port}/redirect`)
 
-  assert.strictEqual(response.url, `http://127.0.0.1:${port}/${encodedPath}`)
+  assert.strictEqual(response.url, `http://127.0.0.1:${port}/${encodeURIComponent('안녕')}`)
 })

--- a/test/fetch/fetch-url-after-redirect.js
+++ b/test/fetch/fetch-url-after-redirect.js
@@ -38,3 +38,53 @@ test('after redirecting the url of the response is set to the target url', async
 
   assert.strictEqual(response.url, `http://127.0.0.1:${port}/target`)
 })
+
+test('location header with non-ASCII character redirects to a properly encoded url', async (t) => {
+  /**
+   * @example
+   * ```ts
+   * const server = createServer((req, res) => {
+   *   // redirect -> %EC%95%88%EB%85%95 (안녕), not %C3%AC%C2%95%C2%88%C3%AB%C2%85%C2%95
+   *   if (res.req.url.endsWith('/redirect')) {
+   *     const path = String.fromCharCode.apply(
+   *       null,
+   *       encodeURIComponent('안녕')
+   *         .split('%')
+   *         .slice(1)
+   *         .map(n => parseInt(n, 16))
+   *     )
+   *     res.writeHead(302, {
+   *       Location: `/${}`
+   *     })
+   *     return res.end()
+   *   }
+   * })
+   * ```
+   */
+  const encodedPath = encodeURIComponent('안녕')
+  const nonEncodedPath = String.fromCharCode.apply(
+    null,
+    encodeURIComponent('안녕')
+      .split('%')
+      .slice(1)
+      .map(n => parseInt(n, 16))
+  )
+
+  const server = createServer((req, res) => {
+    if (res.req.url.endsWith('/redirect')) {
+      res.writeHead(302, undefined, { Location: `/${nonEncodedPath}` })
+      res.end()
+    } else {
+      res.writeHead(200, 'dummy', { 'Content-Type': 'text/plain' })
+      res.end()
+    }
+  })
+  t.after(closeServerAsPromise(server))
+
+  const listenAsync = promisify(server.listen.bind(server))
+  await listenAsync(0)
+  const { port } = server.address()
+  const response = await fetch(`http://127.0.0.1:${port}/redirect`)
+
+  assert.strictEqual(response.url, `http://127.0.0.1:${port}/${encodedPath}`)
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

The fetch function behaves differently from major web browsers(chrome, safari, firefox etc), and even CURL (with `-L` option).

Here is a minimal reproducible URL I made: https://non-ascii-location-header.sys.workers.dev/redirect

<details>
<summary>Worker code</summary>

```ts
export default {
	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
		try {
			const url = new URL(request.url);
			if (url.pathname === '/redirect') {
				return new Response('', {
					status: 302,
					headers: {
						Location: '/안녕',
					},
				});
			}
			return new Response(`pathname ${url.pathname}`);
		} catch (e) {
			return new Response(`error: ${(e as Error).message}`, { status: 500 });
		}
	},
};
```

</details>

By accessing the address at https://non-ascii-location-header.sys.workers.dev/redirect directly 
or https://non-ascii-location-header.sys.workers.dev/ first and then making a fetch request to the /redirect path using the developer tools leads to reaching https://non-ascii-location-header.sys.workers.dev/%EC%95%88%EB%85%95  
which shows `pathname /%EC%95%88%EB%85%95` as a result.

However, using undici fetch function does not behave in the same way.

```
> r = await fetch('https://non-ascii-location-header.sys.workers.dev/redirect')
... await r.text();
pathname /%C3%AC%C2%95%C2%88%C3%AB%C2%85%C2%95
```

This issue can also be observed at chrome web store: https://chromewebstore.google.com/detail/gbgmenmdglilmbmemagekpeaodajbeei

```
Welcome to Node.js v21.6.2.
Type ".help" for more information.
> await fetch('https://chromewebstore.google.com/detail/gbgmenmdglilmbmemagekpeaodajbeei')
Uncaught TypeError: fetch failed
    at node:internal/deps/undici/undici:12443:11
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async REPL1:1:33 {
  cause: Error: redirect count exceeded
      at makeNetworkError (node:internal/deps/undici/undici:5675:35)
      at httpRedirectFetch (node:internal/deps/undici/undici:10696:32)
      at httpFetch (node:internal/deps/undici/undici:10668:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async node:internal/deps/undici/undici:10440:20
      at async mainFetch (node:internal/deps/undici/undici:10430:20)
      at async httpFetch (node:internal/deps/undici/undici:10668:22)
      at async node:internal/deps/undici/undici:10440:20
      at async mainFetch (node:internal/deps/undici/undici:10430:20)
      at async httpFetch (node:internal/deps/undici/undici:10668:22)
}
```

I do not have an in-depth understanding of the fetch standard, so if this PR request violates the standard in any way, please feel free to close it.

Thank you.

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
