### PR TITLE
chore: add explicitly @fastify/busboy

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "prepare": "husky install && node ./scripts/platform-shell.js"
   },
   "devDependencies": {
+    "@fastify/busboy": "2.1.1",
     "@matteo.collina/tspl": "^0.1.1",
     "@sinonjs/fake-timers": "^11.1.0",
     "@types/node": "^18.0.3",


### PR DESCRIPTION
We are using @fastify/busboy but not requiring it as dev dependency. If borp would removes @reporters/github or better say @actions/http-client updates undici to latest, it will break our tests.

Lets add it...