### PR TITLE
ci: node nightly test should use node 23

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'nodejs/undici'
     uses: ./.github/workflows/test.yml
     with:
-      node-version: 22-nightly
+      node-version: 23-nightly
       runs-on: ubuntu-latest
     secrets: inherit
 
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'nodejs/undici'
     uses: ./.github/workflows/test.yml
     with:
-      node-version: 22-nightly
+      node-version: 23-nightly
       runs-on: windows-latest
     secrets: inherit
 
@@ -29,7 +29,7 @@ jobs:
     if: github.repository == 'nodejs/undici'
     uses: ./.github/workflows/test.yml
     with:
-      node-version: 22-nightly
+      node-version: 23-nightly
       runs-on: macos-latest
     secrets: inherit
 


### PR DESCRIPTION
today again i got an email that our nightly fails. checked it and wondered why node nightly from 24 april was used. checked the [node page](https://nodejs.org/download/nightly/)  and saw, that since we have node 23, no node 22 nightlies are published. So we have to change the target.

Also here I wonder if the following condition is correct:

https://github.com/nodejs/undici/blob/38c8b55c699199bd3523511737127a236d1a2521/.github/workflows/nightly.yml#L37

I would actually say, that it should be or conditions and not and conditions. If the tests fail in windows but mac and linux pass, as it is now, then we dont get an issue created. Rn i still get an email that it failed.

Maybe @mweberxyz share his opinion?

Maybe can be taken care in a follow up.