### PR TITLE
chore: ensure automated v6 release compared to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
               repo
             })
 
-            if (versionTag !== releases[0]?.tag_name) {
+            const previousRelease = releases.find((r) => r.tag_name.startsWith('v6'))
+
+            if (versionTag !== previousRelease?.tag_name) {
               return versionTag
             }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -8,12 +8,14 @@ const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBr
     repo
   })
 
+  const previousRelease = releases.find((r) => r.tag_name.startsWith('v6'))
+
   const { data: { body } } = await github.rest.repos.generateReleaseNotes({
     owner,
     repo,
     tag_name: versionTag,
     target_commitish: defaultBranch,
-    previous_tag_name: releases[0]?.tag_name
+    previous_tag_name: previousRelease?.tag_name
   })
 
   const bodyWithoutReleasePr = body.split('\n')


### PR DESCRIPTION
## This relates to...

- https://github.com/nodejs/undici/pull/3089
- https://github.com/nodejs/undici/issues/3103

## Rationale

Auto release logic currently generates release notes compared to most recent release (`releases[0]`). Instead, ensure comparisons are made to most recent **v6** release. This is a stop gap until more robust multi-branch releases can be set up.

I tested this in fork and my concern of v6 release followed by v5 release is probably unwarranted, because it appears releases[0] always refers to the most recent, highest valued, semver major release. I also tested it if a v7.0.0-alpha.1 release exists, and the problem issue arises. Best to get this in sooner than later as a safety precaution, and hopefully will have a proposal for multi-branch release merged before it became an issue.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
