### PR TITLE
build: parametrize the location of wasm-opt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,7 @@ an unbundled version instead of bundling one in `libnode.so`.
 To enable this, pass `EXTERNAL_PATH=/path/to/global/node_modules/undici` to `build/wasm.js`.
 Pass this path with `loader.js` appended to `--shared-builtin-undici/undici-path` in Node.js's `configure.py`.
 If building on a non-Alpine Linux distribution, you may need to also set the `WASM_CC`, `WASM_CFLAGS`, `WASM_LDFLAGS` and `WASM_LDLIBS` environment variables before running `build/wasm.js`.
+Similarly, you can set the `WASM_OPT` environment variable to utilize your own `wasm-opt` optimizer.
 
 <a id="benchmarks"></a>
 ### Benchmarks

--- a/build/wasm.js
+++ b/build/wasm.js
@@ -14,6 +14,7 @@ const WASM_CC = process.env.WASM_CC || 'clang'
 let WASM_CFLAGS = process.env.WASM_CFLAGS || '--sysroot=/usr/share/wasi-sysroot -target wasm32-unknown-wasi'
 let WASM_LDFLAGS = process.env.WASM_LDFLAGS || ''
 const WASM_LDLIBS = process.env.WASM_LDLIBS || ''
+const WASM_OPT = process.env.WASM_OPT || './wasm-opt'
 
 // For compatibility with Node.js' `configure --shared-builtin-undici/undici-path ...`
 const EXTERNAL_PATH = process.env.EXTERNAL_PATH
@@ -77,7 +78,7 @@ const hasApk = (function () {
   try { execSync('command -v apk'); return true } catch (error) { return false }
 })()
 const hasOptimizer = (function () {
-  try { execSync('./wasm-opt --version'); return true } catch (error) { return false }
+  try { execSync(`${WASM_OPT} --version`); return true } catch (error) { return false }
 })()
 if (hasApk) {
   // Gather information about the tools used for the build
@@ -97,7 +98,7 @@ ${join(WASM_SRC, 'src')}/*.c \
 ${WASM_LDLIBS}`, { stdio: 'inherit' })
 
 if (hasOptimizer) {
-  execSync(`./wasm-opt ${WASM_OPT_FLAGS} -o ${join(WASM_OUT, 'llhttp.wasm')} ${join(WASM_OUT, 'llhttp.wasm')}`, { stdio: 'inherit' })
+  execSync(`${WASM_OPT} ${WASM_OPT_FLAGS} -o ${join(WASM_OUT, 'llhttp.wasm')} ${join(WASM_OUT, 'llhttp.wasm')}`, { stdio: 'inherit' })
 }
 writeWasmChunk('llhttp.wasm', 'llhttp-wasm.js')
 
@@ -109,7 +110,7 @@ ${join(WASM_SRC, 'src')}/*.c \
 ${WASM_LDLIBS}`, { stdio: 'inherit' })
 
 if (hasOptimizer) {
-  execSync(`./wasm-opt ${WASM_OPT_FLAGS} --enable-simd -o ${join(WASM_OUT, 'llhttp_simd.wasm')} ${join(WASM_OUT, 'llhttp_simd.wasm')}`, { stdio: 'inherit' })
+  execSync(`${WASM_OPT} ${WASM_OPT_FLAGS} --enable-simd -o ${join(WASM_OUT, 'llhttp_simd.wasm')} ${join(WASM_OUT, 'llhttp_simd.wasm')}`, { stdio: 'inherit' })
 }
 writeWasmChunk('llhttp_simd.wasm', 'llhttp_simd-wasm.js')
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Enhances: https://github.com/nodejs/undici/pull/3421

## Rationale

The wasm-opt binary may be available in different place than the local directory (`./wasm-opt`) – for example, in `/usr/bin/wasm-opt`.

## Changes

Similarly to the other parametrized WASM build options, use WASM_OPT environment variable to identify the wanted binary, with fallback to the previous value (`./wasm-opt`).

Even with the new environment variable, the `hasOptimizer` check is kept for the cases where no optimizer is available anywhere.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
