### PR TITLE
fix: Fix server closing in tests.

### DIFF
--- a/test/fetch/client-node-max-header-size.js
+++ b/test/fetch/client-node-max-header-size.js
@@ -1,21 +1,25 @@
 'use strict'
 
-const { execSync } = require('node:child_process')
+const { tspl } = require('@matteo.collina/tspl')
+const { exec } = require('node:child_process')
 const { test } = require('node:test')
-const assert = require('node:assert')
 
 const command = 'node -e "require(\'./undici-fetch.js\').fetch(\'https://httpbin.org/get\')"'
 
-test("respect Node.js' --max-http-header-size", async () => {
-  assert.throws(
-    () => execSync(`${command} --max-http-header-size=1`),
-    /UND_ERR_HEADERS_OVERFLOW/,
-    'max-http-header-size=1 should throw'
-  )
+test("respect Node.js' --max-http-header-size", async (t) => {
+  t = tspl(t, { plan: 6 })
 
-  assert.doesNotThrow(
-    () => execSync(command),
-    /UND_ERR_HEADERS_OVERFLOW/,
-    'default max-http-header-size should not throw'
-  )
+  exec(`${command} --max-http-header-size=1`, { stdio: 'pipe' }, (err, stdout, stderr) => {
+    t.strictEqual(err.code, 1)
+    t.strictEqual(stdout, '')
+    t.match(stderr, /UND_ERR_HEADERS_OVERFLOW/, '--max-http-header-size=1 should throw')
+  })
+
+  exec(command, { stdio: 'pipe' }, (err, stdout, stderr) => {
+    t.ifError(err)
+    t.strictEqual(stdout, '')
+    t.strictEqual(stderr, '', 'default max-http-header-size should not throw')
+  })
+
+  await t.completed
 })

--- a/test/utils/node-http.js
+++ b/test/utils/node-http.js
@@ -3,7 +3,10 @@
 const util = require('node:util')
 
 function closeServerAsPromise (server) {
-  return () => util.promisify(server.close.bind(server))()
+  return () => {
+    server.closeIdleConnections()
+    return util.promisify(server.close.bind(server))()
+  }
 }
 
 function closeClientAndServerAsPromise (client, server) {


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/node/pull/53028

## Rationale

When running in 18.20.3, the test suite fails to stop the test as the HTTP server does not close if some connections are still pending.

## Changes

This PR changes the test utils to close pending connection first before closing the server. This is already the default behavior in Node 20+.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A
## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
