### PR TITLE
docs: use default link of Web Streams API

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ In this implementation of fetch, `request.duplex` must be set if `request.body` 
 
 #### `response.body`
 
-Nodejs has two kinds of streams: [web streams](https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html), which follow the API of the WHATWG web standard found in browsers, and an older Node-specific [streams API](https://nodejs.org/api/stream.html). `response.body` returns a readable web stream. If you would prefer to work with a Node stream you can convert a web stream using `.fromWeb()`.
+Nodejs has two kinds of streams: [web streams](https://nodejs.org/api/webstreams.html), which follow the API of the WHATWG web standard found in browsers, and an older Node-specific [streams API](https://nodejs.org/api/stream.html). `response.body` returns a readable web stream. If you would prefer to work with a Node stream you can convert a web stream using `.fromWeb()`.
 
 ```js
 import { fetch } from 'undici'


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

Example was added in https://github.com/nodejs/undici/pull/1035 in September 2021, when node 14/16 were still supported and WebStreams were added in v16.5.0.

The link can be switched to the default one, since undici supports >=18.17 where WebStreams are available.

## Changes

Replaces 16.x link of Web Streams API with default link.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md