### PR TITLE
feat: add lookup option to Client, Pool and Agent (#2440)

### DIFF
--- a/docs/docs/api/Client.md
+++ b/docs/docs/api/Client.md
@@ -42,6 +42,7 @@ Every Tls option, see [here](https://nodejs.org/api/tls.html#tls_tls_connect_opt
 Furthermore, the following options can be passed:
 
 * **socketPath** `string | null` (optional) - Default: `null` - An IPC endpoint, either Unix domain socket or Windows named pipe.
+* **lookup** `Function` (optional) - Custom lookup function. Default: [dns.lookup()](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback).
 * **maxCachedSessions** `number | null` (optional) - Default: `100` - Maximum number of TLS cached sessions. Use 0 to disable TLS session caching. Default: 100.
 * **timeout** `number | null` (optional) -  In milliseconds, Default `10e3`.
 * **servername** `string | null` (optional)

--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -50,6 +50,7 @@ class Agent extends DispatcherBase {
     this[kOptions].interceptors = options.interceptors
       ? { ...options.interceptors }
       : undefined
+    this[kOptions].lookup = options.lookup
     this[kMaxRedirections] = maxRedirections
     this[kFactory] = factory
     this[kClients] = new Map()

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -102,6 +102,7 @@ class Client extends DispatcherBase {
     maxResponseSize,
     autoSelectFamily,
     autoSelectFamilyAttemptTimeout,
+    lookup,
     // h2
     maxConcurrentStreams,
     allowH2
@@ -202,6 +203,7 @@ class Client extends DispatcherBase {
         maxCachedSessions,
         allowH2,
         socketPath,
+        lookup,
         timeout: connectTimeout,
         ...(autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -35,6 +35,7 @@ class Pool extends PoolBase {
     autoSelectFamily,
     autoSelectFamilyAttemptTimeout,
     allowH2,
+    lookup,
     ...options
   } = {}) {
     super()
@@ -57,6 +58,7 @@ class Pool extends PoolBase {
         maxCachedSessions,
         allowH2,
         socketPath,
+        lookup,
         timeout: connectTimeout,
         ...(autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -2,6 +2,7 @@ import { Duplex, Readable, Writable } from 'stream'
 import { expectAssignable } from 'tsd'
 import { Client, Dispatcher } from '../..'
 import { URL } from 'url'
+import * as dns from 'node:dns'
 
 expectAssignable<Client>(new Client(''))
 expectAssignable<Client>(new Client('', {}))
@@ -40,6 +41,9 @@ expectAssignable<Client>(new Client(new URL('http://localhost'), {}))
   }))
   expectAssignable<Client>(new Client('', {
     socketPath: '/var/run/docker.sock'
+  }))
+  expectAssignable<Client>(new Client('', {
+    lookup: dns.lookup
   }))
   expectAssignable<Client>(new Client('', {
     pipelining: 1

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -1,3 +1,4 @@
+import * as dns from "node:dns";
 import { URL } from 'url'
 import { TlsOptions } from 'tls'
 import Dispatcher from './dispatcher'
@@ -60,6 +61,8 @@ export declare namespace Client {
     keepAliveTimeoutThreshold?: number;
     /** TODO */
     socketPath?: string;
+    /** Custom DNS lookup function. Default: dns.lookup(). */
+    lookup?: Omit<typeof dns.lookup, '__promisify__'>;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
     pipelining?: number;
     /** @deprecated use the connect option instead */


### PR DESCRIPTION
We add an optional custom lookup function to that has the same interface as the lookup option in TCP/UDP socket.connect. This allows users of this library to implement their own DNS caching implementation.

This does not preclude the future possibility of including a DNS caching implementation by default.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

- https://github.com/nodejs/undici/issues/2440

## Rationale

PR https://github.com/nodejs/undici/pull/2552 is attempting to add a default dns caching implementation to undici. Instead of trying to first add a default implementation, which is a lot of work, this PR adds the standard `lookup` option which allows a user to bring their own DNS lookup implementation.

I believe this is a better place to start from because:

- avoids committing to a default DNS caching implementation
   - there is no one-size DNS caching implementation that fits all use cases
- users may have other DNS implementation requirement beyond caching
- this is a smaller change to the undici public interface
- this follows existing Node.js convention of providing a `lookup` option

Adding DNS caching is now as easy as:

```js
import CacheableLookup from 'cacheable-lookup';

const cacheable = new CacheableLookup();

new Agent({
  lookup: cacheable.lookup
});
```

## Changes

<!-- Write a summary or list of changes here -->

### Features

- adds an optional `lookup` option to `Client`, `Pool` and `Agent`

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
