### PR TITLE
fix(H2-#3140): abort requets upon GOAWAY

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -208,10 +208,9 @@ function onHttp2SessionEnd () {
  * This is the root cause of #3011
  * We need to handle GOAWAY frames properly, and trigger the session close
  * along with the socket right away
- * Find a way to trigger the close cycle from here on.
  */
 function onHTTP2GoAway (code) {
-  const err = new InformationalError(`HTTP/2: "GOAWAY" frame received with code ${code}`)
+  const err = new RequestAbortedError(`HTTP/2: "GOAWAY" frame received with code ${code}`)
 
   // We need to trigger the close cycle right away
   // We need to destroy the session and the socket
@@ -220,8 +219,7 @@ function onHTTP2GoAway (code) {
   this[kClient][kOnError](err)
 
   this.unref()
-  // We send the GOAWAY frame response as no error
-  this.destroy()
+
   util.destroy(this[kSocket], err)
 }
 

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -376,6 +376,7 @@ function onError (client, err) {
     assert(client[kPendingIdx] === client[kRunningIdx])
 
     const requests = client[kQueue].splice(client[kRunningIdx])
+
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
       util.errorRequest(client, request, err)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->
Closes #3140

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->
Upon `GOAWAY` frame, now all requests are aborted

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
