### PR TITLE
types: allow non strict HTTPMethod

### DIFF
--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -35,6 +35,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: mapHeaders, reset: true }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: iteratorHeaders, reset: true }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
+  expectAssignable<boolean>(dispatcher.dispatch({ path: '', method: "CUSTOM" }, {}))
 
   // connect
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', maxRedirections: 0 }))

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -234,7 +234,7 @@ declare namespace Dispatcher {
     onBodySent?(chunkSize: number, totalBytesSent: number): void;
   }
   export type PipelineHandler<TOpaque = null> = (data: PipelineHandlerData<TOpaque>) => Readable;
-  export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
+  export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | (string & Record<never, never>);
 
   /**
    * @link https://fetch.spec.whatwg.org/#body-mixin


### PR DESCRIPTION
fixes #3168 

I still think, that it reduces the necessary strictness, as now also lowercased methods like "get" are allowed via types, but are invalid values. 

So at transpile time we get no warning if the value is wrong. But atleast we keep the autocomplete capability. 

I  think that #3168 should be closed as on wont fix, but here is the solution.

For more inforation for the solution see https://github.com/fastify/fastify/pull/5046