### PR TITLE
build: use `husky` as `husky install` is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "coverage:report:ci": "c8 report",
     "bench": "echo \"Error: Benchmarks have been moved to '/benchmarks'\" && exit 1",
     "serve:website": "echo \"Error: Documentation has been moved to '/docs'\" && exit 1",
-    "prepare": "husky install && node ./scripts/platform-shell.js"
+    "prepare": "husky && node ./scripts/platform-shell.js"
   },
   "devDependencies": {
     "@fastify/busboy": "2.1.1",


### PR DESCRIPTION
Refs: https://github.com/nodejs/undici/issues/3339

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
