### PR TITLE
jsdoc: add jsdoc for errors

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -1,218 +1,313 @@
 'use strict'
 
 class UndiciError extends Error {
-  constructor (message, options) {
-    super(message, options)
-    this.name = 'UndiciError'
-    this.code = 'UND_ERR'
-  }
+  name = /** @type {string} */ 'UndiciError'
+  code = /** @type {string} */ 'UND_ERR'
 }
 
+/**
+ * Connect timeout error.
+ */
 class ConnectTimeoutError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('ConnectTimeoutError')
+  code = /** @type {const} */ ('UND_ERR_CONNECT_TIMEOUT')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'ConnectTimeoutError'
     this.message = message || 'Connect Timeout Error'
-    this.code = 'UND_ERR_CONNECT_TIMEOUT'
   }
 }
-
+/**
+ * A header exceeds the `headersTimeout` option.
+ */
 class HeadersTimeoutError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('HeadersTimeoutError')
+  code = /** @type {const} */ ('UND_ERR_HEADERS_TIMEOUT')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'HeadersTimeoutError'
     this.message = message || 'Headers Timeout Error'
-    this.code = 'UND_ERR_HEADERS_TIMEOUT'
   }
 }
 
+/**
+ * Headers overflow error.
+ */
 class HeadersOverflowError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('HeadersOverflowError')
+  code = /** @type {const} */ ('UND_ERR_HEADERS_OVERFLOW')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'HeadersOverflowError'
     this.message = message || 'Headers Overflow Error'
-    this.code = 'UND_ERR_HEADERS_OVERFLOW'
   }
 }
 
+/**
+ * A body exceeds the `bodyTimeout` option.
+ */
 class BodyTimeoutError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('BodyTimeoutError')
+  code = /** @type {const} */ ('UND_ERR_BODY_TIMEOUT')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'BodyTimeoutError'
     this.message = message || 'Body Timeout Error'
-    this.code = 'UND_ERR_BODY_TIMEOUT'
   }
 }
 
 class ResponseStatusCodeError extends UndiciError {
-  constructor (message, statusCode, headers, body) {
+  name = /** @type {const} */ ('ResponseStatusCodeError')
+  code = /** @type {const} */ ('UND_ERR_RESPONSE_STATUS_CODE')
+  constructor (
+    /** @type {string} */ message,
+    /** @type {number} */ statusCode,
+    /** @type {Record<string, string|string[]>|string[]|null} */ headers,
+    /** @type {*} */ body
+  ) {
     super(message)
-    this.name = 'ResponseStatusCodeError'
     this.message = message || 'Response Status Code Error'
-    this.code = 'UND_ERR_RESPONSE_STATUS_CODE'
-    this.body = body
-    this.status = statusCode
     this.statusCode = statusCode
+    this.status = statusCode
+    this.body = body
     this.headers = headers
   }
 }
 
+/**
+ * Passed an invalid argument.
+ */
 class InvalidArgumentError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('InvalidArgumentError')
+  code = /** @type {const} */ ('UND_ERR_INVALID_ARG')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'InvalidArgumentError'
     this.message = message || 'Invalid Argument Error'
-    this.code = 'UND_ERR_INVALID_ARG'
   }
 }
 
+/**
+ * Returned an invalid value.
+ */
 class InvalidReturnValueError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('InvalidReturnValueError')
+  code = /** @type {const} */ ('UND_ERR_INVALID_RETURN_VALUE')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'InvalidReturnValueError'
     this.message = message || 'Invalid Return Value Error'
-    this.code = 'UND_ERR_INVALID_RETURN_VALUE'
   }
 }
 
 class AbortError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('AbortError')
+  code = /** @type {string} */ ('UND_ERR_ABORT')
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'AbortError'
     this.message = message || 'The operation was aborted'
   }
 }
 
+/**
+ * The request has been aborted by the user.
+ */
 class RequestAbortedError extends AbortError {
-  constructor (message) {
+  name = /** @type {const} */ ('AbortError')
+  code = /** @type {const} */ ('UND_ERR_ABORTED')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'AbortError'
     this.message = message || 'Request aborted'
-    this.code = 'UND_ERR_ABORTED'
   }
 }
 
+/**
+ * Expected error with reason.
+ */
 class InformationalError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('InformationalError')
+  code = /** @type {const} */ ('UND_ERR_INFO')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'InformationalError'
     this.message = message || 'Request information'
-    this.code = 'UND_ERR_INFO'
   }
 }
 
+/**
+ * Request body length does not match content-length header.
+ */
 class RequestContentLengthMismatchError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('RequestContentLengthMismatchError')
+  code = /** @type {const} */ ('UND_ERR_REQ_CONTENT_LENGTH_MISMATCH')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'RequestContentLengthMismatchError'
     this.message = message || 'Request body length does not match content-length header'
-    this.code = 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'
   }
 }
 
+/**
+ * Response body length does not match content-length header.
+ */
 class ResponseContentLengthMismatchError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('ResponseContentLengthMismatchError')
+  code = /** @type {const} */ ('UND_ERR_RES_CONTENT_LENGTH_MISMATCH')
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'ResponseContentLengthMismatchError'
     this.message = message || 'Response body length does not match content-length header'
-    this.code = 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH'
   }
 }
 
+/**
+ * Trying to use a destroyed client.
+ */
 class ClientDestroyedError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('ClientDestroyedError')
+  code = /** @type {const} */ ('UND_ERR_DESTROYED')
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'ClientDestroyedError'
     this.message = message || 'The client is destroyed'
-    this.code = 'UND_ERR_DESTROYED'
   }
 }
 
 class ClientClosedError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('ClientClosedError')
+  code = /** @type {const} */ ('UND_ERR_CLOSED')
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'ClientClosedError'
     this.message = message || 'The client is closed'
-    this.code = 'UND_ERR_CLOSED'
   }
 }
 
+/**
+ * There is an error with the socket.
+ */
 class SocketError extends UndiciError {
-  constructor (message, socket) {
+  name = /** @type {const} */ ('SocketError')
+  code = /** @type {const} */ ('UND_ERR_SOCKET')
+
+  constructor (
+    /** @type {string} **/ message,
+    /** @type {import('net').Socket|null} */ socket
+  ) {
     super(message)
-    this.name = 'SocketError'
     this.message = message || 'Socket error'
-    this.code = 'UND_ERR_SOCKET'
     this.socket = socket
   }
 }
 
+/**
+ * Encountered unsupported functionality.
+ */
 class NotSupportedError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('NotSupportedError')
+  code = /** @type {const} */ ('UND_ERR_NOT_SUPPORTED')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'NotSupportedError'
     this.message = message || 'Not supported error'
-    this.code = 'UND_ERR_NOT_SUPPORTED'
   }
 }
 
+/**
+ * No upstream has been added to the BalancedPool.
+ */
 class BalancedPoolMissingUpstreamError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ ('MissingUpstreamError')
+  code = /** @type {const} */ ('UND_ERR_BPL_MISSING_UPSTREAM')
+
+  constructor (/** @type {string} **/ message) {
     super(message)
-    this.name = 'MissingUpstreamError'
     this.message = message || 'No upstream has been added to the BalancedPool'
-    this.code = 'UND_ERR_BPL_MISSING_UPSTREAM'
   }
 }
 
-class HTTPParserError extends Error {
-  constructor (message, code, data) {
+class HTTPParserError extends UndiciError {
+  name = /** {const} */ 'HTTPParserError'
+  code = /** {const} */ 'UND_ERR_HTTP_PARSER'
+
+  constructor (
+    /** @type {string} */ message,
+    /** @type {string} */ code,
+    /** @type {*} */ data
+  ) {
     super(message)
-    this.name = 'HTTPParserError'
-    this.code = code ? `HPE_${code}` : undefined
+
+    code = (/** @type {`HPE_${string}|undefined`} */ (code ? `HPE_${code}` : undefined))
     this.data = data ? data.toString() : undefined
   }
 }
 
+/**
+ * The response exceed the length allowed.
+ */
 class ResponseExceededMaxSizeError extends UndiciError {
-  constructor (message) {
+  name = /** @type {const} */ 'ResponseExceededMaxSizeError'
+  code = /** @type {const} */ 'UND_ERR_RES_EXCEEDED_MAX_SIZE'
+
+  constructor (/** @type {string} */ message) {
     super(message)
-    this.name = 'ResponseExceededMaxSizeError'
     this.message = message || 'Response content exceeded max size'
-    this.code = 'UND_ERR_RES_EXCEEDED_MAX_SIZE'
   }
 }
 
+/**
+ * @typedef RequestRetryErrorOptions
+ * @type {object}
+ * @property {object} data
+ * @property {number} count
+ * @property {Record<string, string|string[]>|string[]|null} headers
+ */;
+
 class RequestRetryError extends UndiciError {
-  constructor (message, code, { headers, data }) {
+  name = /** @type {const} */ 'RequestRetryError'
+  code = /** @type {const} */ 'UND_ERR_REQ_RETRY'
+
+  constructor (
+    /** @type {string} */ message,
+    /** @type {number} */ statusCode,
+    /** @type {RequestRetryErrorOptions} */ { headers, data }) {
     super(message)
-    this.name = 'RequestRetryError'
     this.message = message || 'Request retry error'
-    this.code = 'UND_ERR_REQ_RETRY'
-    this.statusCode = code
+    this.statusCode = statusCode
     this.data = data
     this.headers = headers
   }
 }
 
+/**
+ * @typedef ResponseErrorOptions
+ * @type {object}
+ * @property {object} data
+ * @property {Record<string, string|string[]>|string[]|null} headers
+ */;
+
 class ResponseError extends UndiciError {
-  constructor (message, code, { headers, data }) {
+  name = /** @type {const} */ 'ResponseError'
+  code = /** @type {const} */ ('UND_ERR_RESPONSE')
+
+  constructor (
+    /** @type {string} */ message,
+    /** @type {number} */ statusCode,
+    /** @type {ResponseErrorOptions} */ { data, headers }
+  ) {
     super(message)
-    this.name = 'ResponseError'
     this.message = message || 'Response error'
-    this.code = 'UND_ERR_RESPONSE'
-    this.statusCode = code
+    this.statusCode = statusCode
     this.data = data
     this.headers = headers
   }
 }
 
 class SecureProxyConnectionError extends UndiciError {
-  constructor (cause, message, options = {}) {
-    super(message, { cause, ...options })
-    this.name = 'SecureProxyConnectionError'
+  name = /** @type {const} */ 'SecureProxyConnectionError'
+  code = /** @type {const} */ ('UND_ERR_PRX_TLS')
+
+  constructor (/** @type {Error} */ cause, /** @type {string} */ message) {
+    super(message, { cause })
     this.message = message || 'Secure Proxy Connection failed'
-    this.code = 'UND_ERR_PRX_TLS'
     this.cause = cause
   }
 }

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -6,11 +6,12 @@ const { UndiciError } = require('../core/errors')
  * The request does not match any registered mock dispatches.
  */
 class MockNotMatchedError extends UndiciError {
+  name = /** @type {const} */ ('MockNotMatchedError')
+  code = /** @type {const} */ ('UND_MOCK_ERR_MOCK_NOT_MATCHED')
+
   constructor (message) {
     super(message)
-    this.name = 'MockNotMatchedError'
     this.message = message || 'The request does not match any registered mock dispatches'
-    this.code = 'UND_MOCK_ERR_MOCK_NOT_MATCHED'
   }
 }
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -71,7 +71,7 @@ describe('Default HTTPParseError Codes', () => {
 
     const error = new errors.HTTPParserError('HTTPParserError')
 
-    t.strictEqual(error.code, undefined)
+    t.strictEqual(error.code, 'UND_ERR_HTTP_PARSER')
     t.strictEqual(error.data, undefined)
   })
 })


### PR DESCRIPTION
Maybe the style seems strange, but with this style the generated typescript typings will have no additional jsdocs

Functional changes:

HTTPParserError is now an UndiciError and has the Error Code `UND_ERR_HTTP_PARSER`
AbortError has now an Error Code `UND_ERR_ABORT`



See in the [ts-playground](https://www.typescriptlang.org/play/?target=9&filetype=js#code/OQVwzgpgBGAuBOBLAxrYBYAUF5AbAhmGFAKoB2AJiogKLzwD28UEAHrBJcXY8wN5YoUMvgC20ALxQA9ACpZUAAKwAngAdofOEjIBzAL5RZ0qMHJVktekwyYhyBhUkz5S1RqhaEiPYeOmSADkAEQB9GgAlCNt9LCw5WUEFAGEGMjIIVChYRHEGEFgWa3gAOiTpHAIiKFT0zNgAFVyIfNgeJhZ2Tgpic2p2-kFhMWcEt3VNBzI4PxMACmBajNQmvIKB4ABKIYcnKCkx5QnPKZmjebMQ8KjQ5IB5QMCaZIbQhoBJAFkaO5IGrbidigpwQIFQHTmh3cmm0PgMRn84iI+F0EE2niGQjAIA08DmSLAKLRmOyAAtEGASgSifsoNTUVAAD6M0xLepQVYtApQDZDWKYfkJJJQACCUFJEHwTmYbGQEAgPTJ0AABhKpRB4GBOa1lVAGGocmkynZjJVCMQABKS6Va5qtAadDhcUiUfrFDFAkTiWlQ458EGzKALK3qzXa9bFAFA3ajVxHDz+tJnfwLIJhSIRUIWmgi4KRADKby+Pz+UZ2SdB4OYkLj0M8sN8CJM9LRHqEWJxGvxEGRqO2QKEsHJlJbtNHzNMIZtHLt3N5QP5-Pi8mFU41xAYADcNQAzXAMADuRV4xvOZuqa81d238D3h4dbCdir6lgdAk9Ix9tb9AfOQeAl5gNeu77geGz9vYjixgo8aTBWgaplcGZZjmeYRIWdwAGqRAAYgAMncADqZbRhW8BgrAEK+gmDbwvIzY9oSfZtu22K4t2vbEgOZIUlSjE0lI44sgB1rrlAwG3qBPKRnyWBLpgQomqKUAAEaOConRygqxBDiqakUCo4awLq+qGmQp6mpgeDmlAABC6lGQ+XTOi+Vi8CxXrQeMCa-imwD2QZjmRhBwJQV+MF1om0ywAhlzpjctl3MEACaRbfL8-z9uW0XkVWQbUTC3iNvRdL8cx77tjAnZ4i2IWDsOfGcWOZXQBO-nqTOayFPOQiLoC1nVBEPZqEmED5rA+CwOAqROE5T69K6r7uhVwzegc34+fBf4LENYAjdMY0TVNYAzRA4Hlns60RT+W1+Wm1yZhEND5gACg8+Y0KE+YNCKDQkIW9x5lGkE5RREIkgV9ZFXRDGcQANBDG2aGQICiCpGqBnAk3TVBCPcZDfBDQ48AUAAPLRcMwNDjK0QA2gAugAfDT0MM4yKO4LggZqjaeOVQTsiBvpKhDOiK0duxtUkkOvGjoJLVMsJu37ZAUDjdjxCndJvC2JVMuUljx1a1Ihs4040sNabxAm0dZsQBbvHC7SwsO5SPNiVI7uarJAqAopRhQC95oKlA+BkFAPibvguCIBQofwLoqOcLAFkVFZVTEO8ZBRzHFAignSdkG07qPt0C0WG5HQrZ54XeXB0WxVnOex-nifiEX52kZdLjXZtDfbXFD2hO8gSYSKeHvGEIoRAA4iRIPaGD1YE7RfiIi1YskmxXZS9x+uNUxzhCaYTfR7HooF+33UyQucl+yuSlDVN8AZHHYcR9nZ9xznIAQKn56Z0-rnJ+IAX6YWjr-OaZcXQVzfEMGuV064nFuhcU+wCIDPzIOA3AkDgoXS8rBZB-c7pIRuCPMeE8whPT+hEQIoQKEkBoPPUKoM8o1l7oVHQdF16cU3txbeNUN6uwPgJUqTU2poPPiAl+UBsG-21jYH28kBrEBFGpeAxd3KlxcotSugwPxrR7kgqKyYLhqKYJomwIUYy10IV4LhsV7rIRFIlCImVsqLzYSvaGa9YaHz4ZVARHF-HCLlmIw+itTANAlHqXEk1EBpCgAeQgod1EcAoLrKAfVsAKQfgHaJ0B4AQAAI6-zgOKFJ6NOCpIsSHFSGldJQHABqf+6cbJDVKT2WA5iNEKigc6Hplj9FCAQUYuxvkzFpM7pBbuBMJn-icTcFxdw3E0GCMwkEuVKLLyRlDBxTZwlEgCaxaqwSjmhIVvLcRSsSllMKPgNJCpMnZOXIkJSNBWAaFQCHDU7kDyICHFAIphAjTlAAVALOO4mCiHiWkaO-Tny6LgQYghkV5kLEhdC2FIhcDTNCrM3ZJiYoD0WZmEeOE7gbLIkvfKhLV4HNqixCWO8hF7wamE4+wAOl3I-lC+AMKzLPLvjk-2ChuVdNUh1XAnBdCAooAwHswgGCFAFcgUkLCnSwAALTSr0ICr2rSVFQHFXAWomq8IyqHJ8CkqrSQIvLm6dy1dPyIPGSg-8JrYBmuThavVpJrVgFtXimxrq0XusQvFR6NAACKtwHgNBoIEV4eFE0zwaBaUInx3j5k+L9ZIFoqWsO2bSjhey4S+MOeVLepzd563ZZcytrUbmdPKU7XVsr1XysVWQZVdJJpqo1cnHVlr1VeyFb7EVeSxXDVGpKgyUB21yoVcQHtKr+3qqmJq4dfrxSiVKGCtpg0Z0HW9UXX1HaA1BpLs5RFsDlrwJdWMsNxCLjK1Gqe2A56rU2vXcGsKoabovoWaQqNAN42JuTam9Nmbs25oaPm4GLDPHFvYcY+lJVGXiyqpLVldbZYNs5W+g6c6NKLs7cupVa7YADs3UOsju7QzjvkqKjk8AVBwmyAwJpqt8BQCcNoBgKgQ54EQMnQ1Gcagx2TsELpjAhMUHtTAx1VcH2GLmeGxYUmi4yYE-Jv9BLS1EscSB0IeZvoRDuMlNZiHNk0tQ3Y9DPD-FMuwyy3hFympXIiW1ApwItOFApHx2TgmnlKP6hJ5I-nIsMEgAp6980lNLSdap1FgHTH-ki6Jou0XYv6dS33dLEah7JAIh9dZ1jqVeLpT4hlG8XNBNre2feHKFY+ZiSJ5OEdiB4Bi6F2+E7XnCgKUUrrodw6-I6P8wFjSwAMGQAAawweJmy+Y5uLaGY6aBrlkUjMfepoDCxVsLYwXl2xz7CuD2QvmO4yQADSNB3E5IXpWFDiNDOOb8USPm7YCa5BGhohYGQ0CbBKEd9b7MQCc0xmtjBot6s1tw01+tnnG2ROAGDjBx5FFst4rN47hQTYw9gGFydbyA40DIA4EARcNQh2p2xf76SoA7mp6gBJOKAUqGW9UQIyr8w4kZ30+LW2kX3pRWdtLxK-K89gPztQgu4s6wqwZ4x6LLs3ECHcV4+YSAvTeqs8rgJntbKotV-ZGG6tYYa4j+q+GUecpl9hhXWP4BMfvmThQvOmlqG0JKUQFTiBVPDlKJwcdKJKjstHMOcoKAvQYAwXA3PiC2Sj5ThUceE8BrAHCEgPuEB+8U9tsXu21OErV1nnPefgWiFOwBgrUuLiktCLZF6eEYP5nzCPGeoRdfmZzJ8QtyHTfvZqxb3h8OcPuZxyOAjrXhJe5xL7sQAfVLymDxQUPnGI8p4IGn2P8fcBu5yUai0DQGh6-wJqDUhfRfJfF4gozf4AJn4v1f+APV8VeUf-4dXmZT-n9CBemng+miCNyQxe3BnxjN3LT-BbG+yEG8XNxMBjHgKfT9EFj-AoEmnwDhytwRynxJBDRLWMWVAtBek+gABJ7Fy1GRqcnAdwfAFRlQEIbEAB+KAUg8g0IKgmMfQXUAALiaUoAgAYNfk2Dqh4kpCwImlpGkN43YLkJKEonGi4TmHREELoJEMYIoBJ0GyUl8yKT2lnVlHlDDxiXo2jlAgVCT2NWPUgA+S0lD0+HwFYHzEQAAC8zphcdE7078S98t650suU7CzpWBHCFRnDXCPCvCdZ8EJd69Axf9QgnpCwaAAANZIGgNZNZTNEUNIr6d4AALSYTANsyqxHyQMbWOWZUESnzwxn3tzn1MCI1VloyLk0lMJDhhVYBgGiKPz0IDlgnoNsJbVgCfjYwGDuANHZzAGFDsQYBUgACt6h+RBi1BGBcRVBPAFjljUBDA5C5j1j9QNQti+AUY0YMZQpqdiclJFAjjNiNJCZMgmAyYKYqYuEWYuEGZmY6Z6YIcocGMbRygABucLdpW5LpcYlQG-XwlTe-NAhIp-T1KEj-Ig-bIIpvJ6WNahCIZKWwDxCA6sN7NDUfT7VEVAgmc49GeATGW2E6XGYkuxZEjBCY4oKYsyMAQMPgQE9cSmOQrJao1zWokJafERBkLzGkNqT1IFFkjSCbV3YRK2Y2KmDWU6YRfkqQA40Ur2a2Hk72frZjKdOuYYlomIpgdkmYuYyKHYlYw4jYk4x4m0vYvjbAu044jRR4omF48maGSmWiT4uEb4gMvQNmDmLmPU2Yk0aQUE4-CTU0mE5TYZVaAIohII+Mm+GZFM7-RvEzFIt6QID6QfQkoMRkyKdDMkiACkwlKky4-wJUhkqAwzdM3gC0pMLkl0iaSmHUrJXA6tSfEU+osUo+Jo4Iow4jeUzJW3A2Ok5U+s82UUjUjsnA7UvdXUnU3Qw9YgfMTIUBCAF6RgVgFQNkNnNIBMpLOE-w+IwIhvUwbc5AXc-chgQ848syVE-9BE684zSNQAiIfIhoPCfMIsk3HZQzAYQMZAfAZpSmRAmApzI5CfNzQ+SmbkiC5pAUjzCJCUhkNqO83cwOA8jSF89nZnfARAaVDJYRVC1WKQKi+2A0wEUQRwSHP+NgRnXUlaQZAYb7f-V-SAd-Yob7IvXgbi1coKYSoYQCCSO8MCASoYAKQyWcIZb7T1D9L9f1H9ajO1WSoEF8sSpgZSkI9WI2KCLioYSRPOS+ZOUyoEcy6RLBCBM0+AAy0YwZIXcSnS-zHTBAELRXfSoYTLZOHLNyvymysgPlAVdneFbSoQDHJSoYGXOXBXayoQU01SkdS9X9aKyPXfGPDPXACvPQXPJfGvLK+MsIzoigSItwzw5KkYu5FE0qkI2q3CopR858tIZYV84oYVIAA) and select `d.ts` in the right window to see the generated types.