### PR TITLE
Add backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,29 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    name: Backport
+    steps:
+      - name: Backport
+        uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've added the same same action that we use in fastify for automated backports.
Doing a backport would only require adding the `backport <branch>` label: https://github.com/tibdex/backport.