### PR TITLE
websocket: don't clone buffer if it's not needed.

### DIFF
--- a/lib/web/websocket/util.js
+++ b/lib/web/websocket/util.js
@@ -104,7 +104,7 @@ function websocketMessageReceived (ws, type, data) {
       // -> type indicates that the data is Binary and binary type is "arraybuffer"
       //      a new ArrayBuffer object, created in the relevant Realm of the
       //      WebSocket object, whose contents are data
-      dataForEvent = new Uint8Array(data).buffer
+      dataForEvent = toArrayBuffer(data)
     }
   }
 
@@ -115,6 +115,13 @@ function websocketMessageReceived (ws, type, data) {
     origin: ws[kWebSocketURL].origin,
     data: dataForEvent
   })
+}
+
+function toArrayBuffer (buffer) {
+  if (buffer.byteLength === buffer.buffer.byteLength) {
+    return buffer.buffer
+  }
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
 }
 
 /**


### PR DESCRIPTION
This can also be adapted to fetch.