### PR TITLE
Make the responseError interceptor backward compatible, add a body property

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -196,13 +196,13 @@ class RequestRetryError extends UndiciError {
 }
 
 class ResponseError extends UndiciError {
-  constructor (message, code, { headers, data }) {
+  constructor (message, code, { headers, body }) {
     super(message)
     this.name = 'ResponseError'
     this.message = message || 'Response error'
     this.code = 'UND_ERR_RESPONSE'
     this.statusCode = code
-    this.data = data
+    this.body = body
     this.headers = headers
   }
 }

--- a/lib/interceptor/response-error.js
+++ b/lib/interceptor/response-error.js
@@ -66,7 +66,7 @@ class ResponseErrorHandler extends DecoratorHandler {
       Error.stackTraceLimit = 0
       try {
         err = new ResponseError('Response Error', this.#statusCode, {
-          data: this.#body,
+          body: this.#body,
           headers: this.#headers
         })
       } finally {

--- a/test/interceptors/response-error.js
+++ b/test/interceptors/response-error.js
@@ -45,7 +45,7 @@ test('should throw error for error response', async () => {
 
   assert.equal(error.statusCode, 400)
   assert.equal(error.message, 'Response Error')
-  assert.equal(error.data, 'Bad Request')
+  assert.equal(error.body, 'Bad Request')
 })
 
 test('should not throw error for ok response', async () => {


### PR DESCRIPTION
This makes the `responseError` interceptor backward compatible.
`throwOnError` added a `err.body` property, while the interceptor adds a `err.data` property. I've renamed `data` to `body`.