### PR TITLE
fetch: add docs on why forbidden header names are not supported

### DIFF
--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -89,8 +89,9 @@ function appendHeader (headers, name, value) {
   // 1. Normalize value.
   value = headerValueNormalize(value)
 
-  // 2. If name is not a header name or value is not a
-  //    header value, then throw a TypeError.
+  // 2. If validating (name, value) for headers returns false, then return.
+  //    1. If name is not a header name or value is not a header value,
+  //    then throw a TypeError.
   if (!isValidHeaderName(name)) {
     throw webidl.errors.invalidArgument({
       prefix: 'Headers.append',
@@ -105,24 +106,28 @@ function appendHeader (headers, name, value) {
     })
   }
 
-  // 3. If headers’s guard is "immutable", then throw a TypeError.
-  // 4. Otherwise, if headers’s guard is "request" and name is a
-  //    forbidden header name, return.
-  // 5. Otherwise, if headers’s guard is "request-no-cors":
-  //    TODO
-  // Note: undici does not implement forbidden header names
+  //    2. If headers’s guard is "immutable", then throw a TypeError.
   if (getHeadersGuard(headers) === 'immutable') {
     throw new TypeError('immutable')
   }
 
-  // 6. Otherwise, if headers’s guard is "response" and name is a
-  //    forbidden response-header name, return.
+  //    3. If headers’s guard is "request" and (name, value) is a forbidden
+  //    request-header, then return.
+  //    4. If headers’s guard is "response" and name is a forbidden
+  //    response-header name, then return.
+  // Note: undici deviates from the spec, and does not implement forbidden
+  // header names to match the behavior of Deno and node-fetch. A server-side
+  // fetch unable to pass all kinds of headers around is not useful.
 
-  // 7. Append (name, value) to headers’s header list.
+  // 3. If headers’s guard is "request-no-cors":
+  // TODO
+
+  // 4. Append (name, value) to headers’s header list.
   return getHeadersList(headers).append(name, value, false)
 
-  // 8. If headers’s guard is "request-no-cors", then remove
+  // 5. If headers’s guard is "request-no-cors", then remove
   //    privileged no-CORS request headers from headers
+  // TODO
 }
 
 // https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine


### PR DESCRIPTION
## This relates to...

* Comment https://github.com/nodejs/undici/pull/3695#pullrequestreview-2350953699
* Fetch spec https://fetch.spec.whatwg.org/#concept-headers-append

## Changes

Documents why undici fetch does not support forbidden header names

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
