### PR TITLE
fix: records of pick callback in dns interceptor is a nested object

### DIFF
--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -20,7 +20,7 @@ declare namespace Interceptors {
     maxTTL?: number
     maxItems?: number
     lookup?: (hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void
-    pick?: (origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord
+    pick?: (origin: URL, records: { records: DNSInterceptorOriginRecords }, affinity: 4 | 6) => DNSInterceptorRecord
     dualStack?: boolean
     affinity?: 4 | 6
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

fix d.ts of dns interceptor['pick']

## Rationale

the parameter `records` pass to pick is from `this.#records`, ref [code](https://github.com/nodejs/undici/blob/65695850297550105e1034a2fdd8927ab2cb1d70/lib/interceptor/dns.js#L58C1-L64C10)

`ths.#records` is a map with type `Record<string, {records: {4: { ips: DNSInterceptorRecord[] } , 6: ...}}>`, ref [code](https://github.com/nodejs/undici/blob/65695850297550105e1034a2fdd8927ab2cb1d70/lib/interceptor/dns.js#L197C1-L213C48)


## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
