### PR TITLE
fix formdata arg validation

### DIFF
--- a/lib/web/fetch/formdata.js
+++ b/lib/web/fetch/formdata.js
@@ -30,21 +30,19 @@ class FormData {
     const prefix = 'FormData.append'
     webidl.argumentLengthCheck(arguments, 2, prefix)
 
-    if (arguments.length === 3 && !(value instanceof Blob)) {
-      throw new TypeError(
-        "Failed to execute 'append' on 'FormData': parameter 2 is not of type 'Blob'"
-      )
+    name = webidl.converters.USVString(name)
+
+    if (arguments.length === 3 || value instanceof Blob) {
+      value = webidl.converters.Blob(value, prefix, 'value')
+
+      if (filename !== undefined) {
+        filename = webidl.converters.USVString(filename)
+      }
+    } else {
+      value = webidl.converters.USVString(value)
     }
 
     // 1. Let value be value if given; otherwise blobValue.
-
-    name = webidl.converters.USVString(name)
-    value = value instanceof Blob
-      ? webidl.converters.Blob(value, prefix, 'value')
-      : webidl.converters.USVString(value)
-    filename = arguments.length === 3
-      ? webidl.converters.USVString(filename)
-      : undefined
 
     // 2. Let entry be the result of creating an entry with
     // name, value, and filename if given.
@@ -123,24 +121,22 @@ class FormData {
     const prefix = 'FormData.set'
     webidl.argumentLengthCheck(arguments, 2, prefix)
 
-    if (arguments.length === 3 && !(value instanceof Blob)) {
-      throw new TypeError(
-        "Failed to execute 'set' on 'FormData': parameter 2 is not of type 'Blob'"
-      )
+    name = webidl.converters.USVString(name)
+
+    if (arguments.length === 3 || value instanceof Blob) {
+      value = webidl.converters.Blob(value, prefix, 'value')
+
+      if (filename !== undefined) {
+        filename = webidl.converters.USVString(filename)
+      }
+    } else {
+      value = webidl.converters.USVString(value)
     }
 
     // The set(name, value) and set(name, blobValue, filename) method steps
     // are:
 
     // 1. Let value be value if given; otherwise blobValue.
-
-    name = webidl.converters.USVString(name)
-    value = value instanceof Blob
-      ? webidl.converters.Blob(value, prefix, 'name')
-      : webidl.converters.USVString(value)
-    filename = arguments.length === 3
-      ? webidl.converters.USVString(filename)
-      : undefined
 
     // 2. Let entry be the result of creating an entry with name, value, and
     // filename if given.

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -81,6 +81,16 @@ test('arg validation', () => {
   })
 })
 
+test('set blob', () => {
+  const form = new FormData()
+
+  form.set('key', new Blob([]), undefined)
+  assert.strictEqual(form.get('key').name, 'blob')
+
+  form.set('key1', new Blob([]), null)
+  assert.strictEqual(form.get('key1').name, 'null')
+})
+
 test('append file', () => {
   const form = new FormData()
   form.set('asd', new File([], 'asd1', { type: 'text/plain' }), 'asd2')
@@ -106,6 +116,12 @@ test('append blob', async () => {
   assert.strictEqual(await form.get('asd').text(), 'asd1')
   form.delete('asd')
   assert.strictEqual(form.get('asd'), null)
+
+  form.append('key', new Blob([]), undefined)
+  assert.strictEqual(form.get('key').name, 'blob')
+
+  form.append('key1', new Blob([]), null)
+  assert.strictEqual(form.get('key1').name, 'null')
 })
 
 test('append string', () => {


### PR DESCRIPTION
```js
var fd = new FormData()

fd.set('key', new Blob([]), undefined)
fd.get('key').name // should be 'blob'

fd.append('key1', new Blob([]), undefined)
fd.get('key1').name // should be 'blob'
```

I painfully found out that the wpts are not extensive