### PR TITLE
chore(docs): add request() example for conditionally reading the body

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -641,18 +641,13 @@ const { body, statusCode } = await client.request({
   method: 'GET'
 })
 
-body.on('error', console.error) // prevent process from crashing on error
-
 if (statusCode === 200) {
-  const buffer = await body.arrayBuffer()
-  return buffer
+  return await body.arrayBuffer()
 }
 
-for await (const _chunk of body) {
-  // force consumption of body to avoid memory leak
-}
+await body.dump()
+
 return null
-```
 
 ### `Dispatcher.stream(options, factory[, callback])`
 

--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -527,6 +527,7 @@ try {
   console.log('headers', headers)
   body.setEncoding('utf8')
   body.on('data', console.log)
+  body.on('error', console.error)
   body.on('end', () => {
     console.log('trailers', trailers)
   })
@@ -628,6 +629,29 @@ try {
   client.close()
   server.close()
 }
+```
+
+#### Example 3 - Conditionally reading the body
+
+Remember to fully consume the body even in the case when it is not read.
+
+```js
+const { body, statusCode } = await client.request({
+  path: '/',
+  method: 'GET'
+})
+
+body.on('error', console.error) // prevent process from crashing on error
+
+if (statusCode === 200) {
+  const buffer = await body.arrayBuffer()
+  return buffer
+}
+
+for await (const _chunk of body) {
+  // force consumption of body to avoid memory leak
+}
+return null
 ```
 
 ### `Dispatcher.stream(options, factory[, callback])`

--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -648,6 +648,7 @@ if (statusCode === 200) {
 await body.dump()
 
 return null
+```
 
 ### `Dispatcher.stream(options, factory[, callback])`
 


### PR DESCRIPTION
## This relates to...

Documentation for dispatcher.request() 

## Rationale

It is very easy to cause a memory leak or even crash the process if you forget to handle the response body.

## Changes

A new example showing how to conditionally reading the body

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
