### PR TITLE
feat: improve testing of http2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -141,6 +141,77 @@ jobs:
       - name: Run tests
         run: npm run test:javascript:without-intl
 
+  test-without-ssl:
+    name: Test with Node.js ${{ matrix.version }} compiled --without-ssl
+    strategy:
+      fail-fast: false
+      max-parallel: 0
+      matrix:
+        version: [22]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
+
+      # Setup node, install deps, and build undici prior to building icu-less node and testing
+      - name: Setup Node.js@${{ inputs.version }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ inputs.version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build undici
+        run: npm run build:node
+
+      - name: Determine latest release
+        id: release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          result-encoding: string
+          script: |
+            const req = await fetch('https://nodejs.org/download/release/index.json')
+            const releases = await req.json()
+
+            const latest = releases.find((r) => r.version.startsWith('v${{ matrix.version }}'))
+            return latest.version
+
+      - name: Download and extract source
+        run: curl https://nodejs.org/download/release/${{ steps.release.outputs.result }}/node-${{ steps.release.outputs.result }}.tar.xz | tar xfJ -
+
+      - name: Install ninja
+        run: sudo apt-get install ninja-build
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@ed74d11c0b343532753ecead8a951bb09bb34bc9 #v1.2.14
+        with:
+          key: node${{ matrix.version }}
+
+      - name: Build node
+        working-directory: ./node-${{ steps.release.outputs.result }}
+        run: |
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+          ./configure --without-ssl --ninja --prefix=./final
+          make
+          make install
+          echo "$(pwd)/final/bin" >> $GITHUB_PATH
+
+      - name: Print version information
+        run: |
+          echo OS: $(node -p "os.version()")
+          echo Node.js: $(node --version)
+          echo npm: $(npm --version)
+          echo git: $(git --version)
+          echo icu config: $(node -e "console.log(process.config)" | grep icu)
+
+      - name: Run tests
+        run: npm run test:javascript
+
   test-fuzzing:
     name: Fuzzing
     runs-on: ubuntu-latest


### PR DESCRIPTION
I am too lazy to build with without-ssl flag locally. I think the values we destructure when importing http2 are not critical. more critical is, that http2.connect is not replaced with some function which throws an Internal Error which would indicate that http2 is not supported. Probably we get only a "connect is not defined" error. when calling it. 