### PR TITLE
meta: move nightly comment body to issue body

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,12 +65,7 @@ jobs:
             if(!issue) {
               issue = (await github.rest.issues.create({
                 title: ISSUE_TITLE,
+                body: `Tests against nightly failed, see: ${actionRunUrl}`,
                 ...issueContext
               })).data
             }
-
-            await github.rest.issues.createComment({
-              issue_number: issue.number,
-              body: `Tests against nightly failed, see: ${actionRunUrl}`,
-              ...issueContext
-            });


### PR DESCRIPTION
[meta]

This change has the issue that is created when nightly tests fail use the issue body for text, rather than creating a seperate comment.