### PR TITLE
fix: pass down context in onConnect

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -49,14 +49,14 @@ class CacheHandler extends DecoratorHandler {
     this.#handler = handler
   }
 
-  onConnect (abort) {
+  onConnect (...args) {
     if (this.#writeStream) {
       this.#writeStream.destroy()
       this.#writeStream = undefined
     }
 
     if (typeof this.#handler.onConnect === 'function') {
-      this.#handler.onConnect(abort)
+      this.#handler.onConnect(...args)
     }
   }
 

--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -37,6 +37,7 @@ class RetryHandler {
     this.opts = { ...dispatchOpts, body: wrapRequestBody(opts.body) }
     this.abort = null
     this.aborted = false
+    this.connectCalled = false
     this.retryOpts = {
       retry: retryFn ?? RetryHandler[kRetryHandlerDefaultRetry],
       retryAfter: retryAfter ?? true,
@@ -68,16 +69,6 @@ class RetryHandler {
     this.end = null
     this.etag = null
     this.resume = null
-
-    // Handle possible onConnect duplication
-    this.handler.onConnect(reason => {
-      this.aborted = true
-      if (this.abort) {
-        this.abort(reason)
-      } else {
-        this.reason = reason
-      }
-    })
   }
 
   onRequestSent () {
@@ -92,11 +83,14 @@ class RetryHandler {
     }
   }
 
-  onConnect (abort) {
-    if (this.aborted) {
-      abort(this.reason)
-    } else {
-      this.abort = abort
+  onConnect (abort, context) {
+    this.abort = abort
+    if (!this.connectCalled) {
+      this.connectCalled = true
+      this.handler.onConnect(reason => {
+        this.aborted = true
+        this.abort(reason)
+      }, context)
     }
   }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

The retry and cache handlers do not pass down the context of the `onConnect` method. This means that using the redirect handler with one of them will not pass the context to the main handler:

```js
request("http://github.com", {
    dispatcher: new Agent().compose(
        interceptors.redirect({ maxRedirections: 1 }),
        interceptors.retry(),
    ),
}).then((res) => console.log(res.context)); // undefined

request("http://github.com", {
    dispatcher: new Agent().compose(
        interceptors.redirect({ maxRedirections: 1 }),
    ),
}).then((res) => console.log(res.context)) // { history: [URL, URL] }
```

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

- Cache handler: used `...args` to pass all the args (like in the decorator handler)
- Retry handler: `onConnect` is now called on the first connection instead that in the constructor, allowing to pass the context

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
