### PR TITLE
set default argument values to undefined instead of {}

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -81,7 +81,7 @@ let patchMethodWarning = false
 // https://fetch.spec.whatwg.org/#request-class
 class Request {
   // https://fetch.spec.whatwg.org/#dom-request
-  constructor (input, init = {}) {
+  constructor (input, init = undefined) {
     if (input === kConstruct) {
       return
     }

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -41,7 +41,7 @@ class Response {
   }
 
   // https://fetch.spec.whatwg.org/#dom-response-json
-  static json (data, init = {}) {
+  static json (data, init = undefined) {
     webidl.argumentLengthCheck(arguments, 1, 'Response.json')
 
     if (init !== null) {
@@ -108,7 +108,7 @@ class Response {
   }
 
   // https://fetch.spec.whatwg.org/#dom-response
-  constructor (body = null, init = {}) {
+  constructor (body = null, init = undefined) {
     if (body === kConstruct) {
       return
     }


### PR DESCRIPTION
now that c108287b85e63bf7c5ef0613c20bd0ee40474897 has landed, this can be done. 

a micro-optimization, but a harmless change