### PR TITLE
Allow disabling autoSelectFamily in an Agent

### DIFF
--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -207,7 +207,7 @@ class Client extends DispatcherBase {
         allowH2,
         socketPath,
         timeout: connectTimeout,
-        ...(autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
+        ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect
       })
     }

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -58,7 +58,7 @@ class Pool extends PoolBase {
         allowH2,
         socketPath,
         timeout: connectTimeout,
-        ...(autoSelectFamily ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
+        ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect
       })
     }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -70,7 +70,7 @@ export declare namespace Client {
     /** TODO */
     maxRedirections?: number;
     /** TODO */
-    connect?: buildConnector.BuildOptions | buildConnector.connector;
+    connect?: Partial<buildConnector.BuildOptions> | buildConnector.connector;
     /** TODO */
     maxRequestsPerClient?: number;
     /** TODO */


### PR DESCRIPTION
Currently the options are only passed if they enable autoSelectFamily. However, if autoSelectFamily is the default, we want to be able to disable it too.

Noticed this while debugging https://github.com/nodejs/node/issues/47822#issuecomment-2689454370

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features. Done
2. Update documentation if relevant. Not relevant
3. Ensure that tests and linting pass. Done

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md Done
-->

## This relates to...

https://github.com/nodejs/node/issues/47822#issuecomment-2689454370

## Rationale

Currently this claims to accept a boolean but really only accepts `true`.

## Changes

React to the autoSelectFamily option if it is passed in.

### Features

Agent's can disable autoSelectFamily

### Breaking Changes and Deprecations

None?

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
