### PR TITLE
feat: use resolved ports in dns interceptor

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -63,11 +63,20 @@ class DNSInstance {
           newOpts.affinity
         )
 
+        let port
+        if (typeof ip.port === 'number') {
+          port = `:${ip.port}`
+        } else if (origin.port !== '') {
+          port = `:${origin.port}`
+        } else {
+          port = ''
+        }
+
         cb(
           null,
           `${origin.protocol}//${
             ip.family === 6 ? `[${ip.address}]` : ip.address
-          }${origin.port === '' ? '' : `:${origin.port}`}`
+          }${port}`
         )
       })
     } else {
@@ -85,11 +94,20 @@ class DNSInstance {
         return
       }
 
+      let port
+      if (typeof ip.port === 'number') {
+        port = `:${ip.port}`
+      } else if (origin.port !== '') {
+        port = `:${origin.port}`
+      } else {
+        port = ''
+      }
+
       cb(
         null,
         `${origin.protocol}//${
           ip.family === 6 ? `[${ip.address}]` : ip.address
-        }${origin.port === '' ? '' : `:${origin.port}`}`
+        }${port}`
       )
     }
   }

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -1396,11 +1396,6 @@ test('Should use resolved ports', async t => {
   await Promise.all([once(server1, 'listening'), once(server2, 'listening')])
 
   const client = new Agent().compose([
-    dispatch => {
-      return (opts, handler) => {
-        return dispatch(opts, handler)
-      }
-    },
     dns({
       lookup (origin, opts, cb) {
         lookupCounter++

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -1366,6 +1366,79 @@ test('Should prefer affinity (dual stack - 6)', async t => {
   t.equal(lookupCounter, 1)
 })
 
+test('Should use resolved ports', async t => {
+  t = tspl(t, { plan: 5 })
+
+  let lookupCounter = 0
+  const server1 = createServer()
+  const server2 = createServer()
+  const requestOptions = {
+    method: 'GET',
+    path: '/',
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+
+  server1.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world!')
+  })
+
+  server1.listen(0)
+
+  server2.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world! (x2)')
+  })
+  server2.listen(0)
+
+  await Promise.all([once(server1, 'listening'), once(server2, 'listening')])
+
+  const client = new Agent().compose([
+    dispatch => {
+      return (opts, handler) => {
+        return dispatch(opts, handler)
+      }
+    },
+    dns({
+      lookup (origin, opts, cb) {
+        lookupCounter++
+        cb(null, [
+          { address: '127.0.0.1', family: 4, port: server1.address().port },
+          { address: '127.0.0.1', family: 4, port: server2.address().port }
+        ])
+      }
+    })
+  ])
+
+  after(async () => {
+    await client.close()
+    server1.close()
+    server2.close()
+
+    await Promise.all([once(server1, 'close'), once(server2, 'close')])
+  })
+
+  const response = await client.request({
+    ...requestOptions,
+    origin: 'http://localhost'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+
+  const response2 = await client.request({
+    ...requestOptions,
+    origin: 'http://localhost'
+  })
+
+  t.equal(response2.statusCode, 200)
+  t.equal(await response2.body.text(), 'hello world! (x2)')
+
+  t.equal(lookupCounter, 1)
+})
+
 test('Should handle max cached items', async t => {
   t = tspl(t, { plan: 9 })
 


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

DNS interceptor

## Rationale

Support custom functions that resolve both IP addresses and ports. It can be used e.g. with `dns.resolveSrv` followed by
`dns.resolve`.

## Changes

Change priority of the port used to:
1. Resolved address port
2. Origin port
3. Default protocol port

### Features

Use port on resolved address.

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
