### PR TITLE
fix: onConnectTimeout remove unnecessary Array.isArray

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -199,7 +199,7 @@ const setupConnectTimeout = process.platform === 'win32'
 
 function onConnectTimeout (socket) {
   let message = 'Connect Timeout Error'
-  if (Array.isArray(socket.autoSelectFamilyAttemptedAddresses)) {
+  if (socket.autoSelectFamilyAttemptedAddresses) {
     message += ` (attempted addresses: ${socket.autoSelectFamilyAttemptedAddresses.join(', ')})`
   }
   util.destroy(socket, new ConnectTimeoutError(message))


### PR DESCRIPTION
If autoSelectFamilyAttemptedAddresses exists, then it is always an array.

https://github.com/nodejs/node/commit/05975d1fb1b4b96938735c371677d032fc497f77
https://nodejs.org/api/net.html#socketautoselectfamilyattemptedaddresses