### PR TITLE
feat: add optional methods to the cache store

### DIFF
--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -76,6 +76,29 @@ class MemoryCacheStore {
   }
 
   /**
+   * @returns {string[]}
+   */
+  getOrigins () {
+    return Array.from(this.#data.keys())
+  }
+
+  /**
+   * @param {string} origin
+   * @returns {{ method: string, path: string }[]}
+   */
+  getRoutesByOrigin (origin) {
+    const paths = this.#data.get(origin)
+    if (!paths) return []
+
+    let cachedRoutes = []
+    for (const cachedValue of paths.keys()) {
+      const [path, method] = cachedValue.split(':')
+      cachedRoutes.push({ method, path })
+    }
+    return cachedRoutes
+  }
+
+  /**
    * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
    * @returns {import('../../types/cache-interceptor.d.ts').default.CacheStoreReadable | undefined}
    */


### PR DESCRIPTION
The idea of this PR is to add some optional methods to the cache store that might not be used by the interceptor, but are useful for managing the cache. Right now it's hard to invalidate the cache from the outside of the package, because there is no way to know what values have been cached. 

Any ideas about the intercase for these methods are welcome. I'm opening it's as a draft because it's missing a docs at least.