### PR TITLE
perf(fetch): improve body mixin methods

### DIFF
--- a/benchmarks/fetch/body-arraybuffer.mjs
+++ b/benchmarks/fetch/body-arraybuffer.mjs
@@ -1,0 +1,24 @@
+import { group, bench, run } from 'mitata'
+import { Response } from '../../lib/web/fetch/response.js'
+
+const settings = {
+  small: 2 << 8,
+  middle: 2 << 12,
+  long: 2 << 16
+}
+
+for (const [name, length] of Object.entries(settings)) {
+  const buffer = Buffer.allocUnsafe(length).map(() => (Math.random() * 100) | 0)
+  group(`${name} (length ${length})`, () => {
+    bench('Response#arrayBuffer', async () => {
+      return await new Response(buffer).arrayBuffer()
+    })
+
+    // for comparison
+    bench('Response#text', async () => {
+      return await new Response(buffer).text()
+    })
+  })
+}
+
+await run()

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -318,7 +318,8 @@ function bodyMixinMethods (instance) {
       // given a byte sequence bytes: return a new ArrayBuffer
       // whose contents are bytes.
       return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes).buffer
+        // Note: arrayBuffer already cloned.
+        return bytes.buffer
       }, instance)
     },
 
@@ -432,7 +433,7 @@ async function consumeBody (object, convertBytesToJSValue, instance) {
   // 5. If object’s body is null, then run successSteps with an
   //    empty byte sequence.
   if (object[kState].body == null) {
-    successSteps(new Uint8Array())
+    successSteps(Buffer.allocUnsafe(0))
     return promise.promise
   }
 

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1069,8 +1069,7 @@ async function fullyReadBody (body, processBody, processBodyError) {
 
   // 5. Read all bytes from reader, given successSteps and errorSteps.
   try {
-    const result = await readAllBytes(reader)
-    successSteps(result)
+    successSteps(await readAllBytes(reader))
   } catch (e) {
     errorSteps(e)
   }
@@ -1128,6 +1127,10 @@ async function readAllBytes (reader) {
 
     if (done) {
       // 1. Call successSteps with bytes.
+      if (bytes.length === 1) {
+        const { buffer, byteOffset, byteLength } = bytes[0]
+        return Buffer.from(buffer.slice(byteOffset, byteOffset + byteLength), 0, byteLength)
+      }
       return Buffer.concat(bytes, byteLength)
     }
 


### PR DESCRIPTION
<!--Optimize cases where the body is a string, BufferSource, URLSearchParams, or stream (only one chunk).

In most cases, the body is a string and would benefit greatly from this optimization.
-->

Optimize arrayBuffer of Body mixin.

- main

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• small (length 512)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  32'459 ns/iter  (9'500 ns … 13'394 µs) 35'000 ns    167 µs    550 µs
Response#text         12'947 ns/iter     (9'100 ns … 567 µs) 13'400 ns 35'100 ns    258 µs

summary for small (length 512)
  Response#text
   2.51x faster than Response#arrayBuffer

• middle (length 8192)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  28'777 ns/iter  (11'700 ns … 2'818 µs) 24'500 ns    118 µs    326 µs
Response#text         23'271 ns/iter    (11'800 ns … 724 µs) 19'300 ns 99'300 ns    258 µs

summary for middle (length 8192)
  Response#text
   1.24x faster than Response#arrayBuffer

• long (length 131072)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer     300 µs/iter  (53'700 ns … 3'534 µs)    280 µs  1'559 µs  3'187 µs
Response#text            322 µs/iter     (120 µs … 3'235 µs)    299 µs  2'027 µs  3'152 µs

summary for long (length 131072)
  Response#arrayBuffer
   1.07x faster than Response#text
```

- this patch

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• small (length 512)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  20'018 ns/iter   (9'500 ns … 4'492 µs) 15'800 ns    102 µs    415 µs
Response#text         13'385 ns/iter    (10'100 ns … 478 µs) 13'200 ns 38'900 ns    214 µs

summary for small (length 512)
  Response#text
   1.5x faster than Response#arrayBuffer

• middle (length 8192)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  22'374 ns/iter  (10'900 ns … 2'683 µs) 18'800 ns 97'200 ns    335 µs
Response#text         22'599 ns/iter    (12'200 ns … 487 µs) 21'500 ns 97'700 ns    284 µs

summary for middle (length 8192)
  Response#arrayBuffer
   1.01x faster than Response#text

• long (length 131072)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer     216 µs/iter  (38'100 ns … 3'201 µs)    200 µs    984 µs  2'929 µs
Response#text            314 µs/iter     (119 µs … 3'251 µs)    290 µs  2'046 µs  3'122 µs

summary for long (length 131072)
  Response#arrayBuffer
   1.46x faster than Response#text
```
