### PR TITLE
fetch: optimize .arrayBuffer() mixin

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -333,7 +333,7 @@ function bodyMixinMethods (instance) {
       // given a byte sequence bytes: return a new ArrayBuffer
       // whose contents are bytes.
       return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes).buffer
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
       }, instance)
     },
 


### PR DESCRIPTION
avoid instantiating an Uint8Array just to get the arraybuffer by directly slicing the necessary arrayBuffer. 