### PR TITLE
jsdoc: improve typing of deepClone

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -288,8 +288,10 @@ function getServerName (host) {
 }
 
 /**
- * @param {*} obj
- * @returns {*}
+ * @function
+ * @template T
+ * @param {T} obj
+ * @returns {T}
  */
 function deepClone (obj) {
   return JSON.parse(JSON.stringify(obj))


### PR DESCRIPTION
now it returns the same type as the provided argument.