### PR TITLE
perf: avoid unnecessary clone

### DIFF
--- a/benchmarks/fetch/body-arraybuffer.mjs
+++ b/benchmarks/fetch/body-arraybuffer.mjs
@@ -1,0 +1,24 @@
+import { group, bench, run } from 'mitata'
+import { Response } from '../../lib/web/fetch/response.js'
+
+const settings = {
+  small: 2 << 8,
+  middle: 2 << 12,
+  long: 2 << 16
+}
+
+for (const [name, length] of Object.entries(settings)) {
+  const buffer = Buffer.allocUnsafe(length).map(() => (Math.random() * 100) | 0)
+  group(`${name} (length ${length})`, () => {
+    bench('Response#arrayBuffer', async () => {
+      return await new Response(buffer).arrayBuffer()
+    })
+
+    // for comparison
+    bench('Response#text', async () => {
+      return await new Response(buffer).text()
+    })
+  })
+}
+
+await run()

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -309,7 +309,7 @@ function bodyMixinMethods (instance) {
         // Return a Blob whose contents are bytes and type attribute
         // is mimeType.
         return new Blob([bytes], { type: mimeType })
-      }, instance)
+      }, instance, false)
     },
 
     arrayBuffer () {
@@ -320,19 +320,19 @@ function bodyMixinMethods (instance) {
       return consumeBody(this, (bytes) => {
         // Note: arrayBuffer already cloned.
         return bytes.buffer
-      }, instance)
+      }, instance, true)
     },
 
     text () {
       // The text() method steps are to return the result of running
       // consume body with this and UTF-8 decode.
-      return consumeBody(this, utf8DecodeBytes, instance)
+      return consumeBody(this, utf8DecodeBytes, instance, false)
     },
 
     json () {
       // The json() method steps are to return the result of running
       // consume body with this and parse JSON from bytes.
-      return consumeBody(this, parseJSONFromBytes, instance)
+      return consumeBody(this, parseJSONFromBytes, instance, false)
     },
 
     formData () {
@@ -384,7 +384,7 @@ function bodyMixinMethods (instance) {
         throw new TypeError(
           'Content-Type was not one of "multipart/form-data" or "application/x-www-form-urlencoded".'
         )
-      }, instance)
+      }, instance, false)
     }
   }
 
@@ -400,8 +400,9 @@ function mixinBody (prototype) {
  * @param {Response|Request} object
  * @param {(value: unknown) => unknown} convertBytesToJSValue
  * @param {Response|Request} instance
+ * @param {boolean} [shouldClone]
  */
-async function consumeBody (object, convertBytesToJSValue, instance) {
+async function consumeBody (object, convertBytesToJSValue, instance, shouldClone) {
   webidl.brandCheck(object, instance)
 
   // 1. If object is unusable, then return a promise rejected
@@ -439,7 +440,7 @@ async function consumeBody (object, convertBytesToJSValue, instance) {
 
   // 6. Otherwise, fully read object’s body given successSteps,
   //    errorSteps, and object’s relevant global object.
-  await fullyReadBody(object[kState].body, successSteps, errorSteps)
+  await fullyReadBody(object[kState].body, successSteps, errorSteps, shouldClone)
 
   // 7. Return promise.
   return promise.promise

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -318,7 +318,8 @@ function bodyMixinMethods (instance) {
       // given a byte sequence bytes: return a new ArrayBuffer
       // whose contents are bytes.
       return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes).buffer
+        // Note: arrayBuffer already cloned.
+        return bytes.buffer
       }, instance)
     },
 
@@ -432,7 +433,7 @@ async function consumeBody (object, convertBytesToJSValue, instance) {
   // 5. If object’s body is null, then run successSteps with an
   //    empty byte sequence.
   if (object[kState].body == null) {
-    successSteps(new Uint8Array())
+    successSteps(Buffer.allocUnsafe(0))
     return promise.promise
   }
 

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1043,7 +1043,7 @@ function iteratorMixin (name, object, kInternalIterator, keyIndex = 0, valueInde
 /**
  * @see https://fetch.spec.whatwg.org/#body-fully-read
  */
-async function fullyReadBody (body, processBody, processBodyError) {
+async function fullyReadBody (body, processBody, processBodyError, shouldClone) {
   // 1. If taskDestination is null, then set taskDestination to
   //    the result of starting a new parallel queue.
 
@@ -1069,7 +1069,7 @@ async function fullyReadBody (body, processBody, processBodyError) {
 
   // 5. Read all bytes from reader, given successSteps and errorSteps.
   try {
-    successSteps(await readAllBytes(reader))
+    successSteps(await readAllBytes(reader, shouldClone))
   } catch (e) {
     errorSteps(e)
   }
@@ -1117,8 +1117,9 @@ function isomorphicEncode (input) {
  * @see https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes
  * @see https://streams.spec.whatwg.org/#read-loop
  * @param {ReadableStreamDefaultReader} reader
+ * @param {boolean} [shouldClone]
  */
-async function readAllBytes (reader) {
+async function readAllBytes (reader, shouldClone) {
   const bytes = []
   let byteLength = 0
 
@@ -1129,6 +1130,9 @@ async function readAllBytes (reader) {
       // 1. Call successSteps with bytes.
       if (bytes.length === 1) {
         const { buffer, byteOffset, byteLength } = bytes[0]
+        if (shouldClone === false) {
+          return Buffer.from(buffer, byteOffset, byteLength)
+        }
         return Buffer.from(buffer.slice(byteOffset, byteOffset + byteLength), 0, byteLength)
       }
       return Buffer.concat(bytes, byteLength)

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1069,8 +1069,7 @@ async function fullyReadBody (body, processBody, processBodyError) {
 
   // 5. Read all bytes from reader, given successSteps and errorSteps.
   try {
-    const result = await readAllBytes(reader)
-    successSteps(result)
+    successSteps(await readAllBytes(reader))
   } catch (e) {
     errorSteps(e)
   }
@@ -1128,6 +1127,10 @@ async function readAllBytes (reader) {
 
     if (done) {
       // 1. Call successSteps with bytes.
+      if (bytes.length === 1) {
+        const { buffer, byteOffset, byteLength } = bytes[0]
+        return Buffer.from(buffer.slice(byteOffset, byteOffset + byteLength), 0, byteLength)
+      }
       return Buffer.concat(bytes, byteLength)
     }
 


### PR DESCRIPTION
Deps: #3109

Optimize cases where the body is a string, BufferSource, URLSearchParams, or stream (only one chunk).

Avoid cloning if unnecessary.

- #3109

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• small (length 512)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  22'113 ns/iter  (11'200 ns … 3'439 µs) 19'100 ns    116 µs    441 µs
Response#text         16'603 ns/iter    (11'700 ns … 673 µs) 15'100 ns 51'600 ns    268 µs

summary for small (length 512)
  Response#text
   1.33x faster than Response#arrayBuffer

• middle (length 8192)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  25'506 ns/iter  (12'500 ns … 3'582 µs) 21'600 ns    113 µs    337 µs
Response#text         27'878 ns/iter    (14'000 ns … 885 µs) 25'900 ns    115 µs    321 µs

summary for middle (length 8192)
  Response#arrayBuffer
   1.09x faster than Response#text

• long (length 131072)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer     233 µs/iter  (40'300 ns … 3'191 µs)    218 µs  1'369 µs  2'948 µs
Response#text            374 µs/iter     (137 µs … 3'573 µs)    350 µs  2'034 µs  3'573 µs

summary for long (length 131072)
  Response#arrayBuffer
   1.61x faster than Response#text
```

- this patch

```
benchmark                 time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------ -----------------------------
• small (length 512)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  22'036 ns/iter  (11'300 ns … 2'884 µs) 21'100 ns    106 µs    453 µs
Response#text         13'975 ns/iter  (10'200 ns … 1'246 µs) 13'200 ns 37'900 ns    235 µs

summary for small (length 512)
  Response#text
   1.58x faster than Response#arrayBuffer

• middle (length 8192)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer  25'928 ns/iter  (12'600 ns … 4'707 µs) 22'400 ns    111 µs    351 µs
Response#text         18'282 ns/iter    (11'900 ns … 473 µs) 17'400 ns 88'400 ns    291 µs

summary for middle (length 8192)
  Response#text
   1.42x faster than Response#arrayBuffer

• long (length 131072)
------------------------------------------------------------ -----------------------------
Response#arrayBuffer     221 µs/iter  (39'700 ns … 3'282 µs)    206 µs    872 µs  3'059 µs
Response#text            265 µs/iter     (124 µs … 2'542 µs)    247 µs  1'394 µs  2'504 µs

summary for long (length 131072)
  Response#arrayBuffer
   1.2x faster than Response#text
```