### PR TITLE
use FinalizationRegistry for cloned response body

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -16,12 +16,25 @@ const { kState } = require('./symbols')
 const { webidl } = require('./webidl')
 const { Blob } = require('node:buffer')
 const assert = require('node:assert')
-const { isErrored } = require('../../core/util')
 const { isArrayBuffer } = require('node:util/types')
 const { serializeAMimeType } = require('./data-url')
 const { multipartFormDataParser } = require('./formdata-parser')
+const { isDisturbed, isErrored } = require('node:stream')
 
 const textEncoder = new TextEncoder()
+function noop () {}
+
+const hasFinalizationRegistry = globalThis.FinalizationRegistry && process.version.indexOf('v18') !== 0
+let streamRegistry
+
+if (hasFinalizationRegistry) {
+  streamRegistry = new FinalizationRegistry((weakRef) => {
+    const stream = weakRef.deref()
+    if (stream && !stream.locked && !isDisturbed(stream) && !isErrored(stream)) {
+      stream.cancel('Response object has been garbage collected').catch(noop)
+    }
+  })
+}
 
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 function extractBody (object, keepalive = false) {
@@ -264,13 +277,17 @@ function safelyExtractBody (object, keepalive = false) {
   return extractBody(object, keepalive)
 }
 
-function cloneBody (body) {
+function cloneBody (instance, body) {
   // To clone a body body, run these steps:
 
   // https://fetch.spec.whatwg.org/#concept-body-clone
 
   // 1. Let « out1, out2 » be the result of teeing body’s stream.
   const [out1, out2] = body.stream.tee()
+
+  if (hasFinalizationRegistry) {
+    streamRegistry.register(instance, new WeakRef(out1))
+  }
 
   // 2. Set body’s stream to out1.
   body.stream = out1
@@ -496,5 +513,7 @@ module.exports = {
   extractBody,
   safelyExtractBody,
   cloneBody,
-  mixinBody
+  mixinBody,
+  streamRegistry,
+  hasFinalizationRegistry
 }

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -875,7 +875,7 @@ function cloneRequest (request) {
   // 2. If request’s body is non-null, set newRequest’s body to the
   // result of cloning request’s body.
   if (request.body != null) {
-    newRequest.body = cloneBody(request.body)
+    newRequest.body = cloneBody(newRequest, request.body)
   }
 
   // 3. Return newRequest.

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -254,6 +254,10 @@ class Response {
     // 2. Let clonedResponse be the result of cloning this’s response.
     const clonedResponse = cloneResponse(this[kState])
 
+    if (hasFinalizationRegistry && this[kState].body?.stream) {
+      registry.register(this, new WeakRef(this[kState].body.stream))
+    }
+
     // 3. Return the result of creating a Response object, given
     // clonedResponse, this’s headers’s guard, and this’s relevant Realm.
     return fromInnerResponse(clonedResponse, getHeadersGuard(this[kHeaders]))

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = require('./headers')
-const { extractBody, cloneBody, mixinBody } = require('./body')
+const { extractBody, cloneBody, mixinBody, hasFinalizationRegistry, streamRegistry } = require('./body')
 const util = require('../../core/util')
 const nodeUtil = require('node:util')
 const { kEnumerableProperty } = util
@@ -26,23 +26,8 @@ const { URLSerializer } = require('./data-url')
 const { kConstruct } = require('../../core/symbols')
 const assert = require('node:assert')
 const { types } = require('node:util')
-const { isDisturbed, isErrored } = require('node:stream')
 
 const textEncoder = new TextEncoder('utf-8')
-
-const hasFinalizationRegistry = globalThis.FinalizationRegistry && process.version.indexOf('v18') !== 0
-let registry
-
-if (hasFinalizationRegistry) {
-  registry = new FinalizationRegistry((weakRef) => {
-    const stream = weakRef.deref()
-    if (stream && !stream.locked && !isDisturbed(stream) && !isErrored(stream)) {
-      stream.cancel('Response object has been garbage collected').catch(noop)
-    }
-  })
-}
-
-function noop () {}
 
 // https://fetch.spec.whatwg.org/#response-class
 class Response {
@@ -254,10 +239,6 @@ class Response {
     // 2. Let clonedResponse be the result of cloning this’s response.
     const clonedResponse = cloneResponse(this[kState])
 
-    if (hasFinalizationRegistry && this[kState].body?.stream) {
-      registry.register(this, new WeakRef(this[kState].body.stream))
-    }
-
     // 3. Return the result of creating a Response object, given
     // clonedResponse, this’s headers’s guard, and this’s relevant Realm.
     return fromInnerResponse(clonedResponse, getHeadersGuard(this[kHeaders]))
@@ -331,7 +312,7 @@ function cloneResponse (response) {
   // 3. If response’s body is non-null, then set newResponse’s body to the
   // result of cloning response’s body.
   if (response.body != null) {
-    newResponse.body = cloneBody(response.body)
+    newResponse.body = cloneBody(newResponse, response.body)
   }
 
   // 4. Return newResponse.
@@ -536,7 +517,7 @@ function fromInnerResponse (innerResponse, guard) {
     // a primitive or an object, even undefined. If the held value is an object, the registry keeps
     // a strong reference to it (so it can pass it to the cleanup callback later). Reworded from
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
-    registry.register(response, new WeakRef(innerResponse.body.stream))
+    streamRegistry.register(response, new WeakRef(innerResponse.body.stream))
   }
 
   return response

--- a/test/fetch/fire-and-forget.js
+++ b/test/fetch/fire-and-forget.js
@@ -37,8 +37,9 @@ test('does not need the body to be consumed to continue', { timeout: 180_000, sk
     // eslint-disable-next-line no-undef
     gc(true)
     const array = new Array(batch)
-    for (let i = 0; i < batch; i++) {
+    for (let i = 0; i < batch; i += 2) {
       array[i] = fetch(url).catch(() => {})
+      array[i + 1] = fetch(url).then(r => r.clone()).catch(() => {})
     }
     await Promise.all(array)
     await sleep(delay)


### PR DESCRIPTION
running test with `node --expose-gc --test test/fetch/fire-and-forget.js`

<details>
<summary>Before</summary>

```
RSS 66 MB after 50 fetch() requests
RSS 68 MB after 100 fetch() requests
RSS 76 MB after 150 fetch() requests
RSS 84 MB after 200 fetch() requests
RSS 93 MB after 250 fetch() requests
RSS 101 MB after 300 fetch() requests
RSS 110 MB after 350 fetch() requests
RSS 117 MB after 400 fetch() requests
RSS 125 MB after 450 fetch() requests
RSS 133 MB after 500 fetch() requests
RSS 141 MB after 550 fetch() requests
RSS 134 MB after 600 fetch() requests
RSS 143 MB after 650 fetch() requests
RSS 149 MB after 700 fetch() requests
RSS 155 MB after 750 fetch() requests
RSS 163 MB after 800 fetch() requests
RSS 171 MB after 850 fetch() requests
RSS 178 MB after 900 fetch() requests
RSS 185 MB after 950 fetch() requests
RSS 183 MB after 1000 fetch() requests
RSS 196 MB after 1050 fetch() requests
RSS 205 MB after 1100 fetch() requests
RSS 212 MB after 1150 fetch() requests
RSS 219 MB after 1200 fetch() requests
RSS 226 MB after 1250 fetch() requests
RSS 233 MB after 1300 fetch() requests
RSS 241 MB after 1350 fetch() requests
RSS 249 MB after 1400 fetch() requests
RSS 257 MB after 1450 fetch() requests
RSS 264 MB after 1500 fetch() requests
RSS 240 MB after 1550 fetch() requests
RSS 244 MB after 1600 fetch() requests
RSS 248 MB after 1650 fetch() requests
RSS 257 MB after 1700 fetch() requests
RSS 263 MB after 1750 fetch() requests
RSS 269 MB after 1800 fetch() requests
RSS 275 MB after 1850 fetch() requests
RSS 282 MB after 1900 fetch() requests
RSS 290 MB after 1950 fetch() requests
RSS 299 MB after 2000 fetch() requests
RSS 307 MB after 2050 fetch() requests
RSS 284 MB after 2100 fetch() requests
RSS 287 MB after 2150 fetch() requests
RSS 294 MB after 2200 fetch() requests
RSS 300 MB after 2250 fetch() requests
RSS 305 MB after 2300 fetch() requests
RSS 312 MB after 2350 fetch() requests
RSS 318 MB after 2400 fetch() requests
RSS 325 MB after 2450 fetch() requests
RSS 333 MB after 2500 fetch() requests
RSS 340 MB after 2550 fetch() requests
RSS 348 MB after 2600 fetch() requests
RSS 328 MB after 2650 fetch() requests
RSS 331 MB after 2700 fetch() requests
RSS 337 MB after 2750 fetch() requests
RSS 344 MB after 2800 fetch() requests
RSS 350 MB after 2850 fetch() requests
RSS 356 MB after 2900 fetch() requests
RSS 362 MB after 2950 fetch() requests
RSS 369 MB after 3000 fetch() requests
RSS 377 MB after 3050 fetch() requests
RSS 384 MB after 3100 fetch() requests
RSS 392 MB after 3150 fetch() requests
RSS 380 MB after 3200 fetch() requests
RSS 389 MB after 3250 fetch() requests
RSS 390 MB after 3300 fetch() requests
RSS 390 MB after 3350 fetch() requests
RSS 392 MB after 3400 fetch() requests
RSS 398 MB after 3450 fetch() requests
RSS 404 MB after 3500 fetch() requests
RSS 411 MB after 3550 fetch() requests
RSS 418 MB after 3600 fetch() requests
RSS 426 MB after 3650 fetch() requests
RSS 433 MB after 3700 fetch() requests
RSS 419 MB after 3750 fetch() requests
RSS 421 MB after 3800 fetch() requests
RSS 423 MB after 3850 fetch() requests
RSS 423 MB after 3900 fetch() requests
RSS 429 MB after 3950 fetch() requests
RSS 435 MB after 4000 fetch() requests
RSS 440 MB after 4050 fetch() requests
RSS 447 MB after 4100 fetch() requests
RSS 454 MB after 4150 fetch() requests
RSS 461 MB after 4200 fetch() requests
RSS 469 MB after 4250 fetch() requests
RSS 477 MB after 4300 fetch() requests
RSS 465 MB after 4350 fetch() requests
RSS 467 MB after 4400 fetch() requests
RSS 467 MB after 4450 fetch() requests
RSS 467 MB after 4500 fetch() requests
RSS 472 MB after 4550 fetch() requests
RSS 478 MB after 4600 fetch() requests
RSS 484 MB after 4650 fetch() requests
RSS 491 MB after 4700 fetch() requests
RSS 497 MB after 4750 fetch() requests
RSS 505 MB after 4800 fetch() requests
RSS 512 MB after 4850 fetch() requests
RSS 520 MB after 4900 fetch() requests
RSS 501 MB after 4950 fetch() requests
RSS 505 MB after 5000 fetch() requests
```
</details>

<details>
<summary>After</summary>

```
RSS 65 MB after 50 fetch() requests
RSS 69 MB after 100 fetch() requests
RSS 77 MB after 150 fetch() requests
RSS 85 MB after 200 fetch() requests
RSS 93 MB after 250 fetch() requests
RSS 98 MB after 300 fetch() requests
RSS 107 MB after 350 fetch() requests
RSS 114 MB after 400 fetch() requests
RSS 122 MB after 450 fetch() requests
RSS 129 MB after 500 fetch() requests
RSS 109 MB after 550 fetch() requests
RSS 119 MB after 600 fetch() requests
RSS 126 MB after 650 fetch() requests
RSS 133 MB after 700 fetch() requests
RSS 139 MB after 750 fetch() requests
RSS 146 MB after 800 fetch() requests
RSS 152 MB after 850 fetch() requests
RSS 160 MB after 900 fetch() requests
RSS 137 MB after 950 fetch() requests
RSS 141 MB after 1000 fetch() requests
RSS 147 MB after 1050 fetch() requests
RSS 154 MB after 1100 fetch() requests
RSS 160 MB after 1150 fetch() requests
RSS 166 MB after 1200 fetch() requests
RSS 173 MB after 1250 fetch() requests
RSS 181 MB after 1300 fetch() requests
RSS 188 MB after 1350 fetch() requests
RSS 196 MB after 1400 fetch() requests
RSS 150 MB after 1450 fetch() requests
RSS 165 MB after 1500 fetch() requests
RSS 172 MB after 1550 fetch() requests
RSS 178 MB after 1600 fetch() requests
RSS 185 MB after 1650 fetch() requests
RSS 191 MB after 1700 fetch() requests
RSS 198 MB after 1750 fetch() requests
RSS 205 MB after 1800 fetch() requests
RSS 212 MB after 1850 fetch() requests
RSS 161 MB after 1900 fetch() requests
RSS 162 MB after 1950 fetch() requests
RSS 167 MB after 2000 fetch() requests
RSS 173 MB after 2050 fetch() requests
RSS 180 MB after 2100 fetch() requests
RSS 186 MB after 2150 fetch() requests
RSS 193 MB after 2200 fetch() requests
RSS 200 MB after 2250 fetch() requests
RSS 207 MB after 2300 fetch() requests
RSS 213 MB after 2350 fetch() requests
RSS 160 MB after 2400 fetch() requests
RSS 164 MB after 2450 fetch() requests
RSS 169 MB after 2500 fetch() requests
RSS 175 MB after 2550 fetch() requests
RSS 182 MB after 2600 fetch() requests
RSS 188 MB after 2650 fetch() requests
RSS 195 MB after 2700 fetch() requests
RSS 202 MB after 2750 fetch() requests
RSS 208 MB after 2800 fetch() requests
RSS 215 MB after 2850 fetch() requests
RSS 161 MB after 2900 fetch() requests
RSS 173 MB after 2950 fetch() requests
RSS 179 MB after 3000 fetch() requests
RSS 186 MB after 3050 fetch() requests
RSS 192 MB after 3100 fetch() requests
RSS 199 MB after 3150 fetch() requests
RSS 205 MB after 3200 fetch() requests
RSS 212 MB after 3250 fetch() requests
RSS 218 MB after 3300 fetch() requests
RSS 225 MB after 3350 fetch() requests
RSS 171 MB after 3400 fetch() requests
RSS 181 MB after 3450 fetch() requests
RSS 187 MB after 3500 fetch() requests
RSS 194 MB after 3550 fetch() requests
RSS 200 MB after 3600 fetch() requests
RSS 206 MB after 3650 fetch() requests
RSS 213 MB after 3700 fetch() requests
RSS 220 MB after 3750 fetch() requests
RSS 226 MB after 3800 fetch() requests
RSS 170 MB after 3850 fetch() requests
RSS 175 MB after 3900 fetch() requests
RSS 179 MB after 3950 fetch() requests
RSS 185 MB after 4000 fetch() requests
RSS 192 MB after 4050 fetch() requests
RSS 198 MB after 4100 fetch() requests
RSS 205 MB after 4150 fetch() requests
RSS 213 MB after 4200 fetch() requests
RSS 219 MB after 4250 fetch() requests
RSS 226 MB after 4300 fetch() requests
RSS 169 MB after 4350 fetch() requests
RSS 177 MB after 4400 fetch() requests
RSS 184 MB after 4450 fetch() requests
RSS 190 MB after 4500 fetch() requests
RSS 197 MB after 4550 fetch() requests
RSS 203 MB after 4600 fetch() requests
RSS 210 MB after 4650 fetch() requests
RSS 217 MB after 4700 fetch() requests
RSS 224 MB after 4750 fetch() requests
RSS 170 MB after 4800 fetch() requests
RSS 178 MB after 4850 fetch() requests
RSS 184 MB after 4900 fetch() requests
RSS 190 MB after 4950 fetch() requests
RSS 197 MB after 5000 fetch() requests
```

</details>