### PR TITLE
ci: pr-title-check

### DIFF
--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,0 +1,17 @@
+name: check pull-request title
+on:
+  pull_request:
+    types: 
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  check-pull-request-title:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: fastify/action-pr-title@v0
+      with:
+        regex: '/^(build|chore|ci|docs|feat|types|fix|perf|refactor|style|test)(?:\([^\):]*\))?!?:\s/'
+        github-token: ${{ github.token }}


### PR DESCRIPTION
This adds a workflow, which we also use in fastify. Benefit is, that pull requests can be implicitly marked as fix or fix! and thus makes it easier to decide if we should backport the bug fix or not. It feels like that some PRs could be put into the v6 branch but we didnt because we dont kept track of which PRs would make sense.