### PR TITLE
chore: ensure automated v7 release compared to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
               repo
             })
 
-            const previousRelease = releases.find((r) => r.tag_name.startsWith('v6'))
+            const previousRelease = releases.find((r) => r.tag_name.startsWith('v7'))
 
             if (versionTag !== previousRelease?.tag_name) {
               return versionTag

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -8,7 +8,7 @@ const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBr
     repo
   })
 
-  const previousRelease = releases.find((r) => r.tag_name.startsWith('v6'))
+  const previousRelease = releases.find((r) => r.tag_name.startsWith('v7'))
 
   const { data: { body } } = await github.rest.repos.generateReleaseNotes({
     owner,


### PR DESCRIPTION
## This relates to...

Fixes: https://github.com/nodejs/undici/issues/3963
Similar to https://github.com/nodejs/undici/pull/3149

## Rationale

Uses previous v7 release when assembling release notes for new v7 release

## Changes

Uses previous v7 release when assembling release notes for new v7 release

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
