### PR TITLE
chore(workflows/nightly.yml): create issue only on all platforms fail

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,25 +9,36 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  test-linux:
     if: github.repository == 'nodejs/undici'
-    strategy:
-      fail-fast: false
-      max-parallel: 0
-      matrix:
-        runs-on:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
     uses: ./.github/workflows/test.yml
     with:
       node-version: 22-nightly
-      runs-on: ${{ matrix.runs-on }}
+      runs-on: ubuntu-latest
+    secrets: inherit
+
+  test-windows:
+    if: github.repository == 'nodejs/undici'
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: 22-nightly
+      runs-on: windows-latest
+    secrets: inherit
+
+  test-macos:
+    if: github.repository == 'nodejs/undici'
+    uses: ./.github/workflows/test.yml
+    with:
+      node-version: 22-nightly
+      runs-on: macos-latest
     secrets: inherit
 
   report-failure:
-    if: failure()
-    needs: test
+    if: ${{ always() && (needs.test-linux.result == 'failure' && needs.test-windows.result == 'failure' && needs.test-macos.result == 'failure') }}
+    needs:
+      - test-linux
+      - test-windows
+      - test-macos
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## This relates to...

- https://github.com/nodejs/undici/issues/3017#issuecomment-2027514900

## Rationale

In the four nightly failures so far, 3 were not undici's fault and only one platform failed. In the one true positive error, all three platforms failed tests, therefore only create/comment issue if all three platform fail.

## Sample Runs

1. All platforms succeed: https://github.com/mweberxyz/nodejs-undici/actions/runs/8491820300
  No issue created
2. Single platform fails: https://github.com/mweberxyz/nodejs-undici/actions/runs/8491975740
  No issue created
3. All platforms fail: https://github.com/mweberxyz/nodejs-undici/actions/runs/8491957840
  Issue created: https://github.com/mweberxyz/nodejs-undici/issues/8

## Changes

.github/workflows/nightly.yml:
- remove matrix to give each platform a stable id
- only run `report-failure`if all three platforms fail

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
