### PR TITLE
chore: set up multi-branch automated release

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -6,9 +6,13 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'The version number to release (has priority over release_type)'
-        type: string
+      major_branch:
+        description: Major version branch
+        type: choice
+        default: main
+        options:
+          - main
+          - v5.x
       release_type:
         description: Type of release
         type: choice
@@ -16,7 +20,6 @@ on:
         options:
           - patch
           - minor
-          - major
 
 jobs:
   create-pr:
@@ -26,11 +29,10 @@ jobs:
       contents: write
       pull-requests: write
 
-    outputs:
-      version: ${{ steps.bump.outputs.version }}
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.major_branch }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -41,7 +43,7 @@ jobs:
       - name: Change version number and push
         id: bump
         run: |
-          npm version ${{ inputs.version || inputs.release_type }} --git-tag-version=false
+          npm version ${{ inputs.release_type }} --git-tag-version=false
           VERSION=`jq -r ".version" package.json`
           RELEASE_BRANCH="release/v$VERSION"
           git add -u
@@ -52,6 +54,5 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const defaultBranch = "${{ github.event.repository.default_branch }}"
             const versionTag = "v${{ steps.bump.outputs.version }}"
-            await require('./scripts/release').generatePr({ github, context, defaultBranch, versionTag })
+            await require('./scripts/release').generatePr({ github, context, versionTag })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create release
 on:
   push:
     branches:
-     - main
+      - main
     paths:
       - package.json
 
@@ -26,12 +26,9 @@ jobs:
             const version = require("./package.json").version
             const versionTag = `v${version}`
 
-            const { data: releases } = await github.rest.repos.listReleases({
-              owner,
-              repo
-            })
+            const previousReleaseTag = await require('./scripts/release').previousReleaseTag({ github, context, versionTag })
 
-            if (versionTag !== releases[0]?.tag_name) {
+            if (versionTag !== previousReleaseTag) {
               return versionTag
             }
 
@@ -55,11 +52,11 @@ jobs:
       - run: npm install -g npm@latest
       - run: npm install
       - name: Create NPM release
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: node scripts/generate-undici-types-package-json.js
-      - run: npm publish --provenance
+      - run: npm publish --provenance --access public --tag latest
         working-directory: './types'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -67,6 +64,5 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const defaultBranch = "${{ github.event.repository.default_branch }}"
             const versionTag = "${{ needs.check-release-version.outputs.release-version }}"
-            await require('./scripts/release').release({ github, context, defaultBranch, versionTag })
+            await require('./scripts/release').release({ github, context, versionTag })

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,18 +2,37 @@
 
 // Called from .github/workflows
 
-const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBranch }) => {
-  const { data: releases } = await github.rest.repos.listReleases({
-    owner,
-    repo
-  })
+// The following two variables should be updated per major version release branch (main, v5.x, etc)
+const VERSION_TAG_PREFIX = 'v6.'
+const BRANCH = 'main'
+
+const getLatestRelease = async ({ github, owner, repo }) => {
+  for await (const { data } of github.paginate.iterator(
+    github.rest.repos.listReleases,
+    {
+      owner,
+      repo
+    }
+  )) {
+    const latestRelease = data.find((r) => r.tag_name.startsWith(VERSION_TAG_PREFIX))
+
+    if (latestRelease) {
+      return latestRelease
+    }
+  }
+
+  throw new Error(`Could not find latest release of ${VERSION_TAG_PREFIX}x`)
+}
+
+const generateReleaseNotes = async ({ github, owner, repo, versionTag }) => {
+  const previousRelease = await getLatestRelease({ github, owner, repo, versionTag })
 
   const { data: { body } } = await github.rest.repos.generateReleaseNotes({
     owner,
     repo,
     tag_name: versionTag,
-    target_commitish: defaultBranch,
-    previous_tag_name: releases[0]?.tag_name
+    target_commitish: `heads/${BRANCH}`,
+    previous_tag_name: previousRelease.tag_name
   })
 
   const bodyWithoutReleasePr = body.split('\n')
@@ -23,29 +42,29 @@ const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBr
   return bodyWithoutReleasePr
 }
 
-const generatePr = async ({ github, context, defaultBranch, versionTag }) => {
+const generatePr = async ({ github, context, versionTag }) => {
   const { owner, repo } = context.repo
-  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, defaultBranch })
+  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag })
 
   await github.rest.pulls.create({
     owner,
     repo,
     head: `release/${versionTag}`,
-    base: defaultBranch,
+    base: BRANCH,
     title: `[Release] ${versionTag}`,
     body: releaseNotes
   })
 }
 
-const release = async ({ github, context, defaultBranch, versionTag }) => {
+const release = async ({ github, context, versionTag }) => {
   const { owner, repo } = context.repo
-  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, defaultBranch })
+  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag })
 
   await github.rest.repos.createRelease({
     owner,
     repo,
     tag_name: versionTag,
-    target_commitish: defaultBranch,
+    target_commitish: BRANCH,
     name: versionTag,
     body: releaseNotes,
     draft: false,
@@ -65,7 +84,14 @@ const release = async ({ github, context, defaultBranch, versionTag }) => {
   }
 }
 
+const previousReleaseTag = async ({ github, context, versionTag }) => {
+  const { owner, repo } = context.repo
+  const previousRelease = await getLatestRelease({ github, owner, repo, versionTag })
+  return previousRelease.tag_name
+}
+
 module.exports = {
   generatePr,
-  release
+  release,
+  previousReleaseTag
 }


### PR DESCRIPTION
Closes nodejs/undici#3103

## This relates to...
- https://github.com/nodejs/undici/issues/3042
- https://github.com/nodejs/undici/pull/3089

## Rationale
An issue was identified in the automatic release logic, where the changelog generation did not take multiple live release branches and major versions into account.

In fixing, automated release of both 6.x from `main` and 5.x from `v5.x` is implemented, but will require two changes: this PR to `main`, and a corresponding change to `v5.x`.

## Changes
- the **Create Release PR** workflow should always be run from main. A new input is required to say which release branch (currently main and v5.x) should the release be created for. The major and specific versions inputs have been removed, because a major version bump _will necessitate_ changes to the release script and release workflow.
  - Read: whenever 7.0.0-alpha.1 comes around, ping me to update workflow to support major version bump and configuration across the three branches 😄
  - In case a non-linear version bump is needed, push the package.json version bump (either directly, or via PR) to `main` or `v5.x` and the release automation will run
- a given branch that deploys to a particular major version should have `scripts/release.js` file with two variables set in header of script: `VERSION_TAG_PREFIX` and `BRANCH` (implemented in this PR for `main`, and the corresponding for `v5.x`)
- `getLatestRelease` logic in `scripts/release.js` paginated and updated to only find the latest release for the given major version
- `latest` npm tag is explicitly being set in `main` releases

### Demo
Create PR as a sample change and merge, then run create release PR workflow, merge PR, and observe releases
Note: both sample changes target package.json, neither triggered a release


| |6.x.x|5.x.x|
|-|-|-|
|Sample change|https://github.com/mweberxyz/nodejs-undici/pull/30|https://github.com/mweberxyz/nodejs-undici/pull/31|
|Skipped release workflow|https://github.com/mweberxyz/nodejs-undici/actions/runs/8673906497|https://github.com/mweberxyz/nodejs-undici/actions/runs/8673905602|
|Create release PR|![CleanShot 2024-04-13 at 09 31 58@2x](https://github.com/nodejs/undici/assets/1062734/b97baaa6-9fca-4c9a-995f-40a69f444c9b)|![CleanShot 2024-04-13 at 09 36 29@2x](https://github.com/nodejs/undici/assets/1062734/f90c0e45-6af8-4dd1-9a9c-c97f52c595ee)|
||https://github.com/mweberxyz/nodejs-undici/actions/runs/8673918032|https://github.com/mweberxyz/nodejs-undici/actions/runs/8673940346|
|PR|https://github.com/mweberxyz/nodejs-undici/pull/32|https://github.com/mweberxyz/nodejs-undici/pull/33|
||https://github.com/mweberxyz/nodejs-undici/actions/runs/8673947634|https://github.com/mweberxyz/nodejs-undici/actions/runs/8673952207|

NPM versions after demo runs: https://www.npmjs.com/package/@mweberxyz/undici?activeTab=versions
GitHub releases after demo runs: https://github.com/mweberxyz/nodejs-undici/releases


## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Review ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
