### PR TITLE
ci: less flaky test/request-timeout.js test

### DIFF
--- a/test/request-timeout.js
+++ b/test/request-timeout.js
@@ -31,7 +31,7 @@ test('request timeout', async (t) => {
   const server = createServer((req, res) => {
     setTimeout(() => {
       res.end('hello')
-    }, 1000)
+    }, 2000)
   })
   after(() => server.close())
 


### PR DESCRIPTION
The CI is a little bit flaky because fast timer resolution is making the underlying test not fail always as expected. This should fix it ;)