### PR TITLE
fix: Fixed the issue that there is no running request when http2 goaway

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -203,11 +203,12 @@ function onHttp2SessionGoAway (errorCode) {
   util.destroy(this[kSocket], err)
 
   // Fail head of pipeline.
-  const request = client[kQueue][client[kRunningIdx]]
-  client[kQueue][client[kRunningIdx]++] = null
-  util.errorRequest(client, request, err)
-
-  client[kPendingIdx] = client[kRunningIdx]
+  if (client[kRunningIdx] < client[kQueue].length) {
+    const request = client[kQueue][client[kRunningIdx]]
+    client[kQueue][client[kRunningIdx]++] = null
+    util.errorRequest(client, request, err)
+    client[kPendingIdx] = client[kRunningIdx]
+  }
 
   assert(client[kRunning] === 0)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->



## This relates to...
onHttp2SessionGoAway throws an error
```log
TypeError: Cannot read properties of undefined (reading 'onError')
    at Object.errorRequest (node:internal/deps/undici/undici:3935:13)
    at ClientHttp2Session.onHttp2SessionGoAway (node:internal/deps/undici/undici:5969:8)
    at ClientHttp2Session.emit (node:events:513:28)
    at ClientHttp2Session.emit (node:domain:489:12)
    at Http2Session.onGoawayData (node:internal/http2/core:683:11)
    at Http2Session.callbackTrampoline (node:internal/async_hooks:130:17)
```

The reason is `const request = client[kQueue][client[kRunningIdx]]` where request is empty.
Then I tried adding some console.log 

```javascript
function onHttp2SessionGoAway (errorCode) {
  ...

  // Fail head of pipeline.
  console.log('clinet[kRunningIdx]:', clinet[kRunningIdx])  // clinet[kRunningIdx]: 2
  console.log('clinet[kPendingIdx]:', clinet[kPendingIdx])  // clinet[kPendingIdx]: 2
  console.log('clinet[kQueue].length:', clinet[kQueue].length)  // clinet[kQueue].length: 2
  console.log('clinet[kQueue]:', clinet[kQueue])  // clinet[kQueue]: [null, null]
  
  const request = client[kQueue][client[kRunningIdx]]
  client[kQueue][client[kRunningIdx]++] = null
  util.errorRequest(client, request, err)  // throws "Cannot read properties of undefined"
  client[kPendingIdx] = client[kRunningIdx]

  assert(client[kRunning] === 0)

  ...
}
```

## Rationale

fix this issue

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
