### PR TITLE
perf: Micro-optimizations in isIterable, isAsyncIterable and parseHeaders core util

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -158,11 +158,11 @@ function deepClone (obj) {
 }
 
 function isAsyncIterable (obj) {
-  return !!(obj != null && typeof obj[Symbol.asyncIterator] === 'function')
+  return obj != null && typeof obj[Symbol.asyncIterator] === 'function'
 }
 
 function isIterable (obj) {
-  return !!(obj != null && (typeof obj[Symbol.iterator] === 'function' || typeof obj[Symbol.asyncIterator] === 'function'))
+  return obj != null && (typeof obj[Symbol.iterator] === 'function' || typeof obj[Symbol.asyncIterator] === 'function')
 }
 
 function bodyLength (body) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -264,8 +264,15 @@ function parseHeaders (headers, obj) {
       const headersValue = headers[i + 1]
       if (typeof headersValue === 'string') {
         obj[key] = headersValue
+      } else if (Array.isArray(headersValue)) {
+        const len = headersValue.length
+        const headersValueAsUTF8 = new Array(len)
+        for (let y = 0; y < len; y++) {
+          headersValueAsUTF8[y] = headersValue[y].toString('utf8')
+        }
+        obj[key] = headersValueAsUTF8
       } else {
-        obj[key] = Array.isArray(headersValue) ? headersValue.map(x => x.toString('utf8')) : headersValue.toString('utf8')
+        obj[key] = headersValue.toString('utf8')
       }
     }
   }


### PR DESCRIPTION
## This relates to...

Micro optimizations regarding performance of core utils

## Rationale

I found two double negations that could be omitted as unnecessary, the map vs for...of adjustment is related to the simple fact that map operations are significantly slower compared to for...of. 

## Changes

- perf: lib/core/util@isIterable: Removed unnecessary double negation
- perf: lib/core/util@isAsyncIterable: Removed unnecessary double negation
- perf: lib/core/util@parseHeaders: Swapped out usage of map in favor of for...of with pre-assigned array

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
