### PR TITLE
fix: emitting unknown error event

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -850,7 +850,7 @@ function errorRequest (client, request, err) {
     request.onError(err)
     assert(request.aborted)
   } catch (err) {
-    client.emit('error', err)
+    console.error(err)
   }
 }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
Might fix #3753
related to #3011 as well, since the fix of that one added `errorRequest` through #3057 and fix another issue

## Rationale

This should fixes the following error, but I'm not sure if it's fine console.error this error or if we expect something else. Also I wonder wether we should check in the first place if request exist before accessing it, or this is expected to be catched in that case.

Let me know if we would like to handle that another way.

We are using undici dispatcher with pool client and this error occur.

This is occurring because when the `onError` from `errorRequest` in utils is called, then if request is undefined it got caught by the try catch and then we try to emit an error, but it seems emit does not expect such event.

```
function errorRequest (client, request, err) {
  try {
    request.onError(err)
    assert(request.aborted)
  } catch (err) {
    client.emit('error', err)
  }
}
```

<img width="722" alt="image" src="https://github.com/user-attachments/assets/3fc2b896-860b-47c3-807c-8906f2dc33e8">


```
node:events:496
      throw er; // Unhandled 'error' event
      ^
TypeError: Cannot read properties of undefined (reading 'onError')
    at Object.errorRequest (/usr/src/app/node_modules/undici/lib/core/util.js:638:13)
    at ClientHttp2Session.onHTTP2GoAway (/usr/src/app/node_modules/undici/lib/dispatcher/client-h2.js:245:8)
    at ClientHttp2Session.emit (node:events:518:28)
    at Http2Session.onGoawayData (node:internal/http2/core:678:11)
    at Http2Session.callbackTrampoline (node:internal/async_hooks:130:17)
Emitted 'error' event on Client instance at:
    at Object.errorRequest (/usr/src/app/node_modules/undici/lib/core/util.js:641:12)
    at ClientHttp2Session.onHTTP2GoAway (/usr/src/app/node_modules/undici/lib/dispatcher/client-h2.js:245:8)
    [... lines matching original stack trace ...]
    at Http2Session.callbackTrampoline (node:internal/async_hooks:130:17)
Node.js v20.11.0
```

Undici v6.20.1

### Bug Fixes

should close #3753

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
