### PR TITLE
Skip the creation of a transform stream in fetch

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1080,23 +1080,17 @@ function fetchFinale (fetchParams, response) {
   if (internalResponse.body == null) {
     processResponseEndOfBody()
   } else {
+    // mcollina: all the following steps of the specs are skipped.
+    // The internal transform stream is not needed.
+    //
     // 1. Let transformStream be a new TransformStream.
     // 2. Let identityTransformAlgorithm be an algorithm which, given chunk, enqueues chunk in transformStream.
     // 3. Set up transformStream with transformAlgorithm set to identityTransformAlgorithm and flushAlgorithm
     //    set to processResponseEndOfBody.
-    const transformStream = new TransformStream({
-      start () { },
-      transform (chunk, controller) {
-        controller.enqueue(chunk)
-      },
-      flush: processResponseEndOfBody
-    })
-
     // 4. Set internalResponse’s body’s stream to the result of internalResponse’s body’s stream piped through transformStream.
-    internalResponse.body.stream.pipeThrough(transformStream)
 
     const byteStream = new ReadableStream({
-      readableStream: transformStream.readable,
+      readableStream: internalResponse.body.stream,
       async start () {
         this._bodyReader = this.readableStream.getReader()
       },
@@ -1105,7 +1099,12 @@ function fetchFinale (fetchParams, response) {
           const { done, value } = await this._bodyReader.read()
 
           if (done) {
-            queueMicrotask(() => readableStreamClose(controller))
+            queueMicrotask(() => {
+              readableStreamClose(controller)
+
+              // Added to in lieu of steps 1-4 of the spec
+              processResponseEndOfBody()
+            })
             break
           }
 


### PR DESCRIPTION
This skips the creation of a `TransformStream`, which showed up glowing in the following flamegraph:

![Screenshot 2024-04-11 at 19 11 07](https://github.com/nodejs/undici/assets/52195/17afdcdf-3370-464e-8eff-fd33b1ae6256)

After this patch:

![Screenshot 2024-04-11 at 19 12 05](https://github.com/nodejs/undici/assets/52195/4a1283a7-6eed-4f06-a0eb-26202c714a44)


## Benchmarks

main:

```
[bench:run] ┌─────────┬───────────────────────┬─────────┬────────────────────┬────────────┬─────────────────────────┐
[bench:run] │ (index) │ Tests                 │ Samples │ Result             │ Tolerance  │ Difference with slowest │
[bench:run] ├─────────┼───────────────────────┼─────────┼────────────────────┼────────────┼─────────────────────────┤
[bench:run] │ 0       │ 'undici - fetch'      │ 30      │ '4571.92 req/sec'  │ '± 2.72 %' │ '-'                     │
[bench:run] │ 1       │ 'request'             │ 35      │ '5183.44 req/sec'  │ '± 2.90 %' │ '+ 13.38 %'             │
[bench:run] │ 2       │ 'node-fetch'          │ 10      │ '5405.14 req/sec'  │ '± 1.25 %' │ '+ 18.22 %'             │
[bench:run] │ 3       │ 'axios'               │ 35      │ '5423.29 req/sec'  │ '± 2.80 %' │ '+ 18.62 %'             │
[bench:run] │ 4       │ 'got'                 │ 25      │ '5672.87 req/sec'  │ '± 2.87 %' │ '+ 24.08 %'             │
[bench:run] │ 5       │ 'http - no keepalive' │ 10      │ '6407.75 req/sec'  │ '± 3.00 %' │ '+ 40.15 %'             │
[bench:run] │ 6       │ 'superagent'          │ 10      │ '9827.22 req/sec'  │ '± 1.69 %' │ '+ 114.95 %'            │
[bench:run] │ 7       │ 'http - keepalive'    │ 10      │ '11160.93 req/sec' │ '± 2.49 %' │ '+ 144.12 %'            │
[bench:run] │ 8       │ 'undici - pipeline'   │ 50      │ '12261.22 req/sec' │ '± 3.00 %' │ '+ 168.19 %'            │
[bench:run] │ 9       │ 'undici - stream'     │ 55      │ '19454.69 req/sec' │ '± 2.95 %' │ '+ 325.53 %'            │
[bench:run] │ 10      │ 'undici - request'    │ 20      │ '21013.26 req/sec' │ '± 2.50 %' │ '+ 359.62 %'            │
[bench:run] │ 11      │ 'undici - dispatch'   │ 60      │ '21457.64 req/sec' │ '± 2.93 %' │ '+ 369.34 %'            │
[bench:run] └─────────┴───────────────────────┴─────────┴────────────────────┴────────────┴─────────────────────────┘
```

this pr:

```
[bench:run] ┌─────────┬───────────────────────┬─────────┬────────────────────┬────────────┬─────────────────────────┐
[bench:run] │ (index) │ Tests                 │ Samples │ Result             │ Tolerance  │ Difference with slowest │
[bench:run] ├─────────┼───────────────────────┼─────────┼────────────────────┼────────────┼─────────────────────────┤
[bench:run] │ 0       │ 'undici - fetch'      │ 50      │ '5056.83 req/sec'  │ '± 2.78 %' │ '-'                     │
[bench:run] │ 1       │ 'axios'               │ 30      │ '5253.49 req/sec'  │ '± 2.92 %' │ '+ 3.89 %'              │
[bench:run] │ 2       │ 'node-fetch'          │ 10      │ '5467.21 req/sec'  │ '± 1.25 %' │ '+ 8.12 %'              │
[bench:run] │ 3       │ 'request'             │ 35      │ '5501.59 req/sec'  │ '± 2.92 %' │ '+ 8.80 %'              │
[bench:run] │ 4       │ 'got'                 │ 30      │ '5758.56 req/sec'  │ '± 2.67 %' │ '+ 13.88 %'             │
[bench:run] │ 5       │ 'http - no keepalive' │ 15      │ '6173.06 req/sec'  │ '± 2.81 %' │ '+ 22.07 %'             │
[bench:run] │ 6       │ 'superagent'          │ 10      │ '9717.62 req/sec'  │ '± 1.60 %' │ '+ 92.17 %'             │
[bench:run] │ 7       │ 'http - keepalive'    │ 10      │ '11309.90 req/sec' │ '± 2.53 %' │ '+ 123.66 %'            │
[bench:run] │ 8       │ 'undici - pipeline'   │ 50      │ '11740.51 req/sec' │ '± 2.95 %' │ '+ 132.17 %'            │
[bench:run] │ 9       │ 'undici - request'    │ 80      │ '17345.44 req/sec' │ '± 2.89 %' │ '+ 243.01 %'            │
[bench:run] │ 10      │ 'undici - stream'     │ 70      │ '20085.77 req/sec' │ '± 2.93 %' │ '+ 297.20 %'            │
[bench:run] │ 11      │ 'undici - dispatch'   │ 60      │ '21427.77 req/sec' │ '± 2.97 %' │ '+ 323.74 %'            │
[bench:run] └─────────┴───────────────────────┴─────────┴────────────────────┴────────────┴─────────────────────────┘
```

It improves our benchmark by 10%.


It also shortens the following:

```
import { fetch } from './index.js'

console.time('fetch')
for (let i = 0; i < 100000; i++) {
  const res = await fetch('http://localhost:3000')
  // console.log(await res.text())
  await res.text()
}
console.timeEnd('fetch')
```

from 20s to 16s. A nice 20% speedup.

