### PR TITLE
fix: do not throw unhandled exception when data is undefined in interceptor.reply

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -124,8 +124,10 @@ function getResponseData (data) {
     return data
   } else if (typeof data === 'object') {
     return JSON.stringify(data)
-  } else {
+  } else if (data) {
     return data.toString()
+  } else {
+    return ''
   }
 }
 

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -107,6 +107,46 @@ describe('MockInterceptor - reply options callback', () => {
     })
   })
 
+  test('should handle undefined data', t => {
+    t = tspl(t, { plan: 2 })
+
+    const mockInterceptor = new MockInterceptor({
+      path: '',
+      method: ''
+    }, [])
+    const result = mockInterceptor.reply((options) => ({
+      statusCode: 200,
+      data: undefined
+    }))
+    t.ok(result instanceof MockScope)
+
+    // Test parameters
+
+    const baseUrl = 'http://localhost:9999'
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+
+    mockPool.intercept({
+      path: '/test',
+      method: 'GET'
+    }).reply((options) => {
+      t.deepStrictEqual(options, { path: '/test', method: 'GET', headers: { foo: 'bar' } })
+      return { statusCode: 200, data: 'hello' }
+    })
+
+    mockPool.dispatch({
+      path: '/test',
+      method: 'GET',
+      headers: { foo: 'bar' }
+    }, {
+      onHeaders: () => { },
+      onData: () => { },
+      onComplete: () => { }
+    })
+  })
+
   test('should error if passed options invalid', async (t) => {
     t = tspl(t, { plan: 4 })
 

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -174,6 +174,12 @@ describe('getResponseData', () => {
     const responseData = getResponseData(new TextEncoder().encode('{"test":true}').buffer)
     t.ok(responseData instanceof ArrayBuffer)
   })
+
+  test('it should handle undefined', (t) => {
+    t = tspl(t, { plan: 1 })
+    const responseData = getResponseData(undefined)
+    t.strictEqual(responseData, '')
+  })
 })
 
 test('getStatusText', (t) => {


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

See below (Bug Fixes)

## Changes

See below (Bug Fixes)

### Features

N/A

### Bug Fixes

When interceptor.reply would return `{ data: undefined }`, it blows up in `getResponseData`:

```
TypeError [Error]: Cannot read properties of undefined (reading 'toString')
      at getResponseData (/Users/frederikprijck/Development/frederikprijck/undici/lib/mock/mock-utils.js:128:17)
      at TestContext.<anonymous> (/Users/frederikprijck/Development/frederikprijck/undici/test/mock-utils.js:180:26)
      at Test.runInAsyncScope (node:async_hooks:206:9)
      at Test.run (node:internal/test_runner/test:639:25)
      at Suite.processPendingSubtests (node:internal/test_runner/test:382:18)
      at Test.postRun (node:internal/test_runner/test:730:19)
      at Test.run (node:internal/test_runner/test:688:12)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:382:7)
```

This got introduced [here](https://github.com/nodejs/undici/pull/3062), more specifcally, this change

![image](https://github.com/user-attachments/assets/de6cec65-178d-44e3-83c5-4e7e3fee7b93)

More specifically, in the before and after, data is not the same when it was undefined originally:

```
const { statusCode, data = '', responseOptions = {} } = {data: undefined}
console.log(data); // ''
```
vs
```
const replyParameters = { data: '', responseOptions: {}, ...{data: undefined} }
console.log(replyParameters.data) // undefined
```

As previously, when data was undefined, `''` would be passed to `getResponseData`, and `getResponseData` would return `''`, I ensured we now also return `''` when `data` being passed to `getResponseData` is `undefined`.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
