### PR TITLE
websocket: 200x faster generate mask

### DIFF
--- a/benchmarks/websocket/generate-mask.mjs
+++ b/benchmarks/websocket/generate-mask.mjs
@@ -1,0 +1,22 @@
+import { randomFillSync, randomBytes } from 'node:crypto'
+import { bench, group, run } from 'mitata'
+
+const BUFFER_SIZE = 16384
+
+const buf = randomFillSync(Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE)
+let bufIdx = 0
+
+function generateMask () {
+  if (bufIdx + 4 > BUFFER_SIZE) {
+    bufIdx = 0
+    randomFillSync(buf, 0, BUFFER_SIZE)
+  }
+  return [buf[bufIdx++], buf[bufIdx++], buf[bufIdx++], buf[bufIdx++]]
+}
+
+group('generate', () => {
+  bench('generateMask', () => generateMask())
+  bench('crypto.randomBytes(4)', () => randomBytes(4))
+})
+
+await run()

--- a/benchmarks/websocket/generate-mask.mjs
+++ b/benchmarks/websocket/generate-mask.mjs
@@ -3,11 +3,11 @@ import { bench, group, run } from 'mitata'
 
 const BUFFER_SIZE = 16384
 
-const buf = randomFillSync(Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE)
-let bufIdx = 0
+const buf = Buffer.allocUnsafe(BUFFER_SIZE)
+let bufIdx = BUFFER_SIZE
 
 function generateMask () {
-  if (bufIdx + 4 > BUFFER_SIZE) {
+  if (bufIdx === BUFFER_SIZE) {
     bufIdx = 0
     randomFillSync(buf, 0, BUFFER_SIZE)
   }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -6,7 +6,7 @@ const BUFFER_SIZE = 16386
 
 /** @type {import('crypto')} */
 let crypto
-const buffer = Buffer.allocUnsafe(BUFFER_SIZE)
+const buffer = null
 let bufIdx = BUFFER_SIZE
 
 try {

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -2,13 +2,29 @@
 
 const { maxUnsigned16Bit } = require('./constants')
 
+const BUFFER_SIZE = 16386
+
 /** @type {import('crypto')} */
 let crypto
+let buffer = null
+let bufIdx = 0
+
 try {
   crypto = require('node:crypto')
 /* c8 ignore next 3 */
 } catch {
 
+}
+
+function generateMask () {
+  if (buffer === null) {
+    buffer = crypto.randomFillSync(Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE)
+  }
+  if (bufIdx + 4 > BUFFER_SIZE) {
+    bufIdx = 0
+    crypto.randomFillSync(buffer, 0, BUFFER_SIZE)
+  }
+  return [buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++]]
 }
 
 class WebsocketFrameSend {
@@ -17,11 +33,12 @@ class WebsocketFrameSend {
    */
   constructor (data) {
     this.frameData = data
-    this.maskKey = crypto.randomBytes(4)
   }
 
   createFrame (opcode) {
-    const bodyLength = this.frameData?.byteLength ?? 0
+    const frameData = this.frameData
+    const maskKey = generateMask()
+    const bodyLength = frameData?.byteLength ?? 0
 
     /** @type {number} */
     let payloadLength = bodyLength // 0-125
@@ -43,10 +60,10 @@ class WebsocketFrameSend {
     buffer[0] = (buffer[0] & 0xF0) + opcode // opcode
 
     /*! ws. MIT License. Einar Otto Stangvik <einaros@gmail.com> */
-    buffer[offset - 4] = this.maskKey[0]
-    buffer[offset - 3] = this.maskKey[1]
-    buffer[offset - 2] = this.maskKey[2]
-    buffer[offset - 1] = this.maskKey[3]
+    buffer[offset - 4] = maskKey[0]
+    buffer[offset - 3] = maskKey[1]
+    buffer[offset - 2] = maskKey[2]
+    buffer[offset - 1] = maskKey[3]
 
     buffer[1] = payloadLength
 
@@ -61,8 +78,8 @@ class WebsocketFrameSend {
     buffer[1] |= 0x80 // MASK
 
     // mask body
-    for (let i = 0; i < bodyLength; i++) {
-      buffer[offset + i] = this.frameData[i] ^ this.maskKey[i % 4]
+    for (let i = 0; i < bodyLength; ++i) {
+      buffer[offset + i] = frameData[i] ^ maskKey[i & 3]
     }
 
     return buffer

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -19,7 +19,7 @@ try {
 function generateMask () {
   if (bufIdx === BUFFER_SIZE) {
     bufIdx = 0
-    crypto.randomFillSync(buffer, 0, BUFFER_SIZE)
+    crypto.randomFillSync((buffer ??= Buffer.allocUnsafe(BUFFER_SIZE)), 0, BUFFER_SIZE)
   }
   return [buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++]]
 }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -13,7 +13,14 @@ try {
   crypto = require('node:crypto')
 /* c8 ignore next 3 */
 } catch {
-
+  crypto = {
+    // not full compatibility, but minimum.
+    randomFillSync: function randomFillSync (buffer, _offset, _size) {
+      for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = Math.floor(Math.random() * 255)
+      }
+    }
+  }
 }
 
 function generateMask () {

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -17,7 +17,7 @@ try {
     // not full compatibility, but minimum.
     randomFillSync: function randomFillSync (buffer, _offset, _size) {
       for (let i = 0; i < buffer.length; ++i) {
-        buffer[i] = Math.floor(Math.random() * 255)
+        buffer[i] = Math.random() * 255 | 0
       }
       return buffer
     }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -6,7 +6,7 @@ const BUFFER_SIZE = 16386
 
 /** @type {import('crypto')} */
 let crypto
-const buffer = null
+let buffer = null
 let bufIdx = BUFFER_SIZE
 
 try {

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -19,6 +19,7 @@ try {
       for (let i = 0; i < buffer.length; ++i) {
         buffer[i] = Math.floor(Math.random() * 255)
       }
+      return buffer
     }
   }
 }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -6,8 +6,8 @@ const BUFFER_SIZE = 16386
 
 /** @type {import('crypto')} */
 let crypto
-let buffer = null
-let bufIdx = 0
+let buffer = Buffer.allocUnsafe(BUFFER_SIZE)
+let bufIdx = BUFFER_SIZE
 
 try {
   crypto = require('node:crypto')
@@ -17,10 +17,7 @@ try {
 }
 
 function generateMask () {
-  if (buffer === null) {
-    buffer = crypto.randomFillSync(Buffer.allocUnsafe(BUFFER_SIZE), 0, BUFFER_SIZE)
-  }
-  if (bufIdx + 4 > BUFFER_SIZE) {
+  if (bufIdx === BUFFER_SIZE) {
     bufIdx = 0
     crypto.randomFillSync(buffer, 0, BUFFER_SIZE)
   }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -6,7 +6,7 @@ const BUFFER_SIZE = 16386
 
 /** @type {import('crypto')} */
 let crypto
-let buffer = Buffer.allocUnsafe(BUFFER_SIZE)
+const buffer = Buffer.allocUnsafe(BUFFER_SIZE)
 let bufIdx = BUFFER_SIZE
 
 try {


### PR DESCRIPTION
The disadvantage is increased memory usage.
```
benchmark                  time (avg)             (min … max)       p75       p99      p999
------------------------------------------------------------- -----------------------------
• generate
------------------------------------------------------------- -----------------------------
generateMask            15.69 ns/iter      (9.77 ns … 332 ns)  15.14 ns  72.66 ns    180 ns
crypto.randomBytes(4)   3'874 ns/iter   (2'971 ns … 6'260 ns)  4'528 ns  6'086 ns  6'260 ns

summary for generate
  generateMask
   246.99x faster than crypto.randomBytes(4)
```
