### PR TITLE
fix: memory leak in finalization first appearing in v6.16.0

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -527,6 +527,11 @@ function fromInnerResponse (innerResponse, guard) {
   setHeadersGuard(response[kHeaders], guard)
 
   if (hasFinalizationRegistry && innerResponse.body?.stream) {
+    // If the target (response) is reclaimed, the cleanup callback may be called at some point with
+    // the held value provided for it (innerResponse.body.stream). The held value can be any value:
+    // a primitive or an object, even undefined. If the held value is an object, the registry keeps
+    // a strong reference to it (so it can pass it to the cleanup callback later). Rewording from
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
     registry.register(response, new WeakRef(innerResponse.body.stream))
   }
 

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -34,8 +34,9 @@ const hasFinalizationRegistry = globalThis.FinalizationRegistry && process.versi
 let registry
 
 if (hasFinalizationRegistry) {
-  registry = new FinalizationRegistry((stream) => {
-    if (!stream.locked && !isDisturbed(stream) && !isErrored(stream)) {
+  registry = new FinalizationRegistry((weakRef) => {
+    const stream = weakRef.deref()
+    if (stream && !stream.locked && !isDisturbed(stream) && !isErrored(stream)) {
       stream.cancel('Response object has been garbage collected').catch(noop)
     }
   })
@@ -526,7 +527,7 @@ function fromInnerResponse (innerResponse, guard) {
   setHeadersGuard(response[kHeaders], guard)
 
   if (hasFinalizationRegistry && innerResponse.body?.stream) {
-    registry.register(response, innerResponse.body.stream)
+    registry.register(response, new WeakRef(innerResponse.body.stream))
   }
 
   return response

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -530,7 +530,7 @@ function fromInnerResponse (innerResponse, guard) {
     // If the target (response) is reclaimed, the cleanup callback may be called at some point with
     // the held value provided for it (innerResponse.body.stream). The held value can be any value:
     // a primitive or an object, even undefined. If the held value is an object, the registry keeps
-    // a strong reference to it (so it can pass it to the cleanup callback later). Rewording from
+    // a strong reference to it (so it can pass it to the cleanup callback later). Reworded from
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
     registry.register(response, new WeakRef(innerResponse.body.stream))
   }


### PR DESCRIPTION
Holding a reference to the stream in the finalization registry causes a memory leak, even when consuming the body.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

https://github.com/orgs/nodejs/discussions/54248

and

https://github.com/vercel/next.js/discussions/68636

## Rationale

I believe we're maintaining a strong reference to `innerResponse.body.stream` even when the body is consumed.

Please see the above issues where many people are seeing a memory leak when Node is updated from 20.15.1 to 20.16.0

I was able to reproduce the issue (https://github.com/vercel/next.js/discussions/68636#discussioncomment-10270351) and use that to test in order to find the commit where things started breaking.

I'm not an expert on memory leaks, but this seems to make sense and fixes the issue.

It seems like this was introduced in https://github.com/nodejs/undici/commit/63b7794af7c282d543a56d13521f9d5e92fa61ae

## Changes

Use a WeakRef instead - if the stream is already GC'd then we have nothing to worry about - otherwise we can do the cleanup as usual.

I'm testing this by building Node + Undici locally and then running load testing on https://github.com/snyamathi/68636/tree/simple

When load testing using a build of the prior commit (https://github.com/nodejs/undici/commit/c0dc3dd37a416bf2650cf042ee04c9e8ec4e82d7) everything is fine. When using the commit https://github.com/nodejs/undici/commit/63b7794af7c282d543a56d13521f9d5e92fa61ae the memory leak can be observed.

Adding this fix to the main branch fixes the issue.

![fixed](https://github.com/user-attachments/assets/95cd6e07-9d06-4ad0-9a96-c35786a642bc)


The chart above shows the memory usage before (main) and after the fix (my branch)

### Features

N/A

### Bug Fixes

https://github.com/orgs/nodejs/discussions/54248

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
