### PR TITLE
util: remove isReadableAborted

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -193,11 +193,6 @@ function isDestroyed (body) {
   return body && !!(body.destroyed || body[kDestroyed] || (stream.isDestroyed?.(body)))
 }
 
-function isReadableAborted (stream) {
-  const state = stream?._readableState
-  return isDestroyed(stream) && state && !state.endEmitted
-}
-
 function destroy (stream, err) {
   if (stream == null || !isStream(stream) || isDestroyed(stream)) {
     return
@@ -575,7 +570,6 @@ module.exports = {
   isReadable,
   toUSVString,
   isUSVString,
-  isReadableAborted,
   isBlobLike,
   parseOrigin,
   parseURL,


### PR DESCRIPTION
This function got obsolete, when we dropped node16 support as it was necessary to implement a stream.isDisturbed equivalent in userland. 

See the original PR by @ronag

https://github.com/nodejs/undici/commit/a3c0413b4fae2c30417f883f67ae6e5d266cb0e7

