### PR TITLE
fix: `undici:request:headers` does not indicate completion of a response

### DIFF
--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -40,7 +40,7 @@ diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) =>
 
 ## `undici:request:headers`
 
-This message is published after the response headers have been received, i.e. the response has been completed.
+This message is published after the response headers have been received.
 
 ```js
 import diagnosticsChannel from 'diagnostics_channel'


### PR DESCRIPTION

## Changes

On diagnostic channel message `undici:request:headers`, it does not indicate completion of a response. Remove the inaccurate doc line.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
