### PR TITLE
don't use internal header state for cookies

### DIFF
--- a/lib/web/cookies/index.js
+++ b/lib/web/cookies/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { parseSetCookie } = require('./parse')
-const { stringify, getHeadersList } = require('./util')
+const { stringify } = require('./util')
 const { webidl } = require('../fetch/webidl')
 const { Headers } = require('../fetch/headers')
 
@@ -78,14 +78,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**

--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const assert = require('node:assert')
-const { getHeadersList: internalGetHeadersList } = require('../fetch/headers')
-
 /**
  * @param {string} value
  * @returns {boolean}
@@ -275,35 +272,11 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  try {
-    return internalGetHeadersList(headers)
-  } catch {
-    // fall-through
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
   validateCookieName,
   validateCookiePath,
   validateCookieValue,
   toIMFDate,
-  stringify,
-  getHeadersList
+  stringify
 }

--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -641,14 +641,6 @@ Object.defineProperties(Headers.prototype, {
   },
   [util.inspect.custom]: {
     enumerable: false
-  },
-  // Compatibility for global headers
-  [Symbol('headers list')]: {
-    configurable: false,
-    enumerable: false,
-    get: function () {
-      return getHeadersList(this)
-    }
   }
 })
 

--- a/test/cookie/global-headers.js
+++ b/test/cookie/global-headers.js
@@ -8,7 +8,6 @@ const {
   getSetCookies,
   setCookie
 } = require('../..')
-const { getHeadersList } = require('../../lib/web/cookies/util')
 
 describe('Using global Headers', async () => {
   test('deleteCookies', () => {
@@ -32,7 +31,7 @@ describe('Using global Headers', async () => {
       'set-cookie': 'undici=getSetCookies; Secure'
     })
 
-    const supportsCookies = getHeadersList(headers).cookies
+    const supportsCookies = headers.getSetCookie()
 
     if (!supportsCookies) {
       assert.deepEqual(getSetCookies(headers), [])


### PR DESCRIPTION
refs: https://github.com/nodejs/undici/pull/3286

I have no idea why we didn't do this before 🤷 