### PR TITLE
fetch: limit web streams usage in body mixin methods

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -146,7 +146,7 @@ class Response {
     // 4. If body is non-null, then set bodyWithType to the result of extracting body.
     if (body != null) {
       const [extractedBody, type] = extractBody(body)
-      bodyWithType = { body: extractedBody, type }
+      bodyWithType = { body: extractedBody, type, source: body }
     }
 
     // 5. Perform initialize a response given this, init, and bodyWithType.

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1056,7 +1056,8 @@ async function fullyReadBody (body, processBody, processBodyError) {
   const errorSteps = processBodyError
 
   if (typeof body.source === 'string') {
-    successSteps(new TextEncoder().encode(body.source))
+    const buffer = new TextEncoder().encode(body.source)
+    successSteps(Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength))
     return
   }
 

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1055,6 +1055,11 @@ async function fullyReadBody (body, processBody, processBodyError) {
   //    with taskDestination.
   const errorSteps = processBodyError
 
+  if (typeof body.source === 'string') {
+    successSteps(new TextEncoder().encode(body.source))
+    return
+  }
+
   // 4. Let reader be the result of getting a reader for body’s stream.
   //    If that threw an exception, then run errorSteps with that
   //    exception and return.


### PR DESCRIPTION
This PR aims to improve performance by optimizing the processing of webflows in the fetch module.
This experiment was already done by @KhafraDev , I just opened a pr

I thought there would be discussion about it and it might benefit fetch 🚀 
#2164
here is a benchmark made by @KhafraDev 🙏 
benchmarks:
```js
import { Response as UndiciResponse } from './index.js'
import { cronometro } from 'cronometro'

await cronometro({
  async 'undici Response' () {
    await new UndiciResponse('abc').text()
  },
  async 'global Response' () {
    await new Response('abc').text()
  }
})

```

```
╔═════════════════╤═════════╤═════════════════╤═══════════╗
║ Slower tests    │ Samples │          Result │ Tolerance ║
╟─────────────────┼─────────┼─────────────────┼───────────╢
║ global Response │   10000 │ 40169.19 op/sec │  ± 1.59 % ║
╟─────────────────┼─────────┼─────────────────┼───────────╢
║ Fastest test    │ Samples │          Result │ Tolerance ║
╟─────────────────┼─────────┼─────────────────┼───────────╢
║ undici Response │   10000 │ 44024.31 op/sec │  ± 2.12 % ║
╚═════════════════╧═════════╧═════════════════╧═══════════╝
```