### PR TITLE
fix: unsafe methods should result in cache purge

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -32,7 +32,7 @@ module.exports = (opts = {}) => {
 
   return dispatch => {
     return (opts, handler) => {
-      if (!opts.origin || !methods.includes(opts.method)) {
+      if (!opts.origin) {
         // Not a method we want to cache or we don't have the origin, skip
         return dispatch(opts, handler)
       }


### PR DESCRIPTION
the problem is, that the cache invalidation logic is done in cache-handler.js. So it makes no sense to avoid calling the cache logic, if the method is unsafe. All requests with origin have to go through the cache logic.

@flakey5 