### PR TITLE
mock: remove Error.captureStackTrace in MockNotMatchedError

### DIFF
--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -5,7 +5,6 @@ const { UndiciError } = require('../core/errors')
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
     super(message)
-    Error.captureStackTrace(this, MockNotMatchedError)
     this.name = 'MockNotMatchedError'
     this.message = message || 'The request does not match any registered mock dispatches'
     this.code = 'UND_MOCK_ERR_MOCK_NOT_MATCHED'

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -2,6 +2,9 @@
 
 const { UndiciError } = require('../core/errors')
 
+/**
+ * The request does not match any registered mock dispatches.
+ */
 class MockNotMatchedError extends UndiciError {
   constructor (message) {
     super(message)


### PR DESCRIPTION
Error.captureStackTrace is not necessary because the stack trace will be generated when calling super().