### PR TITLE
perf: convert object to params

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -978,19 +978,19 @@ function writeH1 (client, request) {
 
   /* istanbul ignore else: assertion */
   if (!body || bodyLength === 0) {
-    writeBuffer({ abort, body: null, client, request, socket, contentLength, header, expectsPayload })
+    writeBuffer(abort, null, client, request, socket, contentLength, header, expectsPayload)
   } else if (util.isBuffer(body)) {
-    writeBuffer({ abort, body, client, request, socket, contentLength, header, expectsPayload })
+    writeBuffer(abort, body, client, request, socket, contentLength, header, expectsPayload)
   } else if (util.isBlobLike(body)) {
     if (typeof body.stream === 'function') {
-      writeIterable({ abort, body: body.stream(), client, request, socket, contentLength, header, expectsPayload })
+      writeIterable(abort, body.stream(), client, request, socket, contentLength, header, expectsPayload)
     } else {
-      writeBlob({ abort, body, client, request, socket, contentLength, header, expectsPayload })
+      writeBlob(abort, body, client, request, socket, contentLength, header, expectsPayload)
     }
   } else if (util.isStream(body)) {
-    writeStream({ abort, body, client, request, socket, contentLength, header, expectsPayload })
+    writeStream(abort, body, client, request, socket, contentLength, header, expectsPayload)
   } else if (util.isIterable(body)) {
-    writeIterable({ abort, body, client, request, socket, contentLength, header, expectsPayload })
+    writeIterable(abort, body, client, request, socket, contentLength, header, expectsPayload)
   } else {
     assert(false)
   }
@@ -998,7 +998,7 @@ function writeH1 (client, request) {
   return true
 }
 
-function writeStream ({ abort, body, client, request, socket, contentLength, header, expectsPayload }) {
+function writeStream (abort, body, client, request, socket, contentLength, header, expectsPayload) {
   assert(contentLength !== 0 || client[kRunning] === 0, 'stream body cannot be pipelined')
 
   let finished = false
@@ -1101,7 +1101,7 @@ function writeStream ({ abort, body, client, request, socket, contentLength, hea
   }
 }
 
-function writeBuffer ({ abort, body, client, request, socket, contentLength, header, expectsPayload }) {
+function writeBuffer (abort, body, client, request, socket, contentLength, header, expectsPayload) {
   try {
     if (!body) {
       if (contentLength === 0) {
@@ -1131,7 +1131,7 @@ function writeBuffer ({ abort, body, client, request, socket, contentLength, hea
   }
 }
 
-async function writeBlob ({ abort, body, client, request, socket, contentLength, header, expectsPayload }) {
+async function writeBlob (abort, body, client, request, socket, contentLength, header, expectsPayload) {
   assert(contentLength === body.size, 'blob body must have content length')
 
   try {
@@ -1159,7 +1159,7 @@ async function writeBlob ({ abort, body, client, request, socket, contentLength,
   }
 }
 
-async function writeIterable ({ abort, body, client, request, socket, contentLength, header, expectsPayload }) {
+async function writeIterable (abort, body, client, request, socket, contentLength, header, expectsPayload) {
   assert(contentLength !== 0 || client[kRunning] === 0, 'iterator body cannot be pipelined')
 
   let callback = null

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -479,72 +479,70 @@ function writeH2 (client, request) {
     if (!body || contentLength === 0) {
       writeBuffer(
         abort,
-        client,
-        request,
-        contentLength,
-        expectsPayload,
         stream,
         null,
-        client[kSocket]
+        client,
+        request,
+        client[kSocket],
+        contentLength,
+        expectsPayload
       )
     } else if (util.isBuffer(body)) {
       writeBuffer(
         abort,
+        stream,
+        expectsPayload,
         client,
         request,
+        client[kSocket],
         contentLength,
-        body,
-        expectsPayload,
-        stream,
-        client[kSocket]
+        body
       )
     } else if (util.isBlobLike(body)) {
       if (typeof body.stream === 'function') {
         writeIterable(
           abort,
-          client,
-          request,
-          contentLength,
-          expectsPayload,
           stream,
           body.stream(),
-          client[kSocket]
+          client,
+          request,
+          client[kSocket],
+          contentLength,
+          expectsPayload
         )
       } else {
         writeBlob(
           abort,
+          stream,
           body,
           client,
           request,
+          client[kSocket],
           contentLength,
-          expectsPayload,
-          stream,
-          client[kSocket]
+          expectsPayload
         )
       }
     } else if (util.isStream(body)) {
       writeStream(
         abort,
+        client[kSocket],
+        expectsPayload,
+        stream,
         body,
         client,
         request,
-        contentLength,
-        expectsPayload,
-        client[kSocket],
-        stream,
-        ''
+        contentLength
       )
     } else if (util.isIterable(body)) {
       writeIterable(
         abort,
+        stream,
         body,
         client,
         request,
+        client[kSocket],
         contentLength,
-        expectsPayload,
-        '',
-        stream,
-        client[kSocket]
+        expectsPayload
       )
     } else {
       assert(false)

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -477,82 +477,82 @@ function writeH2 (client, request) {
   function writeBodyH2 () {
     /* istanbul ignore else: assertion */
     if (!body || contentLength === 0) {
-      writeBuffer({
+      writeBuffer(
         abort,
         client,
         request,
         contentLength,
         expectsPayload,
-        h2stream: stream,
-        body: null,
-        socket: client[kSocket]
-      })
+        stream,
+        null,
+        client[kSocket]
+      )
     } else if (util.isBuffer(body)) {
-      writeBuffer({
+      writeBuffer(
         abort,
         client,
         request,
         contentLength,
         body,
         expectsPayload,
-        h2stream: stream,
-        socket: client[kSocket]
-      })
+        stream,
+        client[kSocket]
+      )
     } else if (util.isBlobLike(body)) {
       if (typeof body.stream === 'function') {
-        writeIterable({
+        writeIterable(
           abort,
           client,
           request,
           contentLength,
           expectsPayload,
-          h2stream: stream,
-          body: body.stream(),
-          socket: client[kSocket]
-        })
+          stream,
+          body.stream(),
+          client[kSocket]
+        )
       } else {
-        writeBlob({
+        writeBlob(
           abort,
           body,
           client,
           request,
           contentLength,
           expectsPayload,
-          h2stream: stream,
-          socket: client[kSocket]
-        })
+          stream,
+          client[kSocket]
+        )
       }
     } else if (util.isStream(body)) {
-      writeStream({
+      writeStream(
         abort,
         body,
         client,
         request,
         contentLength,
         expectsPayload,
-        socket: client[kSocket],
-        h2stream: stream,
-        header: ''
-      })
+        client[kSocket],
+        stream,
+        ''
+      )
     } else if (util.isIterable(body)) {
-      writeIterable({
+      writeIterable(
         abort,
         body,
         client,
         request,
         contentLength,
         expectsPayload,
-        header: '',
-        h2stream: stream,
-        socket: client[kSocket]
-      })
+        '',
+        stream,
+        client[kSocket]
+      )
     } else {
       assert(false)
     }
   }
 }
 
-function writeBuffer ({ abort, h2stream, body, client, request, socket, contentLength, expectsPayload }) {
+function writeBuffer (abort, h2stream, body, client, request, socket, contentLength, expectsPayload) {
   try {
     if (body != null && util.isBuffer(body)) {
       assert(contentLength === body.byteLength, 'buffer body must have content length')
@@ -575,7 +575,7 @@ function writeBuffer ({ abort, h2stream, body, client, request, socket, contentL
   }
 }
 
-function writeStream ({ abort, socket, expectsPayload, h2stream, body, client, request, contentLength }) {
+function writeStream (abort, socket, expectsPayload, h2stream, body, client, request, contentLength) {
   assert(contentLength !== 0 || client[kRunning] === 0, 'stream body cannot be pipelined')
 
   // For HTTP/2, is enough to pipe the stream
@@ -606,7 +606,7 @@ function writeStream ({ abort, socket, expectsPayload, h2stream, body, client, r
   }
 }
 
-async function writeBlob ({ abort, h2stream, body, client, request, socket, contentLength, expectsPayload }) {
+async function writeBlob (abort, h2stream, body, client, request, socket, contentLength, expectsPayload) {
   assert(contentLength === body.size, 'blob body must have content length')
 
   try {
@@ -634,7 +634,7 @@ async function writeBlob ({ abort, h2stream, body, client, request, socket, cont
   }
 }
 
-async function writeIterable ({ abort, h2stream, body, client, request, socket, contentLength, expectsPayload }) {
+async function writeIterable (abort, h2stream, body, client, request, socket, contentLength, expectsPayload) {
   assert(contentLength !== 0 || client[kRunning] === 0, 'iterator body cannot be pipelined')
 
   let callback = null

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -491,12 +491,12 @@ function writeH2 (client, request) {
       writeBuffer(
         abort,
         stream,
-        expectsPayload,
+        body,
         client,
         request,
         client[kSocket],
         contentLength,
-        body
+        expectsPayload
       )
     } else if (util.isBlobLike(body)) {
       if (typeof body.stream === 'function') {


### PR DESCRIPTION
Convert passing object to passing params to `writeBuffer` `writeIterable` `writeBlob` `writeStream`

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

Generally speaking constructing new object and passing it to function is more costly than just passing params.

Also using [deoptexplorer-vscode](https://github.com/microsoft/deoptexplorer-vscode) I have found that writeBuffer was deoptimized probably because off passing different shape of object.

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

- Convert passing object to passing params to `writeBuffer` `writeIterable` `writeBlob` `writeStream`

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
