### PR TITLE
fix: dns interceptor affinity

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -13,7 +13,6 @@ class DNSInstance {
   affinity = null
   lookup = null
   pick = null
-  lastIpFamily = null
 
   constructor (opts) {
     this.#maxTTL = opts.maxTTL
@@ -61,9 +60,7 @@ class DNSInstance {
         const ip = this.pick(
           origin,
           records,
-          // Only set affinity if dual stack is disabled
-          // otherwise let it go through normal flow
-          !newOpts.dualStack && newOpts.affinity
+          newOpts.affinity
         )
 
         cb(
@@ -78,9 +75,7 @@ class DNSInstance {
       const ip = this.pick(
         origin,
         ips,
-        // Only set affinity if dual stack is disabled
-        // otherwise let it go through normal flow
-        !newOpts.dualStack && newOpts.affinity
+        newOpts.affinity
       )
 
       // If no IPs we lookup - deleting old records
@@ -123,36 +118,36 @@ class DNSInstance {
 
   #defaultPick (origin, hostnameRecords, affinity) {
     let ip = null
-    const { records, offset = 0 } = hostnameRecords
-    let newOffset = 0
+    const { records, offset } = hostnameRecords
 
-    if (offset === maxInt) {
-      newOffset = 0
+    let family
+    if (this.dualStack) {
+      if (affinity == null) {
+        // Balance between ip families
+        if (offset == null || offset === maxInt) {
+          hostnameRecords.offset = 0
+          affinity = 4
+        } else {
+          hostnameRecords.offset++
+          affinity = (hostnameRecords.offset & 1) === 1 ? 6 : 4
+        }
+      }
+
+      if (records[affinity] != null && records[affinity].ips.length > 0) {
+        family = records[affinity]
+      } else {
+        family = records[affinity === 4 ? 6 : 4]
+      }
     } else {
-      newOffset = offset + 1
+      family = records[affinity]
     }
 
-    // We balance between the two IP families
-    // If dual-stack disabled, we automatically pick the affinity
-    const newIpFamily = (newOffset & 1) === 1 ? 4 : 6
-    const family =
-      this.dualStack === false
-        ? records[this.affinity] // If dual-stack is disabled, we pick the default affiniy
-        : records[affinity] ?? records[newIpFamily]
-
-    // If no IPs and we have tried both families or dual stack is disabled, we return null
-    if (
-      (family == null || family.ips.length === 0) &&
-      // eslint-disable-next-line eqeqeq
-      (this.dualStack === false || this.lastIpFamily != newIpFamily)
-    ) {
+    // If no IPs we return null
+    if (family == null || family.ips.length === 0) {
       return ip
     }
 
-    family.offset = family.offset ?? 0
-    hostnameRecords.offset = newOffset
-
-    if (family.offset === maxInt) {
+    if (family.offset == null || family.offset === maxInt) {
       family.offset = 0
     } else {
       family.offset++
@@ -172,7 +167,6 @@ class DNSInstance {
       return this.pick(origin, hostnameRecords, affinity)
     }
 
-    this.lastIpFamily = newIpFamily
     return ip
   }
 
@@ -301,12 +295,20 @@ module.exports = interceptorOpts => {
     throw new InvalidArgumentError('Invalid pick. Must be a function')
   }
 
+  const dualStack = interceptorOpts?.dualStack ?? true
+  let affinity
+  if (dualStack) {
+    affinity = interceptorOpts?.affinity ?? null
+  } else {
+    affinity = interceptorOpts?.affinity ?? 4
+  }
+
   const opts = {
     maxTTL: interceptorOpts?.maxTTL ?? 10e3, // Expressed in ms
     lookup: interceptorOpts?.lookup ?? null,
     pick: interceptorOpts?.pick ?? null,
-    dualStack: interceptorOpts?.dualStack ?? true,
-    affinity: interceptorOpts?.affinity ?? 4,
+    dualStack,
+    affinity,
     maxItems: interceptorOpts?.maxItems ?? Infinity
   }
 


### PR DESCRIPTION

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

DNS interceptor

## Rationale

* error was thrown when a single ip address was resolved with dual-stack: "Cannot read properties of null (reading 'offset')"
* `pick` always started on the second ip address if multiple were resolved
* affinity was ignored with dual-stack

## Changes

Always start pick with the first ip address when multiple are resolved (ipv4 before ipv6)

### Features

Prefer affinity family with dual-stack, fallback to other family

### Bug Fixes

Handle single ip address resolved with dual-stack

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
