### PR TITLE
fetch: fix captureStackTrace

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -7,7 +7,7 @@ const fetchImpl = require('./lib/web/fetch').fetch
 module.exports.fetch = function fetch (resource, init = undefined) {
   return fetchImpl(resource, init).catch((err) => {
     if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, this)
+      Error.captureStackTrace(err, fetch)
     }
     throw err
   })

--- a/index-fetch.js
+++ b/index-fetch.js
@@ -7,7 +7,7 @@ const fetchImpl = require('./lib/web/fetch').fetch
 module.exports.fetch = function fetch (resource, init = undefined) {
   return fetchImpl(resource, init).catch((err) => {
     if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, fetch)
+      Error.captureStackTrace(err)
     }
     throw err
   })

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports.fetch = async function fetch (init, options = undefined) {
     return await fetchImpl(init, options)
   } catch (err) {
     if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, this)
+      Error.captureStackTrace(err, fetch)
     }
 
     throw err

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports.fetch = async function fetch (init, options = undefined) {
     return await fetchImpl(init, options)
   } catch (err) {
     if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, fetch)
+      Error.captureStackTrace(err)
     }
 
     throw err

--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -2,8 +2,13 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert')
-const { fetch } = require('../..')
+const { fetch, setGlobalDispatcher, Agent } = require('../..')
 const { fetch: fetchIndex } = require('../../index-fetch')
+
+setGlobalDispatcher(new Agent({
+  headersTimeout: 500,
+  connectTimeout: 500
+}))
 
 test('FETCH: request errors and prints trimmed stack trace', async (t) => {
   try {


### PR DESCRIPTION
Closes #2869 

This is an odd bug. 

Obviously `this` is `undefined`, because nobody will run fetch with the `new` operator.

So currently if fetch throws, we create a second time the same stacktrace?

Maybe it is wrong and we should set fetchImpl instead of fetch as reference point?

Maybe we can improve the perf, by storing the stackTraceLimit and set it to 0 and after the fetch we reset it. But problem is, that aggregated errors in cause will have no stack trace then?

