### PR TITLE
perf: improve isBlobLike

### DIFF
--- a/benchmarks/core/is-blob-like.mjs
+++ b/benchmarks/core/is-blob-like.mjs
@@ -1,0 +1,64 @@
+import { bench, group, run } from 'mitata'
+import { isBlobLike } from '../../lib/core/util.js'
+
+const buffer = Buffer.alloc(1)
+
+const blob = new Blob(['asd'], {
+  type: 'application/json'
+})
+
+const file = new File(['asd'], 'file.txt', {
+  type: 'text/plain'
+})
+
+const blobLikeStream = {
+  [Symbol.toStringTag]: 'Blob',
+  stream: () => {}
+}
+
+const fileLikeStream = {
+  stream: () => {},
+  [Symbol.toStringTag]: 'File'
+}
+
+const blobLikeArrayBuffer = {
+  [Symbol.toStringTag]: 'Blob',
+  arrayBuffer: () => {}
+}
+
+const fileLikeArrayBuffer = {
+  [Symbol.toStringTag]: 'File',
+  arrayBuffer: () => {}
+}
+
+group('isBlobLike', () => {
+  bench('blob', () => {
+    return isBlobLike(blob)
+  })
+  bench('file', () => {
+    return isBlobLike(file)
+  })
+  bench('blobLikeStream', () => {
+    return isBlobLike(blobLikeStream)
+  })
+  bench('fileLikeStream', () => {
+    return isBlobLike(fileLikeStream)
+  })
+  bench('fileLikeArrayBuffer', () => {
+    return isBlobLike(fileLikeArrayBuffer)
+  })
+  bench('blobLikeArrayBuffer', () => {
+    return isBlobLike(blobLikeArrayBuffer)
+  })
+  bench('buffer', () => {
+    return isBlobLike(buffer)
+  })
+  bench('null', () => {
+    return isBlobLike(null)
+  })
+  bench('string', () => {
+    return isBlobLike('invalid')
+  })
+})
+
+await run()

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -22,13 +22,20 @@ function isStream (obj) {
 
 // based on https://github.com/node-fetch/fetch-blob/blob/8ab587d34080de94140b54f07168451e7d0b655e/index.js#L229-L241 (MIT License)
 function isBlobLike (object) {
-  return (Blob && object instanceof Blob) || (
-    object &&
-    typeof object === 'object' &&
-    (typeof object.stream === 'function' ||
-      typeof object.arrayBuffer === 'function') &&
-    /^(Blob|File)$/.test(object[Symbol.toStringTag])
-  )
+  if (object === null) {
+    return false
+  } else if (object instanceof Blob) {
+    return true
+  } else if (typeof object !== 'object') {
+    return false
+  } else {
+    const sTag = object[Symbol.toStringTag]
+
+    return (sTag === 'Blob' || sTag === 'File') && (
+      ('stream' in object && typeof object.stream === 'function') ||
+      ('arrayBuffer' in object && typeof object.arrayBuffer === 'function')
+    )
+  }
 }
 
 function buildURL (url, queryParams) {

--- a/test/util.js
+++ b/test/util.js
@@ -3,6 +3,7 @@
 const { strictEqual } = require('node:assert')
 const { test, describe } = require('node:test')
 const { isBlobLike } = require('../lib/core/util')
+const { Blob, File } = require('node:buffer')
 
 describe('isBlobLike', () => {
   test('buffer', () => {
@@ -10,14 +11,14 @@ describe('isBlobLike', () => {
     strictEqual(isBlobLike(buffer), false)
   })
 
-  test('blob', () => {
+  test('blob', { skip: !Blob }, () => {
     const blob = new Blob(['asd'], {
       type: 'application/json'
     })
     strictEqual(isBlobLike(blob), true)
   })
 
-  test('file', () => {
+  test('file', { skip: !File }, () => {
     const file = new File(['asd'], 'file.txt', {
       type: 'text/plain'
     })

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const { strictEqual } = require('node:assert')
+const { test, describe } = require('node:test')
+const { isBlobLike } = require('../lib/core/util')
+
+describe('isBlobLike', () => {
+  test('buffer', () => {
+    const buffer = Buffer.alloc(1)
+    strictEqual(isBlobLike(buffer), false)
+  })
+
+  test('blob', () => {
+    const blob = new Blob(['asd'], {
+      type: 'application/json'
+    })
+    strictEqual(isBlobLike(blob), true)
+  })
+
+  test('file', () => {
+    const file = new File(['asd'], 'file.txt', {
+      type: 'text/plain'
+    })
+    strictEqual(isBlobLike(file), true)
+  })
+
+  test('blobLikeStream', () => {
+    const blobLikeStream = {
+      [Symbol.toStringTag]: 'Blob',
+      stream: () => { }
+    }
+    strictEqual(isBlobLike(blobLikeStream), true)
+  })
+
+  test('fileLikeStream', () => {
+    const fileLikeStream = {
+      stream: () => { },
+      [Symbol.toStringTag]: 'File'
+    }
+    strictEqual(isBlobLike(fileLikeStream), true)
+  })
+
+  test('fileLikeArrayBuffer', () => {
+    const blobLikeArrayBuffer = {
+      [Symbol.toStringTag]: 'Blob',
+      arrayBuffer: () => { }
+    }
+    strictEqual(isBlobLike(blobLikeArrayBuffer), true)
+  })
+
+  test('blobLikeArrayBuffer', () => {
+    const fileLikeArrayBuffer = {
+      [Symbol.toStringTag]: 'File',
+      arrayBuffer: () => { }
+    }
+    strictEqual(isBlobLike(fileLikeArrayBuffer), true)
+  })
+
+  test('string', () => {
+    strictEqual(isBlobLike('Blob'), false)
+  })
+
+  test('null', () => {
+    strictEqual(isBlobLike(null), false)
+  })
+})


### PR DESCRIPTION
before:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/core/is-blob-like.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark                time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------- -----------------------------
• isBlobLike
----------------------------------------------------------- -----------------------------
blob                    744 ps/iter       (409 ps … 164 ns)    716 ps   1.16 ns   5.35 ns
file                    728 ps/iter       (409 ps … 153 ns)    716 ps    955 ps   5.29 ns
blobLikeStream        18.79 ns/iter     (16.51 ns … 213 ns)  17.73 ns  29.29 ns    143 ns
fileLikeStream        18.66 ns/iter     (15.99 ns … 187 ns)  17.43 ns  31.89 ns    153 ns
fileLikeArrayBuffer   18.33 ns/iter     (15.99 ns … 205 ns)  17.36 ns  27.52 ns    148 ns
blobLikeArrayBuffer   18.88 ns/iter     (16.51 ns … 176 ns)   17.8 ns  35.54 ns    143 ns
buffer                14.45 ns/iter   (12.14 ns … 86.21 ns)  14.22 ns  20.97 ns  31.92 ns
null                    738 ps/iter     (409 ps … 51.09 ns)    716 ps   1.16 ns   5.39 ns
string                  739 ps/iter       (443 ps … 147 ns)    716 ps   1.16 ns   7.95 ns

summary for isBlobLike
  file
   1.01x faster than null
   1.01x faster than string
   1.02x faster than blob
   19.85x faster than buffer
   25.17x faster than fileLikeArrayBuffer
   25.63x faster than fileLikeStream
   25.81x faster than blobLikeStream
   25.94x faster than blobLikeArrayBuffer
```

after:

```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/undici$ node benchmarks/core/is-blob-like.mjs 
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark           time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------ -----------------------------
• isBlobLike
------------------------------------------------------ -----------------------------
blob               735 ps/iter       (409 ps … 189 ns)    716 ps   1.16 ns   5.29 ns
file               729 ps/iter       (409 ps … 131 ns)    716 ps   1.16 ns   5.32 ns
blobLikeStream     721 ps/iter       (443 ps … 102 ns)    716 ps    955 ps   6.45 ns
fileLikeStream     745 ps/iter       (409 ps … 155 ns)    716 ps   1.16 ns   5.39 ns
stream             787 ps/iter       (443 ps … 273 ns)    716 ps   5.25 ns   5.52 ns
arrayBuffer        738 ps/iter     (410 ps … 35.23 ns)    716 ps   1.16 ns   5.29 ns
buffer            1.26 ns/iter     (478 ps … 86.18 ns)   1.36 ns   1.64 ns    5.8 ns
null               736 ps/iter       (409 ps … 258 ns)    716 ps   1.16 ns   5.32 ns
string             730 ps/iter       (443 ps … 130 ns)    716 ps    955 ps   5.32 ns

summary for isBlobLike
  blobLikeStream
   1.01x faster than file
   1.01x faster than string
   1.02x faster than blob
   1.02x faster than null
   1.02x faster than arrayBuffer
   1.03x faster than fileLikeStream
   1.09x faster than stream
   1.74x faster than buffer
```