### PR TITLE
preserve dictionary key name in webidl errors

### DIFF
--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -390,7 +390,7 @@ webidl.dictionaryConverter = function (converters) {
       // When this happens, do not perform a conversion,
       // and do not assign the key a value.
       if (required || hasDefault || value !== undefined) {
-        value = converter(value, prefix, argument)
+        value = converter(value, prefix, `${argument}.${key}`)
 
         if (
           options.allowedValues &&

--- a/lib/web/fetch/webidl.js
+++ b/lib/web/fetch/webidl.js
@@ -242,7 +242,7 @@ webidl.sequenceConverter = function (converter) {
     if (webidl.util.Type(V) !== 'Object') {
       throw webidl.errors.exception({
         header: prefix,
-        message: `${argument} (${webidl.util.Stringify(V)}) is not an Object.`
+        message: `${argument} (${webidl.util.Stringify(V)}) is not iterable.`
       })
     }
 

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -27,7 +27,7 @@ test('Headers initialization', async (t) => {
       throws(() => new Headers(['undici', 'fetch', 'fetch']), TypeError)
       throws(
         () => new Headers([0, 1, 2]),
-        TypeError('Headers contructor: init (0) is not an Object.')
+        TypeError('Headers contructor: init (0) is not iterable.')
       )
     })
 
@@ -42,7 +42,7 @@ test('Headers initialization', async (t) => {
       const init = ['undici', 'fetch', 'fetch', 'undici']
       throws(
         () => new Headers(init),
-        TypeError('Headers contructor: init ("undici") is not an Object.')
+        TypeError('Headers contructor: init ("undici") is not iterable.')
       )
     })
   })

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -1,7 +1,7 @@
 import { IncomingHttpHeaders } from 'http'
 import { Duplex, Readable, Writable } from 'stream'
 import { expectAssignable, expectType } from 'tsd'
-import { Dispatcher } from '../..'
+import { Dispatcher, Headers } from '../..'
 import { URL } from 'url'
 import { Blob } from 'buffer'
 

--- a/test/webidl/errors.js
+++ b/test/webidl/errors.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { test } = require('node:test')
+const { test, describe } = require('node:test')
 const assert = require('node:assert')
-const { Headers } = require('../..')
+const { Headers, MessageEvent } = require('../..')
 
 test('ByteString', (t) => {
   const name = Symbol('')
@@ -20,4 +20,13 @@ test('ByteString', (t) => {
       new TypeError(`Headers.${method}: name is a symbol, which cannot be converted to a DOMString.`)
     )
   }
+})
+
+describe('dictionary converters', () => {
+  test('error message retains property name', () => {
+    assert.throws(
+      () => new MessageEvent('message', { source: 1 }),
+      new TypeError('MessageEvent constructor: Expected eventInitDict.source ("1") to be an instance of MessagePort.')
+    )
+  })
 })

--- a/test/websocket/messageevent.js
+++ b/test/websocket/messageevent.js
@@ -107,7 +107,7 @@ test('test/parallel/test-worker-message-port.js', () => {
   })
   assert.throws(() => new MessageEvent('message', { ports: 0 }), {
     constructor: TypeError,
-    message: 'MessageEvent constructor: eventInitDict.ports (0) is not an Object.'
+    message: 'MessageEvent constructor: eventInitDict.ports (0) is not iterable.'
   })
   assert.throws(() => new MessageEvent('message', { ports: [null] }), {
     constructor: TypeError,

--- a/test/websocket/messageevent.js
+++ b/test/websocket/messageevent.js
@@ -99,25 +99,25 @@ test('test/parallel/test-worker-message-port.js', () => {
 
   assert.throws(() => new MessageEvent('message', { source: 1 }), {
     constructor: TypeError,
-    message: 'MessageEvent constructor: Expected eventInitDict ("1") to be an instance of MessagePort.'
+    message: 'MessageEvent constructor: Expected eventInitDict.source ("1") to be an instance of MessagePort.'
   })
   assert.throws(() => new MessageEvent('message', { source: {} }), {
     constructor: TypeError,
-    message: 'MessageEvent constructor: Expected eventInitDict ("{}") to be an instance of MessagePort.'
+    message: 'MessageEvent constructor: Expected eventInitDict.source ("{}") to be an instance of MessagePort.'
   })
   assert.throws(() => new MessageEvent('message', { ports: 0 }), {
     constructor: TypeError,
-    message: 'MessageEvent constructor: eventInitDict (0) is not an Object.'
+    message: 'MessageEvent constructor: eventInitDict.ports (0) is not an Object.'
   })
   assert.throws(() => new MessageEvent('message', { ports: [null] }), {
     constructor: TypeError,
-    message: 'MessageEvent constructor: Expected eventInitDict ("null") to be an instance of MessagePort.'
+    message: 'MessageEvent constructor: Expected eventInitDict.ports ("null") to be an instance of MessagePort.'
   })
   assert.throws(() =>
     new MessageEvent('message', { ports: [{}] })
   , {
     constructor: TypeError,
-    message: 'MessageEvent constructor: Expected eventInitDict ("{}") to be an instance of MessagePort.'
+    message: 'MessageEvent constructor: Expected eventInitDict.ports ("{}") to be an instance of MessagePort.'
   })
 
   assert(new MessageEvent('message') instanceof Event)


### PR DESCRIPTION
The errors are actually useful now, oops.

Next up, hopefully tomorrow, will be when I get to handling sequence errors.