### PR TITLE
dup-keys-non-strings

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -323,6 +323,10 @@ function processHeader (request, key, val) {
     return
   }
 
+  if (typeof key !== 'string') {
+    throw new InvalidArgumentError('invalid header key, needs to be a "String"')
+  }
+
   let headerName = headerNameLowerCasedRecord[key]
 
   if (headerName === undefined) {
@@ -330,6 +334,11 @@ function processHeader (request, key, val) {
     if (headerNameLowerCasedRecord[headerName] === undefined && !isValidHTTPToken(headerName)) {
       throw new InvalidArgumentError('invalid header key')
     }
+  }
+  const existingHeaderKey = request.headers.find((header, i) => header === key && i % 2 === 0)
+
+  if (existingHeaderKey) {
+    throw new InvalidArgumentError(`duplicated header key: ${key}`)
   }
 
   if (Array.isArray(val)) {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -335,7 +335,10 @@ function processHeader (request, key, val) {
       throw new InvalidArgumentError('invalid header key')
     }
   }
-  const existingHeaderKey = request.headers.find((header, i) => header === key && i % 2 === 0)
+  const existingHeaderKey = request.headers.find((header, i) => {
+    const isValArray = Array.isArray(val)
+    return header === key && i % 2 === 0 && !isValArray
+  })
 
   if (existingHeaderKey) {
     throw new InvalidArgumentError(`duplicated header key: ${key}`)

--- a/test/request.js
+++ b/test/request.js
@@ -439,6 +439,38 @@ describe('Should include headers from iterable objects', scope => {
       t.strictEqual(err.message, 'duplicated header key: hello')
     })
   })
+  test('Should NOT throw error if headers are duplicates AND val is a list', async t => {
+    t = tspl(t, { plan: 1 })
+
+    const server = createServer((req, res) => {
+      res.end('hello')
+    })
+
+    const headers = {
+      * [Symbol.iterator] () {
+        yield ['hello', 'world']
+        yield ['hello', ['world', 'Pluto']]
+      }
+    }
+
+    after(() => server.close())
+
+    await new Promise((resolve, reject) => {
+      server.listen(0, (err) => {
+        if (err != null) reject(err)
+        else resolve()
+      })
+    })
+
+    await request({
+      method: 'GET',
+      origin: `http://localhost:${server.address().port}`,
+      reset: true,
+      headers
+    }).then((res) => {
+      t.ok(res, 'Should succeed')
+    })
+  })
   test('Should throw error if headers are NOT strings', async t => {
     t = tspl(t, { plan: 2 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to #1902

## Rationale

now throws an error if the headers key is not a string or duplicated 

## Changes

- added Tests
- added a guard for duplicate headers 
- added a guard for non string header keys

### Breaking Changes and Deprecations

Not sure, but this will block ALL requests that have headers which are not of type 'String' or are duplicated.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
