### PR TITLE
set ws readyState if closed before connection could be established

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -471,6 +471,8 @@ class WebSocket extends EventTarget {
     }
 
     if (!this.#handler.wasEverConnected) {
+      this.#handler.readyState = states.CLOSED
+
       // If the WebSocket connection could not be established, it is also said
       // that _The WebSocket Connection is Closed_, but not _cleanly_.
       fireEvent('close', this, (type, init) => new CloseEvent(type, init), {

--- a/test/websocket/issue-3697-2399493917.js
+++ b/test/websocket/issue-3697-2399493917.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocket } = require('../..')
+const { tspl } = require('@matteo.collina/tspl')
+
+// https://github.com/nodejs/undici/issues/3697#issuecomment-2399493917
+test('closing before a connection is established changes readyState', async (t) => {
+  const { completed, strictEqual } = tspl(t, { plan: 1 })
+
+  const ws = new WebSocket('wss://example.com/non-existing-url')
+  ws.onclose = () => strictEqual(ws.readyState, WebSocket.CLOSED)
+
+  await completed
+})


### PR DESCRIPTION
https://github.com/nodejs/undici/issues/3697#issuecomment-2399493917

A websocket connection is closed in two ways: 1) when the socket closes, or 2) if a connection could not be established. We were only setting the readyState in the first case.