### PR TITLE
fix: retry handler provide invalid body with fetch

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -319,6 +319,11 @@ class RetryHandler {
 
   onError (err) {
     if (this.aborted || isDisturbed(this.opts.body)) {
+      // when every ended with error we should provide
+      // the non-complete body
+      for (const chunk of this.body) {
+        this.handler.onData(chunk)
+      }
       return this.handler.onError(err)
     }
 
@@ -344,6 +349,11 @@ class RetryHandler {
 
     function onRetry (err) {
       if (err != null || this.aborted || isDisturbed(this.opts.body)) {
+        // when every ended with error we should provide
+        // the non-complete body
+        for (const chunk of this.body) {
+          this.handler.onData(chunk)
+        }
         return this.handler.onError(err)
       }
 

--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -64,6 +64,7 @@ class RetryHandler {
 
     this.retryCount = 0
     this.retryCountCheckpoint = 0
+    this.body = [] // buffered body
     this.start = 0
     this.end = null
     this.etag = null
@@ -168,6 +169,8 @@ class RetryHandler {
     this.retryCount += 1
 
     if (statusCode >= 300) {
+      // body should be reset on each non success status code
+      this.body = []
       if (this.retryOpts.statusCodes.includes(statusCode) === false) {
         return this.handler.onHeaders(
           statusCode,
@@ -193,6 +196,10 @@ class RetryHandler {
       this.resume = null
 
       if (statusCode !== 206) {
+        // body should be reset on non 206 status code
+        // since 206 is partial content which may concatenate
+        // with previous buffered body
+        this.body = []
         return true
       }
 
@@ -295,11 +302,17 @@ class RetryHandler {
 
   onData (chunk) {
     this.start += chunk.length
-
-    return this.handler.onData(chunk)
+    this.body.push(chunk)
+    return true
   }
 
   onComplete (rawTrailers) {
+    // defer onData until no more retry
+    // it ensure the stacked handler always recieve
+    // the latest body instead of partial
+    for (const chunk of this.body) {
+      this.handler.onData(chunk)
+    }
     this.retryCount = 0
     return this.handler.onComplete(rawTrailers)
   }

--- a/test/issue-3356.js
+++ b/test/issue-3356.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+
+const { fetch, Agent, RetryAgent } = require('..')
+
+test('https://github.com/nodejs/undici/issues/3356', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  let shouldRetry = true
+  const server = createServer()
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    if (shouldRetry) {
+      shouldRetry = false
+
+      res.flushHeaders()
+      res.write('h')
+      setTimeout(() => { res.end('ello world!') }, 1000)
+    } else {
+      res.end('hello world!')
+    }
+  })
+
+  server.listen(0)
+
+  await once(server, 'listening')
+
+  after(async () => {
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const agent = new RetryAgent(new Agent({ bodyTimeout: 500 }), {
+    errorCodes: ['UND_ERR_BODY_TIMEOUT']
+  })
+
+  const response = await fetch(`http://localhost:${server.address().port}`, {
+    dispatcher: agent
+  })
+  t.equal(response.status, 200)
+  t.equal(await response.text(), 'hello world!')
+})


### PR DESCRIPTION
## This relates to...

Fixes #3356 

## Rationale

`RetryHandler` should buffer the body instead of streaming to the next handler.
The reason behind is that the body maybe used by the next handler immediately and leads to stacking multiple invalid response.

## Changes

Buffer the body until the response is success or error.
It should result on all status code that is not `206` to retain the current behavior.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

I though it may increase in memory usage for non-fetch people, because the payload can be streamed before but not now.
But in order to retain the correct behavior for retry, buffering should happen.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
