### PR TITLE
chore: add --noEmit for typescript tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test:node-test": "borp -p \"test/node-test/**/*.js\"",
     "test:tdd": "borp --expose-gc -p \"test/*.js\"",
     "test:tdd:node-test": "borp -p \"test/node-test/**/*.js\" -w",
-    "test:typescript": "tsd && tsc test/imports/undici-import.ts --typeRoots ./types && tsc ./types/*.d.ts --noEmit --typeRoots ./types",
+    "test:typescript": "tsd && tsc test/imports/undici-import.ts --typeRoots ./types --noEmit && tsc ./types/*.d.ts --noEmit --typeRoots ./types",
     "test:webidl": "borp -p \"test/webidl/*.js\"",
     "test:websocket": "borp -p \"test/websocket/*.js\"",
     "test:websocket:autobahn": "node test/autobahn/client.js",


### PR DESCRIPTION
super annoying. if you run npm run test:typescript, than it would generate the corresponding `test/imports/undici-import.js`.If you then run lint, you get linting errors.

This PR makes the tsc call not generating the js file.