### PR TITLE
test: use globalThis.Headers and skip if is missing

### DIFF
--- a/lib/web/cookies/index.js
+++ b/lib/web/cookies/index.js
@@ -5,6 +5,10 @@ const { stringify } = require('./util')
 const { webidl } = require('../fetch/webidl')
 const { Headers } = require('../fetch/headers')
 
+const headersToBrandCheck = globalThis.Headers
+  ? [Headers, globalThis.Headers]
+  : [Headers]
+
 /**
  * @typedef {Object} Cookie
  * @property {string} name
@@ -26,7 +30,7 @@ const { Headers } = require('../fetch/headers')
 function getCookies (headers) {
   webidl.argumentLengthCheck(arguments, 1, 'getCookies')
 
-  webidl.brandCheckMultiple(headers, [Headers, globalThis.Headers])
+  webidl.brandCheckMultiple(headers, headersToBrandCheck)
 
   const cookie = headers.get('cookie')
 
@@ -53,7 +57,7 @@ function getCookies (headers) {
  * @returns {void}
  */
 function deleteCookie (headers, name, attributes) {
-  webidl.brandCheckMultiple(headers, [Headers, globalThis.Headers])
+  webidl.brandCheckMultiple(headers, headersToBrandCheck)
 
   const prefix = 'deleteCookie'
   webidl.argumentLengthCheck(arguments, 2, prefix)
@@ -78,7 +82,7 @@ function deleteCookie (headers, name, attributes) {
 function getSetCookies (headers) {
   webidl.argumentLengthCheck(arguments, 1, 'getSetCookies')
 
-  webidl.brandCheckMultiple(headers, [Headers, globalThis.Headers])
+  webidl.brandCheckMultiple(headers, headersToBrandCheck)
 
   const cookies = headers.getSetCookie()
 
@@ -97,7 +101,7 @@ function getSetCookies (headers) {
 function setCookie (headers, cookie) {
   webidl.argumentLengthCheck(arguments, 2, 'setCookie')
 
-  webidl.brandCheckMultiple(headers, [Headers, globalThis.Headers])
+  webidl.brandCheckMultiple(headers, headersToBrandCheck)
 
   cookie = webidl.converters.Cookie(cookie)
 

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -630,7 +630,7 @@ test('Cookie setCookie does not throw if headers is an instance of undici owns H
   })
 })
 
-test('Cookie setCookie does not throw if headers is an instance of the global Headers class', () => {
+test('Cookie setCookie does not throw if headers is an instance of the global Headers class', { skip: !globalThis.Headers }, () => {
   const headers = new globalThis.Headers()
   setCookie(headers, {
     name: 'key',
@@ -659,7 +659,7 @@ test('Cookie getCookies does not throw if headers is an instance of undici owns 
   getCookies(headers)
 })
 
-test('Cookie getCookie does not throw if headers is an instance of the global Headers class', () => {
+test('Cookie getCookie does not throw if headers is an instance of the global Headers class', { skip: !globalThis.Headers }, () => {
   const headers = new globalThis.Headers()
   getCookies(headers)
 })
@@ -682,7 +682,7 @@ test('Cookie getSetCookies does not throw if headers is an instance of undici ow
   getSetCookies(headers)
 })
 
-test('Cookie setCookie does not throw if headers is an instance of the global Headers class', () => {
+test('Cookie setCookie does not throw if headers is an instance of the global Headers class', { skip: !globalThis.Headers }, () => {
   const headers = new globalThis.Headers({ 'set-cookie': 'Space=Cat' })
   getSetCookies(headers)
 })
@@ -705,7 +705,7 @@ test('Cookie deleteCookie does not throw if headers is an instance of undici own
   deleteCookie(headers, 'deno')
 })
 
-test('Cookie getCookie does not throw if headers is an instance of the global Headers class', () => {
+test('Cookie getCookie does not throw if headers is an instance of the global Headers class', { skip: !globalThis.Headers }, () => {
   const headers = new globalThis.Headers()
   deleteCookie(headers, 'deno')
 })

--- a/test/cookie/global-headers.js
+++ b/test/cookie/global-headers.js
@@ -10,24 +10,24 @@ const {
 } = require('../..')
 
 describe('Using global Headers', async () => {
-  test('deleteCookies', () => {
-    const headers = new Headers()
+  test('deleteCookies', { skip: !globalThis.Headers }, () => {
+    const headers = new globalThis.Headers()
 
     assert.equal(headers.get('set-cookie'), null)
     deleteCookie(headers, 'undici')
     assert.equal(headers.get('set-cookie'), 'undici=; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
   })
 
-  test('getCookies', () => {
-    const headers = new Headers({
+  test('getCookies', { skip: !globalThis.Headers }, () => {
+    const headers = new globalThis.Headers({
       cookie: 'get=cookies; and=attributes'
     })
 
     assert.deepEqual(getCookies(headers), { get: 'cookies', and: 'attributes' })
   })
 
-  test('getSetCookies', () => {
-    const headers = new Headers({
+  test('getSetCookies', { skip: !globalThis.Headers }, () => {
+    const headers = new globalThis.Headers({
       'set-cookie': 'undici=getSetCookies; Secure'
     })
 
@@ -46,17 +46,17 @@ describe('Using global Headers', async () => {
     }
   })
 
-  test('setCookie', () => {
-    const headers = new Headers()
+  test('setCookie', { skip: !globalThis.Headers }, () => {
+    const headers = new globalThis.Headers()
 
     setCookie(headers, { name: 'undici', value: 'setCookie' })
     assert.equal(headers.get('Set-Cookie'), 'undici=setCookie')
   })
 })
 
-describe('Headers check is not too lax', () => {
-  class Headers {}
-  Object.defineProperty(Headers.prototype, Symbol.toStringTag, {
+describe('Headers check is not too lax', { skip: !globalThis.Headers }, () => {
+  class Headers { }
+  Object.defineProperty(globalThis.Headers.prototype, Symbol.toStringTag, {
     value: 'Headers',
     configurable: true
   })

--- a/test/node-test/debug.js
+++ b/test/node-test/debug.js
@@ -10,18 +10,12 @@ const removeEscapeColorsRE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4}
 
 const isCITGM = !!process.env.CITGM
 
-const noExperimentalFlags = [
-  '--no-experimental-fetch',
-  '--no-experimental-websocket',
-  '--no-experimental-eventsource'
-]
-
 test('debug#websocket', { skip: !process.versions.icu || isCITGM }, async t => {
   const assert = tspl(t, { plan: 6 })
   const child = spawn(
     process.execPath,
     [
-      ...noExperimentalFlags,
+      '--no-experimental-fetch',
       join(__dirname, '../fixtures/websocket.js')],
     {
       env: {
@@ -59,7 +53,7 @@ test('debug#fetch', { skip: isCITGM }, async t => {
   const child = spawn(
     process.execPath,
     [
-      ...noExperimentalFlags,
+      '--no-experimental-fetch',
       join(__dirname, '../fixtures/fetch.js')
     ],
     {
@@ -97,7 +91,7 @@ test('debug#undici', { skip: isCITGM }, async t => {
   const child = spawn(
     process.execPath,
     [
-      ...noExperimentalFlags,
+      '--no-experimental-fetch',
       join(__dirname, '../fixtures/undici.js')
     ],
     {

--- a/test/node-test/debug.js
+++ b/test/node-test/debug.js
@@ -10,11 +10,19 @@ const removeEscapeColorsRE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4}
 
 const isCITGM = !!process.env.CITGM
 
+const noExperimentalFlags = [
+  '--no-experimental-fetch',
+  '--no-experimental-websocket',
+  '--no-experimental-eventsource'
+]
+
 test('debug#websocket', { skip: !process.versions.icu || isCITGM }, async t => {
   const assert = tspl(t, { plan: 6 })
   const child = spawn(
     process.execPath,
-    [join(__dirname, '../fixtures/websocket.js')],
+    [
+      ...noExperimentalFlags,
+      join(__dirname, '../fixtures/websocket.js')],
     {
       env: {
         NODE_DEBUG: 'websocket'
@@ -50,7 +58,10 @@ test('debug#fetch', { skip: isCITGM }, async t => {
   const assert = tspl(t, { plan: 7 })
   const child = spawn(
     process.execPath,
-    [join(__dirname, '../fixtures/fetch.js')],
+    [
+      ...noExperimentalFlags,
+      join(__dirname, '../fixtures/fetch.js')
+    ],
     {
       env: Object.assign({}, process.env, { NODE_DEBUG: 'fetch' })
     }
@@ -85,7 +96,10 @@ test('debug#undici', { skip: isCITGM }, async t => {
   const assert = tspl(t, { plan: 7 })
   const child = spawn(
     process.execPath,
-    [join(__dirname, '../fixtures/undici.js')],
+    [
+      ...noExperimentalFlags,
+      join(__dirname, '../fixtures/undici.js')
+    ],
     {
       env: {
         NODE_DEBUG: 'undici'

--- a/test/request.js
+++ b/test/request.js
@@ -275,7 +275,7 @@ describe('DispatchOptions#reset', () => {
 })
 
 describe('Should include headers from iterable objects', scope => {
-  test('Should include headers built with Headers global object', async t => {
+  test('Should include headers built with Headers global object', { skip: !globalThis.Headers }, async t => {
     t = tspl(t, { plan: 3 })
 
     const server = createServer((req, res) => {
@@ -286,7 +286,7 @@ describe('Should include headers from iterable objects', scope => {
       res.end('hello')
     })
 
-    const headers = new Headers()
+    const headers = new globalThis.Headers()
     headers.set('hello', 'world')
 
     after(() => server.close())


### PR DESCRIPTION
If you run those test cases with ` --no-experimental-fetch`  they will fail. They use on purpose the global HEaders and this PR makes it clear that they use globalThis.Headers and not by accident undici own Headers.