### PR TITLE
fix: range end is zero-indexed

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -229,7 +229,7 @@ class RetryHandler {
         return false
       }
 
-      const { start, size, end = size } = contentRange
+      const { start, size, end = size - 1 } = contentRange
 
       assert(this.start === start, 'content-range mismatch')
       assert(this.end == null || this.end === end, 'content-range mismatch')
@@ -252,7 +252,7 @@ class RetryHandler {
           )
         }
 
-        const { start, size, end = size } = range
+        const { start, size, end = size - 1 } = range
         assert(
           start != null && Number.isFinite(start),
           'content-range mismatch'
@@ -266,7 +266,7 @@ class RetryHandler {
       // We make our best to checkpoint the body for further range headers
       if (this.end == null) {
         const contentLength = headers['content-length']
-        this.end = contentLength != null ? Number(contentLength) : null
+        this.end = contentLength != null ? Number(contentLength) - 1 : null
       }
 
       assert(Number.isFinite(this.start))

--- a/test/interceptors/retry.js
+++ b/test/interceptors/retry.js
@@ -253,14 +253,15 @@ test('Should handle 206 partial content', async t => {
   const server = createServer((req, res) => {
     if (x === 0) {
       t.ok(true, 'pass')
+      res.setHeader('content-length', '6')
       res.setHeader('etag', 'asd')
       res.write('abc')
       setTimeout(() => {
         res.destroy()
       }, 1e2)
     } else if (x === 1) {
-      t.deepStrictEqual(req.headers.range, 'bytes=3-')
-      res.setHeader('content-range', 'bytes 3-6/6')
+      t.deepStrictEqual(req.headers.range, 'bytes=3-5')
+      res.setHeader('content-range', 'bytes 3-5/6')
       res.setHeader('etag', 'asd')
       res.statusCode = 206
       res.end('def')


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

The retry interceptor treats the `end` parameter of the `Range` or `Content-Range` header as 1-indexed (or 0-indexed but exclusive), leading to an error, for example, when the `Content-Range` header is not present and `end` is assigned to the value of the `Content-Length` header:
```shell
AssertionError [ERR_ASSERTION]: content-range mismatch
    at RetryHandler.onHeaders (D:\_\node_modules\undici\lib\handler\retry-handler.js:236:7)
    at downstreamOnHeaders (D:\_\node_modules\undici\lib\handler\cache-handler.js:64:53)
    at CacheHandler.onHeaders (D:\_\node_modules\undici\lib\handler\cache-handler.js:112:14)
    at CookieHandler.onHeaders (D:\_\node_modules\http-cookie-agent\dist\undici\cookie_handler.js:43:28)
    at Request.onHeaders (D:\_\node_modules\undici\lib\core\request.js:246:29)
    at Parser.onHeadersComplete (D:\_\node_modules\undici\lib\dispatcher\client-h1.js:612:27)
    at wasm_on_headers_complete (D:\_\node_modules\undici\lib\dispatcher\client-h1.js:141:30)
    at wasm://wasm/00032d9a:wasm-function[10]:0x56f
    at wasm://wasm/00032d9a:wasm-function[20]:0x7d57
    at Parser.execute (D:\_\node_modules\undici\lib\dispatcher\client-h1.js:332:22) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '=='
}
```

## Rationale

This PR fixes the issue above by subtracting 1 to `Content-Length` or the size parameter of the `Content-Range` header

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
