### PR TITLE
Fix signature of RetryHandler

### DIFF
--- a/docs/docs/api/RetryHandler.md
+++ b/docs/docs/api/RetryHandler.md
@@ -19,7 +19,7 @@ Extends: [`Dispatch.DispatchOptions`](Dispatcher.md#parameter-dispatchoptions).
 
 #### `RetryOptions`
 
-- **retry** `(err: Error, context: RetryContext, callback: (err?: Error | null) => void) => void` (optional) - Function to be called after every retry. It should pass error if no more retries should be performed.
+- **retry** `(err: Error, context: RetryContext, callback: (err?: Error | null) => void) => number | null` (optional) - Function to be called after every retry. It should pass error if no more retries should be performed.
 - **maxRetries** `number` (optional) - Maximum number of retries. Default: `5`
 - **maxTimeout** `number` (optional) - Maximum number of milliseconds to wait before retrying. Default: `30000` (30 seconds)
 - **minTimeout** `number` (optional) - Minimum number of milliseconds to wait before retrying. Default: `500` (half a second)


### PR DESCRIPTION
## This relates to...

Looking at the typings of [RetryHandler](https://github.com/nodejs/undici/blob/main/types/retry-handler.d.ts#L26), I saw that it must return `number | null` but the [documentation](https://undici.nodejs.org/#/docs/api/RetryAgent?id=parameter-retryhandleroptions) says `void`.

## Changes

Fixed the documentation page for RetryHandler

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

None

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ x ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ S ] Tested
- [ S ] Benchmarked (**optional**)
- [ x ] Documented
- [ x ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
