### PR TITLE
feat!: change default dump maxSize/limit to infinity

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -978,7 +978,7 @@ const client = new Client("http://example.com").compose(
 The `dump` interceptor enables you to dump the response body from a request upon a given limit.
 
 **Options**
-- `maxSize` - The maximum size (in bytes) of the response body to dump. If the size of the request's body exceeds this value then the connection will be closed. Default: `1048576`.
+- `maxSize` - The maximum size (in bytes) of the response body to dump. If the size of the response's body exceeds this value then the connection will be closed. Default: `null`.
 
 > The `Dispatcher#options` also gets extended with the options `dumpMaxSize`, `abortOnDumped`, and `waitForTrailers` which can be used to configure the interceptor at a request-per-request basis.
 
@@ -1021,7 +1021,7 @@ The `dns` interceptor enables you to cache DNS lookups for a given duration, per
   - It can be either `'4` or `6`.
   - It will only take effect if `dualStack` is `false`.
 - `lookup: (hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void` - Custom lookup function. Default: `dns.lookup`.
-  - For more info see [dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback). 
+  - For more info see [dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback).
 - `pick: (origin: URL, records: DNSInterceptorRecords, affinity: 4 | 6) => DNSInterceptorRecord` - Custom pick function. Default: `RoundRobin`.
   - The function should return a single record from the records array.
   - By default a simplified version of Round Robin is used.

--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -251,7 +251,7 @@ class BodyReadable extends Readable {
   /**
    * Dumps the response body by reading `limit` number of bytes.
    * @param {object} opts
-   * @param {number} [opts.limit = 131072] Number of bytes to read.
+   * @param {number} [opts.limit] Number of bytes to read.
    * @param {AbortSignal} [opts.signal] An AbortSignal to cancel the dump.
    * @returns {Promise<null>}
    */
@@ -264,7 +264,7 @@ class BodyReadable extends Readable {
 
     const limit = opts?.limit && Number.isFinite(opts.limit)
       ? opts.limit
-      : 128 * 1024
+      : null
 
     signal?.throwIfAborted()
 
@@ -273,9 +273,9 @@ class BodyReadable extends Readable {
     }
 
     return await new Promise((resolve, reject) => {
-      if (
+      if (limit !== null && (
         (this[kContentLength] && (this[kContentLength] > limit)) ||
-        this[kBytesRead] > limit
+        this[kBytesRead] > limit)
       ) {
         this.destroy(new AbortError())
       }
@@ -301,7 +301,7 @@ class BodyReadable extends Readable {
       this
         .on('error', noop)
         .on('data', () => {
-          if (this[kBytesRead] > limit) {
+          if (limit !== null && this[kBytesRead] > limit) {
             this.destroy()
           }
         })

--- a/lib/interceptor/dump.js
+++ b/lib/interceptor/dump.js
@@ -5,7 +5,7 @@ const { InvalidArgumentError, RequestAbortedError } = require('../core/errors')
 const DecoratorHandler = require('../handler/decorator-handler')
 
 class DumpHandler extends DecoratorHandler {
-  #maxSize = 1024 * 1024
+  #maxSize = null
   #abort = null
   #dumped = false
   #aborted = false
@@ -40,7 +40,7 @@ class DumpHandler extends DecoratorHandler {
     const headers = util.parseHeaders(rawHeaders)
     const contentLength = headers['content-length']
 
-    if (contentLength != null && contentLength > this.#maxSize) {
+    if (contentLength != null && this.#maxSize != null && contentLength > this.#maxSize) {
       throw new RequestAbortedError(
         `Response size (${contentLength}) larger than maxSize (${
           this.#maxSize
@@ -73,7 +73,7 @@ class DumpHandler extends DecoratorHandler {
   onData (chunk) {
     this.#size = this.#size + chunk.length
 
-    if (this.#size >= this.#maxSize) {
+    if (this.#maxSize != null && this.#size >= this.#maxSize) {
       this.#dumped = true
 
       if (this.#aborted) {
@@ -102,7 +102,7 @@ class DumpHandler extends DecoratorHandler {
 
 function createDumpInterceptor (
   { maxSize: defaultMaxSize } = {
-    maxSize: 1024 * 1024
+    maxSize: null
   }
 ) {
   return dispatch => {

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -61,7 +61,7 @@ declare class BodyReadable extends Readable {
   readonly body: never | undefined
 
   /** Dumps the response body by reading `limit` number of bytes.
-   * @param opts.limit Number of bytes to read (optional) - Default: 131072
+   * @param opts.limit Number of bytes to read (optional)
    * @param opts.signal AbortSignal to cancel the operation (optional)
    */
   dump (opts?: { limit: number; signal?: AbortSignal }): Promise<void>


### PR DESCRIPTION
## This relates to...

- https://github.com/nodejs/undici/pull/3743#discussion_r1804929992

## Rationale

I think `dump()` should be able to dump the entire response body, not limited to a max size, you often don't know how big the response body will be.

## Changes

N/A

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

- Change default maxSize from `1048576` (1024 * 1024) to `null` (Infinity)
- Change default limit from `131072` (128 * 1024) to `null` (Infinity)

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
