### PR TITLE
fix: instantiation of SecureProxyConnectionError should pass options to parent class

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -1,8 +1,8 @@
 'use strict'
 
 class UndiciError extends Error {
-  constructor (message) {
-    super(message)
+  constructor (message, options) {
+    super(message, options)
     this.name = 'UndiciError'
     this.code = 'UND_ERR'
   }
@@ -208,8 +208,8 @@ class ResponseError extends UndiciError {
 }
 
 class SecureProxyConnectionError extends UndiciError {
-  constructor (cause, message, options) {
-    super(message, { cause, ...(options ?? {}) })
+  constructor (cause, message, options = {}) {
+    super(message, { cause, ...options })
     this.name = 'SecureProxyConnectionError'
     this.message = message || 'Secure Proxy Connection failed'
     this.code = 'UND_ERR_PRX_TLS'

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -794,7 +794,7 @@ test('Proxy via HTTP to HTTP endpoint', async (t) => {
 })
 
 test('Proxy via HTTPS to HTTP fails on wrong SNI', async (t) => {
-  t = tspl(t, { plan: 2 })
+  t = tspl(t, { plan: 3 })
   const server = await buildServer()
   const proxy = await buildSSLProxy()
 
@@ -832,8 +832,10 @@ test('Proxy via HTTPS to HTTP fails on wrong SNI', async (t) => {
 
   try {
     await request(serverUrl, { dispatcher: proxyAgent })
+    throw new Error('should fail')
   } catch (e) {
     t.ok(e instanceof SecureProxyConnectionError)
+    t.ok(e.cause instanceof Error)
     t.ok(e.cause.code === 'ERR_TLS_CERT_ALTNAME_INVALID')
   }
 

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -144,7 +144,7 @@ declare namespace Errors {
 
   export class SecureProxyConnectionError extends UndiciError {
     constructor (
-      cause: Error,
+      cause?: Error,
       message?: string,
       options?: ErrorOptions
     );

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -143,6 +143,11 @@ declare namespace Errors {
   }
 
   export class SecureProxyConnectionError extends UndiciError {
+    constructor (
+      cause: Error,
+      message?: string,
+      options?: ErrorOptions
+    );
     name: 'SecureProxyConnectionError';
     code: 'UND_ERR_PRX_TLS';
   }

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -146,7 +146,7 @@ declare namespace Errors {
     constructor (
       cause?: Error,
       message?: string,
-      options?: ErrorOptions
+      options?: Record<any, any>
     );
     name: 'SecureProxyConnectionError';
     code: 'UND_ERR_PRX_TLS';


### PR DESCRIPTION
calling super(message, options) was not working.

Is there a reason, that we set cause "manually"?