### PR TITLE
 feature: support pre-shared sessions

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -73,7 +73,7 @@ if (global.FinalizationRegistry && !(process.env.NODE_V8_COVERAGE || process.env
   }
 }
 
-function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...opts }) {
+function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, session: customSession, ...opts }) {
   if (maxCachedSessions != null && (!Number.isInteger(maxCachedSessions) || maxCachedSessions < 0)) {
     throw new InvalidArgumentError('maxCachedSessions must be a positive integer or zero')
   }
@@ -91,7 +91,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, ...o
       servername = servername || options.servername || util.getServerName(host) || null
 
       const sessionKey = servername || hostname
-      const session = sessionCache.get(sessionKey) || null
+      const session = customSession || sessionCache.get(sessionKey) || null
 
       assert(sessionKey)
 

--- a/test/connect-pre-shared-session.js
+++ b/test/connect-pre-shared-session.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after, mock } = require('node:test')
+const { Client } = require('..')
+const { createServer } = require('node:https')
+const pem = require('https-pem')
+const tls = require('node:tls')
+
+test('custom session passed to client will be used in tls connect call', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  const mockConnect = mock.method(tls, 'connect')
+
+  const server = createServer(pem, (req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    res.setHeader('content-type', 'text/plain')
+    res.end('hello')
+  })
+  after(() => server.close())
+
+  server.listen(0, async () => {
+    const session = Buffer.from('test-session')
+
+    const client = new Client(`https://localhost:${server.address().port}`, {
+      connect: {
+        rejectUnauthorized: false,
+        session
+      }
+    })
+    after(() => client.close())
+
+    const { statusCode, headers, body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+
+    t.strictEqual(statusCode, 200)
+    t.strictEqual(headers['content-type'], 'text/plain')
+
+    const responseText = await body.text()
+    t.strictEqual('hello', responseText)
+
+    const connectSession = mockConnect.mock.calls[0].arguments[0].session
+    t.strictEqual(connectSession, session)
+  })
+
+  await t.completed
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

#3315 

## Rationale

Support passing custom session in connect options for pre-shared sessions.

## Changes

- Session passed to client connect will be passed to tls.connect instead of using the built-in module session store.

### Features

### Bug Fixes

### Breaking Changes and Deprecations

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
