### PR TITLE
reuse realm for Request/Response

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -11,7 +11,7 @@ const {
   isValidHTTPToken,
   sameOrigin,
   normalizeMethod,
-  EnvironmentSettingsObject,
+  environmentSettingsObject,
   normalizeMethodRecord
 } = require('./util')
 const {
@@ -54,8 +54,8 @@ class Request {
     init = webidl.converters.RequestInit(init)
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object
-    // Note: Slow initialization of object literals with getters.
-    this[kRealm] = new EnvironmentSettingsObject()
+    this[kRealm] = environmentSettingsObject
+
     // 1. Let request be null.
     let request = null
 

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -13,7 +13,7 @@ const {
   serializeJavascriptValueToJSONString,
   isErrorLike,
   isomorphicEncode,
-  EnvironmentSettingsObject
+  environmentSettingsObject: relevantRealm
 } = require('./util')
 const {
   redirectStatusSet,
@@ -33,8 +33,6 @@ const textEncoder = new TextEncoder('utf-8')
 class Response {
   // Creates network error Response.
   static error () {
-    const relevantRealm = new EnvironmentSettingsObject()
-
     // The static error() method steps are to return the result of creating a
     // Response object, given a new network error, "immutable", and this’s
     // relevant Realm.
@@ -61,7 +59,6 @@ class Response {
 
     // 3. Let responseObject be the result of creating a Response object, given a new response,
     //    "response", and this’s relevant Realm.
-    const relevantRealm = new EnvironmentSettingsObject()
     const responseObject = fromInnerResponse(makeResponse({}), 'response', relevantRealm)
 
     // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
@@ -73,8 +70,6 @@ class Response {
 
   // Creates a redirect Response that redirects to url with status status.
   static redirect (url, status = 302) {
-    const relevantRealm = new EnvironmentSettingsObject()
-
     webidl.argumentLengthCheck(arguments, 1, { header: 'Response.redirect' })
 
     url = webidl.converters.USVString(url)
@@ -125,8 +120,7 @@ class Response {
 
     init = webidl.converters.ResponseInit(init)
 
-    // TODO
-    this[kRealm] = new EnvironmentSettingsObject()
+    this[kRealm] = relevantRealm
 
     // 1. Set this’s response to a new response.
     this[kState] = makeResponse({})

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1570,7 +1570,9 @@ function utf8DecodeBytes (buffer) {
 }
 
 class EnvironmentSettingsObjectBase {
-  baseUrl = getGlobalOrigin()
+  get baseUrl () {
+    return getGlobalOrigin()
+  }
 
   get origin () {
     return this.baseUrl?.origin
@@ -1582,6 +1584,8 @@ class EnvironmentSettingsObjectBase {
 class EnvironmentSettingsObject {
   settingsObject = new EnvironmentSettingsObjectBase()
 }
+
+const environmentSettingsObject = new EnvironmentSettingsObject()
 
 module.exports = {
   isAborted,
@@ -1635,5 +1639,5 @@ module.exports = {
   extractMimeType,
   getDecodeSplit,
   utf8DecodeBytes,
-  EnvironmentSettingsObject
+  environmentSettingsObject
 }


### PR DESCRIPTION
This change has a slight speedup, but this is mostly for correctness. Having a new "realm" (which is meant to be a distinct global environment) or settings object per Request/Response doesn't make sense.