### PR TITLE
chore: update typescript testing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@fastify/busboy": "3.0.0",
     "@matteo.collina/tspl": "^0.1.1",
     "@sinonjs/fake-timers": "^11.1.0",
-    "@types/node": "~18.17.19",
+    "@types/node": "^18.19.50",
     "abort-controller": "^3.0.0",
     "borp": "^0.17.0",
     "c8": "^10.0.0",
@@ -120,8 +120,8 @@
     "node-forge": "^1.3.1",
     "pre-commit": "^1.2.2",
     "proxy": "^2.1.1",
-    "tsd": "^0.31.0",
-    "typescript": "^5.0.2",
+    "tsd": "^0.31.2",
+    "typescript": "^5.6.2",
     "ws": "^8.11.0"
   },
   "engines": {


### PR DESCRIPTION
it seems like latest typescript brakes the typing tests. This PR updates the deps accordingly...