### PR TITLE
fix: regexp pattern

### DIFF
--- a/lib/web/fetch/data-url.js
+++ b/lib/web/fetch/data-url.js
@@ -8,12 +8,12 @@ const encoder = new TextEncoder()
  * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
  */
 const HTTP_TOKEN_CODEPOINTS = /^[!#$%&'*+-.^_|~A-Za-z0-9]+$/
-const HTTP_WHITESPACE_REGEX = /[\u000A|\u000D|\u0009|\u0020]/ // eslint-disable-line
+const HTTP_WHITESPACE_REGEX = /[\u000A\u000D\u0009\u0020]/ // eslint-disable-line
 const ASCII_WHITESPACE_REPLACE_REGEX = /[\u0009\u000A\u000C\u000D\u0020]/g // eslint-disable-line
 /**
  * @see https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
  */
-const HTTP_QUOTED_STRING_TOKENS = /[\u0009|\u0020-\u007E|\u0080-\u00FF]/ // eslint-disable-line
+const HTTP_QUOTED_STRING_TOKENS = /[\u0009\u0020-\u007E\u0080-\u00FF]/ // eslint-disable-line
 
 // https://fetch.spec.whatwg.org/#data-url-processor
 /** @param {URL} dataURL */


### PR DESCRIPTION
```shell
> require("undici").parseMIMEType("text/plain; |charset=UTF-16; charset=UTF-8"); // before
{
  type: 'text',
  subtype: 'plain',
  parameters: Map(1) { 'charset' => 'UTF-16' },
  essence: 'text/plain'
}
> require("undici").parseMIMEType("text/plain; |charset=UTF-16; charset=UTF-8"); // after
{
  type: 'text',
  subtype: 'plain',
  parameters: Map(2) { '|charset' => 'UTF-16', 'charset' => 'UTF-8' },
  essence: 'text/plain'
}
```