### PR TITLE
websocket: move codeblock in parseCloseBody

### DIFF
--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -314,6 +314,10 @@ class ByteParser extends Writable {
       code = data.readUInt16BE(0)
     }
 
+    if (code !== undefined && !isValidStatusCode(code)) {
+      return { code: 1002, reason: 'Invalid status code', error: true }
+    }
+
     // https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.6
     /** @type {Buffer} */
     let reason = data.subarray(2)
@@ -321,10 +325,6 @@ class ByteParser extends Writable {
     // Remove BOM
     if (reason[0] === 0xEF && reason[1] === 0xBB && reason[2] === 0xBF) {
       reason = reason.subarray(3)
-    }
-
-    if (code !== undefined && !isValidStatusCode(code)) {
-      return { code: 1002, reason: 'Invalid status code', error: true }
     }
 
     try {


### PR DESCRIPTION
I know, I know... we wont improve the performance of cold branches... but I really think it makes sense to move these lines higher. Checking the code for validity after we set the code makes more sense then checking the validity after we instantiate a buffer for reason. 