### PR TITLE
Remove patched DOM types

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@fastify/busboy": "3.0.0",
     "@matteo.collina/tspl": "^0.1.1",
     "@sinonjs/fake-timers": "^11.1.0",
-    "@types/node": "^18.0.3",
+    "@types/node": "~18.17.19",
     "abort-controller": "^3.0.0",
     "borp": "^0.17.0",
     "c8": "^10.0.0",

--- a/types/eventsource.d.ts
+++ b/types/eventsource.d.ts
@@ -2,8 +2,6 @@ import { MessageEvent, ErrorEvent } from './websocket'
 import Dispatcher from './dispatcher'
 
 import {
-  EventTarget,
-  Event,
   EventListenerOptions,
   AddEventListenerOptions,
   EventListenerOrEventListenerObject

--- a/types/patch.d.ts
+++ b/types/patch.d.ts
@@ -2,48 +2,6 @@
 
 // See https://github.com/nodejs/undici/issues/1740
 
-export type DOMException = typeof globalThis extends { DOMException: infer T }
-  ? T
-  : any
-
-export type EventTarget = typeof globalThis extends { EventTarget: infer T }
-  ? T
-  : {
-      addEventListener(
-        type: string,
-        listener: any,
-        options?: any,
-      ): void
-      dispatchEvent(event: Event): boolean
-      removeEventListener(
-        type: string,
-        listener: any,
-        options?: any | boolean,
-      ): void
-    }
-
-export type Event = typeof globalThis extends { Event: infer T }
-  ? T
-  : {
-      readonly bubbles: boolean
-      cancelBubble: () => void
-      readonly cancelable: boolean
-      readonly composed: boolean
-      composedPath(): [EventTarget?]
-      readonly currentTarget: EventTarget | null
-      readonly defaultPrevented: boolean
-      readonly eventPhase: 0 | 2
-      readonly isTrusted: boolean
-      preventDefault(): void
-      returnValue: boolean
-      readonly srcElement: EventTarget | null
-      stopImmediatePropagation(): void
-      stopPropagation(): void
-      readonly target: EventTarget | null
-      readonly timeStamp: number
-      readonly type: string
-    }
-
 export interface EventInit {
   bubbles?: boolean
   cancelable?: boolean

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -3,8 +3,6 @@
 import type { Blob } from 'buffer'
 import type { MessagePort } from 'worker_threads'
 import {
-  EventTarget,
-  Event,
   EventInit,
   EventListenerOptions,
   AddEventListenerOptions,


### PR DESCRIPTION
## This relates to...

Fixes #3524

PR #3531

## Rationale

Several missing DOM types from `@types/node` were added as part of `patch.d.ts`. `Event` & `EventTarget` exported DOM types in global were overwritten with `patch.d.ts`.

## Changes

* Remove patched `Event` & `EventTarget` type and references to it from other declaration files.
* Lock version for `@types/node` to `~18.17.19`.

### Features

N/A

### Bug Fixes

* Fixes typing bug related to DOM `Event` type.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md

### Notes

`@types/node` version was updated to reflect the minimum supported engine version in `package.json`.