### PR TITLE
Add "decompress" response utility

### DIFF
--- a/lib/web/fetch/decompress.js
+++ b/lib/web/fetch/decompress.js
@@ -1,0 +1,80 @@
+const { pipeline } = require('node:stream')
+const zlib = require('node:zlib')
+const { redirectStatusSet, nullBodyStatus } = require('./constants')
+const { createInflate } = require('./util')
+
+/**
+ * Decompress the given response body.
+ * @param {Request} request
+ * @param {Response} response
+ * @returns {ReadableStream<Uint8Array> | null}
+ */
+function decompress (request, response) {
+  const contentEncoding = response.headers.get('content-encoding')
+
+  if (!contentEncoding) {
+    return response.body
+  }
+
+  // https://www.rfc-editor.org/rfc/rfc7231#section-3.1.2.1
+  // "All content-coding values are case-insensitive..."
+  const codings = contentEncoding
+    .toLowerCase()
+    .split(',')
+    .map((coding) => coding.trim())
+
+  if (codings.length === 0) {
+    return response.body
+  }
+
+  const willFollow =
+    response.headers.get('location') &&
+    request.redirect === 'follow' &&
+    redirectStatusSet.has(response.status)
+
+  if (
+    request.method === 'HEAD' ||
+    request.method === 'CONNECT' ||
+    nullBodyStatus.includes(response.status) ||
+    willFollow
+  ) {
+    return response.body
+  }
+
+  const decoders = []
+
+  for (let i = codings.length - 1; i >= 0; --i) {
+    const coding = codings[i]
+
+    // https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2
+    if (coding === 'x-gzip' || coding === 'gzip') {
+      decoders.push(
+        zlib.createGunzip({
+          // Be less strict when decoding compressed responses, since sometimes
+          // servers send slightly invalid responses that are still accepted
+          // by common browsers.
+          // Always using Z_SYNC_FLUSH is what cURL does.
+          flush: zlib.constants.Z_SYNC_FLUSH,
+          finishFlush: zlib.constants.Z_SYNC_FLUSH
+        })
+      )
+    } else if (coding === 'deflate') {
+      decoders.push(createInflate())
+    } else if (coding === 'br') {
+      decoders.push(zlib.createBrotliDecompress())
+    } else {
+      decoders.length = 0
+      break
+    }
+  }
+
+  if (decoders.length === 0) {
+    return response.body
+  }
+
+  return pipeline(response.body, ...decoders)
+}
+
+module.exports = {
+  decompress
+}


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

- Fixes #3412

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Exposing the response decompression logic (i.e. the handling of the `Content-Encoding` header) will allow other Node.js libraries to reuse it, resulting in a consistent experience for everyone. 

> See more detailed reasoning in the referenced issue. 

## Changes

<!-- Write a summary or list of changes here -->

- Adds a new `decompress` utility, abstracting the `Content-Type` handling from the existing `lib/fetch/index.js`.
- [ ] Uses the `decompress` utility in the `onHeaders` callback.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
