### PR TITLE
websocket: reduce memory usage

### DIFF
--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -2,7 +2,7 @@
 
 const { maxUnsigned16Bit } = require('./constants')
 
-const BUFFER_SIZE = 16386
+const BUFFER_SIZE = 8 * 1024
 
 /** @type {import('crypto')} */
 let crypto


### PR DESCRIPTION
```shell
> $ node memory.js // before
memoryUsage: 104Kib
> $ node memory.js // after
memoryUsage: 68Kib
```

```js
const socket = new WebSocket("ws://localhost:5001")

socket.onopen = function () {
    const rss = process.memoryUsage.rss()
    socket.send("hi")
    socket.onmessage = function () {
        console.log(`memoryUsage: ${(process.memoryUsage.rss() - rss) / 1024}Kib`)
        socket.close()
    }
}
```

Refs: https://github.com/websockets/ws/commit/ddfe4a804d79e7788ab136290e609f91cf68423f