### PR TITLE
feat: add support for cache tags

### DIFF
--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -30,6 +30,7 @@ class MemoryCacheStore {
    * @type {Map<string, Map<string, MemoryStoreValue>>}
    */
   #data = new Map()
+  #tags = new Map()
 
   /**
    * @param {import('../../types/cache-interceptor.d.ts').default.MemoryCacheStoreOpts | undefined} [opts]
@@ -84,7 +85,7 @@ class MemoryCacheStore {
       throw new TypeError(`expected req to be object, got ${typeof req}`)
     }
 
-    const values = this.#getValuesForRequest(req, false)
+    const values = this.#getValuesForRequest(req, { makeIfDoesntExist: false })
     if (!values) {
       return undefined
     }
@@ -115,7 +116,10 @@ class MemoryCacheStore {
       return undefined
     }
 
-    const values = this.#getValuesForRequest(req, true)
+    const values = this.#getValuesForRequest(req, {
+      makeIfDoesntExist: true,
+      cacheTags: opts.cacheTags
+    })
 
     let value = this.#findValue(req, values)
     if (!value) {
@@ -211,6 +215,46 @@ class MemoryCacheStore {
    */
   deleteByOrigin (origin) {
     this.#data.delete(origin)
+    this.#tags.delete(origin)
+  }
+
+  /**
+   * @param {string} origin
+   * @param {string[]} cacheTags
+   */
+  async deleteByCacheTags (origin, cacheTags) {
+    const originTags = this.#tags.get(origin)
+    if (!originTags) return
+
+    const originRoutes = this.#data.get(origin)
+    if (!originRoutes) return
+
+    for (const cacheTag of cacheTags) {
+      const cacheKeys = originTags.get(cacheTag)
+      if (!cacheKeys) continue
+
+      for (const cacheKey of cacheKeys) {
+        originRoutes.delete(cacheKey)
+      }
+
+      originTags.delete(cacheTag)
+    }
+  }
+
+  #unlinkRouteFromCacheTag (origin, cacheTags, cacheKey) {
+    const originTags = this.#tags.get(origin)
+    if (!originTags) return
+
+    for (const cacheTag of cacheTags) {
+      const cacheKeys = originTags.get(cacheTag)
+      if (!cacheKeys) continue
+
+      cacheKeys.delete(cacheKey)
+
+      if (cacheKeys.size === 0) {
+        originTags.delete(cacheTag)
+      }
+    }
   }
 
   /**
@@ -219,7 +263,9 @@ class MemoryCacheStore {
    * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
    * @param {boolean} [makeIfDoesntExist=false]
    */
-  #getValuesForRequest (req, makeIfDoesntExist) {
+  #getValuesForRequest (req, opts = {}) {
+    const makeIfDoesntExist = opts.makeIfDoesntExist ?? true
+
     // https://www.rfc-editor.org/rfc/rfc9111.html#section-2-3
     let cachedPaths = this.#data.get(req.origin)
     if (!cachedPaths) {
@@ -231,10 +277,30 @@ class MemoryCacheStore {
       this.#data.set(req.origin, cachedPaths)
     }
 
-    let values = cachedPaths.get(`${req.path}:${req.method}`)
+    const cacheKey = `${req.path}:${req.method}`
+
+    const cacheTags = opts.cacheTags
+    if (cacheTags && cacheTags.length > 0) {
+      let originTags = this.#tags.get(req.origin)
+      if (!originTags) {
+        originTags = new Map()
+        this.#tags.set(req.origin, originTags)
+      }
+
+      for (const cacheTag of cacheTags) {
+        let tagPaths = originTags.get(cacheTag)
+        if (!tagPaths) {
+          tagPaths = new Set()
+          originTags.set(cacheTag, tagPaths)
+        }
+        tagPaths.add(cacheKey)
+      }
+    }
+
+    let values = cachedPaths.get(cacheKey)
     if (!values && makeIfDoesntExist) {
       values = []
-      cachedPaths.set(`${req.path}:${req.method}`, values)
+      cachedPaths.set(cacheKey, values)
     }
 
     return values
@@ -258,6 +324,12 @@ class MemoryCacheStore {
       const currentCacheValue = current.opts
       if (now >= currentCacheValue.deleteAt) {
         // We've reached expired values, let's delete them
+        const cacheTags = currentCacheValue.cacheTags
+        if (cacheTags) {
+          const cacheKey = `${req.path}:${req.method}`
+          this.#unlinkRouteFromCacheTag(req.origin, cacheTags, cacheKey)
+        }
+
         this.#entryCount -= values.length - i
         values.length = i
         break

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -32,17 +32,22 @@ class CacheHandler extends DecoratorHandler {
   #writeStream
 
   /**
+   * @type {string | undefined}
+   */
+  #cacheTagHeader
+  /**
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheOptions} opts
    * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} requestOptions
    * @param {import('../../types/dispatcher.d.ts').default.DispatchHandlers} handler
    */
   constructor (opts, requestOptions, handler) {
-    const { store } = opts
+    const { store, cacheTagHeader } = opts
 
     super(handler)
 
     this.#store = store
     this.#requestOptions = requestOptions
+    this.#cacheTagHeader = cacheTagHeader
     this.#handler = handler
   }
 
@@ -126,11 +131,20 @@ class CacheHandler extends DecoratorHandler {
         cacheControlDirectives
       )
 
+      let cacheTags = []
+      if (this.#cacheTagHeader) {
+        const cacheTagHeader = headers[this.#cacheTagHeader]
+        if (cacheTagHeader) {
+          cacheTags = cacheTagHeader.split(',')
+        }
+      }
+
       this.#writeStream = this.#store.createWriteStream(this.#requestOptions, {
         statusCode,
         statusMessage,
         rawHeaders: strippedHeaders,
         vary: varyDirectives,
+        cacheTags,
         cachedAt: now,
         staleAt,
         deleteAt

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -15,7 +15,8 @@ const AGE_HEADER = Buffer.from('age')
 module.exports = (opts = {}) => {
   const {
     store = new MemoryCacheStore(),
-    methods = ['GET']
+    methods = ['GET'],
+    cacheTagHeader
   } = opts
 
   if (typeof opts !== 'object' || opts === null) {
@@ -27,7 +28,8 @@ module.exports = (opts = {}) => {
 
   const globalOpts = {
     store,
-    methods
+    methods,
+    cacheTagHeader
   }
 
   const safeMethodsToNotCache = util.safeHTTPMethods.filter(method => methods.includes(method) === false)

--- a/test/cache-interceptor/cache-stores.js
+++ b/test/cache-interceptor/cache-stores.js
@@ -18,6 +18,7 @@ function cacheStoreTests (CacheStore) {
       equal(typeof store.createReadStream, 'function')
       equal(typeof store.createWriteStream, 'function')
       equal(typeof store.deleteByOrigin, 'function')
+      equal(typeof store.deleteByCacheTags, 'function')
     })
 
     // Checks that it can store & fetch different responses

--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -15,6 +15,10 @@ const store: CacheInterceptor.CacheStore = {
 
   deleteByOrigin (_: string): void | Promise<void> {
     throw new Error('stub')
+  },
+
+  deleteByCacheTags (origin: string, cacheTags: string[]): Promise<void> {
+    throw new Error('stub')
   }
 }
 

--- a/types/cache-interceptor.d.ts
+++ b/types/cache-interceptor.d.ts
@@ -36,6 +36,7 @@ declare namespace CacheHandler {
      * Delete all of the cached responses from a certain origin (host)
      */
     deleteByOrigin(origin: string): void | Promise<void>
+    deleteByCacheTags?(origin: string, cacheTags: string[]): void | Promise<void>
   }
 
   export interface CacheStoreReadable extends Readable {
@@ -56,6 +57,10 @@ declare namespace CacheHandler {
      *  later comparison
      */
     vary?: Record<string, string>;
+    /**
+     * Tags to be used for cache invalidation
+     */
+    cacheTags?: string[];
     /**
      * Time in millis that this value was cached
      */
@@ -93,5 +98,7 @@ declare namespace CacheHandler {
     createWriteStream (req: Dispatcher.RequestOptions, value: CacheStoreValue): CacheStoreWriteable
 
     deleteByOrigin (origin: string): void
+
+    deleteByCacheTags (origin: string, cacheTags: string[]): void
   }
 }


### PR DESCRIPTION
The idea of this PR is to add support for cache tags. A user can specify a cache tag/ a list of cache tags in a resonse header and use these tags later to invalidate some routes using these tags.