### PR TITLE
Update response.js

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -531,7 +531,7 @@ function fromInnerResponse (innerResponse, guard) {
 
   return response
 }
-
+require('web-streams-polyfill/polyfill/es5');
 webidl.converters.ReadableStream = webidl.interfaceConverter(
   ReadableStream
 )


### PR DESCRIPTION
I was getting an error "ReferenceError: ReadableStream is not defined
    at Object.<anonymous> (C:\Projects\ticketer\node_modules\undici\lib\web\fetch\response.js:530:3)" 

after searching all over the web and reading that specific file for a bit I got to know that ` require('web-streams-polyfill/polyfill/es5'); ` should be there so that ReadableStream could be imported i the file .

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [x] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
