### PR TITLE
fix(H2 Client): bind stream 'data' listener only after received 'response' event

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -253,7 +253,6 @@ function writeH2 (client, request) {
 
   /** @type {import('node:http2').ClientHttp2Stream} */
   let stream
-  let isStreamResponseStarted = false
 
   const { hostname, port } = client[kUrl]
 
@@ -389,7 +388,6 @@ function writeH2 (client, request) {
   ++session[kOpenStreams]
 
   stream.once('response', headers => {
-    isStreamResponseStarted = true
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
     request.onResponseStarted()
 
@@ -421,7 +419,7 @@ function writeH2 (client, request) {
   })
 
   stream.on('data', (chunk) => {
-    if (!isStreamResponseStarted || request.onData(chunk) === false) {
+    if (request.onData(chunk) === false) {
       stream.pause()
     }
   })

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -253,6 +253,7 @@ function writeH2 (client, request) {
 
   /** @type {import('node:http2').ClientHttp2Stream} */
   let stream
+  let isStreamResponseStarted = false
 
   const { hostname, port } = client[kUrl]
 
@@ -388,6 +389,7 @@ function writeH2 (client, request) {
   ++session[kOpenStreams]
 
   stream.once('response', headers => {
+    isStreamResponseStarted = true
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
     request.onResponseStarted()
 
@@ -419,7 +421,7 @@ function writeH2 (client, request) {
   })
 
   stream.on('data', (chunk) => {
-    if (request.onData(chunk) === false) {
+    if (!isStreamResponseStarted || request.onData(chunk) === false) {
       stream.pause()
     }
   })

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -394,6 +394,12 @@ function writeH2 (client, request) {
     if (request.onHeaders(Number(statusCode), realHeaders, stream.resume.bind(stream), '') === false) {
       stream.pause()
     }
+
+    stream.on('data', (chunk) => {
+      if (request.onData(chunk) === false) {
+        stream.pause()
+      }
+    })
   })
 
   stream.once('end', () => {
@@ -416,12 +422,6 @@ function writeH2 (client, request) {
     const err = new InformationalError('HTTP/2: stream half-closed (remote)')
     errorRequest(client, request, err)
     util.destroy(stream, err)
-  })
-
-  stream.on('data', (chunk) => {
-    if (request.onData(chunk) === false) {
-      stream.pause()
-    }
   })
 
   stream.once('close', () => {

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2230,7 +2230,7 @@ async function httpNetworkFetch (
 
           //  4. See pullAlgorithm...
 
-          return this.body.push(bytes)
+          return this.body ? this.body.push(bytes) : false
         },
 
         onComplete () {

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2230,7 +2230,7 @@ async function httpNetworkFetch (
 
           //  4. See pullAlgorithm...
 
-          return this.body ? this.body.push(bytes) : false
+          return this.body.push(bytes)
         },
 
         onComplete () {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

https://github.com/nodejs/undici/issues/2808

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Sporadically when doing massive h2 requests for a certain period of time a breaking assertion is triggered "assert(!this.aborted)" in onHeaders Method [undici/lib/core/request.js] causing application crash

## Changes

<!-- Write a summary or list of changes here -->
 - lib/dispatcher/client-h2.js

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->
- Sometimes happens that H2 Stream "data" event is triggered some milliseconds before the "response" event, this leads to an uninitialized body. To avoid this breaking error if the onData is called before onHeaders, return false so the stream is paused in client-h2.js

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md #