### PR TITLE
fix: restructure determineRequestsReferrer to match better spec

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -418,18 +418,37 @@ function determineRequestsReferrer (request) {
     referrerURL = referrerOrigin
   }
 
-  const areSameOrigin = sameOrigin(request, referrerURL)
-  const isNonPotentiallyTrustWorthy = isURLPotentiallyTrustworthy(referrerURL) &&
-    !isURLPotentiallyTrustworthy(request.url)
+  // 7. The user agent MAY alter referrerURL or referrerOrigin at this point
+  // to enforce arbitrary policy considerations in the interests of minimizing
+  // data leakage. For example, the user agent could strip the URL down to an
+  // origin, modify its host, replace it with an empty string, etc.
 
   // 8. Execute the switch statements corresponding to the value of policy:
   switch (policy) {
-    case 'origin': return referrerOrigin != null ? referrerOrigin : stripURLForReferrer(referrerSource, true)
-    case 'unsafe-url': return referrerURL
-    case 'same-origin':
-      return areSameOrigin ? referrerOrigin : 'no-referrer'
-    case 'origin-when-cross-origin':
-      return areSameOrigin ? referrerURL : referrerOrigin
+    case 'no-referrer':
+      // Return no referrer
+      return 'no-referrer'
+    case 'origin':
+      // Return referrerOrigin
+      if (referrerOrigin != null) {
+        return referrerOrigin
+      }
+      return stripURLForReferrer(referrerSource, true)
+    case 'unsafe-url':
+      // Return referrerURL.
+      return referrerURL
+    case 'strict-origin': {
+      const currentURL = requestCurrentURL(request)
+
+      // 1. If referrerURL is a potentially trustworthy URL and request’s
+      //    current URL is not a potentially trustworthy URL, then return no
+      //    referrer.
+      if (isURLPotentiallyTrustworthy(referrerURL) && !isURLPotentiallyTrustworthy(currentURL)) {
+        return 'no-referrer'
+      }
+      // 2. Return referrerOrigin
+      return referrerOrigin
+    }
     case 'strict-origin-when-cross-origin': {
       const currentURL = requestCurrentURL(request)
 
@@ -449,23 +468,34 @@ function determineRequestsReferrer (request) {
       // 3. Return referrerOrigin.
       return referrerOrigin
     }
-    case 'strict-origin':
-      /**
-         * 1. If referrerURL is a potentially trustworthy URL and
-         * request’s current URL is not a potentially trustworthy URL,
-         * then return no referrer.
-         * 2. Return referrerOrigin
-        */
-    case 'no-referrer-when-downgrade': // eslint-disable-line
-      /**
-       * 1. If referrerURL is a potentially trustworthy URL and
-       * request’s current URL is not a potentially trustworthy URL,
-       * then return no referrer.
-       * 2. Return referrerOrigin
-      */
+    case 'same-origin':
+      // 1. If the origin of referrerURL and the origin of request’s current
+      // URL are the same, then return referrerURL.
+      if (sameOrigin(request, referrerURL)) {
+        return referrerURL
+      }
+      // 2. Return no referrer.
+      return 'no-referrer'
+    case 'origin-when-cross-origin':
+      // 1. If the origin of referrerURL and the origin of request’s current
+      // URL are the same, then return referrerURL.
+      if (sameOrigin(request, referrerURL)) {
+        return referrerURL
+      }
+      // 2. Return referrerOrigin.
+      return referrerOrigin
+    case 'no-referrer-when-downgrade': {
+      const currentURL = requestCurrentURL(request)
 
-    default: // eslint-disable-line
-      return isNonPotentiallyTrustWorthy ? 'no-referrer' : referrerOrigin
+      // 1. If referrerURL is a potentially trustworthy URL and request’s
+      //    current URL is not a potentially trustworthy URL, then return no
+      //    referrer.
+      if (isURLPotentiallyTrustworthy(referrerURL) && !isURLPotentiallyTrustworthy(currentURL)) {
+        return 'no-referrer'
+      }
+      // 2. Return referrerOrigin
+      return referrerOrigin
+    }
   }
 }
 


### PR DESCRIPTION
While I investigated if there were significant changes in esbuild, I found the following change:

![Screenshot from 2024-10-08 01-30-40](https://github.com/user-attachments/assets/617c798b-424b-4806-b969-65ad27916a74)

So the comments were added because they were of  `/** */`  notation and not of `//` notation. While I fixed, I saw that the implementation is not matching 1:1 the spec text, like the order of the cases. So I adapted it accordingly.