### PR TITLE
h2: do not emit data after goaway

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -501,16 +501,18 @@ function writeH2 (client, request) {
   })
 
   stream.once('error', function (err) {
+    stream.removeAllListeners('data')
     abort(err)
   })
 
   stream.once('frameError', (type, code) => {
+    stream.removeAllListeners('data')
     abort(new InformationalError(`HTTP/2: "frameError" received - type ${type}, code ${code}`))
   })
 
-  // stream.on('aborted', () => {
-  //   // TODO(HTTP/2): Support aborted
-  // })
+  stream.on('aborted', () => {
+    stream.removeAllListeners('data')
+  })
 
   // stream.on('timeout', () => {
   //   // TODO(HTTP/2): Support timeout


### PR DESCRIPTION
I've seen the HTTP2 goaway test fail a bunch, and I've tried a fix.