### PR TITLE
fix(proxy-agent): add fallback value for servername when using reques…

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -87,12 +87,7 @@ class ProxyAgent extends DispatcherBase {
             callback(null, socket)
             return
           }
-          let servername
-          if (this[kRequestTls]) {
-            servername = this[kRequestTls].servername
-          } else {
-            servername = opts.servername
-          }
+          const servername = this[kRequestTls]?.servername || opts.servername
           this[kConnectEndpoint]({ ...opts, servername, httpSocket: socket }, callback)
         } catch (err) {
           if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {


### PR DESCRIPTION
## This relates to...

#3988

## Changes

Added fallback for `requestTls.servername`

### Bug Fixes

Fix `servername` when using `requestTls` #3988

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
