### PR TITLE
fix: keep raw header name

### DIFF
--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -250,9 +250,21 @@ class HeadersList {
   get entries () {
     const headers = {}
 
-    if (this[kHeadersMap].size) {
+    if (this[kHeadersMap].size !== 0) {
       for (const { name, value } of this[kHeadersMap].values()) {
         headers[name] = value
+      }
+    }
+
+    return headers
+  }
+
+  get entriesRawList () {
+    const headers = []
+
+    if (this[kHeadersMap].size !== 0) {
+      for (const { name, value } of this[kHeadersMap].values()) {
+        headers.push([name, value])
       }
     }
 

--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -259,16 +259,8 @@ class HeadersList {
     return headers
   }
 
-  get entriesRawList () {
-    const headers = []
-
-    if (this[kHeadersMap].size !== 0) {
-      for (const { name, value } of this[kHeadersMap].values()) {
-        headers.push([name, value])
-      }
-    }
-
-    return headers
+  rawValues () {
+    return this[kHeadersMap].values()
   }
 
   get entriesList () {

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -477,8 +477,8 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        for (const { key, value } of headers.rawValues()) {
-          headersList.append(key, value, false)
+        for (const { name, value } of headers.rawValues()) {
+          headersList.append(name, value, false)
         }
         // Note: Copy the `set-cookie` meta-data.
         headersList.cookies = headers.cookies

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -477,9 +477,7 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        const rawList = headers.entriesRawList
-        for (let i = 0; i < rawList.length; ++i) {
-          const { 0: key, 1: value } = rawList[i]
+        for (const { key, value } of headers.rawValues()) {
           headersList.append(key, value, false)
         }
         // Note: Copy the `set-cookie` meta-data.

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -477,7 +477,7 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        const rawList = headersList.entriesRawList
+        const rawList = headers.entriesRawList
         // TODO: optimizing this.
         for (let i = 0; i < rawList.length; ++i) {
           const { 0: key, 1: value } = rawList[i]

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -477,9 +477,11 @@ class Request {
       // 4. If headers is a Headers object, then for each header in its header
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
-        for (const { 0: key, 1: val } of headers) {
-          // Note: The header names are already in lowercase.
-          headersList.append(key, val, true)
+        const rawList = headersList.entriesRawList
+        // TODO: optimizing this.
+        for (let i = 0; i < rawList.length; ++i) {
+          const { 0: key, 1: value } = rawList[i]
+          headersList.append(key, value, false)
         }
         // Note: Copy the `set-cookie` meta-data.
         headersList.cookies = headers.cookies

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -478,7 +478,6 @@ class Request {
       // list, append header’s name/header’s value to this’s headers.
       if (headers instanceof HeadersList) {
         const rawList = headers.entriesRawList
-        // TODO: optimizing this.
         for (let i = 0; i < rawList.length; ++i) {
           const { 0: key, 1: value } = rawList[i]
           headersList.append(key, value, false)

--- a/test/fetch/headers-case.js
+++ b/test/fetch/headers-case.js
@@ -28,5 +28,5 @@ test('Headers retain keys case-sensitive', async (t) => {
     await fetch(url, { headers })
   }
   // see https://github.com/nodejs/undici/pull/3183
-  await fetch(new Request(url, { headers: new Headers([['Content-Type', 'text/plain']]) }), { headers: undefined })
+  await fetch(new Request(url, { headers: new Headers([['Content-Type', 'text/plain']]) }), { method: 'GET' })
 })

--- a/test/fetch/headers-case.js
+++ b/test/fetch/headers-case.js
@@ -28,5 +28,5 @@ test('Headers retain keys case-sensitive', async (t) => {
     await fetch(url, { headers })
   }
   // see https://github.com/nodejs/undici/pull/3183
-  await fetch(new Request(url, { headers: new Headers([['Content-Type', 'text/plain']]) }), { method: 'GET' })
+  await fetch(new Request(url, { headers: [['Content-Type', 'text/plain']] }), { method: 'GET' })
 })

--- a/test/fetch/headers-case.js
+++ b/test/fetch/headers-case.js
@@ -27,5 +27,6 @@ test('Headers retain keys case-sensitive', async (t) => {
   ]) {
     await fetch(url, { headers })
   }
-  await fetch(new Request(url, { headers: new Headers([['Content-Type', 'text/plain']]) }), { body: null })
+  // see https://github.com/nodejs/undici/pull/3183
+  await fetch(new Request(url, { headers: new Headers([['Content-Type', 'text/plain']]) }), { headers: undefined })
 })


### PR DESCRIPTION
Follow up of #3160.
In the following cases. Lose the original raw header name.
```js
await fetch(new Request(url, { headers: [['Content-Type', 'text/plain']] }), { method: 'GET' })
```