### PR TITLE
fix: add missing kOriginalDispatch Symbol in mock-logic

### DIFF
--- a/lib/mock/mock-symbols.js
+++ b/lib/mock/mock-symbols.js
@@ -15,6 +15,7 @@ module.exports = {
   kMockDispatch: Symbol('mock dispatch'),
   kClose: Symbol('close'),
   kOriginalClose: Symbol('original agent close'),
+  kOriginalDispatch: Symbol('original dispatch'),
   kOrigin: Symbol('origin'),
   kIsMockActive: Symbol('is mock active'),
   kNetConnect: Symbol('net connect'),


### PR DESCRIPTION
kOriginalDispatch is not existing, thus resulting in being  undefined. It works as long there are not two keys missing...