### PR TITLE
fetch: optimize .bytes() mixin

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -305,6 +305,8 @@ function throwIfAborted (state) {
 }
 
 function bodyMixinMethods (instance) {
+  const uint8ArrayFromBytes = Uint8Array.from.bind(Uint8Array)
+
   const methods = {
     blob () {
       // The blob() method steps are to return the result of
@@ -405,9 +407,7 @@ function bodyMixinMethods (instance) {
       // The bytes() method steps are to return the result of running consume body
       // with this and the following step given a byte sequence bytes: return the
       // result of creating a Uint8Array from bytes in this’s relevant realm.
-      return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes)
-      }, instance)
+      return consumeBody(this, uint8ArrayFromBytes, instance)
     }
   }
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -84,6 +84,21 @@ test('request arrayBuffer', (t, done) => {
   })
 })
 
+test('request bytes', (t, done) => {
+  const { deepStrictEqual } = tspl(t, { plan: 1 })
+
+  const server = createServer((req, res) => {
+    res.end('hello world')
+  })
+  t.after(closeServerAsPromise(server))
+
+  server.listen(0, async () => {
+    const body = await fetch(`http://localhost:${server.address().port}`)
+    deepStrictEqual(new Uint8Array(Buffer.from('hello world')), await body.bytes())
+    done()
+  })
+})
+
 test('should set type of blob object to the value of the `Content-Type` header from response', (t, done) => {
   const { strictEqual } = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
looks faster... :-P

Needs a Benchmark like the one for arraybuffers made by @tsctx 