### PR TITLE
ReadableStreamFrom pull until cannot on empty enqueu

### DIFF
--- a/test/fetch/issue-node-56474.js
+++ b/test/fetch/issue-node-56474.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('node:test')
+const { deepStrictEqual } = require('node:assert')
+const { Response } = require('../..')
+
+// https://github.com/nodejs/node/issues/56474
+test('ReadableStream empty enqueue then other enqueued', async () => {
+  const iterable = {
+    async * [Symbol.asyncIterator] () {
+      yield ''
+      yield '3'
+      yield '4'
+    }
+  }
+
+  const response = new Response(iterable)
+  deepStrictEqual(await response.text(), '34')
+})
+
+test('ReadableStream empty enqueue', async () => {
+  const iterable = {
+    async * [Symbol.asyncIterator] () {
+      yield ''
+    }
+  }
+
+  const response = new Response(iterable)
+  deepStrictEqual(await response.text(), '')
+})


### PR DESCRIPTION
refs: https://github.com/nodejs/node/issues/56474

ReadableByteStreamController.enqueue handles empty typed arrays differently than the normal ReadableStreamController: it throws an error when receiving one. To combat this, we didn't enqueue anything and did nothing if the buffer was empty. For whatever reason, this caused the promise to never resolve (I didn't dig into the spec long enough to figure out why, sorry). The fix is to simply continue pulling until we respond to the pull in some manner.

I am not a webstreams expert please review with caution.