### PR TITLE
fix(types): add missing DNS interceptor

### DIFF
--- a/test/types/interceptor.test-d.ts
+++ b/test/types/interceptor.test-d.ts
@@ -1,5 +1,9 @@
 import {expectAssignable} from "tsd";
 import Undici from "../..";
 import Dispatcher from "../../types/dispatcher";
+import Interceptors from "../../types/interceptors";
 
 expectAssignable<Dispatcher.DispatchInterceptor>(Undici.createRedirectInterceptor({ maxRedirections: 3 }))
+
+expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose([Interceptors.dns({maxTTL: 2_000})]));
+

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -28,4 +28,5 @@ declare namespace Interceptors {
   export function retry(opts?: RetryInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
   export function redirect(opts?: RedirectInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
   export function responseError(opts?: ResponseErrorInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
+  export function dns (opts?: DNSInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
 }


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
#3684 has backported the DNS interceptor from #3490. However, the func that is exported, was not added to TypeScript defs. Opts and return type were added with the backport already.

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
Allow v6 + TS users to hook the DNS interceptor in.
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

[fix(types): add missing DNS interceptor](https://github.com/nodejs/undici/commit/a235e2067402dfece6886c0a4ad84c2567a12698)
<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
