### PR TITLE
fix: fire `close` on failed WebSocket connection

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -537,6 +537,14 @@ class WebSocket extends EventTarget {
         message: reason
       })
     }
+
+    if (!this.#parser && !this.#handler.receivedClose) {
+      fireEvent('close', this, (type, init) => new CloseEvent(type, init), {
+        wasClean: false,
+        code: 1006,
+        reason
+      })
+    }
   }
 
   #onMessage (type, data) {

--- a/test/websocket/issue-3546.js
+++ b/test/websocket/issue-3546.js
@@ -5,7 +5,7 @@ const { WebSocket } = require('../..')
 const { tspl } = require('@matteo.collina/tspl')
 
 test('first error than close event is fired on failed connection', async (t) => {
-  const { completed, strictEqual } = tspl(t, { plan: 2 })
+  const { completed, strictEqual } = tspl(t, { plan: 4 })
   const ws = new WebSocket('ws://localhost:1')
 
   let orderOfEvents = 0


### PR DESCRIPTION
## This relates to...

See nodejs/undici#3546, nodejs/undici#3548 & nodejs/undici#3565

CC: @Uzlopak @KhafraDev

## Rationale

#3565 attempted to fix #3546, however the test for #3546 made in #3548 was modified in #3565 and [skipped the `close` event check](https://github.com/nodejs/undici/pull/3565/files#r1749099808), which ultimately ended up with not actually fixing the original issue. This PR will check the `close` event correctly and correctly fixes the original issue.

Additionally, [this commit has been already tested to make sure it passes the autobahn testsuite](https://github.com/eXhumer/undici/actions/runs/10758006235/job/29832745599)

## Changes

* correctly fire `close` event if there is no successful connection to server.
* fix test to actually check the `close` event correctly firing.

### Features

_N/A_

### Bug Fixes

* correctly fire `close` event on unsuccessful connection

### Breaking Changes and Deprecations

_N/A_

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
