### PR TITLE
Add example for `request` + "Garbage Collection"

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,7 @@ The same applies for `request` too:
 // Do
 const response = await request(url)
   .then(res => {
-    response.body.dump().catch(err => {
-      console.error('Error while dumping the body');
-    });
+    response.body.dump();
     return res.headers;
   });
 

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ const { headers } = await fetch(url);
 The same applies for `request` too:
 ```js
 // Do
-const { body, headers } = await request(url)
-await res.body.dump();
+const { body, headers } = await request(url);
+await res.body.dump(); // force consumption of body
 
 // Do not
 const { headers } = await request(url);

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The same applies for `request` too:
 // Do
 const response = await request(url)
   .then(res => {
-    response.body.dump();
+    res.body.dump();
     return res.headers;
   });
 

--- a/README.md
+++ b/README.md
@@ -281,31 +281,23 @@ stalls or deadlocks when running out of connections.
 
 ```js
 // Do
-const headers = await fetch(url)
-  .then(async res => {
-    for await (const chunk of res.body) {
-      // force consumption of body
-    }
-    return res.headers
-  })
+const { body, headers } = await fetch(url);
+for await (const chunk of body) {
+  // force consumption of body
+}
 
 // Do not
-const headers = await fetch(url)
-  .then(res => res.headers)
+const { headers } = await fetch(url);
 ```
 
 The same applies for `request` too:
 ```js
 // Do
-const response = await request(url)
-  .then(res => {
-    res.body.dump();
-    return res.headers;
-  });
+const { body, headers } = await request(url)
+await res.body.dump();
 
 // Do not
-const response = await request(url)
-  .then(res => res.headers);
+const { headers } = await request(url);
 ```
 
 However, if you want to get only headers, it might be better to use `HEAD` request method. Usage of this method will obviate the need for consumption or cancelling of the response body. See [MDN - HTTP - HTTP request methods - HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) for more details.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,22 @@ const headers = await fetch(url)
   .then(res => res.headers)
 ```
 
+The same applies for `request` too:
+```js
+// Do
+const response = await request(url)
+  .then(res => {
+    response.body.dump().catch(err => {
+      console.error('Error while dumping the body');
+    });
+    return res.headers;
+  });
+
+// Do not
+const response = await request(url)
+  .then(res => res.headers);
+```
+
 However, if you want to get only headers, it might be better to use `HEAD` request method. Usage of this method will obviate the need for consumption or cancelling of the response body. See [MDN - HTTP - HTTP request methods - HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) for more details.
 
 ```js


### PR DESCRIPTION
## This relates to...

See #3914

## Changes

Added an example for `request` + "Garbage Collection".

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
