### PR TITLE
websocket: fix ByteParser.run and parseCloseBody

### DIFF
--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -108,7 +108,7 @@ class ByteParser extends Writable {
             // sending a Close frame in response, the endpoint typically echos the
             // status code it received.)
             let body = emptyBuffer
-            if (this.#info.closeInfo.code) {
+            if (this.#info.closeInfo?.code) {
               body = Buffer.allocUnsafe(2)
               body.writeUInt16BE(this.#info.closeInfo.code, 0)
             }
@@ -298,26 +298,30 @@ class ByteParser extends Writable {
       // defined as the status code (Section 7.4) contained in the first Close
       // control frame received by the application
       code = data.readUInt16BE(0)
+      if (!isValidStatusCode(code)) {
+        return null
+      }
+    } else {
+      return null
     }
 
     // https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.6
-    /** @type {Buffer} */
-    let reason = data.subarray(2)
+    /** @type {number} */
+    let reasonOffset = 2
 
-    // Remove BOM
-    if (reason[0] === 0xEF && reason[1] === 0xBB && reason[2] === 0xBF) {
-      reason = reason.subarray(3)
+    // Detect BOM and ignore it
+    if (data.length >= 5 && data[2] === 0xEF && data[3] === 0xBB && data[4] === 0xBF) {
+      reasonOffset = 5
     }
 
-    if (code !== undefined && !isValidStatusCode(code)) {
-      return null
+    if (data.length - reasonOffset < 1) {
+      return { code, reason: '' }
     }
 
+    let reason = ''
     try {
-      reason = utf8Decode(reason)
-    } catch {
-      return null
-    }
+      reason = utf8Decode(data.subarray(reasonOffset))
+    } catch { }
 
     return { code, reason }
   }

--- a/test/websocket/close.js
+++ b/test/websocket/close.js
@@ -151,4 +151,27 @@ describe('Close', () => {
 
     await t.completed
   })
+
+  test('Close with code and invalid encoded reason', () => {
+    return new Promise((resolve) => {
+      const server = new WebSocketServer({ port: 0 })
+
+      server.on('connection', (ws) => {
+        ws.close(1000, Buffer.from([0xFF, 0xFE]))
+
+        ws.on('close', (code, reason) => {
+          assert.equal(code, 1000)
+          assert.equal(reason.length, 0)
+        })
+      })
+
+      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      ws.onclose = (ev) => {
+        assert.equal(ev.code, 1000)
+        assert.equal(ev.reason, '')
+        server.close()
+        resolve()
+      }
+    })
+  })
 })


### PR DESCRIPTION
ParseCloseBody can return null. In that case this.#info.closeInfo would be null and the following line would result in a crash.

https://github.com/nodejs/undici/blob/5d5454380b72889706146a9c4d5f65225a99640f/lib/web/websocket/receiver.js#L111


Also reduces the amount of Buffers created.
