### PR TITLE
prefer fail over close the websocket connection in error cases

### DIFF
--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -15,7 +15,6 @@ const {
   isContinuationFrame
 } = require('./util')
 const { WebsocketFrameSend } = require('./frame')
-const { closeWebSocketConnection } = require('./connection')
 const { PerMessageDeflate } = require('./permessage-deflate')
 
 // This code was influenced by ws released under the MIT license.
@@ -225,7 +224,7 @@ class ByteParser extends Writable {
           } else {
             this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
               if (error) {
-                closeWebSocketConnection(this.#handler, 1007, error.message)
+                failWebsocketConnection(this.#handler, 1007, error.message)
                 return
               }
 

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -50,7 +50,7 @@ class WebSocketStream {
     onConnectionEstablished: (response, extensions) => this.#onConnectionEstablished(response, extensions),
     onFail: (reason) => this.#onFail(reason),
     onMessage: (opcode, data) => this.#onMessage(opcode, data),
-    onParserError: (err) => {}, // eslint-disable-line
+    onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message), // eslint-disable-line
     onParserDrain: () => this.#handler.socket.resume(),
     onSocketData: (chunk) => {
       if (!this.#parser.write(chunk)) {

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -50,7 +50,7 @@ class WebSocketStream {
     onConnectionEstablished: (response, extensions) => this.#onConnectionEstablished(response, extensions),
     onFail: (reason) => this.#onFail(reason),
     onMessage: (opcode, data) => this.#onMessage(opcode, data),
-    onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message), // eslint-disable-line
+    onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message),
     onParserDrain: () => this.#handler.socket.resume(),
     onSocketData: (chunk) => {
       if (!this.#parser.write(chunk)) {

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -61,7 +61,7 @@ class WebSocket extends EventTarget {
     onConnectionEstablished: (response, extensions) => this.#onConnectionEstablished(response, extensions),
     onFail: (code, reason) => this.#onFail(code, reason),
     onMessage: (opcode, data) => this.#onMessage(opcode, data),
-    onParserError: (err) => this.#onParserError(err),
+    onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message),
     onParserDrain: () => this.#onParserDrain(),
     onSocketData: (chunk) => {
       if (!this.#parser.write(chunk)) {
@@ -527,14 +527,6 @@ class WebSocket extends EventTarget {
       origin: this.#url.origin,
       data: dataForEvent
     })
-  }
-
-  #onParserError (err) {
-    const message = err.message
-
-    fireEvent('error', this, () => new ErrorEvent('error', { error: err, message }))
-
-    failWebsocketConnection(this.#handler, null, message)
   }
 
   #onParserDrain () {

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -530,19 +530,11 @@ class WebSocket extends EventTarget {
   }
 
   #onParserError (err) {
-    let message
-    let code
-
-    if (err instanceof CloseEvent) {
-      message = err.reason
-      code = err.code
-    } else {
-      message = err.message
-    }
+    const message = err.message
 
     fireEvent('error', this, () => new ErrorEvent('error', { error: err, message }))
 
-    closeWebSocketConnection(this.#handler, code, null)
+    failWebsocketConnection(this.#handler, null, message)
   }
 
   #onParserDrain () {


### PR DESCRIPTION
both \_fail the websocket connection\_ and \_close the websocket connection\_ do fundamentally the same things, but failing it will emit an error event (for WebSocket) which is a better fit for these cases