### PR TITLE
fix(engines): Define proper `node` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ws": "^8.11.0"
   },
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=22.11.0"
   },
   "tsd": {
     "directory": "test/types",


### PR DESCRIPTION

## This relates to...
When installing the last `undici` version (`v7.0.0`) on `node` version `20.18.1`:
```shell
node:internal/modules/cjs/loader:1225
  const err = new Error(message);
              ^

Error: Cannot find module 'node:sqlite'
```
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
The `node` version defined in the `engines` of the `package.json` should be updated, considering that the brand [new SQLite version](https://nodejs.org/docs/latest-v22.x/api/sqlite.html) is available only on `node >= 22.x`
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes
Updated the `package.json`
<!-- Write a summary or list of changes here -->

### Features
N/A
<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes
N/A
<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations
I think we should communicate that `undici` version `7` will NOT work on `node` version `20.x`
<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
