### PR TITLE
fix(deps): Allow Node 20.9.0 and higher

### DIFF
--- a/.github/workflows/nodejs-shared.yml
+++ b/.github/workflows/nodejs-shared.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 0
       matrix:
-        version: [20, 22, 23]
+        version: [20.9.0, 20, 22, 23]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,6 +56,7 @@ jobs:
       max-parallel: 0
       matrix:
         node-version:
+          - 20.9.0
           - 20
           - 22
           - 23
@@ -75,7 +76,7 @@ jobs:
       fail-fast: false
       max-parallel: 0
       matrix:
-        version: [20, 22, 23]
+        version: [20.9.0, 20, 22, 23]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ws": "^8.11.0"
   },
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=20.9.0"
   },
   "tsd": {
     "directory": "test/types",


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

#3880 

## Rationale

While dropping Node 18 support for v7, almost the entire Node 20.x support was also dropped [unreasonably](https://github.com/nodejs/undici/pull/3880#discussion_r1865492928).
The `engines` should declare the minimum requirements for the environment to run the software.
It should not be the latest patch available at the moment, it should not be a favourite version of a particular individual, but a reasonable limitation based on the internal architecture and further development strategy.
[Node 20.9.0 is the LTS version of 20.x](https://nodejs.org/en/blog/release/v20.9.0) and `undici` works perfectly fine with it, so I'm suggesting to correct the minimum supported Node version from 20.18.1 to 20.9.0.

## Changes

- Allow Node.js starting from 20.9.0
- Test against that version as well

### Features

_None_

### Bug Fixes

_None_

### Breaking Changes and Deprecations

_None_

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
