### PR TITLE
fix: setEncoding should not throw on body #1125

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -201,6 +201,17 @@ class BodyReadable extends Readable {
         .resume()
     })
   }
+
+  /**
+   * @param {BufferEncoding} encoding
+   * @returns {BodyReadable}
+   */
+  setEncoding (encoding) {
+    if (Buffer.isEncoding(encoding)) {
+      this._readableState.encoding = encoding
+    }
+    return this
+  }
 }
 
 // https://streams.spec.whatwg.org/#readablestream-locked
@@ -278,10 +289,10 @@ function consumeStart (consume) {
   }
 
   if (state.endEmitted) {
-    consumeEnd(this[kConsume])
+    consumeEnd(this[kConsume], this._readableState.encoding)
   } else {
     consume.stream.on('end', function () {
-      consumeEnd(this[kConsume])
+      consumeEnd(this[kConsume], this._readableState.encoding)
     })
   }
 
@@ -295,8 +306,10 @@ function consumeStart (consume) {
 /**
  * @param {Buffer[]} chunks
  * @param {number} length
+ * @param {BufferEncoding} encoding
+ * @returns {string}
  */
-function chunksDecode (chunks, length) {
+function chunksDecode (chunks, length, encoding) {
   if (chunks.length === 0 || length === 0) {
     return ''
   }
@@ -311,7 +324,11 @@ function chunksDecode (chunks, length) {
     buffer[2] === 0xbf
       ? 3
       : 0
-  return buffer.utf8Slice(start, bufferLength)
+  if (!encoding || encoding === 'utf8' || encoding === 'utf-8') {
+    return buffer.utf8Slice(start, bufferLength)
+  } else {
+    return buffer.subarray(start, bufferLength).toString(encoding)
+  }
 }
 
 /**
@@ -339,14 +356,14 @@ function chunksConcat (chunks, length) {
   return buffer
 }
 
-function consumeEnd (consume) {
+function consumeEnd (consume, encoding) {
   const { type, body, resolve, stream, length } = consume
 
   try {
     if (type === 'text') {
-      resolve(chunksDecode(body, length))
+      resolve(chunksDecode(body, length, encoding))
     } else if (type === 'json') {
-      resolve(JSON.parse(chunksDecode(body, length)))
+      resolve(JSON.parse(chunksDecode(body, length, encoding)))
     } else if (type === 'arrayBuffer') {
       resolve(chunksConcat(body, length).buffer)
     } else if (type === 'blob') {


### PR DESCRIPTION
Fixes #1125 

Super old bug #1125 is the result of some premature encoding of already buffered content in node core.

https://github.com/nodejs/node/blob/4e68b541fd7ccd9fe1328d5b4dc93a3689aa505d/lib/internal/streams/readable.js#L585

This PR overwrites the setEncoding function, with a custom solution which is not encoding the buffered content.