### PR TITLE
fetch: fix content-encoding order

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2137,7 +2137,7 @@ async function httpNetworkFetch (
 
           // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
           if (codings.length !== 0 && request.method !== 'HEAD' && request.method !== 'CONNECT' && !nullBodyStatus.includes(status) && !willFollow) {
-            for (let i = 0; i < codings.length; ++i) {
+            for (let i = codings.length - 1; i >= 0; --i) {
               const coding = codings[i]
               // https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2
               if (coding === 'x-gzip' || coding === 'gzip') {

--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -19,10 +19,10 @@ test('content-encoding header is case-iNsENsITIve', async (t) => {
     res.setHeader('Content-Encoding', contentCodings)
     res.setHeader('Content-Type', 'text/plain')
 
-    brotli.pipe(gzip).pipe(res)
+    gzip.pipe(brotli).pipe(res)
 
-    brotli.write(text)
-    brotli.end()
+    gzip.write(text)
+    gzip.end()
   }).listen(0)
 
   t.after(closeServerAsPromise(server))
@@ -45,10 +45,10 @@ test('response decompression according to content-encoding should be handled in 
     res.setHeader('Content-Encoding', contentCodings)
     res.setHeader('Content-Type', 'text/plain')
 
-    gzip.pipe(deflate).pipe(res)
+    deflate.pipe(gzip).pipe(res)
 
-    gzip.write(text)
-    gzip.end()
+    deflate.write(text)
+    deflate.end()
   }).listen(0)
 
   t.after(closeServerAsPromise(server))


### PR DESCRIPTION
When decoding, it must be processed from the reverse. We didn't catch this because the test is wrong.