### PR TITLE
feat: dispatcher _buildConnector() method

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -132,15 +132,9 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, sess
       })
     }
 
-    // Set TCP keep alive options on the socket here instead of in connect() for the case of assigning the socket
-    if (options.keepAlive == null || options.keepAlive) {
-      const keepAliveInitialDelay = options.keepAliveInitialDelay === undefined ? 60e3 : options.keepAliveInitialDelay
-      socket.setKeepAlive(true, keepAliveInitialDelay)
-    }
-
     const clearConnectTimeout = setupConnectTimeout(new WeakRef(socket), { timeout, hostname, port })
 
-    socket
+    configureSocket(socket, options)
       .setNoDelay(true)
       .once(protocol === 'https:' ? 'secureConnect' : 'connect', function () {
         queueMicrotask(clearConnectTimeout)
@@ -232,4 +226,19 @@ function onConnectTimeout (socket, opts) {
   util.destroy(socket, new ConnectTimeoutError(message))
 }
 
+function configureSocket (socket, options) {
+  // Set TCP keep alive options on the socket here instead of in connect() for the case of assigning the socket
+  if (options.keepAlive == null || options.keepAlive) {
+    const keepAliveInitialDelay = options.keepAliveInitialDelay === undefined ? 60e3 : options.keepAliveInitialDelay
+
+    socket.setKeepAlive(true, keepAliveInitialDelay)
+  }
+
+  socket.setNoDelay(true)
+
+  return socket
+}
+
 module.exports = buildConnector
+
+module.exports.configureSocket = configureSocket

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -14,7 +14,6 @@ const {
   InformationalError,
   ClientDestroyedError
 } = require('../core/errors.js')
-const buildConnector = require('../core/connect.js')
 const {
   kUrl,
   kServerName,
@@ -190,7 +189,7 @@ class Client extends DispatcherBase {
     super()
 
     if (typeof connect !== 'function') {
-      connect = buildConnector({
+      connect = this._buildConnector({
         ...tls,
         maxCachedSessions,
         allowH2,

--- a/lib/dispatcher/dispatcher-base.js
+++ b/lib/dispatcher/dispatcher-base.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const buildConnector = require('../core/connect.js')
+
 const Dispatcher = require('./dispatcher')
 const {
   ClientDestroyedError,
@@ -152,6 +154,10 @@ class DispatcherBase extends Dispatcher {
 
       return false
     }
+  }
+
+  _buildConnector (options) {
+    return buildConnector(options)
   }
 }
 

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -13,7 +13,6 @@ const {
 } = require('../core/errors')
 const util = require('../core/util')
 const { kUrl } = require('../core/symbols')
-const buildConnector = require('../core/connect')
 
 const kOptions = Symbol('options')
 const kConnections = Symbol('connections')
@@ -52,7 +51,7 @@ class Pool extends PoolBase {
     super()
 
     if (typeof connect !== 'function') {
-      connect = buildConnector({
+      connect = this._buildConnector({
         ...tls,
         maxCachedSessions,
         allowH2,

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -6,7 +6,6 @@ const Agent = require('./agent')
 const Pool = require('./pool')
 const DispatcherBase = require('./dispatcher-base')
 const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = require('../core/errors')
-const buildConnector = require('../core/connect')
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -57,8 +56,8 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
     }
 
-    const connect = buildConnector({ ...opts.proxyTls })
-    this[kConnectEndpoint] = buildConnector({ ...opts.requestTls })
+    const connect = this._buildConnector({ ...opts.proxyTls })
+    this[kConnectEndpoint] = this._buildConnector({ ...opts.requestTls })
     this[kClient] = clientFactory(url, { connect })
     this[kAgent] = new Agent({
       ...opts,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->
https://github.com/nodejs/undici/issues/3486

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

This patch allows to access buildConnector options in the DispatcherBase subclasses.
This will allows to create custom `connect` function in subclasses using `buiildConnector` options.

## Changes

<!-- Write a summary or list of changes here -->
1. `_buildConnector()` protected method added to `DispatcherBase`.
2. `buildConnector` calls changed from direct use to use `this._buildConnector()` method.
3. helper function `configureSocket()` added. It sets socket `no delay` and `keep alive` based on passed options.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->
It is too hard to make `connect` callback receive full list of connect options. 
At least I have no idea how to implement it on current code base without deep refactoring.
This patch helps to solve this problem in dispatcher subclasses, that will be enough for most of developers.

Use case:
```
import Client from 'undici/dispatcher/client'
import { configureSocket } from 'undici/core/connect'

export default class extends Client {

  _buildConnector (buildOptions) {

    // create custom connector
    if (this.proxy) {
      return async (options, callback) => {
        const socket = await this._createSocket(buildOptions, options)

        callback(configureSocket(socket))
      }

    // or fallback to the default behavior
    } else {
      return super._buildConnector(buildOptions)
    }
  }
}
```


### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->
https://github.com/nodejs/undici/issues/3486
### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
