### PR TITLE
chore: remove unused `pre-commit` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "jest": "^29.0.2",
     "neostandard": "^0.11.2",
     "node-forge": "^1.3.1",
-    "pre-commit": "^1.2.2",
     "proxy": "^2.1.1",
     "tsd": "^0.31.2",
     "typescript": "^5.6.2",


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/pull/3593#issuecomment-2348013546

## Rationale

`pre-commit` usage (introduced with commit 25b8a5480ce7fe620911c94683520b3e02b01306) has been replaced with husky in #605.

## Changes

* remove `pre-commit` from `devDependencies` in `package.json`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
