### PR TITLE
fetch: wpt add /fetch/api/resources/cache.py to server.mjs

### DIFF
--- a/test/wpt/server/server.mjs
+++ b/test/wpt/server/server.mjs
@@ -159,6 +159,22 @@ const server = createServer(async (req, res) => {
       res.end()
       break
     }
+    case '/fetch/api/resources/cache.py': {
+      if (req.headers['if-none-match'] === '"123abc"') {
+        res.statusCode = 304
+        res.statusMessage = 'Not Modified'
+        res.setHeader('X-HTTP-STATUS', '304')
+        res.end()
+      } else {
+        // cache miss, so respond with the actual content
+        res.statusCode = 200
+        res.statusMessage = 'OK'
+        res.setHeader('Content-Type', 'text/plain')
+        res.setHeader('ETag', '"123abc"')
+        res.end('lorem ipsum dolor sit amet')
+      }
+      break
+    }
     case '/fetch/api/resources/status.py': {
       const code = parseInt(fullUrl.searchParams.get('code') ?? 200)
       const text = fullUrl.searchParams.get('text') ?? 'OMG'

--- a/test/wpt/status/fetch.status.json
+++ b/test/wpt/status/fetch.status.json
@@ -18,7 +18,8 @@
       "conditional-get.any.js": {
         "fail": [
           "Testing conditional GET with ETags"
-        ]
+        ],
+        "note": "undici doesn't keep track of etags"
       },
       "header-value-combining.any.js": {
         "fail": [


### PR DESCRIPTION
while investigating failing tests, here conditional-get.any.js, I created the cache.py equivalent in server.mjs. Because our fetch is not caching by etag, the second fetch in conditional-get.any.js wont send the if-none-match header.

