### PR TITLE
Bumped v6.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undici",
-  "version": "6.19.8",
+  "version": "6.20.0",
   "description": "An HTTP/1.1 client, written from scratch for Node.js",
   "homepage": "https://undici.nodejs.org",
   "bugs": {


### PR DESCRIPTION
## This relates to...

Next 6.x release based on discussions from OpenJS Slack:
* Release https://openjs-foundation.slack.com/archives/C01QF9Q31QD/p1728263701097419
* PRs https://openjs-foundation.slack.com/archives/C01QF9Q31QD/p1728048500317479

## Rationale

The last version https://github.com/nodejs/undici/releases/tag/v6.19.8 was published 1.5 months ago on Aug 19, and there have been [14 commits](https://github.com/nodejs/undici/commits/v6.x/) in 6.x since the release. It will be nice to have updated 6.x version in node 22 before it goes LTS on 10/15.

This is similar to v6.19.8 commit https://github.com/nodejs/undici/commit/3d3ce0695c8c3f9a8f3c8af90dd42d0569d3f0bb

## Changes

Bumps version in package.json to v6.20.0

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

Changelog will be listed on GitHub release
* Release https://github.com/nodejs/undici/releases/tag/v6.20.0
* Full changelog https://github.com/nodejs/undici/compare/v6.19.8...v6.20.0

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
