### PR TITLE
fix: dual-stack retries infinite loop

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -32,7 +32,7 @@ class DNSInstance {
 
     // If full, we just return the origin
     if (ips == null && this.full) {
-      cb(null, origin.origin)
+      cb(null, origin)
       return
     }
 
@@ -74,9 +74,9 @@ class DNSInstance {
 
         cb(
           null,
-          `${origin.protocol}//${
+          new URL(`${origin.protocol}//${
             ip.family === 6 ? `[${ip.address}]` : ip.address
-          }${port}`
+          }${port}`)
         )
       })
     } else {
@@ -105,9 +105,9 @@ class DNSInstance {
 
       cb(
         null,
-        `${origin.protocol}//${
+        new URL(`${origin.protocol}//${
           ip.family === 6 ? `[${ip.address}]` : ip.address
-        }${port}`
+        }${port}`)
       )
     }
   }
@@ -192,6 +192,38 @@ class DNSInstance {
     return ip
   }
 
+  pickFamily (origin, ipFamily) {
+    const records = this.#records.get(origin.hostname)?.records
+    if (!records) {
+      return null
+    }
+
+    const family = records[ipFamily]
+    if (!family) {
+      return null
+    }
+
+    if (family.offset == null || family.offset === maxInt) {
+      family.offset = 0
+    } else {
+      family.offset++
+    }
+
+    const position = family.offset % family.ips.length
+    const ip = family.ips[position] ?? null
+    if (ip == null) {
+      return ip
+    }
+
+    if (Date.now() - ip.timestamp > ip.ttl) { // record TTL is already in ms
+      // We delete expired records
+      // It is possible that they have different TTL, so we manage them individually
+      family.ips.splice(position, 1)
+    }
+
+    return ip
+  }
+
   setRecords (origin, addresses) {
     const timestamp = Date.now()
     const records = { records: { 4: null, 6: null } }
@@ -228,10 +260,13 @@ class DNSDispatchHandler extends DecoratorHandler {
   #dispatch = null
   #origin = null
   #controller = null
+  #newOrigin = null
+  #firstTry = true
 
-  constructor (state, { origin, handler, dispatch }, opts) {
+  constructor (state, { origin, handler, dispatch, newOrigin }, opts) {
     super(handler)
     this.#origin = origin
+    this.#newOrigin = newOrigin
     this.#opts = { ...opts }
     this.#state = state
     this.#dispatch = dispatch
@@ -242,21 +277,36 @@ class DNSDispatchHandler extends DecoratorHandler {
       case 'ETIMEDOUT':
       case 'ECONNREFUSED': {
         if (this.#state.dualStack) {
-          // We delete the record and retry
-          this.#state.runLookup(this.#origin, this.#opts, (err, newOrigin) => {
-            if (err) {
-              super.onResponseError(controller, err)
-              return
-            }
+          if (!this.#firstTry) {
+            super.onResponseError(controller, err)
+            return
+          }
+          this.#firstTry = false
 
-            const dispatchOpts = {
-              ...this.#opts,
-              origin: newOrigin
-            }
+          // Pick an ip address from the other family
+          const otherFamily = this.#newOrigin.hostname[0] === '[' ? 4 : 6
+          const ip = this.#state.pickFamily(this.#origin, otherFamily)
+          if (ip == null) {
+            super.onResponseError(controller, err)
+            return
+          }
 
-            this.#dispatch(dispatchOpts, this)
-          })
+          let port
+          if (typeof ip.port === 'number') {
+            port = `:${ip.port}`
+          } else if (this.#origin.port !== '') {
+            port = `:${this.#origin.port}`
+          } else {
+            port = ''
+          }
 
+          const dispatchOpts = {
+            ...this.#opts,
+            origin: `${this.#origin.protocol}//${
+                ip.family === 6 ? `[${ip.address}]` : ip.address
+              }${port}`
+          }
+          this.#dispatch(dispatchOpts, this)
           return
         }
 
@@ -266,7 +316,8 @@ class DNSDispatchHandler extends DecoratorHandler {
       }
       case 'ENOTFOUND':
         this.#state.deleteRecords(this.#origin)
-      // eslint-disable-next-line no-fallthrough
+        super.onResponseError(controller, err)
+        break
       default:
         super.onResponseError(controller, err)
         break
@@ -356,11 +407,10 @@ module.exports = interceptorOpts => {
           return handler.onResponseError(null, err)
         }
 
-        let dispatchOpts = null
-        dispatchOpts = {
+        const dispatchOpts = {
           ...origDispatchOpts,
           servername: origin.hostname, // For SNI on TLS
-          origin: newOrigin,
+          origin: newOrigin.origin,
           headers: {
             host: origin.host,
             ...origDispatchOpts.headers
@@ -369,7 +419,10 @@ module.exports = interceptorOpts => {
 
         dispatch(
           dispatchOpts,
-          instance.getHandler({ origin, dispatch, handler }, origDispatchOpts)
+          instance.getHandler(
+            { origin, dispatch, handler, newOrigin },
+            origDispatchOpts
+          )
         )
       })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

DNS interceptor

## Rationale

The DNS interceptor can be stuck in an infinite loop if dual-stack is enabled and a lookup results in a network error. It is also possible for a request to retry the same family multiple times if another request is made in-between.

## Changes

Retry a failed request **once** with dual-stack and force it to use the other ip family.
If no valid ip address is found, e.g. due to ttl timeout, no retry should be made.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
