### PR TITLE
fetch: improve performance of urlHasHttpsScheme

### DIFF
--- a/benchmarks/fetch/url-has-https-scheme.mjs
+++ b/benchmarks/fetch/url-has-https-scheme.mjs
@@ -1,0 +1,22 @@
+import { bench, run } from 'mitata'
+import { urlHasHttpsScheme } from '../../lib/web/fetch/util.js'
+
+const httpString = 'http://example.com'
+const httpObject = { protocol: 'http:' }
+const httpsString = 'https://example.com'
+const httpsObject = { protocol: 'https:' }
+
+bench('urlHasHttpsScheme "http:" String', () => {
+  urlHasHttpsScheme(httpString)
+})
+bench('urlHasHttpsScheme "https:" String', () => {
+  urlHasHttpsScheme(httpsString)
+})
+bench('urlHasHttpsScheme "http:" Object', () => {
+  urlHasHttpsScheme(httpObject)
+})
+bench('urlHasHttpsScheme "https:" Object', () => {
+  urlHasHttpsScheme(httpsObject)
+})
+
+await run()

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1168,13 +1168,21 @@ function urlIsLocal (url) {
 
 /**
  * @param {string|URL} url
+ * @returns {boolean}
  */
 function urlHasHttpsScheme (url) {
-  if (typeof url === 'string') {
-    return url.startsWith('https:')
-  }
-
-  return url.protocol === 'https:'
+  return (
+    (
+      typeof url === 'string' &&
+      url[5] === ':' &&
+      url[0] === 'h' &&
+      url[1] === 't' &&
+      url[2] === 't' &&
+      url[3] === 'p' &&
+      url[4] === 's'
+    ) ||
+    url.protocol === 'https:'
+  )
 }
 
 /**

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const util = require('../../lib/web/fetch/util')
@@ -336,5 +336,22 @@ test('parseMetadata', async (t) => {
       { algo: 'sha384', hash: undefined },
       { algo: 'sha512', hash: hash512.replace(/=/g, '') }
     ])
+  })
+})
+
+describe('urlHasHttpsScheme', () => {
+  const { urlHasHttpsScheme } = util
+
+  test('should return false for http url', () => {
+    assert.strictEqual(urlHasHttpsScheme('http://example.com'), false)
+  })
+  test('should return true for https url', () => {
+    assert.strictEqual(urlHasHttpsScheme('https://example.com'), true)
+  })
+  test('should return false for http object', () => {
+    assert.strictEqual(urlHasHttpsScheme({ protocol: 'http:' }), false)
+  })
+  test('should return true for https object', () => {
+    assert.strictEqual(urlHasHttpsScheme({ protocol: 'https:' }), true)
   })
 })


### PR DESCRIPTION
before:
```sh
benchmark                              time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------- -----------------------------
urlHasHttpsScheme "http:" String    25.31 ns/iter      (23.7 ns … 263 ns)  24.66 ns   41.4 ns  74.99 ns
urlHasHttpsScheme "https:" String   31.63 ns/iter     (29.23 ns … 120 ns)  30.49 ns  60.29 ns  66.36 ns
urlHasHttpsScheme "http:" Object      927 ps/iter       (443 ps … 186 ns)    955 ps   1.16 ns   8.56 ns
urlHasHttpsScheme "https:" Object     929 ps/iter     (409 ps … 44.81 ns)    955 ps    1.4 ns   8.49 ns
```

after:
```sh
cpu: AMD Ryzen 7 4800H with Radeon Graphics
runtime: node v21.7.1 (x64-linux)

benchmark                              time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------------------- -----------------------------
urlHasHttpsScheme "http:" String     1.03 ns/iter       (443 ps … 282 ns)   1.13 ns   1.43 ns   8.59 ns
urlHasHttpsScheme "https:" String     931 ps/iter       (409 ps … 153 ns)    955 ps    1.4 ns  10.54 ns
urlHasHttpsScheme "http:" Object      931 ps/iter     (409 ps … 94.12 ns)    955 ps   1.36 ns  12.45 ns
urlHasHttpsScheme "https:" Object     927 ps/iter     (409 ps … 45.01 ns)    955 ps   1.36 ns   8.42 ns
```