### PR TITLE
fix: make EventSource properties enumerable

### DIFF
--- a/lib/web/eventsource/eventsource.js
+++ b/lib/web/eventsource/eventsource.js
@@ -10,6 +10,7 @@ const { parseMIMEType } = require('../fetch/data-url')
 const { MessageEvent } = require('../websocket/events')
 const { isNetworkError } = require('../fetch/response')
 const { delay } = require('./util')
+const { kEnumerableProperty } = require('../../core/util')
 
 let experimentalWarned = false
 
@@ -459,54 +460,15 @@ const constantsPropertyDescriptors = {
 Object.defineProperties(EventSource, constantsPropertyDescriptors)
 Object.defineProperties(EventSource.prototype, constantsPropertyDescriptors)
 
-Object.defineProperty(EventSource.prototype, 'readyState', {
-  enumerable: true,
-  get: function() {
-    return this.readyState;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'url', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'withCredentials', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'close', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'onopen', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'onmessage', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
-
-Object.defineProperty(EventSource.prototype, 'onerror', {
-  enumerable: true,
-  get: function() {
-    return this.url;
-  }
-});
+Object.defineProperties(EventSource.prototype, {
+  close: kEnumerableProperty,
+  onerror: kEnumerableProperty,
+  onmessage: kEnumerableProperty,
+  onopen: kEnumerableProperty,
+  readyState: kEnumerableProperty,
+  url: kEnumerableProperty,
+  withCredentials: kEnumerableProperty,
+})
 
 webidl.converters.EventSourceInitDict = webidl.dictionaryConverter([
   { key: 'withCredentials', converter: webidl.converters.boolean, defaultValue: false }

--- a/lib/web/eventsource/eventsource.js
+++ b/lib/web/eventsource/eventsource.js
@@ -467,13 +467,12 @@ Object.defineProperties(EventSource.prototype, {
   onopen: kEnumerableProperty,
   readyState: kEnumerableProperty,
   url: kEnumerableProperty,
-  withCredentials: kEnumerableProperty,
+  withCredentials: kEnumerableProperty
 })
 
 webidl.converters.EventSourceInitDict = webidl.dictionaryConverter([
   { key: 'withCredentials', converter: webidl.converters.boolean, defaultValue: false }
 ])
-
 
 module.exports = {
   EventSource,

--- a/lib/web/eventsource/eventsource.js
+++ b/lib/web/eventsource/eventsource.js
@@ -459,9 +459,59 @@ const constantsPropertyDescriptors = {
 Object.defineProperties(EventSource, constantsPropertyDescriptors)
 Object.defineProperties(EventSource.prototype, constantsPropertyDescriptors)
 
+Object.defineProperty(EventSource.prototype, 'readyState', {
+  enumerable: true,
+  get: function() {
+    return this.readyState;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'url', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'withCredentials', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'close', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'onopen', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'onmessage', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
+Object.defineProperty(EventSource.prototype, 'onerror', {
+  enumerable: true,
+  get: function() {
+    return this.url;
+  }
+});
+
 webidl.converters.EventSourceInitDict = webidl.dictionaryConverter([
   { key: 'withCredentials', converter: webidl.converters.boolean, defaultValue: false }
 ])
+
 
 module.exports = {
   EventSource,

--- a/test/eventsource/eventsource-properties.js
+++ b/test/eventsource/eventsource-properties.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { EventSource } = require('../..') // assuming the test is in test/eventsource/
+
+test('EventSource.prototype properties are configured correctly', () => {
+    const props = Object.entries(Object.getOwnPropertyDescriptors(EventSource.prototype))
+
+    for (const [key, value] of props) {
+        if (key !== 'constructor') {
+            assert(value.enumerable, `${key} is not enumerable`)
+        }
+    }
+})

--- a/test/eventsource/eventsource-properties.js
+++ b/test/eventsource/eventsource-properties.js
@@ -8,7 +8,7 @@ test('EventSource.prototype properties are configured correctly', () => {
   const props = Object.entries(Object.getOwnPropertyDescriptors(EventSource.prototype))
 
   for (const [key, value] of props) {
-        if (key !== 'constructor') {
+    if (key !== 'constructor') {
       assert(value.enumerable, `${key} is not enumerable`)
     }
   }

--- a/test/eventsource/eventsource-properties.js
+++ b/test/eventsource/eventsource-properties.js
@@ -5,11 +5,11 @@ const assert = require('node:assert')
 const { EventSource } = require('../..') // assuming the test is in test/eventsource/
 
 test('EventSource.prototype properties are configured correctly', () => {
-    const props = Object.entries(Object.getOwnPropertyDescriptors(EventSource.prototype))
+  const props = Object.entries(Object.getOwnPropertyDescriptors(EventSource.prototype))
 
-    for (const [key, value] of props) {
+  for (const [key, value] of props) {
         if (key !== 'constructor') {
-            assert(value.enumerable, `${key} is not enumerable`)
-        }
+      assert(value.enumerable, `${key} is not enumerable`)
     }
+  }
 })


### PR DESCRIPTION
## This relates to...

Makes Eventsource properties enumerable

- https://github.com/nodejs/undici/issues/2948


## Changes

Sets eventsource class fields to be enumerable

### Features

N/A

### Bug Fixes

Eventsource properties are not 
https://github.com/nodejs/undici/issues/2948

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [x] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
