### PR TITLE
perf: use isIPv6 for checking if hostname is isIPv6

### DIFF
--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -374,7 +374,7 @@ async function connect (client) {
     assert(idx !== -1)
     const ip = hostname.substring(1, idx)
 
-    assert(net.isIP(ip))
+    assert(net.isIPv6(ip))
     hostname = ip
   }
 


### PR DESCRIPTION
trivial change. isIP will first run isIPv4 and then isIPv6. Also both are basically calling regexes on node. So by calling isIPv6 directly we improve the performance.