### PR TITLE
types(websocket): Import from stream/web

### DIFF
--- a/test/types/websocket.test-d.ts
+++ b/test/types/websocket.test-d.ts
@@ -1,0 +1,10 @@
+import { ReadableStream, WritableStream } from 'stream/web'
+import { expectType } from 'tsd'
+import { WebSocketStream } from '../../types'
+
+declare const webSocketStream: WebSocketStream
+const webSocketStreamOpened = await webSocketStream.opened
+
+// Test that the readable and writable streams are of identical types to ones from stream/web
+expectType<WritableStream>(webSocketStreamOpened.writable)
+expectType<ReadableStream>(webSocketStreamOpened.readable)

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import type { Blob } from 'buffer'
+import type { ReadableStream, WritableStream } from 'stream/web'
 import type { MessagePort } from 'worker_threads'
 import {
   EventInit,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

`ReadableStream` and `WritableStream` were not imported in the typings. This pull request imports them from `stream/web`.

## Changes

<!-- Write a summary or list of changes here -->

### Features

N/A

### Bug Fixes

Fixes TypeScript compilation error:

```
types/websocket.d.ts(167,15): error TS2304: Cannot find name 'ReadableStream'.
types/websocket.d.ts(168,15): error TS2304: Cannot find name 'WritableStream'.
```

https://github.com/discordjs/discord.js/actions/runs/13081715315/job/36506493876

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
