### PR TITLE
fetch: improve performance of isValidEncodedURL

### DIFF
--- a/benchmarks/fetch/is-valid-encoded-url.mjs
+++ b/benchmarks/fetch/is-valid-encoded-url.mjs
@@ -1,0 +1,14 @@
+import { bench, run } from 'mitata'
+import { isValidEncodedURL } from '../../lib/web/fetch/util.js'
+
+const validUrl = 'https://example.com'
+const invalidUrl = 'https://example.com\x00'
+
+bench('isValidEncodedURL valid', () => {
+  isValidEncodedURL(validUrl)
+})
+bench('isValidEncodedURL invalid', () => {
+  isValidEncodedURL(invalidUrl)
+})
+
+await run()

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -73,14 +73,13 @@ function responseLocationURL (response, requestFragment) {
  * @returns {boolean}
  */
 function isValidEncodedURL (url) {
-  for (const c of url) {
-    const code = c.charCodeAt(0)
-    // Not used in US-ASCII
-    if (code >= 0x80) {
-      return false
-    }
-    // Control characters
-    if ((code >= 0x00 && code <= 0x1F) || code === 0x7F) {
+  for (let i = 0; i < url.length; ++i) {
+    const code = url.charCodeAt(i)
+
+    if (
+      code > 0x7E || // Non-US-ASCII + DEL
+      code < 0x20 // Control characters NUL - US
+    ) {
       return false
     }
   }
@@ -1567,6 +1566,7 @@ function utf8DecodeBytes (buffer) {
 module.exports = {
   isAborted,
   isCancelled,
+  isValidEncodedURL,
   createDeferredPromise,
   ReadableStreamFrom,
   tryUpgradeRequestToAPotentiallyTrustworthyURL,


### PR DESCRIPTION
before:

```sh
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark                      time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------- -----------------------------
isValidEncodedURL valid       181 ns/iter       (174 ns … 567 ns)    182 ns    218 ns    262 ns
isValidEncodedURL invalid     178 ns/iter       (173 ns … 425 ns)    176 ns    220 ns    277 ns
```

after:

```sh
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark                      time (avg)             (min … max)       p75       p99      p999
----------------------------------------------------------------- -----------------------------
isValidEncodedURL valid      61.9 ns/iter     (58.62 ns … 228 ns)  61.51 ns  79.86 ns  97.25 ns
isValidEncodedURL invalid   64.04 ns/iter     (60.94 ns … 137 ns)  63.87 ns  75.49 ns    122 ns
```