### PR TITLE
In CITGM, skip tests that are flaky there

### DIFF
--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -6,8 +6,10 @@ const { Client, Pool, errors } = require('..')
 const net = require('node:net')
 const assert = require('node:assert')
 
+const skip = !!process.env.CITGM
+
 // Using describe instead of test to avoid the timeout
-describe('prioritize socket errors over timeouts', async () => {
+describe('prioritize socket errors over timeouts', { skip }, async () => {
   const t = tspl({ ...assert, after: () => {} }, { plan: 1 })
   const client = new Pool('http://foorbar.invalid:1234', { connectTimeout: 1 })
 
@@ -29,7 +31,7 @@ net.connect = function (options) {
   return new net.Socket(options)
 }
 
-test('connect-timeout', async t => {
+test('connect-timeout', { skip }, async t => {
   t = tspl(t, { plan: 1 })
 
   const client = new Client('http://localhost:9000', {
@@ -52,7 +54,7 @@ test('connect-timeout', async t => {
   await t.completed
 })
 
-test('connect-timeout', async t => {
+test('connect-timeout', { skip }, async t => {
   t = tspl(t, { plan: 1 })
 
   const client = new Pool('http://localhost:9000', {

--- a/test/node-test/debug.js
+++ b/test/node-test/debug.js
@@ -8,7 +8,9 @@ const { tspl } = require('@matteo.collina/tspl')
 // eslint-disable-next-line no-control-regex
 const removeEscapeColorsRE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
 
-test('debug#websocket', { skip: !process.versions.icu }, async t => {
+const isCITGM = !!process.env.CITGM
+
+test('debug#websocket', { skip: !process.versions.icu || isCITGM }, async t => {
   const assert = tspl(t, { plan: 6 })
   const child = spawn(
     process.execPath,
@@ -44,7 +46,7 @@ test('debug#websocket', { skip: !process.versions.icu }, async t => {
   await assert.completed
 })
 
-test('debug#fetch', async t => {
+test('debug#fetch', { skip: isCITGM }, async t => {
   const assert = tspl(t, { plan: 7 })
   const child = spawn(
     process.execPath,
@@ -78,7 +80,7 @@ test('debug#fetch', async t => {
   await assert.completed
 })
 
-test('debug#undici', async t => {
+test('debug#undici', { skip: isCITGM }, async t => {
   // Due to Node.js webpage redirect
   const assert = tspl(t, { plan: 7 })
   const child = spawn(


### PR DESCRIPTION
Our tests are failing on CITGM because we rely on IPv6 being available on all hosts and a few other OSS flavours. I'm skipping those tests there. 

Fixes https://github.com/nodejs/citgm/issues/1051