### PR TITLE
Support SQLite unflagged without useless warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,15 +49,8 @@ module.exports.cacheStores = {
   MemoryCacheStore: require('./lib/cache/memory-cache-store')
 }
 
-try {
-  const SqliteCacheStore = require('./lib/cache/sqlite-cache-store')
-  module.exports.cacheStores.SqliteCacheStore = SqliteCacheStore
-} catch (err) {
-  // Most likely node:sqlite was not present, since SqliteCacheStore is
-  // optional, don't throw. Don't check specific error codes here because while
-  // ERR_UNKNOWN_BUILTIN_MODULE is expected, users have seen other codes like
-  // MODULE_NOT_FOUND
-}
+const SqliteCacheStore = require('./lib/cache/sqlite-cache-store')
+module.exports.cacheStores.SqliteCacheStore = SqliteCacheStore
 
 module.exports.buildConnector = buildConnector
 module.exports.errors = errors

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const { DatabaseSync } = require('node:sqlite')
 const { Writable } = require('stream')
 const { assertCacheKey, assertCacheValue } = require('../util/cache.js')
+
+let DatabaseSync
 
 const VERSION = 3
 
@@ -101,6 +102,9 @@ module.exports = class SqliteCacheStore {
       }
     }
 
+    if (!DatabaseSync) {
+      DatabaseSync = require('node:sqlite').DatabaseSync
+    }
     this.#db = new DatabaseSync(opts?.location ?? ':memory:')
 
     this.#db.exec(`


### PR DESCRIPTION
`node:sqlite` is now unflagged, and it emits a warning every time it's loaded, and we load it every time. This PR prevents the warning by moving the require inside the constructor.