### PR TITLE
websocket: fix parsing of control frames

### DIFF
--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -65,7 +65,9 @@ class ByteParser extends Writable {
 
         // If we receive a fragmented message, we use the type of the first
         // frame to parse the full message as binary/text, when it's terminated
-        this.#info.originalOpcode ??= this.#info.opcode
+        if (this.#info.opcode === opcodes.BINARY || this.#info.opcode === opcodes.TEXT) {
+          this.#info.originalOpcode ??= this.#info.opcode
+        }
 
         this.#info.fragmented = !this.#info.fin && this.#info.opcode !== opcodes.CONTINUATION
 

--- a/test/websocket/issue-2859.js
+++ b/test/websocket/issue-2859.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+const diagnosticsChannel = require('node:diagnostics_channel')
+const { tspl } = require('@matteo.collina/tspl')
+
+test('Fragmented frame with a ping frame in the first of it', async (t) => {
+  const { completed, deepStrictEqual, strictEqual } = tspl(t, { plan: 2 })
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (ws) => {
+    const socket = ws._socket
+
+    socket.write(Buffer.from([0x89, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f])) // ping "Hello"
+    socket.write(Buffer.from([0x01, 0x03, 0x48, 0x65, 0x6c])) // Text frame "Hel"
+    socket.write(Buffer.from([0x80, 0x02, 0x6c, 0x6f])) // Text frame "lo"
+  })
+
+  t.after(() => {
+    server.close()
+    ws.close()
+  })
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+
+  diagnosticsChannel.channel('undici:websocket:ping').subscribe(
+    ({ payload }) => deepStrictEqual(payload, Buffer.from('Hello'))
+  )
+
+  ws.addEventListener('message', ({ data }) => {
+    strictEqual(data, 'Hello')
+  })
+
+  await completed
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to #2859

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

If a PING frame is received before binary/text frames is received, those data will be dropped.

Message data is decoded to UTF-8 text if the `opcode` is TEXT, or converted to Blob or ArrayBuffer if it is BINARY. However, the receiver (`ByteParser`) determines that the `opcode` of a frame that cannot be fragmented, such as a PING, is the `opcode` of a potentially fragmented message. And it will not be overturned until a message handler is called. Therefore, by restricting the type of `opcode` that is set in `this.#info.originalOpcode`, we ensure that messages are processed accordingly with the appropriate `opcode`.

## Changes

- Restrict the frame type of fragmented messages to be binary or text only.

### Features

N/A

### Bug Fixes

- #2859

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
