### PR TITLE
diagnostics-channel: use not deprecated subscribe fn

### DIFF
--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -36,57 +36,57 @@ function trackClientEvents (debugLog = undiciDebugLog) {
 
   isTrackingClientEvents = true
 
-  diagnosticsChannel.subscribe('undici:client:beforeConnect', 
+  diagnosticsChannel.subscribe('undici:client:beforeConnect',
     evt => {
-    const {
-      connectParams: { version, protocol, port, host }
-    } = evt
-    debugLog(
-      'connecting to %s%s using %s%s',
-      host,
-      port ? `:${port}` : '',
-      protocol,
-      version
-    )
-  })
+      const {
+        connectParams: { version, protocol, port, host }
+      } = evt
+      debugLog(
+        'connecting to %s%s using %s%s',
+        host,
+        port ? `:${port}` : '',
+        protocol,
+        version
+      )
+    })
 
-  diagnosticsChannel.subscribe('undici:client:connected', 
+  diagnosticsChannel.subscribe('undici:client:connected',
     evt => {
-    const {
-      connectParams: { version, protocol, port, host }
-    } = evt
-    debugLog(
-      'connected to %s%s using %s%s',
-      host,
-      port ? `:${port}` : '',
-      protocol,
-      version
-    )
-  })
+      const {
+        connectParams: { version, protocol, port, host }
+      } = evt
+      debugLog(
+        'connected to %s%s using %s%s',
+        host,
+        port ? `:${port}` : '',
+        protocol,
+        version
+      )
+    })
 
-  diagnosticsChannel.subscribe('undici:client:connectError', 
+  diagnosticsChannel.subscribe('undici:client:connectError',
     evt => {
-    const {
-      connectParams: { version, protocol, port, host },
-      error
-    } = evt
-    debugLog(
-      'connection to %s%s using %s%s errored - %s',
-      host,
-      port ? `:${port}` : '',
-      protocol,
-      version,
-      error.message
-    )
-  })
+      const {
+        connectParams: { version, protocol, port, host },
+        error
+      } = evt
+      debugLog(
+        'connection to %s%s using %s%s errored - %s',
+        host,
+        port ? `:${port}` : '',
+        protocol,
+        version,
+        error.message
+      )
+    })
 
-  diagnosticsChannel.subscribe('undici:client:sendHeaders', 
+  diagnosticsChannel.subscribe('undici:client:sendHeaders',
     evt => {
-    const {
-      request: { method, path, origin }
-    } = evt
-    debugLog('sending request to %s %s/%s', method, origin, path)
-  })
+      const {
+        request: { method, path, origin }
+      } = evt
+      debugLog('sending request to %s %s/%s', method, origin, path)
+    })
 }
 
 let isTrackingRequestEvents = false
@@ -98,43 +98,43 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
 
   isTrackingRequestEvents = true
 
-  diagnosticsChannel.subscribe('undici:request:headers', 
+  diagnosticsChannel.subscribe('undici:request:headers',
     evt => {
-    const {
-      request: { method, path, origin },
-      response: { statusCode }
-    } = evt
-    debugLog(
-      'received response to %s %s/%s - HTTP %d',
-      method,
-      origin,
-      path,
-      statusCode
-    )
-  })
+      const {
+        request: { method, path, origin },
+        response: { statusCode }
+      } = evt
+      debugLog(
+        'received response to %s %s/%s - HTTP %d',
+        method,
+        origin,
+        path,
+        statusCode
+      )
+    })
 
-  diagnosticsChannel.subscribe('undici:request:trailers', 
+  diagnosticsChannel.subscribe('undici:request:trailers',
     evt => {
-    const {
-      request: { method, path, origin }
-    } = evt
-    debugLog('trailers received from %s %s/%s', method, origin, path)
-  })
+      const {
+        request: { method, path, origin }
+      } = evt
+      debugLog('trailers received from %s %s/%s', method, origin, path)
+    })
 
-  diagnosticsChannel.subscribe('undici:request:error', 
+  diagnosticsChannel.subscribe('undici:request:error',
     evt => {
-    const {
-      request: { method, path, origin },
-      error
-    } = evt
-    debugLog(
-      'request to %s %s/%s errored - %s',
-      method,
-      origin,
-      path,
-      error.message
-    )
-  })
+      const {
+        request: { method, path, origin },
+        error
+      } = evt
+      debugLog(
+        'request to %s %s/%s errored - %s',
+        method,
+        origin,
+        path,
+        error.message
+      )
+    })
 }
 
 let isTrackingWebSocketEvents = false
@@ -146,39 +146,39 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
 
   isTrackingWebSocketEvents = true
 
-  diagnosticsChannel.subscribe('undici:websocket:open', 
+  diagnosticsChannel.subscribe('undici:websocket:open',
     evt => {
-    const {
-      address: { address, port }
-    } = evt
-    debugLog('connection opened %s%s', address, port ? `:${port}` : '')
-  })
+      const {
+        address: { address, port }
+      } = evt
+      debugLog('connection opened %s%s', address, port ? `:${port}` : '')
+    })
 
-  diagnosticsChannel.subscribe('undici:websocket:close', 
+  diagnosticsChannel.subscribe('undici:websocket:close',
     evt => {
-    const { websocket, code, reason } = evt
-    debugLog(
-      'closed connection to %s - %s %s',
-      websocket.url,
-      code,
-      reason
-    )
-  })
+      const { websocket, code, reason } = evt
+      debugLog(
+        'closed connection to %s - %s %s',
+        websocket.url,
+        code,
+        reason
+      )
+    })
 
-  diagnosticsChannel.subscribe('undici:websocket:socket_error', 
+  diagnosticsChannel.subscribe('undici:websocket:socket_error',
     err => {
-    debugLog('connection errored - %s', err.message)
-  })
+      debugLog('connection errored - %s', err.message)
+    })
 
-  diagnosticsChannel.subscribe('undici:websocket:ping', 
+  diagnosticsChannel.subscribe('undici:websocket:ping',
     evt => {
-    debugLog('ping received')
-  })
+      debugLog('ping received')
+    })
 
-  diagnosticsChannel.subscribe('undici:websocket:pong', 
+  diagnosticsChannel.subscribe('undici:websocket:pong',
     evt => {
-    debugLog('pong received')
-  })
+      debugLog('pong received')
+    })
 }
 
 if (undiciDebugLog.enabled || fetchDebuglog.enabled) {

--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const diagnosticsChannel = require('node:diagnostics_channel')
 const util = require('node:util')
 
@@ -35,7 +36,8 @@ function trackClientEvents (debugLog = undiciDebugLog) {
 
   isTrackingClientEvents = true
 
-  diagnosticsChannel.channel('undici:client:beforeConnect').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:client:beforeConnect', 
+    evt => {
     const {
       connectParams: { version, protocol, port, host }
     } = evt
@@ -48,7 +50,8 @@ function trackClientEvents (debugLog = undiciDebugLog) {
     )
   })
 
-  diagnosticsChannel.channel('undici:client:connected').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:client:connected', 
+    evt => {
     const {
       connectParams: { version, protocol, port, host }
     } = evt
@@ -61,7 +64,8 @@ function trackClientEvents (debugLog = undiciDebugLog) {
     )
   })
 
-  diagnosticsChannel.channel('undici:client:connectError').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:client:connectError', 
+    evt => {
     const {
       connectParams: { version, protocol, port, host },
       error
@@ -76,7 +80,8 @@ function trackClientEvents (debugLog = undiciDebugLog) {
     )
   })
 
-  diagnosticsChannel.channel('undici:client:sendHeaders').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:client:sendHeaders', 
+    evt => {
     const {
       request: { method, path, origin }
     } = evt
@@ -93,7 +98,8 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
 
   isTrackingRequestEvents = true
 
-  diagnosticsChannel.channel('undici:request:headers').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:request:headers', 
+    evt => {
     const {
       request: { method, path, origin },
       response: { statusCode }
@@ -107,14 +113,16 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
     )
   })
 
-  diagnosticsChannel.channel('undici:request:trailers').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:request:trailers', 
+    evt => {
     const {
       request: { method, path, origin }
     } = evt
     debugLog('trailers received from %s %s/%s', method, origin, path)
   })
 
-  diagnosticsChannel.channel('undici:request:error').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:request:error', 
+    evt => {
     const {
       request: { method, path, origin },
       error
@@ -138,14 +146,16 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
 
   isTrackingWebSocketEvents = true
 
-  diagnosticsChannel.channel('undici:websocket:open').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:websocket:open', 
+    evt => {
     const {
       address: { address, port }
     } = evt
     debugLog('connection opened %s%s', address, port ? `:${port}` : '')
   })
 
-  diagnosticsChannel.channel('undici:websocket:close').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:websocket:close', 
+    evt => {
     const { websocket, code, reason } = evt
     debugLog(
       'closed connection to %s - %s %s',
@@ -155,15 +165,18 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
     )
   })
 
-  diagnosticsChannel.channel('undici:websocket:socket_error').subscribe(err => {
+  diagnosticsChannel.subscribe('undici:websocket:socket_error', 
+    err => {
     debugLog('connection errored - %s', err.message)
   })
 
-  diagnosticsChannel.channel('undici:websocket:ping').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:websocket:ping', 
+    evt => {
     debugLog('ping received')
   })
 
-  diagnosticsChannel.channel('undici:websocket:pong').subscribe(evt => {
+  diagnosticsChannel.subscribe('undici:websocket:pong', 
+    evt => {
     debugLog('pong received')
   })
 }


### PR DESCRIPTION
In engines we declare that we support node >= 18.17. and the new subscribe notation is existitng since 18.7. 

https://nodejs.org/api/diagnostics_channel.html#diagnostics_channelsubscribename-onmessage