### PR TITLE
chore: integrate consume functions into BodyReadable

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -8,7 +8,15 @@ const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError
 const util = require('../core/util')
 const { ReadableStreamFrom } = require('../core/util')
 
-const kConsume = Symbol('kConsume')
+const noop = () => {}
+
+const kConsuming = Symbol('kConsuming')
+const kBytesConsumed = Symbol('kBytesConsumed')
+const kConsumeBodyChunks = Symbol('kConsumeBodyChunks')
+const kConsumeResolve = Symbol('kConsumeResolve')
+const kConsumeReject = Symbol('kConsumeReject')
+const kConsumeType = Symbol('kConsumeType')
+
 const kReading = Symbol('kReading')
 const kBody = Symbol('kBody')
 const kAbort = Symbol('kAbort')
@@ -16,8 +24,6 @@ const kContentType = Symbol('kContentType')
 const kContentLength = Symbol('kContentLength')
 const kUsed = Symbol('kUsed')
 const kBytesRead = Symbol('kBytesRead')
-
-const noop = () => {}
 
 /**
  * @class
@@ -50,10 +56,13 @@ class BodyReadable extends Readable {
 
     this[kAbort] = abort
 
-    /**
-     * @type {Consume | null}
-     */
-    this[kConsume] = null
+    this[kConsuming] = false
+    this[kBytesConsumed] = 0
+    this[kConsumeBodyChunks] = null
+    this[kConsumeResolve] = null
+    this[kConsumeReject] = null
+    this[kConsumeType] = null
+
     this[kBytesRead] = 0
     /**
      * @type {ReadableStream|null}
@@ -151,8 +160,8 @@ class BodyReadable extends Readable {
   push (chunk) {
     this[kBytesRead] += chunk ? chunk.length : 0
 
-    if (this[kConsume] && chunk !== null) {
-      consumePush(this[kConsume], chunk)
+    if (this[kConsuming] && chunk !== null) {
+      this.#consumePush(chunk)
       return this[kReading] ? super.push(chunk) : true
     }
     return super.push(chunk)
@@ -165,7 +174,7 @@ class BodyReadable extends Readable {
    * @returns {Promise<string>}
    */
   async text () {
-    return consume(this, 'text')
+    return this.#consume('text')
   }
 
   /**
@@ -175,7 +184,7 @@ class BodyReadable extends Readable {
    * @returns {Promise<unknown>}
    */
   async json () {
-    return consume(this, 'json')
+    return this.#consume('json')
   }
 
   /**
@@ -185,7 +194,7 @@ class BodyReadable extends Readable {
    * @returns {Promise<Blob>}
    */
   async blob () {
-    return consume(this, 'blob')
+    return this.#consume('blob')
   }
 
   /**
@@ -195,7 +204,7 @@ class BodyReadable extends Readable {
    * @returns {Promise<Uint8Array>}
    */
   async bytes () {
-    return consume(this, 'bytes')
+    return this.#consume('bytes')
   }
 
   /**
@@ -205,7 +214,7 @@ class BodyReadable extends Readable {
    * @returns {Promise<ArrayBuffer>}
    */
   async arrayBuffer () {
-    return consume(this, 'arrayBuffer')
+    return this.#consume('arrayBuffer')
   }
 
   /**
@@ -239,13 +248,145 @@ class BodyReadable extends Readable {
   get body () {
     if (!this[kBody]) {
       this[kBody] = ReadableStreamFrom(this)
-      if (this[kConsume]) {
+      if (this[kConsuming]) {
         // TODO: Is this the best way to force a lock?
         this[kBody].getReader() // Ensure stream is locked.
         assert(this[kBody].locked)
       }
     }
     return this[kBody]
+  }
+
+  /**
+   * @param {string} type
+   * @returns {Promise<any>}
+   */
+  #consume (type) {
+    assert(this[kConsuming] === false)
+
+    return new Promise((resolve, reject) => {
+      if (isUnusable(this)) {
+        const rState = this._readableState
+        if (rState.destroyed && rState.closeEmitted === false) {
+          this
+            .on('error', reject)
+            .on('close', () => {
+              reject(new TypeError('unusable'))
+            })
+        } else {
+          reject(rState.errored ?? new TypeError('unusable'))
+        }
+      } else {
+        queueMicrotask(() => {
+          this[kConsuming] = true
+          this[kConsumeType] = type
+          this[kConsumeResolve] = resolve
+          this[kConsumeReject] = reject
+          this[kConsumeBodyChunks] = []
+
+          this
+            .on('error', this.#consumeFinish)
+            .on('close', function () {
+              if (this[kConsumeBodyChunks] !== null) {
+                this.#consumeFinish(new RequestAbortedError())
+              }
+            })
+
+          this.#consumeStart()
+        })
+      }
+    })
+  }
+
+  /**
+   * @returns {void}
+   */
+  #consumeStart () {
+    if (this[kConsumeBodyChunks] === null) {
+      return
+    }
+
+    const state = this._readableState
+
+    if (state.bufferIndex) {
+      const start = state.bufferIndex
+      const end = state.buffer.length
+      for (let n = start; n < end; n++) {
+        this.#consumePush(state.buffer[n])
+      }
+    } else {
+      for (const chunk of state.buffer) {
+        this.#consumePush(chunk)
+      }
+    }
+
+    if (state.endEmitted) {
+      this.#consumeEnd()
+    } else {
+      this.on('end', this.#consumeEnd)
+    }
+
+    this.resume()
+
+    while (this.read() != null) {
+      // Loop
+    }
+  }
+
+  /**
+   * @param {Buffer} chunk
+   * @returns {void}
+   */
+  #consumePush (chunk) {
+    this[kBytesConsumed] += chunk.length
+    this[kConsumeBodyChunks].push(chunk)
+  }
+
+  /**
+   * @returns {void}
+   */
+  #consumeEnd () {
+    const { [kConsumeType]: type, [kConsumeBodyChunks]: bodyChunks, [kConsumeResolve]: resolve, [kBytesConsumed]: length } = this
+    const encoding = this._readableState.encoding
+    try {
+      if (type === 'text') {
+        resolve(chunksDecode(bodyChunks, length, encoding))
+      } else if (type === 'json') {
+        resolve(JSON.parse(chunksDecode(bodyChunks, length, encoding)))
+      } else if (type === 'arrayBuffer') {
+        resolve(chunksConcat(bodyChunks, length).buffer)
+      } else if (type === 'blob') {
+        resolve(new Blob(bodyChunks, { type: this[kContentType] }))
+      } else if (type === 'bytes') {
+        resolve(chunksConcat(bodyChunks, length))
+      }
+
+      this.#consumeFinish()
+    } catch (err) {
+      this.destroy(err)
+    }
+  }
+
+  /**
+ * @param {Error} [err]
+ * @returns {void}
+ */
+  #consumeFinish (err) {
+    if (this[kConsumeBodyChunks] === null) {
+      return
+    }
+
+    if (err) {
+      this[kConsumeReject](err)
+    } else {
+      this[kConsumeResolve]()
+    }
+
+    // Reset the consume object to allow for garbage collection.
+    this[kConsumeType] = null
+    this[kConsumeResolve] = null
+    this[kConsumeReject] = null
+    this[kConsumeBodyChunks] = null
   }
 
   /**
@@ -328,7 +469,7 @@ class BodyReadable extends Readable {
  */
 function isLocked (bodyReadable) {
   // Consume is an implicit lock.
-  return bodyReadable[kBody]?.locked === true || bodyReadable[kConsume] !== null
+  return bodyReadable[kBody]?.locked === true || bodyReadable[kConsuming] === true
 }
 
 /**
@@ -338,103 +479,6 @@ function isLocked (bodyReadable) {
  */
 function isUnusable (bodyReadable) {
   return util.isDisturbed(bodyReadable) || isLocked(bodyReadable)
-}
-
-/**
- * @typedef {object} Consume
- * @property {string} type
- * @property {BodyReadable} stream
- * @property {((value?: any) => void)} resolve
- * @property {((err: Error) => void)} reject
- * @property {number} length
- * @property {Buffer[]} body
- */
-
-/**
- * @param {BodyReadable} stream
- * @param {string} type
- * @returns {Promise<any>}
- */
-async function consume (stream, type) {
-  assert(!stream[kConsume])
-
-  return new Promise((resolve, reject) => {
-    if (isUnusable(stream)) {
-      const rState = stream._readableState
-      if (rState.destroyed && rState.closeEmitted === false) {
-        stream
-          .on('error', err => {
-            reject(err)
-          })
-          .on('close', () => {
-            reject(new TypeError('unusable'))
-          })
-      } else {
-        reject(rState.errored ?? new TypeError('unusable'))
-      }
-    } else {
-      queueMicrotask(() => {
-        stream[kConsume] = {
-          type,
-          stream,
-          resolve,
-          reject,
-          length: 0,
-          body: []
-        }
-
-        stream
-          .on('error', function (err) {
-            consumeFinish(this[kConsume], err)
-          })
-          .on('close', function () {
-            if (this[kConsume].body !== null) {
-              consumeFinish(this[kConsume], new RequestAbortedError())
-            }
-          })
-
-        consumeStart(stream[kConsume])
-      })
-    }
-  })
-}
-
-/**
- * @param {Consume} consume
- * @returns {void}
- */
-function consumeStart (consume) {
-  if (consume.body === null) {
-    return
-  }
-
-  const { _readableState: state } = consume.stream
-
-  if (state.bufferIndex) {
-    const start = state.bufferIndex
-    const end = state.buffer.length
-    for (let n = start; n < end; n++) {
-      consumePush(consume, state.buffer[n])
-    }
-  } else {
-    for (const chunk of state.buffer) {
-      consumePush(consume, chunk)
-    }
-  }
-
-  if (state.endEmitted) {
-    consumeEnd(this[kConsume], this._readableState.encoding)
-  } else {
-    consume.stream.on('end', function () {
-      consumeEnd(this[kConsume], this._readableState.encoding)
-    })
-  }
-
-  consume.stream.resume()
-
-  while (consume.stream.read() != null) {
-    // Loop
-  }
 }
 
 /**
@@ -488,68 +532,6 @@ function chunksConcat (chunks, length) {
   }
 
   return buffer
-}
-
-/**
- * @param {Consume} consume
- * @param {BufferEncoding} encoding
- * @returns {void}
- */
-function consumeEnd (consume, encoding) {
-  const { type, body, resolve, stream, length } = consume
-
-  try {
-    if (type === 'text') {
-      resolve(chunksDecode(body, length, encoding))
-    } else if (type === 'json') {
-      resolve(JSON.parse(chunksDecode(body, length, encoding)))
-    } else if (type === 'arrayBuffer') {
-      resolve(chunksConcat(body, length).buffer)
-    } else if (type === 'blob') {
-      resolve(new Blob(body, { type: stream[kContentType] }))
-    } else if (type === 'bytes') {
-      resolve(chunksConcat(body, length))
-    }
-
-    consumeFinish(consume)
-  } catch (err) {
-    stream.destroy(err)
-  }
-}
-
-/**
- * @param {Consume} consume
- * @param {Buffer} chunk
- * @returns {void}
- */
-function consumePush (consume, chunk) {
-  consume.length += chunk.length
-  consume.body.push(chunk)
-}
-
-/**
- * @param {Consume} consume
- * @param {Error} [err]
- * @returns {void}
- */
-function consumeFinish (consume, err) {
-  if (consume.body === null) {
-    return
-  }
-
-  if (err) {
-    consume.reject(err)
-  } else {
-    consume.resolve()
-  }
-
-  // Reset the consume object to allow for garbage collection.
-  consume.type = null
-  consume.stream = null
-  consume.resolve = null
-  consume.reject = null
-  consume.length = 0
-  consume.body = null
 }
 
 module.exports = {


### PR DESCRIPTION
All the consume functions are actually processing the internal state of the BodyReadable indicating that they should be private methods and not standalone functions.