### PR TITLE
perf: Remove double-stringify in setCookie

### DIFF
--- a/lib/web/cookies/index.js
+++ b/lib/web/cookies/index.js
@@ -102,7 +102,7 @@ function setCookie (headers, cookie) {
   const str = stringify(cookie)
 
   if (str) {
-    headers.append('Set-Cookie', stringify(cookie))
+    headers.append('Set-Cookie', str);
   }
 }
 

--- a/lib/web/cookies/index.js
+++ b/lib/web/cookies/index.js
@@ -102,7 +102,7 @@ function setCookie (headers, cookie) {
   const str = stringify(cookie)
 
   if (str) {
-    headers.append('Set-Cookie', str);
+    headers.append('Set-Cookie', str)
   }
 }
 


### PR DESCRIPTION
## This relates to...

Was perusing the code and spotted a double call to 'stringify' in setCookie

## Rationale

Didn't seem logical to run stringify multiple times on the same value as this might be an expensive operation behind the scenes.

## Changes

Removed the additional call to stringify

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
