### PR TITLE
Fix fetch `duplex` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ await fetch('http://example.com', { method: 'POST', body })
 
 #### `request.duplex`
 
-- half
+- `'half'`
 
-In this implementation of fetch, `request.duplex` must be set if `request.body` is `ReadableStream` or `Async Iterables`, however, fetch requests are currently always full duplex. For more detail refer to the [Fetch Standard.](https://fetch.spec.whatwg.org/#dom-requestinit-duplex).
+In this implementation of fetch, `request.duplex` must be set if `request.body` is `ReadableStream` or `Async Iterables`, however, even though the value must be set to `'half'`, it is actually a _full_ duplex. For more detail refer to the [Fetch Standard.](https://fetch.spec.whatwg.org/#dom-requestinit-duplex).
 
 #### `response.body`
 


### PR DESCRIPTION
I've been toying with the `duplex` option, and I noticed our docs are a little confusing. The implementation forces me to use `'half'` for the value, but it seem like a full duplex operation... unless the `'full'` duplex refers to just the `request` or `response` individually? 

It's a bit confusing. 

WDYT @KhafraDev ? 