### PR TITLE
fix: fire close on fail for WebSocket

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -531,6 +531,8 @@ class WebSocket extends EventTarget {
         message: reason
       })
     }
+
+    this.#onSocketClose()
   }
 
   #onMessage (type, data) {
@@ -666,7 +668,7 @@ class WebSocket extends EventTarget {
     let code = 1005
     let reason = ''
 
-    const result = this.#parser.closingInfo
+    const result = this.#parser?.closingInfo
 
     if (result && !result.error) {
       code = result.code ?? 1005

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -515,7 +515,7 @@ class WebSocket extends EventTarget {
     fireEvent('open', this)
   }
 
-  #onFail (reason) {
+  #onFail (reason = '') {
     this.#controller.abort()
 
     if (this.#handler.socket && !this.#handler.socket.destroyed) {
@@ -524,15 +524,29 @@ class WebSocket extends EventTarget {
 
     this.#handler.readyState = states.CLOSED
 
-    if (reason) {
-      // TODO: process.nextTick
-      fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new Error(reason),
-        message: reason
-      })
+    // TODO: process.nextTick
+    fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
+      error: new Error(reason),
+      message: reason
+    })
+
+    const result = this.#parser?.closingInfo
+    let code
+    if (result && !result.error) {
+      code = result.code ?? 1005
+    } else if (!this.#handler.receivedClose) {
+      // If _The WebSocket
+      // Connection is Closed_ and no Close control frame was received by the
+      // endpoint (such as could occur if the underlying transport connection
+      // is lost), _The WebSocket Connection Close Code_ is considered to be
+      // 1006.
+      code = 1006
     }
 
-    this.#onSocketClose()
+    // TODO: process.nextTick
+    fireEvent('close', this, (type, init) => new CloseEvent(type, init), {
+      wasClean: false, code, reason
+    })
   }
 
   #onMessage (type, data) {

--- a/test/websocket/issue-3546.js
+++ b/test/websocket/issue-3546.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocket } = require('../..')
+const { tspl } = require('@matteo.collina/tspl')
+
+test('first error than close event is fired on failed connection', async (t) => {
+  const { completed, strictEqual } = tspl(t, { plan: 4 })
+  const ws = new WebSocket('ws://localhost:1')
+
+  let orderOfEvents = 0
+
+  ws.addEventListener('error', () => {
+    strictEqual(orderOfEvents++, 0)
+    strictEqual(ws.readyState, WebSocket.CLOSED)
+  })
+
+  ws.addEventListener('close', () => {
+    strictEqual(orderOfEvents++, 1)
+    strictEqual(ws.readyState, WebSocket.CLOSED)
+  })
+
+  await completed
+})


### PR DESCRIPTION
## This relates to...

Fixes #3546

## Rationale

`close` event is never fired after a WebSocket connection is failed to establish.

## Changes

* change `WebSocket.#onSocketClose` when trying to access `closingInfo`. `WebSocket.#parser` is `undefined` when connection fails to establish.
* run `WebSocket.#onSocketClose` after firing `error` event, which in turn fires the `close` event.

### Features

_N/A_

### Bug Fixes

* fix `close` event not firing on failed connection.

### Breaking Changes and Deprecations

_N/A_

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
