### PR TITLE
perf: use class instead of object literals with getters

### DIFF
--- a/benchmarks/fetch/request-creation.mjs
+++ b/benchmarks/fetch/request-creation.mjs
@@ -1,0 +1,8 @@
+import { bench, run } from 'mitata'
+import { Request } from '../../lib/web/fetch/request.js'
+
+const input = 'https://example.com/post'
+
+bench('new Request(input)', () => new Request(input, undefined))
+
+await run()

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -41,6 +41,21 @@ const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
 
 let patchMethodWarning = false
 
+class RequestRealmSettingsObject {
+  baseUrl = getGlobalOrigin()
+
+  get origin () {
+    return this.baseUrl?.origin
+  }
+
+  policyContainer = makePolicyContainer()
+
+  static {
+    delete this.prototype.constructor
+    Object.freeze(this.prototype)
+  }
+}
+
 // https://fetch.spec.whatwg.org/#request-class
 class Request {
   // https://fetch.spec.whatwg.org/#dom-request
@@ -56,13 +71,9 @@ class Request {
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
     this[kRealm] = {
-      settingsObject: {
-        baseUrl: getGlobalOrigin(),
-        get origin () {
-          return this.baseUrl?.origin
-        },
-        policyContainer: makePolicyContainer()
-      }
+      // Note: Slow initialization of object literals with getters.
+      // TODO: Remove workaround.
+      settingsObject: new RequestRealmSettingsObject()
     }
 
     // 1. Let request be null.

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -373,7 +373,6 @@ class Request {
     // (https://dom.spec.whatwg.org/#dom-abortsignal-any)
     const ac = new AbortController()
     this[kSignal] = ac.signal
-    this[kSignal][kRealm] = this[kRealm]
 
     // 29. If signal is not null, then make this’s signal follow signal.
     if (signal != null) {
@@ -443,7 +442,6 @@ class Request {
     this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kHeadersList] = request.headersList
     this[kHeaders][kGuard] = 'request'
-    this[kHeaders][kRealm] = this[kRealm]
 
     // 31. If this’s request’s mode is "no-cors", then:
     if (mode === 'no-cors') {
@@ -888,11 +886,9 @@ function fromInnerRequest (innerRequest, signal, guard, realm) {
   request[kState] = innerRequest
   request[kRealm] = realm
   request[kSignal] = signal
-  request[kSignal][kRealm] = realm
   request[kHeaders] = new Headers(kConstruct)
   request[kHeaders][kHeadersList] = innerRequest.headersList
   request[kHeaders][kGuard] = guard
-  request[kHeaders][kRealm] = realm
   return request
 }
 

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -41,7 +41,7 @@ const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
 
 let patchMethodWarning = false
 
-class RequestRealmSettingsObject {
+class EnvironmentSettingsObjectBase {
   baseUrl = getGlobalOrigin()
 
   get origin () {
@@ -49,6 +49,10 @@ class RequestRealmSettingsObject {
   }
 
   policyContainer = makePolicyContainer()
+}
+
+class EnvironmentSettingsObject {
+  settingsObject = new EnvironmentSettingsObjectBase()
 }
 
 // https://fetch.spec.whatwg.org/#request-class
@@ -65,12 +69,9 @@ class Request {
     init = webidl.converters.RequestInit(init)
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
-    this[kRealm] = {
-      // Note: Slow initialization of object literals with getters.
-      // TODO: Remove workaround.
-      settingsObject: new RequestRealmSettingsObject()
-    }
-
+    // Note: Slow initialization of object literals with getters.
+    // TODO: Remove workaround.
+    this[kRealm] = new EnvironmentSettingsObject()
     // 1. Let request be null.
     let request = null
 

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -11,7 +11,7 @@ const {
   isValidHTTPToken,
   sameOrigin,
   normalizeMethod,
-  makePolicyContainer,
+  EnvironmentSettingsObject,
   normalizeMethodRecord
 } = require('./util')
 const {
@@ -27,7 +27,6 @@ const {
 const { kEnumerableProperty } = util
 const { kHeaders, kSignal, kState, kGuard, kRealm, kDispatcher } = require('./symbols')
 const { webidl } = require('./webidl')
-const { getGlobalOrigin } = require('./global')
 const { URLSerializer } = require('./data-url')
 const { kHeadersList, kConstruct } = require('../../core/symbols')
 const assert = require('node:assert')
@@ -40,20 +39,6 @@ const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
 })
 
 let patchMethodWarning = false
-
-class EnvironmentSettingsObjectBase {
-  baseUrl = getGlobalOrigin()
-
-  get origin () {
-    return this.baseUrl?.origin
-  }
-
-  policyContainer = makePolicyContainer()
-}
-
-class EnvironmentSettingsObject {
-  settingsObject = new EnvironmentSettingsObjectBase()
-}
 
 // https://fetch.spec.whatwg.org/#request-class
 class Request {

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -49,11 +49,6 @@ class RequestRealmSettingsObject {
   }
 
   policyContainer = makePolicyContainer()
-
-  static {
-    delete this.prototype.constructor
-    Object.freeze(this.prototype)
-  }
 }
 
 // https://fetch.spec.whatwg.org/#request-class

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -70,7 +70,6 @@ class Request {
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
     // Note: Slow initialization of object literals with getters.
-    // TODO: Remove workaround.
     this[kRealm] = new EnvironmentSettingsObject()
     // 1. Let request be null.
     let request = null

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -138,7 +138,6 @@ class Response {
     this[kHeaders] = new Headers(kConstruct)
     this[kHeaders][kGuard] = 'response'
     this[kHeaders][kHeadersList] = this[kState].headersList
-    this[kHeaders][kRealm] = this[kRealm]
 
     // 3. Let bodyWithType be null.
     let bodyWithType = null
@@ -522,7 +521,6 @@ function fromInnerResponse (innerResponse, guard, realm) {
   response[kHeaders] = new Headers(kConstruct)
   response[kHeaders][kHeadersList] = innerResponse.headersList
   response[kHeaders][kGuard] = guard
-  response[kHeaders][kRealm] = realm
   return response
 }
 

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -12,7 +12,8 @@ const {
   isBlobLike,
   serializeJavascriptValueToJSONString,
   isErrorLike,
-  isomorphicEncode
+  isomorphicEncode,
+  EnvironmentSettingsObject
 } = require('./util')
 const {
   redirectStatusSet,
@@ -29,15 +30,10 @@ const { types } = require('node:util')
 
 const textEncoder = new TextEncoder('utf-8')
 
-class EnvironmentSettingsObject {
-  settingsObject = {}
-}
-
 // https://fetch.spec.whatwg.org/#response-class
 class Response {
   // Creates network error Response.
   static error () {
-    // TODO
     const relevantRealm = new EnvironmentSettingsObject()
 
     // The static error() method steps are to return the result of creating a

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -33,7 +33,6 @@ class EnvironmentSettingsObject {
   settingsObject = {}
 }
 
-
 // https://fetch.spec.whatwg.org/#response-class
 class Response {
   // Creates network error Response.

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -22,7 +22,6 @@ const {
 const { kState, kHeaders, kGuard, kRealm } = require('./symbols')
 const { webidl } = require('./webidl')
 const { FormData } = require('./formdata')
-const { getGlobalOrigin } = require('./global')
 const { URLSerializer } = require('./data-url')
 const { kHeadersList, kConstruct } = require('../../core/symbols')
 const assert = require('node:assert')
@@ -87,7 +86,7 @@ class Response {
     // TODO: base-URL?
     let parsedURL
     try {
-      parsedURL = new URL(url, getGlobalOrigin())
+      parsedURL = new URL(url, relevantRealm.settingsObject.baseUrl)
     } catch (err) {
       throw new TypeError(`Failed to parse URL from ${url}`, { cause: err })
     }

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -29,12 +29,17 @@ const { types } = require('node:util')
 
 const textEncoder = new TextEncoder('utf-8')
 
+class EnvironmentSettingsObject {
+  settingsObject = {}
+}
+
+
 // https://fetch.spec.whatwg.org/#response-class
 class Response {
   // Creates network error Response.
   static error () {
     // TODO
-    const relevantRealm = { settingsObject: {} }
+    const relevantRealm = new EnvironmentSettingsObject()
 
     // The static error() method steps are to return the result of creating a
     // Response object, given a new network error, "immutable", and this’s
@@ -62,7 +67,7 @@ class Response {
 
     // 3. Let responseObject be the result of creating a Response object, given a new response,
     //    "response", and this’s relevant Realm.
-    const relevantRealm = { settingsObject: {} }
+    const relevantRealm = new EnvironmentSettingsObject()
     const responseObject = fromInnerResponse(makeResponse({}), 'response', relevantRealm)
 
     // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
@@ -74,7 +79,7 @@ class Response {
 
   // Creates a redirect Response that redirects to url with status status.
   static redirect (url, status = 302) {
-    const relevantRealm = { settingsObject: {} }
+    const relevantRealm = new EnvironmentSettingsObject()
 
     webidl.argumentLengthCheck(arguments, 1, { header: 'Response.redirect' })
 
@@ -127,7 +132,7 @@ class Response {
     init = webidl.converters.ResponseInit(init)
 
     // TODO
-    this[kRealm] = { settingsObject: {} }
+    this[kRealm] = new EnvironmentSettingsObject()
 
     // 1. Set this’s response to a new response.
     this[kState] = makeResponse({})

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1569,6 +1569,28 @@ function utf8DecodeBytes (buffer) {
   return output
 }
 
+class EnvironmentSettingsObjectBase {
+  #baseUrl
+
+  get baseUrl() {
+    return (this.#baseUrl ??= getGlobalOrigin())
+  }
+
+  set baseUrl(baseUrl) {
+    this.#baseUrl = baseUrl
+  }
+
+  get origin () {
+    return this.baseUrl?.origin
+  }
+
+  policyContainer = makePolicyContainer()
+}
+
+class EnvironmentSettingsObject {
+  settingsObject = new EnvironmentSettingsObjectBase()
+}
+
 module.exports = {
   isAborted,
   isCancelled,
@@ -1620,5 +1642,6 @@ module.exports = {
   createInflate,
   extractMimeType,
   getDecodeSplit,
-  utf8DecodeBytes
+  utf8DecodeBytes,
+  EnvironmentSettingsObject
 }

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1572,11 +1572,11 @@ function utf8DecodeBytes (buffer) {
 class EnvironmentSettingsObjectBase {
   #baseUrl
 
-  get baseUrl() {
+  get baseUrl () {
     return (this.#baseUrl ??= getGlobalOrigin())
   }
 
-  set baseUrl(baseUrl) {
+  set baseUrl (baseUrl) {
     this.#baseUrl = baseUrl
   }
 

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1570,15 +1570,7 @@ function utf8DecodeBytes (buffer) {
 }
 
 class EnvironmentSettingsObjectBase {
-  #baseUrl
-
-  get baseUrl () {
-    return (this.#baseUrl ??= getGlobalOrigin())
-  }
-
-  set baseUrl (baseUrl) {
-    this.#baseUrl = baseUrl
-  }
+  baseUrl =  getGlobalOrigin()
 
   get origin () {
     return this.baseUrl?.origin

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1570,7 +1570,7 @@ function utf8DecodeBytes (buffer) {
 }
 
 class EnvironmentSettingsObjectBase {
-  baseUrl =  getGlobalOrigin()
+  baseUrl = getGlobalOrigin()
 
   get origin () {
     return this.baseUrl?.origin

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -499,8 +499,6 @@ test('fromInnerRequest', () => {
   assert.strictEqual(request[kState], innerRequest)
   assert.strictEqual(request[kRealm], realm)
   assert.strictEqual(request[kSignal], signal)
-  assert.strictEqual(request[kSignal][kRealm], realm)
   assert.strictEqual(request[kHeaders][kHeadersList], innerRequest.headersList)
   assert.strictEqual(request[kHeaders][kGuard], 'immutable')
-  assert.strictEqual(request[kHeaders][kRealm], realm)
 })

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -286,5 +286,4 @@ test('fromInnerResponse', () => {
   assert.strictEqual(response[kRealm], realm)
   assert.strictEqual(response[kHeaders][kHeadersList], innerResponse.headersList)
   assert.strictEqual(response[kHeaders][kGuard], 'immutable')
-  assert.strictEqual(response[kHeaders][kRealm], realm)
 })


### PR DESCRIPTION
Slow initialization of object literals with getters.

- main
```
benchmark               time (avg)             (min … max)       p75       p99      p999
---------------------------------------------------------- -----------------------------
new Request(input)  12'398 ns/iter   (8'100 ns … 4'134 µs) 11'000 ns 34'100 ns    147 µs
```

- this patch

```
benchmark               time (avg)             (min … max)       p75       p99      p999
---------------------------------------------------------- -----------------------------
new Request(input)  10'997 ns/iter   (7'000 ns … 3'704 µs)  9'700 ns 34'000 ns    159 µs
```