### PR TITLE
perf: reduce amount of used Uin8Arrays in client-h1.js

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -57,6 +57,7 @@ const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const addListener = util.addListener
 const removeAllListeners = util.removeAllListeners
+const utf8Slice = Buffer.prototype.utf8Slice
 
 let extractBody
 
@@ -128,6 +129,11 @@ let currentParser = null
 let currentBufferRef = null
 let currentBufferSize = 0
 let currentBufferPtr = null
+
+/**
+ * @type {Uint8Array|null}
+ */
+let currentBufferView = null
 
 const TIMEOUT_HEADERS = 1
 const TIMEOUT_BODY = 2
@@ -230,9 +236,10 @@ class Parser {
       }
       currentBufferSize = Math.ceil(data.length / 4096) * 4096
       currentBufferPtr = llhttp.malloc(currentBufferSize)
+      currentBufferView = new Uint8Array(llhttp.memory.buffer, 0, llhttp.memory.buffer.byteLength)
     }
 
-    new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize).set(data)
+    currentBufferView.set(data, currentBufferPtr)
 
     // Call `execute` on the wasm parser.
     // We pass the `llhttp_parser` pointer address, the pointer address of buffer view data,
@@ -266,10 +273,10 @@ class Parser {
         let message = ''
         /* istanbul ignore else: difficult to make a test case for */
         if (ptr) {
-          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
+          const end = currentBufferView.indexOf(0, ptr)
           message =
             'Response does not match the HTTP/1.1 protocol (' +
-            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+            utf8Slice.call(currentBufferView, ptr, end) +
             ')'
         }
         throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))


### PR DESCRIPTION
instead of instantiating an Uint8Array on every llhttp execution, we keep a view on the ArrayBuffer and reuse it.