### PR TITLE
fix: publish undici:client:sendHeaders message on H2

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -30,6 +30,7 @@ const {
   kClosed,
   kBodyTimeout
 } = require('../core/symbols.js')
+const { channels } = require('../core/diagnostics.js')
 
 const kOpenStreams = Symbol('open streams')
 
@@ -447,6 +448,14 @@ function writeH2 (client, request) {
   }
 
   session.ref()
+
+  if (channels.sendHeaders.hasSubscribers) {
+    let header = ''
+    for (const key in headers) {
+      header += `${key}: ${headers[key]}\r\n`
+    }
+    channels.sendHeaders.publish({ request, headers: header, socket: session[kSocket] })
+  }
 
   // TODO(metcoder95): add support for sending trailers
   const shouldEndStream = method === 'GET' || method === 'HEAD' || body === null

--- a/test/node-test/diagnostics-channel/get-h2.js
+++ b/test/node-test/diagnostics-channel/get-h2.js
@@ -1,0 +1,101 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const diagnosticsChannel = require('node:diagnostics_channel')
+const { once } = require('node:events')
+const pem = require('https-pem')
+const { Client } = require('../../..')
+
+test('Diagnostics channel - get support H2', async t => {
+  const server = createSecureServer(pem)
+
+  server.on('stream', (stream, headers, _flags, rawHeaders) => {
+    t.strictEqual(headers['x-my-header'], 'foo')
+    t.strictEqual(headers[':method'], 'GET')
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': 'hello',
+      ':status': 200
+    })
+    stream.end('hello h2!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
+    t.strictEqual(request.origin, `https://localhost:${server.address().port}`)
+    t.strictEqual(request.completed, false)
+    t.strictEqual(request.method, 'GET')
+    t.strictEqual(request.path, '/')
+  })
+
+  let _socket
+  diagnosticsChannel.channel('undici:client:connected').subscribe(({ socket }) => {
+    _socket = socket
+  })
+
+  diagnosticsChannel.channel('undici:client:sendHeaders').subscribe(({ headers, socket }) => {
+    t.strictEqual(_socket, socket)
+    const expectedHeaders = [
+      'x-my-header: foo',
+      `:authority: localhost:${server.address().port}`,
+      ':method: GET',
+      ':path: /',
+      ':scheme: https'
+    ]
+    t.strictEqual(headers, expectedHeaders.join('\r\n') + '\r\n')
+  })
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t = tspl(t, { plan: 24 })
+  after(() => server.close())
+  after(() => client.close())
+
+  let body = []
+  let response = await client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-my-header': 'foo'
+    }
+  })
+
+  response.body.on('data', chunk => {
+    body.push(chunk)
+  })
+
+  await once(response.body, 'end')
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  t.strictEqual(response.headers['x-custom-h2'], 'hello')
+  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+
+  // request again
+  body = []
+  response = await client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-my-header': 'foo'
+    }
+  })
+
+  response.body.on('data', chunk => {
+    body.push(chunk)
+  })
+
+  await once(response.body, 'end')
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  t.strictEqual(response.headers['x-custom-h2'], 'hello')
+  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

Add `undici:client:sendHeaders` message back on H2 request

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
