### PR TITLE
fix: husky deprecation warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run lint


### PR DESCRIPTION
## This relates to...

Fixes #3592

## Rationale

husky made changes on how it is used on v9. See https://github.com/typicode/husky/releases/tag/v9.0.1 for more information.

## Changes

* fix husky deprecation warning

### Features

_N/A_

### Bug Fixes

_N/A_

### Breaking Changes and Deprecations

* fix husky deprecation warning

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
