### PR TITLE
docs: document about global dispatcher and errors (#3987)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ See [Dispatcher.upgrade](./docs/docs/api/Dispatcher.md#dispatcherupgradeoptions-
 
 * dispatcher `Dispatcher`
 
-Sets the global dispatcher used by Common API Methods.
+Sets the global dispatcher used by Common API Methods. Global dispatcher is shared among compatible undici modules,
+including undici that is bundled internally with node.js.
 
 ### `undici.getGlobalDispatcher()`
 

--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -28,6 +28,9 @@ import { errors } from 'undici'
 | `ResponseExceededMaxSizeError`       | `UND_ERR_RES_EXCEEDED_MAX_SIZE`       | response body exceed the max size allowed                                 |
 | `SecureProxyConnectionError`         | `UND_ERR_PRX_TLS`                     | tls connection to a proxy failed                                          |
 
+Be aware that some errors are created by dispatcher. If you plan to check `instanceof errors.UndiciError` then don't use the default global dispatcher,
+as it may come from another `undici` module and have its own errors classes.
+
 ### `SocketError`
 
 The `SocketError` has a `.socket` property which holds socket metadata:

--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -28,9 +28,7 @@ import { errors } from 'undici'
 | `ResponseExceededMaxSizeError`       | `UND_ERR_RES_EXCEEDED_MAX_SIZE`       | response body exceed the max size allowed                                 |
 | `SecureProxyConnectionError`         | `UND_ERR_PRX_TLS`                     | tls connection to a proxy failed                                          |
 
-Be aware that some errors are created by dispatcher. If you plan to check `instanceof errors.UndiciError` then don't use the default global dispatcher,
-as it may come from another `undici` module and have its own errors classes.
-
+Be aware of the possible difference between the global dispatcher version and the actual undici version you might be using. We recommend to avoid the check `instanceof errors.UndiciError` and seek for the `error.code === '<error_code>'` instead to avoid inconsistencies.
 ### `SocketError`
 
 The `SocketError` has a `.socket` property which holds socket metadata:


### PR DESCRIPTION
## This relates to...

errors from node:internal leak #3987

## Rationale

As discussed in #3987 - errors are affected by global dispatcher

## Changes

Docs about globalDispatcher being truely global
Docs about errors coming from globalDispathcer from another module

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [s] Tested
- [s] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
