### PR TITLE
feat: sqlite cache store

### DIFF
--- a/docs/docs/api/CacheStore.md
+++ b/docs/docs/api/CacheStore.md
@@ -13,8 +13,20 @@ The `MemoryCacheStore` stores the responses in-memory.
 
 **Options**
 
-- `maxEntries` - The maximum amount of responses to store. Default `Infinity`.
+- `maxCount` - The maximum amount of responses to store. Default `Infinity`.
 - `maxEntrySize` - The maximum size in bytes that a response's body can be. If a response's body is greater than or equal to this, the response will not be cached.
+
+### `SqliteCacheStore`
+
+The `SqliteCacheStore` stores the responses in a SQLite database.
+Under the hood, it uses Node.js' [`node:sqlite`](https://nodejs.org/api/sqlite.html) api.
+The `SqliteCacheStore` is only exposed if the `node:sqlite` api is present.
+
+**Options**
+
+- `location` - The location of the SQLite database to use. Default `:memory:`.
+- `maxCount` - The maximum number of entries to store in the database. Default `Infinity`.
+- `maxEntrySize` - The maximum size in bytes that a resposne's body can be. If a response's body is greater than or equal to this, the response will not be cached. Default `Infinity`.
 
 ## Defining a Custom Cache Store
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,15 @@ module.exports.cacheStores = {
   MemoryCacheStore: require('./lib/cache/memory-cache-store')
 }
 
+try {
+  const SqliteCacheStore = require('./lib/cache/sqlite-cache-store')
+  module.exports.cacheStores.SqliteCacheStore = SqliteCacheStore
+} catch (err) {
+  if (err.code !== 'ERR_UNKNOWN_BUILTIN_MODULE') {
+    throw err
+  }
+}
+
 module.exports.buildConnector = buildConnector
 module.exports.errors = errors
 module.exports.util = {

--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Writable } = require('node:stream')
+const { assertCacheKey, assertCacheValue } = require('../util/cache.js')
 
 /**
  * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheKey} CacheKey
@@ -41,17 +42,6 @@ class MemoryCacheStore {
         this.#maxCount = opts.maxCount
       }
 
-      if (opts.maxSize !== undefined) {
-        if (
-          typeof opts.maxSize !== 'number' ||
-          !Number.isInteger(opts.maxSize) ||
-          opts.maxSize < 0
-        ) {
-          throw new TypeError('MemoryCacheStore options.maxSize must be a non-negative integer')
-        }
-        this.#maxSize = opts.maxSize
-      }
-
       if (opts.maxEntrySize !== undefined) {
         if (
           typeof opts.maxEntrySize !== 'number' ||
@@ -70,9 +60,7 @@ class MemoryCacheStore {
    * @returns {import('../../types/cache-interceptor.d.ts').default.GetResult | undefined}
    */
   get (key) {
-    if (typeof key !== 'object') {
-      throw new TypeError(`expected key to be object, got ${typeof key}`)
-    }
+    assertCacheKey(key)
 
     const topLevelKey = `${key.origin}:${key.path}`
 
@@ -103,12 +91,8 @@ class MemoryCacheStore {
    * @returns {Writable | undefined}
    */
   createWriteStream (key, val) {
-    if (typeof key !== 'object') {
-      throw new TypeError(`expected key to be object, got ${typeof key}`)
-    }
-    if (typeof val !== 'object') {
-      throw new TypeError(`expected value to be object, got ${typeof val}`)
-    }
+    assertCacheKey(key)
+    assertCacheValue(val)
 
     const topLevelKey = `${key.origin}:${key.path}`
 
@@ -142,7 +126,7 @@ class MemoryCacheStore {
         store.#size += entry.size
         store.#count += 1
 
-        if (store.#size > store.#maxSize || store.#count > store.#maxCount) {
+        if (store.#size > store.#maxEntrySize || store.#count > store.#maxCount) {
           for (const [key, entries] of store.#entries) {
             for (const entry of entries.splice(0, entries.length / 2)) {
               store.#size -= entry.size

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -1,0 +1,450 @@
+'use strict'
+
+const { DatabaseSync } = require('node:sqlite')
+const { Writable } = require('stream')
+const { assertCacheKey, assertCacheValue } = require('../util/cache.js')
+
+/**
+ * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheStore} CacheStore
+ * @implements {CacheStore}
+ *
+ * @typedef {{
+ *  id: Readonly<number>
+ *  rawHeaders?: string
+ *  vary?: string | object
+ *  body: string
+ * } & import('../../types/cache-interceptor.d.ts').default.CacheValue} SqliteStoreValue
+ */
+class SqliteCacheStore {
+  #maxEntrySize = Infinity
+  #maxCount = Infinity
+
+  /**
+   * @type {import('node:sqlite').DatabaseSync}
+   */
+  #db
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #getValuesQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #updateValueQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #insertValueQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #deleteExpiredValuesQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #deleteByUrlQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #countEntriesQuery
+
+  /**
+   * @type {import('node:sqlite').StatementSync}
+   */
+  #deleteOldValuesQuery
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.SqliteCacheStoreOpts | undefined} opts
+   */
+  constructor (opts) {
+    if (opts) {
+      if (typeof opts !== 'object') {
+        throw new TypeError('SqliteCacheStore options must be an object')
+      }
+
+      if (opts.maxEntrySize !== undefined) {
+        if (
+          typeof opts.maxEntrySize !== 'number' ||
+          !Number.isInteger(opts.maxEntrySize) ||
+          opts.maxEntrySize < 0
+        ) {
+          throw new TypeError('SqliteCacheStore options.maxEntrySize must be a non-negative integer')
+        }
+        this.#maxEntrySize = opts.maxEntrySize
+      }
+
+      if (opts.maxCount !== undefined) {
+        if (
+          typeof opts.maxCount !== 'number' ||
+          !Number.isInteger(opts.maxCount) ||
+          opts.maxCount < 0
+        ) {
+          throw new TypeError('SqliteCacheStore options.maxCount must be a non-negative integer')
+        }
+        this.#maxCount = opts.maxCount
+      }
+    }
+
+    this.#db = new DatabaseSync(opts?.location ?? ':memory:')
+
+    this.#db.exec(`
+      CREATE TABLE IF NOT EXISTS cacheInterceptorV1 (
+        -- Data specific to us
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url TEXT NOT NULL,
+        method TEXT NOT NULL,
+
+        -- Data returned to the interceptor
+        body TEXT NULL,
+        deleteAt INTEGER NOT NULL,
+        statusCode INTEGER NOT NULL,
+        statusMessage TEXT NOT NULL,
+        rawHeaders TEXT NULL,
+        etag TEXT NULL,
+        vary TEXT NULL,
+        cachedAt INTEGER NOT NULL,
+        staleAt INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV1_url ON cacheInterceptorV1(url);
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV1_method ON cacheInterceptorV1(method);
+      CREATE INDEX IF NOT EXISTS idx_cacheInterceptorV1_deleteAt ON cacheInterceptorV1(deleteAt);
+    `)
+
+    this.#getValuesQuery = this.#db.prepare(`
+      SELECT
+        id,
+        body,
+        deleteAt,
+        statusCode,
+        statusMessage,
+        rawHeaders,
+        etag,
+        vary,
+        cachedAt,
+        staleAt
+      FROM cacheInterceptorV1
+      WHERE
+        url = ?
+        AND method = ?
+      ORDER BY
+        deleteAt ASC
+    `)
+
+    this.#updateValueQuery = this.#db.prepare(`
+      UPDATE cacheInterceptorV1 SET
+        body = ?,
+        deleteAt = ?,
+        statusCode = ?,
+        statusMessage = ?,
+        rawHeaders = ?,
+        etag = ?,
+        cachedAt = ?,
+        staleAt = ?,
+        deleteAt = ?
+      WHERE
+        id = ?
+    `)
+
+    this.#insertValueQuery = this.#db.prepare(`
+      INSERT INTO cacheInterceptorV1 (
+        url,
+        method,
+        body,
+        deleteAt,
+        statusCode,
+        statusMessage,
+        rawHeaders,
+        etag,
+        vary,
+        cachedAt,
+        staleAt,
+        deleteAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+
+    this.#deleteExpiredValuesQuery = this.#db.prepare(
+      'DELETE FROM cacheInterceptorV1 WHERE deleteAt <= ?'
+    )
+
+    this.#deleteByUrlQuery = this.#db.prepare(
+      'DELETE FROM cacheInterceptorV1 WHERE url = ?'
+    )
+
+    this.#countEntriesQuery = this.#db.prepare(
+      'SELECT COUNT(*) AS total FROM cacheInterceptorV1'
+    )
+
+    const pruneLimit = this.#maxCount === Infinity
+      ? 20
+      : Math.max(Math.floor(this.#maxCount * 0.1), 1)
+
+    this.#deleteOldValuesQuery = this.#db.prepare(`
+      DELETE FROM cacheInterceptorV1
+      WHERE id IN (
+        SELECT
+          id
+        FROM cacheInterceptorV1
+        ORDER BY cachedAt DESC
+        LIMIT ${pruneLimit}
+      )
+    `)
+  }
+
+  close () {
+    this.#db.close()
+  }
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @returns {import('../../types/cache-interceptor.d.ts').default.GetResult | undefined}
+   */
+  get (key) {
+    assertCacheKey(key)
+
+    const value = this.#findValue(key)
+
+    if (!value) {
+      return undefined
+    }
+
+    /**
+     * @type {import('../../types/cache-interceptor.d.ts').default.GetResult}
+     */
+    const result = {
+      body: value.body ? parseBufferArray(JSON.parse(value.body)) : null,
+      statusCode: value.statusCode,
+      statusMessage: value.statusMessage,
+      rawHeaders: value.rawHeaders ? parseBufferArray(JSON.parse(value.rawHeaders)) : undefined,
+      etag: value.etag ? value.etag : undefined,
+      cachedAt: value.cachedAt,
+      staleAt: value.staleAt,
+      deleteAt: value.deleteAt
+    }
+
+    return result
+  }
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheValue} value
+   * @returns {Writable | undefined}
+   */
+  createWriteStream (key, value) {
+    assertCacheKey(key)
+    assertCacheValue(value)
+
+    const url = this.#makeValueUrl(key)
+    let currentSize = 0
+    /**
+     * @type {Buffer[] | null}
+     */
+    let body = key.method !== 'HEAD' ? [] : null
+    const maxEntrySize = this.#maxEntrySize
+    const findValue = this.#findValue.bind(this)
+    const updateValueQuery = this.#updateValueQuery
+    const insertValueQuery = this.#insertValueQuery
+
+    this.prune()
+
+    const writable = new Writable({
+      write (chunk, encoding, callback) {
+        if (typeof chunk === 'string') {
+          chunk = Buffer.from(chunk, encoding)
+        }
+
+        currentSize += chunk.byteLength
+
+        if (body) {
+          if (currentSize >= maxEntrySize) {
+            body = null
+            this.end()
+            return callback()
+          }
+
+          body.push(chunk)
+        }
+
+        callback()
+      },
+      final (callback) {
+        if (body === null) {
+          return callback()
+        }
+
+        /**
+         * @type {SqliteStoreValue | undefined}
+         */
+        const existingValue = findValue(key, true)
+        if (existingValue) {
+          // Updating an existing response, let's delete it
+          updateValueQuery.run(
+            JSON.stringify(stringifyBufferArray(body)),
+            value.deleteAt,
+            value.statusCode,
+            value.statusMessage,
+            value.rawHeaders ? JSON.stringify(stringifyBufferArray(value.rawHeaders)) : null,
+            value.etag,
+            value.cachedAt,
+            value.staleAt,
+            value.deleteAt,
+            existingValue.id
+          )
+        } else {
+          // New response, let's insert it
+          insertValueQuery.run(
+            url,
+            key.method,
+            JSON.stringify(stringifyBufferArray(body)),
+            value.deleteAt,
+            value.statusCode,
+            value.statusMessage,
+            value.rawHeaders ? JSON.stringify(stringifyBufferArray(value.rawHeaders)) : null,
+            value.etag ? value.etag : null,
+            value.vary ? JSON.stringify(value.vary) : null,
+            value.cachedAt,
+            value.staleAt,
+            value.deleteAt
+          )
+        }
+
+        callback()
+      }
+    })
+
+    return writable
+  }
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   */
+  delete (key) {
+    if (typeof key !== 'object') {
+      throw new TypeError(`expected key to be object, got ${typeof key}`)
+    }
+
+    this.#deleteByUrlQuery.run(this.#makeValueUrl(key))
+  }
+
+  /**
+   * This method is called to prune the cache when it exceeds the maximum number
+   * of entries. It removes half the entries in the cache, ordering them the oldest.
+   *
+   * @returns {Number} The number of entries removed
+   */
+  prune () {
+    const total = this.size
+
+    if (total <= this.#maxCount) {
+      return
+    }
+
+    const res = this.#deleteOldValuesQuery.run()
+
+    return res.changes
+  }
+
+  /**
+   * Counts the number of rows in the cache
+   * @returns {Number}
+   */
+  get size () {
+    const { total } = this.#countEntriesQuery.get()
+    return total
+  }
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @returns {string}
+   */
+  #makeValueUrl (key) {
+    return `${key.origin}/${key.path}`
+  }
+
+  /**
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @param {boolean} [canBeExpired=false]
+   * @returns {(SqliteStoreValue & { vary?: Record<string, string[]> }) | undefined}
+   */
+  #findValue (key, canBeExpired = false) {
+    const url = this.#makeValueUrl(key)
+
+    /**
+     * @type {SqliteStoreValue[]}
+     */
+    const values = this.#getValuesQuery.all(url, key.method)
+
+    if (values.length === 0) {
+      // No responses, let's just return early
+      return undefined
+    }
+
+    const now = Date.now()
+    for (const value of values) {
+      if (now >= value.deleteAt && !canBeExpired) {
+        this.#deleteExpiredValuesQuery.run(now)
+        return undefined
+      }
+
+      let matches = true
+
+      if (value.vary) {
+        if (!key.headers) {
+          // Request doesn't have headers so it can't fulfill the vary
+          //  requirements no matter what, let's return early
+          return undefined
+        }
+
+        value.vary = JSON.parse(value.vary)
+
+        for (const header in value.vary) {
+          if (key.headers[header] !== value.vary[header]) {
+            matches = false
+            break
+          }
+        }
+      }
+
+      if (matches) {
+        return value
+      }
+    }
+
+    return undefined
+  }
+}
+
+/**
+ * @param {Buffer[]} buffers
+ * @returns {string[]}
+ */
+function stringifyBufferArray (buffers) {
+  const output = new Array(buffers.length)
+  for (let i = 0; i < buffers.length; i++) {
+    output[i] = buffers[i].toString()
+  }
+
+  return output
+}
+
+/**
+ * @param {string[]} strings
+ * @returns {Buffer[]}
+ */
+function parseBufferArray (strings) {
+  const output = new Array(strings.length)
+
+  for (let i = 0; i < strings.length; i++) {
+    output[i] = Buffer.from(strings[i])
+  }
+
+  return output
+}
+
+module.exports = SqliteCacheStore

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -27,6 +27,56 @@ function makeCacheKey (opts) {
 }
 
 /**
+ * @param {any} value
+ */
+function assertCacheKey (key) {
+  if (typeof key !== 'object') {
+    throw new TypeError(`expected key to be object, got ${typeof key}`)
+  }
+
+  for (const property of ['origin', 'method', 'path']) {
+    if (typeof key[property] !== 'string') {
+      throw new TypeError(`expected key.${property} to be string, got ${typeof key[property]}`)
+    }
+  }
+
+  if (key.headers !== undefined && typeof key.headers !== 'object') {
+    throw new TypeError(`expected headers to be object, got ${typeof key}`)
+  }
+}
+
+/**
+ * @param {any} value
+ */
+function assertCacheValue (value) {
+  if (typeof value !== 'object') {
+    throw new TypeError(`expected value to be object, got ${typeof value}`)
+  }
+
+  for (const property of ['statusCode', 'cachedAt', 'staleAt', 'deleteAt']) {
+    if (typeof value[property] !== 'number') {
+      throw new TypeError(`expected value.${property} to be number, got ${typeof value[property]}`)
+    }
+  }
+
+  if (typeof value.statusMessage !== 'string') {
+    throw new TypeError(`expected value.statusMessage to be string, got ${typeof value.statusMessage}`)
+  }
+
+  if (!Array.isArray(value.rawHeaders)) {
+    throw new TypeError(`expected value.rawHeaders to be array, got ${typeof value.rawHeaders}`)
+  }
+
+  if (value.vary !== undefined && typeof value.vary !== 'object') {
+    throw new TypeError(`expected value.vary to be object, got ${typeof value.vary}`)
+  }
+
+  if (value.etag !== undefined && typeof value.etag !== 'string') {
+    throw new TypeError(`expected value.etag to be string, got ${typeof value.etag}`)
+  }
+}
+
+/**
  * @see https://www.rfc-editor.org/rfc/rfc9111.html#name-cache-control
  * @see https://www.iana.org/assignments/http-cache-directives/http-cache-directives.xhtml
  *
@@ -276,6 +326,8 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
 
 module.exports = {
   makeCacheKey,
+  assertCacheKey,
+  assertCacheValue,
   parseCacheControlHeader,
   parseVaryHeader,
   isEtagUsable,

--- a/test/cache-interceptor/cache-store-test-utils.js
+++ b/test/cache-interceptor/cache-store-test-utils.js
@@ -1,20 +1,20 @@
 'use strict'
 
 const { describe, test } = require('node:test')
-const { deepStrictEqual, notEqual, equal } = require('node:assert')
+const { deepStrictEqual, notEqual, equal, ok } = require('node:assert')
 const { Readable } = require('node:stream')
 const { once } = require('node:events')
-const MemoryCacheStore = require('../../lib/cache/memory-cache-store')
-
-cacheStoreTests(MemoryCacheStore)
 
 /**
- * @param {import('../../types/cache-interceptor.d.ts').default.CacheStore} CacheStore
+ * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheStore} CacheStore
+ *
+ * @param {{ new(...any): CacheStore }} CacheStore
  */
 function cacheStoreTests (CacheStore) {
   describe(CacheStore.prototype.constructor.name, () => {
     test('matches interface', async () => {
       const store = new CacheStore()
+      ok(['boolean', 'undefined'].includes(typeof store.isFull))
       equal(typeof store.get, 'function')
       equal(typeof store.createWriteStream, 'function')
       equal(typeof store.delete, 'function')
@@ -144,6 +144,7 @@ function cacheStoreTests (CacheStore) {
         statusCode: 200,
         statusMessage: '',
         cachedAt: Date.now() - 20000,
+        rawHeaders: [],
         staleAt: Date.now() - 10000,
         deleteAt: Date.now() - 5
       }
@@ -227,6 +228,7 @@ function writeResponse (stream, body) {
   }
 
   stream.end()
+  return stream
 }
 
 /**
@@ -253,4 +255,10 @@ async function readResponse ({ body: src, ...response }) {
     ...response,
     body
   }
+}
+
+module.exports = {
+  cacheStoreTests,
+  writeResponse,
+  readResponse
 }

--- a/test/cache-interceptor/memory-cache-store-tests.js
+++ b/test/cache-interceptor/memory-cache-store-tests.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const MemoryCacheStore = require('../../lib/cache/memory-cache-store')
+const { cacheStoreTests } = require('./cache-store-test-utils.js')
+
+cacheStoreTests(MemoryCacheStore)

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -1,0 +1,127 @@
+'use strict'
+
+const { test, skip } = require('node:test')
+const { deepStrictEqual, notEqual, strictEqual } = require('node:assert')
+const { rm } = require('node:fs/promises')
+const { cacheStoreTests, writeResponse, readResponse } = require('./cache-store-test-utils.js')
+const { once } = require('node:events')
+
+let hasSqlite = false
+try {
+  require('node:sqlite')
+
+  const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
+  cacheStoreTests(SqliteCacheStore)
+  hasSqlite = true
+} catch (err) {
+  if (err.code === 'ERR_UNKNOWN_BUILTIN_MODULE') {
+    skip('`node:sqlite` not present')
+  } else {
+    throw err
+  }
+}
+
+test('SqliteCacheStore works nicely with multiple stores', async (t) => {
+  if (!hasSqlite) {
+    t.skip()
+    return
+  }
+
+  const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
+  const sqliteLocation = 'cache-interceptor.sqlite'
+
+  const storeA = new SqliteCacheStore({
+    location: sqliteLocation
+  })
+
+  const storeB = new SqliteCacheStore({
+    location: sqliteLocation
+  })
+
+  t.after(async () => {
+    await rm(sqliteLocation)
+  })
+
+  const request = {
+    origin: 'localhost',
+    path: '/',
+    method: 'GET',
+    headers: {}
+  }
+
+  const requestValue = {
+    statusCode: 200,
+    statusMessage: '',
+    rawHeaders: [Buffer.from('1'), Buffer.from('2'), Buffer.from('3')],
+    cachedAt: Date.now(),
+    staleAt: Date.now() + 10000,
+    deleteAt: Date.now() + 20000
+  }
+  const requestBody = ['asd', '123']
+
+  const writable = storeA.createWriteStream(request, requestValue)
+  notEqual(writable, undefined)
+  writeResponse(writable, requestBody)
+
+  // Make sure we got the expected response from store a
+  let readable = storeA.get(request)
+  notEqual(readable, undefined)
+  deepStrictEqual(await readResponse(readable), {
+    ...requestValue,
+    etag: undefined,
+    body: requestBody
+  })
+
+  // Make sure we got the expected response from store b
+  readable = storeB.get(request)
+  notEqual(readable, undefined)
+  deepStrictEqual(await readResponse(readable), {
+    ...requestValue,
+    etag: undefined,
+    body: requestBody
+  })
+})
+
+test('SqliteCacheStore maxEntries', async (t) => {
+  if (!hasSqlite) {
+    t.skip()
+    return
+  }
+
+  const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
+  const sqliteLocation = 'cache-interceptor.sqlite'
+
+  const store = new SqliteCacheStore({
+    location: sqliteLocation,
+    maxCount: 10
+  })
+
+  t.after(async () => {
+    await rm(sqliteLocation)
+  })
+
+  for (let i = 0; i < 20; i++) {
+    const request = {
+      origin: 'localhost',
+      path: '/' + i,
+      method: 'GET',
+      headers: {}
+    }
+
+    const requestValue = {
+      statusCode: 200,
+      statusMessage: '',
+      rawHeaders: [Buffer.from('1'), Buffer.from('2'), Buffer.from('3')],
+      cachedAt: Date.now(),
+      staleAt: Date.now() + 10000,
+      deleteAt: Date.now() + 20000
+    }
+    const requestBody = ['asd', '123']
+
+    const writable = store.createWriteStream(request, requestValue)
+    notEqual(writable, undefined)
+    await once(writeResponse(writable, requestBody), 'close')
+  }
+
+  strictEqual(store.size <= 11, true)
+})

--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -54,5 +54,11 @@ expectNotAssignable<CacheInterceptor.CacheValue>({
 
 expectAssignable<CacheInterceptor.MemoryCacheStoreOpts>({})
 expectAssignable<CacheInterceptor.MemoryCacheStoreOpts>({
+  maxSize: 0
+})
+
+expectAssignable<CacheInterceptor.SqliteCacheStoreOpts>({})
+expectAssignable<CacheInterceptor.SqliteCacheStoreOpts>({
+  location: '',
   maxEntrySize: 0
 })

--- a/types/cache-interceptor.d.ts
+++ b/types/cache-interceptor.d.ts
@@ -46,6 +46,7 @@ declare namespace CacheHandler {
     statusCode: number
     statusMessage: string
     rawHeaders: Buffer[]
+    etag?: string
     body: null | Readable | Iterable<Buffer> | AsyncIterable<Buffer> | Buffer | Iterable<string> | AsyncIterable<string> | string
     cachedAt: number
     staleAt: number
@@ -70,20 +71,48 @@ declare namespace CacheHandler {
     maxCount?: number
 
     /**
-       * @default Infinity
-       */
+     * @default Infinity
+     */
     maxSize?: number
-
-    /**
-       * @default Infinity
-       */
-    maxEntrySize?: number
 
     errorCallback?: (err: Error) => void
   }
 
   export class MemoryCacheStore implements CacheStore {
     constructor (opts?: MemoryCacheStoreOpts)
+
+    get (key: CacheKey): GetResult | Promise<GetResult | undefined> | undefined
+
+    createWriteStream (key: CacheKey, value: CacheValue): Writable | undefined
+
+    delete (key: CacheKey): void | Promise<void>
+  }
+
+  export interface SqliteCacheStoreOpts {
+    /**
+     * Location of the database
+     * @default ':memory:'
+     */
+    location?: string
+
+    /**
+     * @default Infinity
+     */
+    maxCount?: number
+
+    /**
+     * @default Infinity
+     */
+    maxEntrySize?: number
+  }
+
+  export class SqliteCacheStore implements CacheStore {
+    constructor (opts?: SqliteCacheStoreOpts)
+
+    /**
+     * Closes the connection to the database
+     */
+    close (): void
 
     get (key: CacheKey): GetResult | Promise<GetResult | undefined> | undefined
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

~~**Note**: this is a draft since #3562 isn't landed. Until it is landed, this will be based off of that pr's branch. For the actual diff see https://github.com/flakey5/undici/compare/flakey5/3231...flakey5:undici:flakey5/20240910/sqlite-cache-store~~

## This relates to...

Adding client side http caching (#3562)

## Rationale

Adds a sqlite cache store option given the `--experimental-sqlite` flag is provided

## Changes

<!-- Write a summary or list of changes here -->

### Features

 * Cache store using sqlite as a backend

### Bug Fixes

n/a

### Breaking Changes and Deprecations

n/a

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md

cc @mcollina @ronag 
