### PR TITLE
fix: ProxyAgent causes request.headers.host to be forcibly reset

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -115,8 +115,8 @@ class ProxyAgent extends DispatcherBase {
       {
         ...opts,
         headers: {
-          ...headers,
-          host
+          host,
+          ...headers
         }
       },
       handler

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -64,19 +64,19 @@ class ProxyAgent extends DispatcherBase {
     this[kAgent] = new Agent({
       ...opts,
       connect: async (opts, callback) => {
-        let requestedHost = opts.host
+        let requestedPath = opts.host
         if (!opts.port) {
-          requestedHost += `:${defaultProtocolPort(opts.protocol)}`
+          requestedPath += `:${defaultProtocolPort(opts.protocol)}`
         }
         try {
           const { socket, statusCode } = await this[kClient].connect({
             origin,
             port,
-            path: requestedHost,
+            path: requestedPath,
             signal: opts.signal,
             headers: {
               ...this[kProxyHeaders],
-              host: requestedHost
+              host: opts.host
             },
             servername: this[kProxyTls]?.servername || proxyHostname
           })

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -108,16 +108,18 @@ class ProxyAgent extends DispatcherBase {
   }
 
   dispatch (opts, handler) {
-    const { host } = new URL(opts.origin)
     const headers = buildHeaders(opts.headers)
     throwIfProxyAuthIsSent(headers)
+
+    if (headers && !('host' in headers) && !('Host' in headers)) {
+      const { host } = new URL(opts.origin)
+      headers.host = host
+    }
+
     return this[kAgent].dispatch(
       {
         ...opts,
-        headers: {
-          host,
-          ...headers
-        }
+        headers
       },
       handler
     )


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
Closes https://github.com/nodejs/undici/issues/3019
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
