### PR TITLE
fix: instantiation of ResponseError, pass headers and data correctly

### DIFF
--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -65,7 +65,10 @@ class Handler extends DecoratorHandler {
       const stackTraceLimit = Error.stackTraceLimit
       Error.stackTraceLimit = 0
       try {
-        err = new ResponseError('Response Error', this.#statusCode, this.#headers, this.#body)
+        err = new ResponseError('Response Error', this.#statusCode, {
+          data: this.#body,
+          headers: this.#headers
+        })
       } finally {
         Error.stackTraceLimit = stackTraceLimit
       }


### PR DESCRIPTION
It is disputable. Maybe body should not be passed as data?