### PR TITLE
fix: post request signal

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -154,6 +154,11 @@ class RequestHandler extends AsyncResource {
   }
 
   onComplete (trailers) {
+    if (this.removeAbortListener) {
+      this.removeAbortListener()
+      this.removeAbortListener = null
+    }
+
     util.parseHeaders(trailers, this.trailers)
     this.res.push(null)
   }


### PR DESCRIPTION
## Fix post request abort signal 

Fix issue #3353 

## Rationale

Request API doesn't remove the signal listener after complete the request

## Changes

Remove abort listener after success

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
