### PR TITLE
fetch: improve performance of isValidHeaderValue

### DIFF
--- a/benchmarks/fetch/is-valid-header-value.mjs
+++ b/benchmarks/fetch/is-valid-header-value.mjs
@@ -1,0 +1,38 @@
+import { bench, run } from 'mitata'
+import { isValidHeaderValue } from '../../lib/web/fetch/util.js'
+
+const valid = 'valid123'
+const invalidNUL = 'invalid\x00'
+const invalidCR = 'invalid\r'
+const invalidLF = 'invalid\n'
+const invalidTrailingTab = 'invalid\t'
+const invalidLeadingTab = '\tinvalid'
+const invalidTrailingSpace = 'invalid '
+const invalidLeadingSpace = ' invalid'
+
+bench('isValidHeaderValue valid', () => {
+  isValidHeaderValue(valid)
+})
+bench('isValidHeaderValue invalid containing NUL', () => {
+  isValidHeaderValue(invalidNUL)
+})
+bench('isValidHeaderValue invalid containing CR', () => {
+  isValidHeaderValue(invalidCR)
+})
+bench('isValidHeaderValue invalid containing LF', () => {
+  isValidHeaderValue(invalidLF)
+})
+bench('isValidHeaderValue invalid trailing TAB', () => {
+  isValidHeaderValue(invalidTrailingTab)
+})
+bench('isValidHeaderValue invalid leading TAB', () => {
+  isValidHeaderValue(invalidLeadingTab)
+})
+bench('isValidHeaderValue invalid trailing SPACE', () => {
+  isValidHeaderValue(invalidTrailingSpace)
+})
+bench('isValidHeaderValue invalid leading SPACE', () => {
+  isValidHeaderValue(invalidLeadingSpace)
+})
+
+await run()

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -159,24 +159,15 @@ const isValidHeaderName = isValidHTTPToken
 function isValidHeaderValue (potentialValue) {
   // - Has no leading or trailing HTTP tab or space bytes.
   // - Contains no 0x00 (NUL) or HTTP newline bytes.
-  if (
-    potentialValue.startsWith('\t') ||
-    potentialValue.startsWith(' ') ||
-    potentialValue.endsWith('\t') ||
-    potentialValue.endsWith(' ')
-  ) {
-    return false
-  }
-
-  if (
-    potentialValue.includes('\0') ||
+  return (
+    potentialValue[0] === '\t' ||
+    potentialValue[0] === ' ' ||
+    potentialValue[potentialValue.length - 1] === '\t' ||
+    potentialValue[potentialValue.length - 1] === ' ' ||
+    potentialValue.includes('\n') ||
     potentialValue.includes('\r') ||
-    potentialValue.includes('\n')
-  ) {
-    return false
-  }
-
-  return true
+    potentialValue.includes('\0')
+  ) === false
 }
 
 // https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -355,3 +355,41 @@ describe('urlHasHttpsScheme', () => {
     assert.strictEqual(urlHasHttpsScheme({ protocol: 'https:' }), true)
   })
 })
+
+describe('isValidHeaderValue', () => {
+  const { isValidHeaderValue } = util
+
+  test('should return true for valid string', () => {
+    assert.strictEqual(isValidHeaderValue('valid123'), true)
+    assert.strictEqual(isValidHeaderValue('va lid123'), true)
+    assert.strictEqual(isValidHeaderValue('va\tlid123'), true)
+  })
+  test('should return false for string containing NUL', () => {
+    assert.strictEqual(isValidHeaderValue('invalid\0'), false)
+    assert.strictEqual(isValidHeaderValue('in\0valid'), false)
+    assert.strictEqual(isValidHeaderValue('\0invalid'), false)
+  })
+  test('should return false for string containing CR', () => {
+    assert.strictEqual(isValidHeaderValue('invalid\r'), false)
+    assert.strictEqual(isValidHeaderValue('in\rvalid'), false)
+    assert.strictEqual(isValidHeaderValue('\rinvalid'), false)
+  })
+  test('should return false for string containing LF', () => {
+    assert.strictEqual(isValidHeaderValue('invalid\n'), false)
+    assert.strictEqual(isValidHeaderValue('in\nvalid'), false)
+    assert.strictEqual(isValidHeaderValue('\ninvalid'), false)
+  })
+
+  test('should return false for string with leading TAB', () => {
+    assert.strictEqual(isValidHeaderValue('\tinvalid'), false)
+  })
+  test('should return false for string with trailing TAB', () => {
+    assert.strictEqual(isValidHeaderValue('invalid\t'), false)
+  })
+  test('should return false for string with leading SPACE', () => {
+    assert.strictEqual(isValidHeaderValue(' invalid'), false)
+  })
+  test('should return false for string with trailing SPACE', () => {
+    assert.strictEqual(isValidHeaderValue('invalid '), false)
+  })
+})


### PR DESCRIPTION
before:
```sh
benchmark                                      time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------------------------------- -----------------------------
isValidHeaderValue valid                    10.79 ns/iter      (8.87 ns … 620 ns)   9.72 ns  28.58 ns    124 ns
isValidHeaderValue invalid containing NUL    9.91 ns/iter    (8.66 ns … 45.73 ns)   9.96 ns  18.55 ns  34.65 ns
isValidHeaderValue invalid containing CR     12.4 ns/iter   (10.23 ns … 75.84 ns)  12.82 ns  27.69 ns  37.79 ns
isValidHeaderValue invalid containing LF    13.54 ns/iter    (11.39 ns … 57.7 ns)  14.19 ns  33.01 ns  47.61 ns
isValidHeaderValue invalid trailing TAB      7.76 ns/iter    (6.82 ns … 30.76 ns)   7.74 ns   9.79 ns  19.44 ns
isValidHeaderValue invalid leading TAB       4.51 ns/iter    (3.68 ns … 48.63 ns)   4.47 ns   6.04 ns   9.48 ns
isValidHeaderValue invalid trailing SPACE     7.2 ns/iter     (6.27 ns … 51.8 ns)   7.23 ns   9.04 ns  19.61 ns
isValidHeaderValue invalid leading SPACE     4.94 ns/iter    (4.09 ns … 30.04 ns)   4.91 ns   6.65 ns  13.03 ns
```

after:

```sh
benchmark                                      time (avg)             (min … max)       p75       p99      p999
--------------------------------------------------------------------------------- -----------------------------
isValidHeaderValue valid                     5.85 ns/iter      (4.43 ns … 465 ns)   5.35 ns   14.9 ns  88.46 ns
isValidHeaderValue invalid containing NUL    5.49 ns/iter    (4.54 ns … 72.57 ns)   5.39 ns    7.5 ns  24.86 ns
isValidHeaderValue invalid containing CR     5.45 ns/iter     (4.6 ns … 77.55 ns)   5.39 ns   6.14 ns  36.86 ns
isValidHeaderValue invalid containing LF     4.49 ns/iter    (3.65 ns … 44.95 ns)   4.47 ns   5.32 ns  25.34 ns
isValidHeaderValue invalid trailing TAB      3.46 ns/iter    (2.59 ns … 30.28 ns)   3.51 ns   4.23 ns   7.13 ns
isValidHeaderValue invalid leading TAB        974 ps/iter       (443 ps … 175 ns)    955 ps   1.19 ns   5.35 ns
isValidHeaderValue invalid trailing SPACE    3.99 ns/iter    (3.21 ns … 39.12 ns)   3.99 ns   6.51 ns   8.18 ns
isValidHeaderValue invalid leading SPACE      963 ps/iter     (443 ps … 28.65 ns)    955 ps   1.19 ns   5.18 ns
```