### PR TITLE
fix mimetype parser wrong operator

### DIFF
--- a/lib/web/fetch/data-url.js
+++ b/lib/web/fetch/data-url.js
@@ -283,7 +283,7 @@ function parseMIMEType (input) {
 
   // 5. If position is past the end of input, then return
   // failure
-  if (position.position > input.length) {
+  if (position.position >= input.length) {
     return 'failure'
   }
 
@@ -364,7 +364,7 @@ function parseMIMEType (input) {
     }
 
     // 6. If position is past the end of input, then break.
-    if (position.position > input.length) {
+    if (position.position >= input.length) {
       break
     }
 


### PR DESCRIPTION
The current code does not include *past the end of input*, so add equal sign.