### PR TITLE
lib: more cache fixes

### DIFF
--- a/docs/docs/api/CacheStore.md
+++ b/docs/docs/api/CacheStore.md
@@ -25,13 +25,14 @@ The store must implement the following functions:
 Optional. This tells the cache interceptor if the store is full or not. If this is true,
 the cache interceptor will not attempt to cache the response.
 
-### Function: `getValueByKey`
+### Function: `get`
 
 Parameters:
 
 * **req** `Dispatcher.RequestOptions` - Incoming request
 
-Returns: `GetValueByKeyResult | Promise<GetValueByKeyResult | undefined> | undefined` - If the request is cached, a readable for the body is returned. Otherwise, `undefined` is returned.
+Returns: `GetResult | Promise<GetResult | undefined> | undefined` - If the request is cached, the cached response is returned. If the request's method is anything other than HEAD, the response is also returned.
+If the request isn't cached, `undefined` is returned.
 
 Response properties:
 

--- a/docs/docs/api/CacheStore.md
+++ b/docs/docs/api/CacheStore.md
@@ -2,7 +2,8 @@
 
 A Cache Store is responsible for storing and retrieving cached responses.
 It is also responsible for deciding which specific response to use based off of
-a response's `Vary` header (if present).
+a response's `Vary` header (if present). It is expected to be compliant with
+[RFC-9111](https://www.rfc-editor.org/rfc/rfc9111.html).
 
 ## Pre-built Cache Stores
 
@@ -21,27 +22,32 @@ The store must implement the following functions:
 
 ### Getter: `isFull`
 
-This tells the cache interceptor if the store is full or not. If this is true,
+Optional. This tells the cache interceptor if the store is full or not. If this is true,
 the cache interceptor will not attempt to cache the response.
 
-### Function: `createReadStream`
+### Function: `getValueByKey`
 
 Parameters:
 
 * **req** `Dispatcher.RequestOptions` - Incoming request
 
-Returns: `CacheStoreReadable | Promise<CacheStoreReadable | undefined> | undefined` - If the request is cached, a readable for the body is returned. Otherwise, `undefined` is returned.
+Returns: `GetValueByKeyResult | Promise<GetValueByKeyResult | undefined> | undefined` - If the request is cached, a readable for the body is returned. Otherwise, `undefined` is returned.
+
+Response properties:
+
+* **response** `CachedResponse` - The cached response data.
+* **body** `Readable | undefined` - The response's body.
 
 ### Function: `createWriteStream`
 
 Parameters:
 
 * **req** `Dispatcher.RequestOptions` - Incoming request
-* **value** `CacheStoreValue` - Response to store
+* **value** `CachedResponse` - Response to store
 
-Returns: `CacheStoreWriteable | undefined` - If the store is full, return `undefined`. Otherwise, return a writable so that the cache interceptor can stream the body and trailers to the store.
+Returns: `Writable | undefined` - If the store is full, return `undefined`. Otherwise, return a writable so that the cache interceptor can stream the body and trailers to the store.
 
-## `CacheStoreValue`
+## `CachedResponse`
 
 This is an interface containing the majority of a response's data (minus the body).
 
@@ -55,15 +61,11 @@ This is an interface containing the majority of a response's data (minus the bod
 
 ### Property `rawHeaders`
 
-`(Buffer | Buffer[])[]` - The response's headers.
-
-### Property `rawTrailers`
-
-`string[] | undefined` - The response's trailers.
+`Buffer[]` - The response's headers.
 
 ### Property `vary`
 
-`Record<string, string> | undefined` - The headers defined by the response's `Vary` header
+`Record<string, string | string[]> | undefined` - The headers defined by the response's `Vary` header
 and their respective values for later comparison
 
 For example, for a response like
@@ -95,22 +97,3 @@ This would be
 is either the same sa staleAt or the `max-stale` caching directive.
 
 The store must not return a response after the time defined in this property.
-
-## `CacheStoreReadable`
-
-This extends Node's [`Readable`](https://nodejs.org/api/stream.html#class-streamreadable)
-and defines extra properties relevant to the cache interceptor.
-
-### Getter: `value`
-
-The response's [`CacheStoreValue`](#cachestorevalue)
-
-## `CacheStoreWriteable`
-
-This extends Node's [`Writable`](https://nodejs.org/api/stream.html#class-streamwritable)
-and defines extra properties relevant to the cache interceptor.
-
-### Setter: `rawTrailers`
-
-If the response has trailers, the cache interceptor will pass them to the cache
-interceptor through this method.

--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -7,11 +7,9 @@ const { Writable, Readable } = require('node:stream')
  * @implements {CacheStore}
  *
  * @typedef {{
- *  readers: number
- *  readLock: boolean
- *  writeLock: boolean
- *  opts: import('../../types/cache-interceptor.d.ts').default.CacheStoreValue
- *  body: Buffer[]
+ *  locked: boolean
+ *  opts: import('../../types/cache-interceptor.d.ts').default.CachedResponse
+ *  body?: Buffer[]
  * }} MemoryStoreValue
  */
 class MemoryCacheStore {
@@ -19,15 +17,10 @@ class MemoryCacheStore {
 
   #maxEntrySize = Infinity
 
-  /**
-   * @type {((err) => void) | undefined}
-   */
-  #errorCallback = undefined
-
   #entryCount = 0
 
   /**
-   * @type {Map<string, Map<string, MemoryStoreValue>>}
+   * @type {Map<string, Map<string, MemoryStoreValue[]>>}
    */
   #data = new Map()
 
@@ -61,13 +54,6 @@ class MemoryCacheStore {
         }
         this.#maxEntrySize = opts.maxEntrySize
       }
-
-      if (opts.errorCallback !== undefined) {
-        if (typeof opts.errorCallback !== 'function') {
-          throw new TypeError('MemoryCacheStore options.errorCallback must be a function')
-        }
-        this.#errorCallback = opts.errorCallback
-      }
     }
   }
 
@@ -76,36 +62,53 @@ class MemoryCacheStore {
   }
 
   /**
-   * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
-   * @returns {import('../../types/cache-interceptor.d.ts').default.CacheStoreReadable | undefined}
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @returns {import('../../types/cache-interceptor.d.ts').default.GetValueByKeyResult | undefined}
    */
-  createReadStream (req) {
-    if (typeof req !== 'object') {
-      throw new TypeError(`expected req to be object, got ${typeof req}`)
+  getValueByKey (key) {
+    if (typeof key !== 'object') {
+      throw new TypeError(`expected key to be object, got ${typeof key}`)
     }
 
-    const values = this.#getValuesForRequest(req, false)
+    const values = this.#getValuesForRequest(key, false)
     if (!values) {
       return undefined
     }
 
-    const value = this.#findValue(req, values)
+    const value = this.#findValue(key, values)
 
-    if (!value || value.readLock) {
+    if (!value || value.locked) {
       return undefined
     }
 
-    return new MemoryStoreReadableStream(value)
+    /**
+     * @type {Readable | undefined}
+     */
+    let readable
+    if (value.body) {
+      readable = new Readable()
+
+      for (const chunk of value.body) {
+        readable.push(chunk)
+      }
+
+      readable.push(null)
+    }
+
+    return {
+      response: value.opts,
+      body: readable
+    }
   }
 
   /**
-   * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
-   * @param {import('../../types/cache-interceptor.d.ts').default.CacheStoreValue} opts
-   * @returns {import('../../types/cache-interceptor.d.ts').default.CacheStoreWriteable | undefined}
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
+   * @param {import('../../types/cache-interceptor.d.ts').default.CachedResponse} opts
+   * @returns {Writable | undefined}
    */
-  createWriteStream (req, opts) {
-    if (typeof req !== 'object') {
-      throw new TypeError(`expected req to be object, got ${typeof req}`)
+  createWriteStream (key, opts) {
+    if (typeof key !== 'object') {
+      throw new TypeError(`expected key to be object, got ${typeof key}`)
     }
     if (typeof opts !== 'object') {
       throw new TypeError(`expected value to be object, got ${typeof opts}`)
@@ -115,9 +118,12 @@ class MemoryCacheStore {
       return undefined
     }
 
-    const values = this.#getValuesForRequest(req, true)
+    const values = this.#getValuesForRequest(key, true)
 
-    let value = this.#findValue(req, values)
+    /**
+     * @type {number}
+     */
+    let value = this.#findValue(key, values)
     if (!value) {
       // The value doesn't already exist, meaning we haven't cached this
       //  response before. Let's assign it a value and insert it into our data
@@ -131,11 +137,8 @@ class MemoryCacheStore {
       this.#entryCount++
 
       value = {
-        readers: 0,
-        readLock: false,
-        writeLock: false,
-        opts,
-        body: []
+        locked: true,
+        opts
       }
 
       // We want to sort our responses in decending order by their deleteAt
@@ -178,7 +181,7 @@ class MemoryCacheStore {
     } else {
       // Check if there's already another request writing to the value or
       //  a request reading from it
-      if (value.writeLock || value.readLock) {
+      if (value.locked) {
         return undefined
       }
 
@@ -186,70 +189,98 @@ class MemoryCacheStore {
       value.body = []
     }
 
-    const writable = new MemoryStoreWritableStream(
-      value,
-      this.#maxEntrySize
-    )
+    let currentSize = 0
+    /**
+     * @type {Buffer[] | null}
+     */
+    let body = key.method !== 'HEAD' ? [] : null
+    const maxEntrySize = this.#maxEntrySize
 
-    // Remove the value if there was some error
-    writable.on('error', (err) => {
-      values.filter(current => value !== current)
-      if (this.#errorCallback) {
-        this.#errorCallback(err)
+    const writable = new Writable({
+      write (chunk, encoding, callback) {
+        if (key.method === 'HEAD') {
+          throw new Error('HEAD request shouldn\'t have a body')
+        }
+
+        if (!body) {
+          return callback()
+        }
+
+        if (typeof chunk === 'string') {
+          chunk = Buffer.from(chunk, encoding)
+        }
+
+        currentSize += chunk.byteLength
+
+        if (currentSize >= maxEntrySize) {
+          body = null
+          this.end()
+          // TODO remove element from values
+          return callback()
+        }
+
+        body.push(chunk)
+        callback()
+      },
+      final (callback) {
+        value.locked = false
+        if (body !== null) {
+          value.body = body
+        }
+
+        callback()
       }
-    })
-
-    writable.on('bodyOversized', () => {
-      values.filter(current => value !== current)
     })
 
     return writable
   }
 
   /**
-   * @param {string} origin
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
    */
-  deleteByOrigin (origin) {
-    this.#data.delete(origin)
+  deleteByKey (key) {
+    this.#data.delete(`${key.origin}:${key.path}`)
   }
 
   /**
    * Gets all of the requests of the same origin, path, and method. Does not
    *  take the `vary` property into account.
-   * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
    * @param {boolean} [makeIfDoesntExist=false]
+   * @returns {MemoryStoreValue[] | undefined}
    */
-  #getValuesForRequest (req, makeIfDoesntExist) {
+  #getValuesForRequest (key, makeIfDoesntExist) {
     // https://www.rfc-editor.org/rfc/rfc9111.html#section-2-3
-    let cachedPaths = this.#data.get(req.origin)
+    const topLevelKey = `${key.origin}:${key.path}`
+    let cachedPaths = this.#data.get(topLevelKey)
     if (!cachedPaths) {
       if (!makeIfDoesntExist) {
         return undefined
       }
 
       cachedPaths = new Map()
-      this.#data.set(req.origin, cachedPaths)
+      this.#data.set(topLevelKey, cachedPaths)
     }
 
-    let values = cachedPaths.get(`${req.path}:${req.method}`)
-    if (!values && makeIfDoesntExist) {
-      values = []
-      cachedPaths.set(`${req.path}:${req.method}`, values)
+    let value = cachedPaths.get(key.method)
+    if (!value && makeIfDoesntExist) {
+      value = []
+      cachedPaths.set(key.method, value)
     }
 
-    return values
+    return value
   }
 
   /**
    * Given a list of values of a certain request, this decides the best value
    *  to respond with.
-   * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} req
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} req
    * @param {MemoryStoreValue[]} values
    * @returns {MemoryStoreValue | undefined}
    */
   #findValue (req, values) {
     /**
-     * @type {MemoryStoreValue}
+     * @type {MemoryStoreValue | undefined}
      */
     let value
     const now = Date.now()
@@ -286,132 +317,6 @@ class MemoryCacheStore {
     }
 
     return value
-  }
-}
-
-class MemoryStoreReadableStream extends Readable {
-  /**
-   * @type {MemoryStoreValue}
-   */
-  #value
-
-  /**
-   * @type {Buffer[]}
-   */
-  #chunksToSend = []
-
-  /**
-   * @param {MemoryStoreValue} value
-   */
-  constructor (value) {
-    super()
-
-    if (value.readLock) {
-      throw new Error('can\'t read a locked value')
-    }
-
-    this.#value = value
-    this.#chunksToSend = value?.body ? [...value.body, null] : [null]
-
-    this.#value.readers++
-    this.#value.writeLock = true
-
-    this.on('close', () => {
-      this.#value.readers--
-
-      if (this.#value.readers === 0) {
-        this.#value.writeLock = false
-      }
-    })
-  }
-
-  get value () {
-    return this.#value.opts
-  }
-
-  /**
-   * @param {number} size
-   */
-  _read (size) {
-    if (this.#chunksToSend.length === 0) {
-      throw new Error('no chunks left to read, stream should have closed')
-    }
-
-    if (size > this.#chunksToSend.length) {
-      size = this.#chunksToSend.length
-    }
-
-    for (let i = 0; i < size; i++) {
-      this.push(this.#chunksToSend.shift())
-    }
-  }
-}
-
-class MemoryStoreWritableStream extends Writable {
-  /**
-   * @type {MemoryStoreValue}
-   */
-  #value
-  #currentSize = 0
-  #maxEntrySize = 0
-  /**
-   * @type {Buffer[]|null}
-   */
-  #body = []
-
-  /**
-   * @param {MemoryStoreValue} value
-   * @param {number} maxEntrySize
-   */
-  constructor (value, maxEntrySize) {
-    super()
-    this.#value = value
-    this.#value.readLock = true
-    this.#maxEntrySize = maxEntrySize ?? Infinity
-  }
-
-  get rawTrailers () {
-    return this.#value.opts.rawTrailers
-  }
-
-  /**
-   * @param {string[] | undefined} trailers
-   */
-  set rawTrailers (trailers) {
-    this.#value.opts.rawTrailers = trailers
-  }
-
-  /**
-   * @param {Buffer} chunk
-   * @param {string} encoding
-   * @param {BufferEncoding} encoding
-   */
-  _write (chunk, encoding, callback) {
-    if (typeof chunk === 'string') {
-      chunk = Buffer.from(chunk, encoding)
-    }
-
-    this.#currentSize += chunk.byteLength
-    if (this.#currentSize < this.#maxEntrySize) {
-      this.#body.push(chunk)
-    } else {
-      this.#body = null // release memory as early as possible
-      this.emit('bodyOversized')
-    }
-
-    callback()
-  }
-
-  /**
-   * @param {() => void} callback
-   */
-  _final (callback) {
-    if (this.#currentSize < this.#maxEntrySize) {
-      this.#value.readLock = false
-      this.#value.body = this.#body
-    }
-
-    callback()
   }
 }
 

--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -63,9 +63,9 @@ class MemoryCacheStore {
 
   /**
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
-   * @returns {import('../../types/cache-interceptor.d.ts').default.GetValueByKeyResult | undefined}
+   * @returns {import('../../types/cache-interceptor.d.ts').default.GetResult | undefined}
    */
-  getValueByKey (key) {
+  get (key) {
     if (typeof key !== 'object') {
       throw new TypeError(`expected key to be object, got ${typeof key}`)
     }
@@ -121,9 +121,10 @@ class MemoryCacheStore {
     const values = this.#getValuesForRequest(key, true)
 
     /**
-     * @type {number}
+     * @type {(MemoryStoreValue & { index: number }) | undefined}
      */
     let value = this.#findValue(key, values)
+    let valueIndex = value?.index
     if (!value) {
       // The value doesn't already exist, meaning we haven't cached this
       //  response before. Let's assign it a value and insert it into our data
@@ -150,9 +151,11 @@ class MemoryCacheStore {
         // Our value is either the only response for this path or our deleteAt
         //  time is sooner than all the other responses
         values.push(value)
+        valueIndex = values.length - 1
       } else if (opts.deleteAt >= values[0].deleteAt) {
         // Our deleteAt is later than everyone elses
         values.unshift(value)
+        valueIndex = 0
       } else {
         // We're neither in the front or the end, let's just binary search to
         //  find our stop we need to be in
@@ -168,6 +171,7 @@ class MemoryCacheStore {
           const middleValue = values[middleIndex]
           if (opts.deleteAt === middleIndex) {
             values.splice(middleIndex, 0, value)
+            valueIndex = middleIndex
             break
           } else if (opts.deleteAt > middleValue.opts.deleteAt) {
             endIndex = middleIndex
@@ -215,7 +219,7 @@ class MemoryCacheStore {
         if (currentSize >= maxEntrySize) {
           body = null
           this.end()
-          // TODO remove element from values
+          shiftAtIndex(values, valueIndex)
           return callback()
         }
 
@@ -276,7 +280,7 @@ class MemoryCacheStore {
    *  to respond with.
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} req
    * @param {MemoryStoreValue[]} values
-   * @returns {MemoryStoreValue | undefined}
+   * @returns {(MemoryStoreValue & { index: number }) | undefined}
    */
   #findValue (req, values) {
     /**
@@ -311,13 +315,28 @@ class MemoryCacheStore {
       }
 
       if (matches) {
-        value = current
+        value = {
+          ...current,
+          index: i
+        }
         break
       }
     }
 
     return value
   }
+}
+
+/**
+ * @param {any[]} array Array to modify
+ * @param {number} idx Index to delete
+ */
+function shiftAtIndex (array, idx) {
+  for (let i = idx + 1; idx < array.length; i++) {
+    array[i - 1] = array[i]
+  }
+
+  array.length--
 }
 
 module.exports = MemoryCacheStore

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -486,14 +486,7 @@ function encodeRawHeaders (headers) {
   if (!Array.isArray(headers)) {
     throw new TypeError('expected headers to be an array')
   }
-
-  const rawHeaders = new Array(headers.length)
-
-  for (let i = 0; i < headers.length; i++) {
-    rawHeaders[i] = Buffer.from(headers[i])
-  }
-
-  return rawHeaders
+  return headers.map(x => Buffer.from(x))
 }
 
 /**

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -10,7 +10,7 @@ const nodeUtil = require('node:util')
 const { stringify } = require('node:querystring')
 const { EventEmitter: EE } = require('node:events')
 const { InvalidArgumentError } = require('./errors')
-const { headerNameLowerCasedRecord, getHeaderNameAsBuffer } = require('./constants')
+const { headerNameLowerCasedRecord } = require('./constants')
 const { tree } = require('./tree')
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
@@ -437,44 +437,6 @@ function parseHeaders (headers, obj) {
 }
 
 /**
- * @param {Record<string, string | string[]>} headers
- * @returns {(Buffer | Buffer[])[]}
- */
-function encodeHeaders (headers) {
-  const headerNames = Object.keys(headers)
-
-  /**
-   * @type {Buffer[]|Buffer[][]}
-   */
-  const rawHeaders = new Array(headerNames.length * 2)
-
-  let rawHeadersIndex = 0
-  for (const header of headerNames) {
-    let rawValue
-    const value = headers[header]
-    if (Array.isArray(value)) {
-      rawValue = new Array(value.length)
-
-      for (let i = 0; i < value.length; i++) {
-        rawValue[i] = Buffer.from(value[i])
-      }
-    } else {
-      rawValue = Buffer.from(value)
-    }
-
-    const headerBuffer = getHeaderNameAsBuffer(header)
-
-    rawHeaders[rawHeadersIndex] = headerBuffer
-    rawHeadersIndex++
-
-    rawHeaders[rawHeadersIndex] = rawValue
-    rawHeadersIndex++
-  }
-
-  return rawHeaders
-}
-
-/**
  * @param {Buffer[]} headers
  * @returns {string[]}
  */
@@ -514,6 +476,24 @@ function parseRawHeaders (headers) {
   }
 
   return ret
+}
+
+/**
+ * @param {string[]} headers
+ * @param {Buffer[]} headers
+ */
+function encodeRawHeaders (headers) {
+  if (!Array.isArray(headers)) {
+    throw new TypeError('expected headers to be an array')
+  }
+
+  const rawHeaders = new Array(headers.length)
+
+  for (let i = 0; i < headers.length; i++) {
+    rawHeaders[i] = Buffer.from(headers[i])
+  }
+
+  return rawHeaders
 }
 
 /**
@@ -901,8 +881,8 @@ module.exports = {
   removeAllListeners,
   errorRequest,
   parseRawHeaders,
+  encodeRawHeaders,
   parseHeaders,
-  encodeHeaders,
   parseKeepAliveTimeout,
   destroy,
   bodyLength,

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -135,31 +135,43 @@ class CacheHandler extends DecoratorHandler {
         cacheControlDirectives
       )
 
-      this.#writeStream = this.#store.createWriteStream(this.#cacheKey, {
-        statusCode,
-        statusMessage,
-        rawHeaders: strippedHeaders,
-        vary: varyDirectives,
-        cachedAt: now,
-        staleAt,
-        deleteAt
-      })
+      if (this.#cacheKey.method === 'HEAD') {
+        this.#store.createWriteStream(this.#cacheKey, {
+          statusCode,
+          statusMessage,
+          rawHeaders: strippedHeaders,
+          vary: varyDirectives,
+          cachedAt: now,
+          staleAt,
+          deleteAt
+        })
+      } else {
+        this.#writeStream = this.#store.createWriteStream(this.#cacheKey, {
+          statusCode,
+          statusMessage,
+          rawHeaders: strippedHeaders,
+          vary: varyDirectives,
+          cachedAt: now,
+          staleAt,
+          deleteAt
+        })
 
-      if (this.#writeStream) {
-        const handler = this
-        this.#writeStream
-          .on('drain', resume)
-          .on('error', function () {
+        if (this.#writeStream) {
+          const handler = this
+          this.#writeStream
+            .on('drain', resume)
+            .on('error', function () {
             // TODO (fix): Make error somehow observable?
-          })
-          .on('close', function () {
-            if (handler.#writeStream === this) {
-              handler.#writeStream = undefined
-            }
+            })
+            .on('close', function () {
+              if (handler.#writeStream === this) {
+                handler.#writeStream = undefined
+              }
 
-            // TODO (fix): Should we resume even if was paused downstream?
-            resume()
-          })
+              // TODO (fix): Should we resume even if was paused downstream?
+              resume()
+            })
+        }
       }
     }
 
@@ -175,7 +187,7 @@ class CacheHandler extends DecoratorHandler {
   onData (chunk) {
     let paused = false
 
-    if (this.#writeStream && this.#cacheKey.method !== 'HEAD') {
+    if (this.#writeStream) {
       paused ||= this.#writeStream.write(chunk) === false
     }
 
@@ -234,7 +246,6 @@ function canCacheResponse (statusCode, headers, cacheControlDirectives) {
   }
 
   if (
-    !cacheControlDirectives.public ||
     cacheControlDirectives.private === true ||
     cacheControlDirectives['no-cache'] === true ||
     cacheControlDirectives['no-store']
@@ -249,7 +260,7 @@ function canCacheResponse (statusCode, headers, cacheControlDirectives) {
 
   // https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
   if (headers.authorization) {
-    if (typeof headers.authorization !== 'string') {
+    if (!cacheControlDirectives.public || typeof headers.authorization !== 'string') {
       return false
     }
 
@@ -299,7 +310,10 @@ function determineStaleAt (now, headers, cacheControlDirectives) {
 
   if (headers.expire && typeof headers.expire === 'string') {
     // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.3
-    return now + (Date.now() - new Date(headers.expire).getTime())
+    const expiresDate = new Date(headers.expire)
+    if (expiresDate instanceof Date && !isNaN(expiresDate)) {
+      return now + (Date.now() - expiresDate.getTime())
+    }
   }
 
   return undefined

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -14,14 +14,14 @@ function noop () {}
  */
 class CacheHandler extends DecoratorHandler {
   /**
+   * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}
+   */
+  #cacheKey
+
+  /**
    * @type {import('../../types/cache-interceptor.d.ts').default.CacheStore}
    */
   #store
-
-  /**
-   * @type {import('../../types/dispatcher.d.ts').default.RequestOptions}
-   */
-  #requestOptions
 
   /**
    * @type {import('../../types/dispatcher.d.ts').default.DispatchHandlers}
@@ -29,22 +29,22 @@ class CacheHandler extends DecoratorHandler {
   #handler
 
   /**
-   * @type {import('../../types/cache-interceptor.d.ts').default.CacheStoreWriteable | undefined}
+   * @type {import('node:stream').Writable | undefined}
    */
   #writeStream
 
   /**
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheOptions} opts
-   * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} requestOptions
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} cacheKey
    * @param {import('../../types/dispatcher.d.ts').default.DispatchHandlers} handler
    */
-  constructor (opts, requestOptions, handler) {
+  constructor (opts, cacheKey, handler) {
     const { store } = opts
 
     super(handler)
 
     this.#store = store
-    this.#requestOptions = requestOptions
+    this.#cacheKey = cacheKey
     this.#handler = handler
   }
 
@@ -88,35 +88,34 @@ class CacheHandler extends DecoratorHandler {
     }
 
     if (
-      !util.safeHTTPMethods.includes(this.#requestOptions.method) &&
+      !util.safeHTTPMethods.includes(this.#cacheKey.method) &&
       statusCode >= 200 &&
       statusCode <= 399
     ) {
       // https://www.rfc-editor.org/rfc/rfc9111.html#name-invalidating-stored-response
       try {
-        this.#store.deleteByOrigin(this.#requestOptions.origin.toString())?.catch?.(noop)
+        this.#store.deleteByKey(this.#cacheKey).catch?.(noop)
       } catch {
         // Fail silently
       }
       return downstreamOnHeaders()
     }
 
-    const headers = util.parseHeaders(rawHeaders)
+    const parsedRawHeaders = util.parseRawHeaders(rawHeaders)
+    const headers = util.parseHeaders(parsedRawHeaders)
 
     const cacheControlHeader = headers['cache-control']
-    if (!cacheControlHeader || typeof cacheControlHeader !== 'string') {
-      // Don't have cache-control, can't cache.
+    const isCacheFull = typeof this.#store.isFull !== 'undefined'
+      ? this.#store.isFull
+      : false
+
+    if (
+      !cacheControlHeader ||
+      isCacheFull
+    ) {
+      // Don't have the cache control header or the cache is full
       return downstreamOnHeaders()
     }
-
-    const contentLengthHeader = headers['content-length']
-    const contentLength = contentLengthHeader ? Number(contentLengthHeader) : null
-    if (!Number.isInteger(contentLength)) {
-      // Don't know the final size, don't cache.
-      // TODO (fix): Why not cache?
-      return downstreamOnHeaders()
-    }
-
     const cacheControlDirectives = parseCacheControlHeader(cacheControlHeader)
     if (!canCacheResponse(statusCode, headers, cacheControlDirectives)) {
       return downstreamOnHeaders()
@@ -125,18 +124,18 @@ class CacheHandler extends DecoratorHandler {
     const now = Date.now()
     const staleAt = determineStaleAt(now, headers, cacheControlDirectives)
     if (staleAt) {
-      const varyDirectives = headers.vary
-        ? parseVaryHeader(headers.vary, this.#requestOptions.headers)
+      const varyDirectives = this.#cacheKey.headers && headers.vary && !Array.isArray(headers.vary)
+        ? parseVaryHeader(headers.vary, this.#cacheKey.headers)
         : undefined
       const deleteAt = determineDeleteAt(now, cacheControlDirectives, staleAt)
 
       const strippedHeaders = stripNecessaryHeaders(
         rawHeaders,
-        headers,
+        parsedRawHeaders,
         cacheControlDirectives
       )
 
-      this.#writeStream = this.#store.createWriteStream(this.#requestOptions, {
+      this.#writeStream = this.#store.createWriteStream(this.#cacheKey, {
         statusCode,
         statusMessage,
         rawHeaders: strippedHeaders,
@@ -176,7 +175,7 @@ class CacheHandler extends DecoratorHandler {
   onData (chunk) {
     let paused = false
 
-    if (this.#writeStream) {
+    if (this.#writeStream && this.#cacheKey.method !== 'HEAD') {
       paused ||= this.#writeStream.write(chunk) === false
     }
 
@@ -194,7 +193,6 @@ class CacheHandler extends DecoratorHandler {
    */
   onComplete (rawTrailers) {
     if (this.#writeStream) {
-      this.#writeStream.rawTrailers = rawTrailers ?? []
       this.#writeStream.end()
     }
 
@@ -224,7 +222,7 @@ class CacheHandler extends DecoratorHandler {
  * @see https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
  *
  * @param {number} statusCode
- * @param {Record<string, string>} headers
+ * @param {Record<string, string | string[]>} headers
  * @param {import('../util/cache.js').CacheControlDirectives} cacheControlDirectives
  */
 function canCacheResponse (statusCode, headers, cacheControlDirectives) {
@@ -250,7 +248,11 @@ function canCacheResponse (statusCode, headers, cacheControlDirectives) {
   }
 
   // https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
-  if (headers['authorization']) {
+  if (headers.authorization) {
+    if (typeof headers.authorization !== 'string') {
+      return false
+    }
+
     if (
       Array.isArray(cacheControlDirectives['no-cache']) &&
       cacheControlDirectives['no-cache'].includes('authorization')
@@ -295,7 +297,7 @@ function determineStaleAt (now, headers, cacheControlDirectives) {
     return now + (maxAge * 1000)
   }
 
-  if (headers.expire) {
+  if (headers.expire && typeof headers.expire === 'string') {
     // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.3
     return now + (Date.now() - new Date(headers.expire).getTime())
   }
@@ -319,11 +321,11 @@ function determineDeleteAt (now, cacheControlDirectives, staleAt) {
 /**
  * Strips headers required to be removed in cached responses
  * @param {Buffer[]} rawHeaders
- * @param {Record<string, string | string[]>} parsedHeaders
+ * @param {string[]} parsedRawHeaders
  * @param {import('../util/cache.js').CacheControlDirectives} cacheControlDirectives
- * @returns {(Buffer|Buffer[])[]}
+ * @returns {Buffer[]}
  */
-function stripNecessaryHeaders (rawHeaders, parsedHeaders, cacheControlDirectives) {
+function stripNecessaryHeaders (rawHeaders, parsedRawHeaders, cacheControlDirectives) {
   const headersToRemove = ['connection']
 
   if (Array.isArray(cacheControlDirectives['no-cache'])) {
@@ -334,39 +336,52 @@ function stripNecessaryHeaders (rawHeaders, parsedHeaders, cacheControlDirective
     headersToRemove.push(...cacheControlDirectives['private'])
   }
 
-  /**
-   * These are the headers that are okay to cache. If this is assigned, we need
-   *  to remake the buffer representation of the headers
-   * @type {Record<string, string | string[]> | undefined}
-   */
   let strippedHeaders
 
-  const headerNames = Object.keys(parsedHeaders)
-  for (let i = 0; i < headerNames.length; i++) {
-    const header = headerNames[i]
+  let offset = 0
+  for (let i = 0; i < parsedRawHeaders.length; i += 2) {
+    const headerName = parsedRawHeaders[i]
 
-    if (headersToRemove.includes(header)) {
-      // We have a at least one header we want to remove
+    if (headersToRemove.includes(headerName)) {
+      // We have at least one header we want to remove
       if (!strippedHeaders) {
-        // This is the first header we want to remove, let's create the object
-        //  and backfill the previous headers into it
-        strippedHeaders = {}
+        // This is the first header we want to remove, let's create the array
+        // Since we're stripping headers, this will over allocate. We'll trim
+        //  it later.
+        strippedHeaders = new Array(parsedRawHeaders.length)
 
-        for (let j = 0; j < i; j++) {
-          strippedHeaders[headerNames[j]] = parsedHeaders[headerNames[j]]
+        // Backfill the previous headers into it
+        for (let j = 0; j < i; j += 2) {
+          strippedHeaders[j] = parsedRawHeaders[j]
+          strippedHeaders[j + 1] = parsedRawHeaders[j + 1]
         }
       }
+
+      // We can't map indices 1:1 from stripped headers to rawHeaders without
+      //  creating holes (if we skip a header, we now have two holes where at
+      //  element should be). So, let's keep an offset to keep strippedHeaders
+      //  flattened. We can also use this at the end for trimming the empty
+      //  elements off of strippedHeaders.
+      offset += 2
 
       continue
     }
 
-    // This header is fine. Let's add it to strippedHeaders if it exists.
+    // We want to keep this header. Let's add it to strippedHeaders if it exists
     if (strippedHeaders) {
-      strippedHeaders[header] = parsedHeaders[header]
+      strippedHeaders[i - offset] = parsedRawHeaders[i]
+      strippedHeaders[i + 1 - offset] = parsedRawHeaders[i + 1]
     }
   }
 
-  return strippedHeaders ? util.encodeHeaders(strippedHeaders) : rawHeaders
+  if (strippedHeaders) {
+    // Trim off the empty values at the end
+    strippedHeaders.length -= offset
+  }
+
+  return strippedHeaders
+    ? util.encodeRawHeaders(strippedHeaders)
+    : rawHeaders
 }
 
 module.exports = CacheHandler

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -124,7 +124,7 @@ class CacheHandler extends DecoratorHandler {
     const now = Date.now()
     const staleAt = determineStaleAt(now, headers, cacheControlDirectives)
     if (staleAt) {
-      const varyDirectives = this.#cacheKey.headers && headers.vary && !Array.isArray(headers.vary)
+      const varyDirectives = this.#cacheKey.headers && headers.vary
         ? parseVaryHeader(headers.vary, this.#cacheKey.headers)
         : undefined
       const deleteAt = determineDeleteAt(now, cacheControlDirectives, staleAt)

--- a/lib/handler/cache-revalidation-handler.js
+++ b/lib/handler/cache-revalidation-handler.js
@@ -29,6 +29,7 @@ class CacheRevalidationHandler extends DecoratorHandler {
   #handler
 
   #abort
+
   /**
    * @param {(boolean) => void} callback Function to call if the cached value is valid
    * @param {import('../../types/dispatcher.d.ts').default.DispatchHandlers} handler

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -55,7 +55,7 @@ module.exports = (opts = {}) => {
       // TODO (perf): For small entries support returning a Buffer instead of a stream.
       // Maybe store should return { staleAt, headers, body, etc... } instead of a stream + stream.value?
       // Where body can be a Buffer, string, stream or blob?
-      const result = store.getValueByKey(cacheKey)
+      const result = store.get(cacheKey)
       if (!result) {
         // Request isn't cached
         return dispatch(opts, new CacheHandler(globalOpts, cacheKey, handler))
@@ -114,6 +114,8 @@ module.exports = (opts = {}) => {
             if (typeof handler.onComplete === 'function') {
               handler.onComplete([])
             }
+
+            stream?.destroy()
           } else {
             stream.on('data', function (chunk) {
               if (typeof handler.onData === 'function' && !handler.onData(chunk)) {
@@ -127,7 +129,7 @@ module.exports = (opts = {}) => {
       }
 
       /**
-       * @param {import('../../types/cache-interceptor.d.ts').default.GetValueByKeyResult} result
+       * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
        */
       const handleStream = (result) => {
         const { response: value, body: stream } = result

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -5,12 +5,12 @@ const util = require('../core/util')
 const CacheHandler = require('../handler/cache-handler')
 const MemoryCacheStore = require('../cache/memory-cache-store')
 const CacheRevalidationHandler = require('../handler/cache-revalidation-handler')
-const { assertCacheStore, assertCacheMethods } = require('../util/cache.js')
+const { assertCacheStore, assertCacheMethods, makeCacheKey } = require('../util/cache.js')
 
 const AGE_HEADER = Buffer.from('age')
 
 /**
- * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheStoreValue} CacheStoreValue
+ * @typedef {import('../../types/cache-interceptor.d.ts').default.CachedResponse} CachedResponse
  */
 
 /**
@@ -47,27 +47,30 @@ module.exports = (opts = {}) => {
         return dispatch(opts, handler)
       }
 
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}
+       */
+      const cacheKey = makeCacheKey(opts)
+
       // TODO (perf): For small entries support returning a Buffer instead of a stream.
       // Maybe store should return { staleAt, headers, body, etc... } instead of a stream + stream.value?
       // Where body can be a Buffer, string, stream or blob?
-
-      const stream = store.createReadStream(opts)
-      if (!stream) {
+      const result = store.getValueByKey(cacheKey)
+      if (!result) {
         // Request isn't cached
-        return dispatch(opts, new CacheHandler(globalOpts, opts, handler))
+        return dispatch(opts, new CacheHandler(globalOpts, cacheKey, handler))
       }
 
       /**
-       * @param {import('node:stream').Readable} stream
-       * @param {import('../../types/cache-interceptor.d.ts').default.CacheStoreValue} value
+       * @param {import('node:stream').Readable | undefined} stream
+       * @param {import('../../types/cache-interceptor.d.ts').default.CachedResponse} value
        */
       const respondWithCachedValue = (stream, value) => {
-        assert(!stream.destroyed, 'stream should not be destroyed')
-        assert(!stream.readableDidRead, 'stream should not be readableDidRead')
-
+        assert(!stream || !stream.destroyed, 'stream should not be destroyed')
+        assert(!stream || !stream.readableDidRead, 'stream should not be readableDidRead')
         try {
           stream
-            .on('error', function (err) {
+            ?.on('error', function (err) {
               if (!this.readableEnded) {
                 if (typeof handler.onError === 'function') {
                   handler.onError(err)
@@ -76,21 +79,22 @@ module.exports = (opts = {}) => {
                     throw err
                   })
                 }
-              } else {
-                // Ignore error...
               }
             })
             .on('close', function () {
               if (!this.errored && typeof handler.onComplete === 'function') {
-                handler.onComplete(value.rawTrailers ?? [])
+                handler.onComplete([])
               }
             })
 
           if (typeof handler.onConnect === 'function') {
             handler.onConnect((err) => {
-              stream.destroy(err)
+              if (stream) {
+                stream.destroy(err)
+              }
             })
-            if (stream.destroyed) {
+
+            if (stream?.destroyed) {
               return
             }
           }
@@ -103,13 +107,15 @@ module.exports = (opts = {}) => {
             // TODO (fix): What if rawHeaders already contains age header?
             const rawHeaders = [...value.rawHeaders, AGE_HEADER, Buffer.from(`${age}`)]
 
-            if (handler.onHeaders(value.statusCode, rawHeaders, () => stream.resume(), value.statusMessage) === false) {
-              stream.pause()
+            if (handler.onHeaders(value.statusCode, rawHeaders, () => stream?.resume(), value.statusMessage) === false) {
+              stream?.pause()
             }
           }
 
           if (opts.method === 'HEAD') {
-            stream.destroy()
+            if (typeof handler.onComplete === 'function') {
+              handler.onComplete([])
+            }
           } else {
             stream.on('data', function (chunk) {
               if (typeof handler.onData === 'function' && !handler.onData(chunk)) {
@@ -118,18 +124,18 @@ module.exports = (opts = {}) => {
             })
           }
         } catch (err) {
-          stream.destroy(err)
+          stream?.destroy(err)
         }
       }
 
       /**
-       * @param {import('node:stream').Readable | undefined} stream
-       * @param {CacheStoreValue | undefined} value
+       * @param {import('../../types/cache-interceptor.d.ts').default.GetValueByKeyResult} result
        */
-      const handleStream = (stream, value) => {
-        if (!stream || !value) {
-          stream?.on('error', () => {}).destroy()
-          return dispatch(opts, new CacheHandler(globalOpts, opts, handler))
+      const handleStream = (result) => {
+        const { response: value, body: stream } = result
+
+        if (!stream && opts.method !== 'HEAD') {
+          throw new Error('stream is undefined but method isn\'t HEAD')
         }
 
         // Check if the response is stale
@@ -143,7 +149,7 @@ module.exports = (opts = {}) => {
         } else if (util.isStream(opts.body) && util.bodyLength(opts.body) !== 0) {
           // If body is is stream we can't revalidate...
           // TODO (fix): This could be less strict...
-          dispatch(opts, new CacheHandler(globalOpts, opts, handler))
+          dispatch(opts, new CacheHandler(globalOpts, cacheKey, handler))
         } else {
           // Need to revalidate the response
           dispatch(
@@ -162,22 +168,23 @@ module.exports = (opts = {}) => {
                   stream.on('error', () => {}).destroy()
                 }
               },
-              new CacheHandler(globalOpts, opts, handler)
+              new CacheHandler(globalOpts, cacheKey, handler)
             )
           )
         }
       }
 
-      if (util.isStream(stream)) {
-        handleStream(stream, stream.value)
-      } else {
-        Promise.resolve(stream).then(stream => handleStream(stream, stream?.value), err => {
-          if (typeof handler.onError === 'function') {
-            handler.onError(err)
-          } else {
-            throw err
+      if (typeof result.then === 'function') {
+        result.then((result) => {
+          if (!result) {
+            // Request isn't cached
+            return dispatch(opts, new CacheHandler(globalOpts, cacheKey, handler))
           }
-        })
+
+          handleStream(result)
+        }).catch(handler.onError)
+      } else {
+        handleStream(result)
       }
 
       return true

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -89,9 +89,7 @@ module.exports = (opts = {}) => {
 
           if (typeof handler.onConnect === 'function') {
             handler.onConnect((err) => {
-              if (stream) {
-                stream.destroy(err)
-              }
+              stream?.destroy(err)
             })
 
             if (stream?.destroyed) {
@@ -182,7 +180,7 @@ module.exports = (opts = {}) => {
           }
 
           handleStream(result)
-        }).catch(handler.onError)
+        }).catch(err => handler.onError(err))
       } else {
         handleStream(result)
       }

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -176,20 +176,22 @@ function parseCacheControlHeader (header) {
 }
 
 /**
- * @param {string} varyHeader Vary header from the server
+ * @param {string | string[]} varyHeader Vary header from the server
  * @param {Record<string, string | string[]>} headers Request headers
  * @returns {Record<string, string | string[]>}
  */
 function parseVaryHeader (varyHeader, headers) {
-  if (varyHeader === '*') {
+  if (typeof varyHeader === 'string' && varyHeader === '*') {
     return headers
   }
 
   const output = /** @type {Record<string, string | string[]>} */ ({})
 
-  const varyingHeaders = varyHeader.toLowerCase().split(',')
+  const varyingHeaders = typeof varyHeader === 'string'
+    ? varyHeader.split(',')
+    : varyHeader
   for (const header of varyingHeaders) {
-    const trimmedHeader = header.trim()
+    const trimmedHeader = header.trim().toLowerCase()
 
     if (headers[trimmedHeader]) {
       output[trimmedHeader] = headers[trimmedHeader]

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -19,11 +19,8 @@ function makeCacheKey (opts) {
   const cacheKey = {
     origin: opts.origin.toString(),
     method: opts.method,
-    path: opts.path
-  }
-
-  if (opts.headers) {
-    cacheKey.headers = opts.headers
+    path: opts.path,
+    headers: opts.headers
   }
 
   return cacheKey

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -208,7 +208,7 @@ function assertCacheStore (store, name = 'CacheStore') {
     throw new TypeError(`expected type of ${name} to be a CacheStore, got ${store === null ? 'null' : typeof store}`)
   }
 
-  for (const fn of ['getValueByKey', 'createWriteStream', 'deleteByKey']) {
+  for (const fn of ['get', 'createWriteStream', 'deleteByKey']) {
     if (typeof store[fn] !== 'function') {
       throw new TypeError(`${name} needs to have a \`${fn}()\` function`)
     }

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -5,6 +5,31 @@ const {
 } = require('../core/util')
 
 /**
+ *
+ * @param {import('../../types/dispatcher.d.ts').default.DispatchOptions} opts
+ */
+function makeCacheKey (opts) {
+  if (!opts.origin) {
+    throw new Error('opts.origin is undefined')
+  }
+
+  /**
+   * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}
+   */
+  const cacheKey = {
+    origin: opts.origin.toString(),
+    method: opts.method,
+    path: opts.path
+  }
+
+  if (opts.headers) {
+    cacheKey.headers = opts.headers
+  }
+
+  return cacheKey
+}
+
+/**
  * @see https://www.rfc-editor.org/rfc/rfc9111.html#name-cache-control
  * @see https://www.iana.org/assignments/http-cache-directives/http-cache-directives.xhtml
  *
@@ -27,7 +52,7 @@ const {
  *   'only-if-cached'?: true;
  * }} CacheControlDirectives
  *
- * @param {string} header
+ * @param {string | string[]} header
  * @returns {CacheControlDirectives}
  */
 function parseCacheControlHeader (header) {
@@ -36,9 +61,9 @@ function parseCacheControlHeader (header) {
    */
   const output = {}
 
-  const directives = header.toLowerCase().split(',')
+  const directives = Array.isArray(header) ? header : header.split(',')
   for (let i = 0; i < directives.length; i++) {
-    const directive = directives[i]
+    const directive = directives[i].toLowerCase()
     const keyValueDelimiter = directive.indexOf('=')
 
     let key
@@ -155,15 +180,15 @@ function parseCacheControlHeader (header) {
 
 /**
  * @param {string} varyHeader Vary header from the server
- * @param {Record<string, string>} headers Request headers
- * @returns {Record<string, string>}
+ * @param {Record<string, string | string[]>} headers Request headers
+ * @returns {Record<string, string | string[]>}
  */
 function parseVaryHeader (varyHeader, headers) {
   if (varyHeader === '*') {
     return headers
   }
 
-  const output = /** @type {Record<string, string>} */ ({})
+  const output = /** @type {Record<string, string | string[]>} */ ({})
 
   const varyingHeaders = varyHeader.toLowerCase().split(',')
   for (const header of varyingHeaders) {
@@ -186,14 +211,14 @@ function assertCacheStore (store, name = 'CacheStore') {
     throw new TypeError(`expected type of ${name} to be a CacheStore, got ${store === null ? 'null' : typeof store}`)
   }
 
-  for (const fn of ['createReadStream', 'createWriteStream', 'deleteByOrigin']) {
+  for (const fn of ['getValueByKey', 'createWriteStream', 'deleteByKey']) {
     if (typeof store[fn] !== 'function') {
       throw new TypeError(`${name} needs to have a \`${fn}()\` function`)
     }
   }
 
-  if (typeof store.isFull !== 'boolean') {
-    throw new TypeError(`${name} needs a isFull getter with type boolean, current type: ${typeof store.isFull}`)
+  if (typeof store.isFull !== 'undefined' && typeof store.isFull !== 'boolean') {
+    throw new TypeError(`${name} needs a isFull getter with type boolean or undefined, current type: ${typeof store.isFull}`)
   }
 }
 /**
@@ -217,6 +242,7 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
 }
 
 module.exports = {
+  makeCacheKey,
   parseCacheControlHeader,
   parseVaryHeader,
   assertCacheMethods,

--- a/test/cache-interceptor/utils.js
+++ b/test/cache-interceptor/utils.js
@@ -131,6 +131,49 @@ describe('parseCacheControlHeader', () => {
       'only-if-cached': true
     })
   })
+
+  test('handles multiple headers correctly', () => {
+    // For requests like
+    //  cache-control: max-stale=1
+    //  cache-control: min-fresh-1
+    //  ...
+    const directives = parseCacheControlHeader([
+      'max-stale=1',
+      'min-fresh=1',
+      'max-age=1',
+      's-maxage=1',
+      'stale-while-revalidate=1',
+      'stale-if-error=1',
+      'public',
+      'private',
+      'no-store',
+      'no-cache',
+      'must-revalidate',
+      'proxy-revalidate',
+      'immutable',
+      'no-transform',
+      'must-understand',
+      'only-if-cached'
+    ])
+    deepStrictEqual(directives, {
+      'max-stale': 1,
+      'min-fresh': 1,
+      'max-age': 1,
+      's-maxage': 1,
+      'stale-while-revalidate': 1,
+      'stale-if-error': 1,
+      public: true,
+      private: true,
+      'no-store': true,
+      'no-cache': true,
+      'must-revalidate': true,
+      'proxy-revalidate': true,
+      immutable: true,
+      'no-transform': true,
+      'must-understand': true,
+      'only-if-cached': true
+    })
+  })
 })
 
 describe('parseVaryHeader', () => {

--- a/test/cache-interceptor/utils.js
+++ b/test/cache-interceptor/utils.js
@@ -202,4 +202,16 @@ describe('parseVaryHeader', () => {
       'something-else': 'asd123'
     })
   })
+
+  test('handles multiple headers correctly', () => {
+    const output = parseVaryHeader(['some-header', 'another-one'], {
+      'some-header': 'asd',
+      'another-one': '123',
+      'third-header': 'cool'
+    })
+    deepStrictEqual(output, {
+      'some-header': 'asd',
+      'another-one': '123'
+    })
+  })
 })

--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -5,7 +5,7 @@ import CacheInterceptor from '../../types/cache-interceptor'
 const store: CacheInterceptor.CacheStore = {
   isFull: false,
 
-  getValue (_: CacheInterceptor.CacheKey): CacheInterceptor.GetResult | Promise<CacheInterceptor.GetResult | undefined> | undefined {
+  get (_: CacheInterceptor.CacheKey): CacheInterceptor.GetResult | Promise<CacheInterceptor.GetResult | undefined> | undefined {
     throw new Error('stub')
   },
 

--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -1,19 +1,19 @@
+import { Writable } from 'node:stream'
 import { expectAssignable, expectNotAssignable } from 'tsd'
 import CacheInterceptor from '../../types/cache-interceptor'
-import Dispatcher from '../../types/dispatcher'
 
 const store: CacheInterceptor.CacheStore = {
   isFull: false,
 
-  createReadStream (_: Dispatcher.RequestOptions): CacheInterceptor.CacheStoreReadable | undefined {
+  getValue (_: CacheInterceptor.CacheKey): CacheInterceptor.GetValueByKeyResult | Promise<CacheInterceptor.GetValueByKeyResult | undefined> | undefined {
     throw new Error('stub')
   },
 
-  createWriteStream (_: Dispatcher.RequestOptions, _2: CacheInterceptor.CacheStoreValue): CacheInterceptor.CacheStoreWriteable | undefined {
+  createWriteStream (_: CacheInterceptor.CacheKey, _2: CacheInterceptor.CachedResponse): Writable | undefined {
     throw new Error('stub')
   },
 
-  deleteByOrigin (_: string): void | Promise<void> {
+  deleteByKey (_: CacheInterceptor.CacheKey): void | Promise<void> {
     throw new Error('stub')
   }
 }
@@ -23,7 +23,7 @@ expectAssignable<CacheInterceptor.CacheOptions>({ store })
 expectAssignable<CacheInterceptor.CacheOptions>({ methods: [] })
 expectAssignable<CacheInterceptor.CacheOptions>({ store, methods: ['GET'] })
 
-expectAssignable<CacheInterceptor.CacheStoreValue>({
+expectAssignable<CacheInterceptor.CachedResponse>({
   statusCode: 200,
   statusMessage: 'OK',
   rawHeaders: [],
@@ -32,24 +32,21 @@ expectAssignable<CacheInterceptor.CacheStoreValue>({
   deleteAt: 0
 })
 
-expectAssignable<CacheInterceptor.CacheStoreValue>({
+expectAssignable<CacheInterceptor.CachedResponse>({
   statusCode: 200,
   statusMessage: 'OK',
   rawHeaders: [],
-  rawTrailers: [],
   vary: {},
   cachedAt: 0,
   staleAt: 0,
   deleteAt: 0
 })
 
-expectNotAssignable<CacheInterceptor.CacheStoreValue>({})
-expectNotAssignable<CacheInterceptor.CacheStoreValue>({
+expectNotAssignable<CacheInterceptor.CachedResponse>({})
+expectNotAssignable<CacheInterceptor.CachedResponse>({
   statusCode: '123',
   statusMessage: 123,
   rawHeaders: '',
-  rawTrailers: '',
-  body: 0,
   vary: '',
   size: '',
   cachedAt: '',

--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -5,7 +5,7 @@ import CacheInterceptor from '../../types/cache-interceptor'
 const store: CacheInterceptor.CacheStore = {
   isFull: false,
 
-  getValue (_: CacheInterceptor.CacheKey): CacheInterceptor.GetValueByKeyResult | Promise<CacheInterceptor.GetValueByKeyResult | undefined> | undefined {
+  getValue (_: CacheInterceptor.CacheKey): CacheInterceptor.GetResult | Promise<CacheInterceptor.GetResult | undefined> | undefined {
     throw new Error('stub')
   },
 

--- a/types/cache-interceptor.d.ts
+++ b/types/cache-interceptor.d.ts
@@ -31,7 +31,7 @@ declare namespace CacheHandler {
     path: string
   }
 
-  export interface GetValueByKeyResult {
+  export interface GetResult {
     response: CachedResponse
     body?: Readable
   }
@@ -45,7 +45,7 @@ declare namespace CacheHandler {
      */
     get isFull(): boolean | undefined
 
-    getValueByKey(key: CacheKey): GetValueByKeyResult | Promise<GetValueByKeyResult | undefined> | undefined
+    get(key: CacheKey): GetResult | Promise<GetResult | undefined> | undefined
 
     createWriteStream(key: CacheKey, value: CachedResponse): Writable | undefined
 
@@ -93,7 +93,7 @@ declare namespace CacheHandler {
 
     get isFull (): boolean
 
-    getValueByKey (key: CacheKey): GetValueByKeyResult | Promise<GetValueByKeyResult | undefined> | undefined
+    get (key: CacheKey): GetResult | Promise<GetResult | undefined> | undefined
 
     createWriteStream (key: CacheKey, value: CachedResponse): Writable | undefined
 


### PR DESCRIPTION
Closes #3806

- Removes `CacheStoreReadable` and `CacheStoreWritable`, replaces w/ just `Readable` and `Writable`
  - Reasoning: api simplicity
- Renames `CacheStoreValue` type to `CachedResponse`
- Removes `CacheStore#createReadStream` function (see one below on reasoning)
- Adds `CacheStore#get` function that acts similarly to `createReadStream`
  - Reasoning: api simplicity & niceness. Returns a `GetResult` which separates the `CacheResponse` and `Readable` for the body
- Simplifies `MemoryCacheStore`
  - Inline readable & writables
  - `readLock` and `writeLock` condensed into just `locked` that only stops value from being read
- Introduces `CacheKey` type that we pass into the cache handler, cache stores
  - Replaces us passing in the full request options
  - Reasoning: cache stores don't need the full thing, guides them to be more spec-compliant
- Various internal type fixes
- Fixes regarding a header being present multiple times
  - Stripping headers would result in them being re-encoded in the wrong format
  - Cache control & vary header parsings
- Makes `isFull` optional
  - Reasoning: some cache stores can't get full / don't have a max. This only exists as a very small optimization
- Removes caching of trailers
  - Reasoning: simplicity sakes, ideally this will be added back later
- Replace `deleteByOrigin` with `deleteByKey`
  - Reasoning: #3806
- Adds `CachedValue` type
  - Separates the `body` stream and the properties in `CachedResponse`
  - Allows the stream to be undefined for HEAD requests since there's no body

cc @mcollina @ronag 