### PR TITLE
feat: support mocking a reply with Uint8Arrays

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -116,7 +116,7 @@ function matchKey (mockDispatch, { path, method, body, headers }) {
 }
 
 function getResponseData (data) {
-  if (Buffer.isBuffer(data)) {
+  if (Buffer.isBuffer(data) || data?.[Symbol.toStringTag] === 'Uint8Array') {
     return data
   } else if (typeof data === 'object') {
     return JSON.stringify(data)

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -162,6 +162,13 @@ describe('getResponseData', () => {
     const responseData = getResponseData(Buffer.from('test'))
     t.ok(Buffer.isBuffer(responseData))
   })
+
+  test('it should return Uint8Arrays untouched', (t) => {
+    t = tspl(t, { plan: 1 })
+    const testData = new TextEncoder().encode('test')
+    const responseData = getResponseData(testData)
+    t.strictEqual(responseData, testData)
+  })
 })
 
 test('getStatusText', (t) => {


### PR DESCRIPTION
## This relates to...

Resolves #3660 

## Rationale

It was previously not possible to provide `MockInterceptor.reply` with a Uint8Array and have those same bytes be returned as the result of a mocked request

## Changes

Updated `getResponseData` to check for Uint8Arrays

### Features

### Bug Fixes

### Breaking Changes and Deprecations

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready
