### PR TITLE
fix 3 mimesniff tests

### DIFF
--- a/lib/web/fetch/data-url.js
+++ b/lib/web/fetch/data-url.js
@@ -7,13 +7,13 @@ const encoder = new TextEncoder()
 /**
  * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
  */
-const HTTP_TOKEN_CODEPOINTS = /^[!#$%&'*+-.^_|~A-Za-z0-9]+$/
+const HTTP_TOKEN_CODEPOINTS = /^[!#$%&'*+\-.^_|~A-Za-z0-9]+$/
 const HTTP_WHITESPACE_REGEX = /[\u000A\u000D\u0009\u0020]/ // eslint-disable-line
 const ASCII_WHITESPACE_REPLACE_REGEX = /[\u0009\u000A\u000C\u000D\u0020]/g // eslint-disable-line
 /**
  * @see https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
  */
-const HTTP_QUOTED_STRING_TOKENS = /[\u0009\u0020-\u007E\u0080-\u00FF]/ // eslint-disable-line
+const HTTP_QUOTED_STRING_TOKENS = /^[\u0009\u0020-\u007E\u0080-\u00FF]+$/ // eslint-disable-line
 
 // https://fetch.spec.whatwg.org/#data-url-processor
 /** @param {URL} dataURL */


### PR DESCRIPTION
I noticed that these tests were failing in node but were passing in Deno. 
https://wpt.fyi/results/mimesniff/mime-types/parsing.any.html?label=master&label=experimental&product=node.js&product=deno&product=chrome&product=firefox&view=subtest

Of course it was an issue with regex.

We now pass 1031/1898 of the tests while Deno "only" passes 1030/1898!