### PR TITLE
test: add test for memory leak

### DIFF
--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const assert = require('node:assert')
 const { setImmediate } = require('node:timers/promises')
-const { AsyncLocalStorage } = require('node:async_hooks');
+const { AsyncLocalStorage } = require('node:async_hooks')
 const { tspl } = require('@matteo.collina/tspl')
 const {
   Response,
@@ -304,21 +304,21 @@ test('fromInnerResponse', () => {
 })
 
 test('clone body garbage collection', async () => {
-  const asyncLocalStorage = new AsyncLocalStorage();
+  const asyncLocalStorage = new AsyncLocalStorage()
   let ref
-  
+
   await new Promise(resolve => {
     asyncLocalStorage.run(new Map(), async () => {
       const res = new Response('hello world')
       const clone = res.clone()
-      
-      asyncLocalStorage.getStore().set('key', clone);
+
+      asyncLocalStorage.getStore().set('key', clone)
       ref = new WeakRef(clone.body)
 
       await res.text()
       await clone.text() // consume body
 
-      resolve();
+      resolve()
     })
   })
 

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -2,6 +2,8 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert')
+const { setImmediate } = require('node:timers/promises')
+const { AsyncLocalStorage } = require('node:async_hooks');
 const { tspl } = require('@matteo.collina/tspl')
 const {
   Response,
@@ -299,4 +301,30 @@ test('fromInnerResponse', () => {
   assert.strictEqual(response[kState], innerResponse)
   assert.strictEqual(getHeadersList(response[kHeaders]), innerResponse.headersList)
   assert.strictEqual(getHeadersGuard(response[kHeaders]), 'immutable')
+})
+
+test('clone body garbage collection', async () => {
+  const asyncLocalStorage = new AsyncLocalStorage();
+  let ref
+  
+  await new Promise(resolve => {
+    asyncLocalStorage.run(new Map(), async () => {
+      const res = new Response('hello world')
+      const clone = res.clone()
+      
+      asyncLocalStorage.getStore().set('key', clone);
+      ref = new WeakRef(clone.body)
+
+      await res.text()
+      await clone.text() // consume body
+
+      resolve();
+    })
+  })
+
+  await setImmediate()
+  global.gc()
+
+  const cloneBody = ref.deref()
+  assert.equal(cloneBody, undefined, 'clone body was not garbage collected')
 })


### PR DESCRIPTION
@mcollina I was able to finally get a minimal reproduction without using next or react 

https://github.com/snyamathi/undici-mem-leak

![chart2](https://github.com/user-attachments/assets/12169c64-5822-4849-b169-cabcf74d8450)

Looking at the chart, it does indeed appear to be a memory leak but it seems to be specific to Node's `AsyncLocalStorage` which is something that I dug out of the React source code [here](https://github.com/facebook/react/commit/cce18e3504fca651051da72cf9c2d126c16eb013)

This may actually have a root issue in Node itself which the team may want to be aware of - it seems like the reference prevents garbage collection so this same bug could bite others using `AsyncLocalStorage` in the same way.

-----

The test is a little round-a-bout in its testing, but it tries to assert that the body is garbage collected by checking that the weak ref becomes `undefined`.

This test fails before the change that I put in, and only succeeds after.

-----

I have the reproduction setup to test multiple versions of `undici` and show the problem does not exist in 6.15.0, does exist in 6.16.0 and is then fixed in 6.19.7 - check out the repo link above, but it looks like this:

```js
import { setImmediate } from "node:timers/promises";
import { AsyncLocalStorage } from "node:async_hooks";

const { UNDICI_VERSION = "6.19.7" } = process.env;
const { Response } = await import(`undici-${UNDICI_VERSION}`);
const asyncLocalStorage = new AsyncLocalStorage();

const res = new Response("hello world");
const format = (bytes) => Math.round(bytes / 1024 ** 2) + "MB";

for (let i = 0; ; ++i) {
  if (i % 100 === 0) {
    console.log(i, format(process.memoryUsage().heapUsed));
  }

  asyncLocalStorage.run(new Map(), async () => {
    const clone = res.clone();
    asyncLocalStorage.getStore().set("key", clone);
    await clone.text(); // consume body
  });

  await setImmediate(); // allow gc
}
```

related to https://github.com/nodejs/undici/pull/3445