### PR TITLE
feat: add no throw status codes option in retry agent

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -29,7 +29,8 @@ class RetryHandler {
       methods,
       errorCodes,
       retryAfter,
-      statusCodes
+      statusCodes,
+      noThrowStatusCodes
     } = retryOptions ?? {}
 
     this.dispatch = dispatch
@@ -57,7 +58,9 @@ class RetryHandler {
         'EHOSTUNREACH',
         'EPIPE',
         'UND_ERR_SOCKET'
-      ]
+      ],
+      // List of status codes that should not throw an error if encountered in the last attempt and are present in statusCodes.
+      noThrowStatusCodes: noThrowStatusCodes ?? []
     }
 
     this.retryCount = 0
@@ -149,7 +152,19 @@ class RetryHandler {
           statusMessage
         )
         return
-      } else {
+      }
+
+      // If we reached the max number of retries
+      const areAttemptsOver = this.retryCount > this.retryOpts.maxRetries
+
+      // If the status code is in the noThrowStatusCodes list
+      const isNoThrowStatusCode = this.retryOpts.noThrowStatusCodes.includes(
+        statusCode
+      )
+
+      const throwByStatusCode = !isNoThrowStatusCode || !areAttemptsOver
+
+      if (throwByStatusCode) {
         throw new RequestRetryError('Request failed', statusCode, {
           headers,
           data: {

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -8,6 +8,7 @@ const { Readable } = require('node:stream')
 
 const { RetryHandler, Client } = require('..')
 const { RequestHandler } = require('../lib/api/api-request')
+const { kRetryHandlerDefaultRetry } = require('../lib/core/symbols')
 
 test('Should retry status code', async t => {
   t = tspl(t, { plan: 3 })
@@ -1543,6 +1544,119 @@ test('Should throw RequestRetryError when Content-Range mismatch', async t => {
       server.close()
       await once(server, 'close')
     })
+  })
+
+  await t.completed
+})
+
+test('Should not throw error if status code is present in noThrowStatusCodes and statusCodes', async t => {
+  // This test verifies that retries occur correctly for:
+  // - Status codes listed in `statusCodes`
+  // - Errors in `errorCodes`
+  // - Ensuring no errors are thrown for `noThrowStatusCodes` at the final attempt
+  // - `noThrowStatusCodes` should NOT interfere with retries caused by `errorCodes` or `statusCodes`
+
+  t = tspl(t, { plan: 11 })
+
+  const chunks = []
+  let x = 0
+
+  const server = createServer()
+
+  server.on('request', (req, res) => {
+    t.ok(true, 'Request received by server')
+
+    switch (x) {
+      case 0:
+        // 404 is in statusCodes, the it should not throw an error and retry because it is the first attempt.
+        // Test if noThrowStatusCodes interferes with statusCodes
+        res.writeHead(404)
+        res.end('def')
+        break
+      case 1:
+        // Throw an error with code 'UND_ERR_SOCKET' to test if noThrowStatusCodes interferes with it
+        setTimeout(() => {
+          res.destroy()
+        }, 1e2)
+        break
+      case 2:
+        // 503 is in noThrowStatusCodes, then it should not throw an error
+        res.writeHead(503)
+        res.end('def')
+        break
+      default: {
+        t.fail()
+        break
+      }
+    }
+
+    x += 1
+  })
+
+  const dispatchOptions = {
+    retryOptions: {
+      // works before invoking the retry callback
+      noThrowStatusCodes: [503],
+      statusCodes: [503, 404],
+      errorCodes: ['UND_ERR_SOCKET'],
+      maxRetries: 2,
+
+      // execute normal retry handler
+      retry: (err, ctx, done) => {
+        t.ok(true, `Retry attempt: ${ctx.state.counter}`)
+
+        return RetryHandler[kRetryHandlerDefaultRetry](err, ctx, done)
+      }
+    },
+    method: 'GET',
+    path: '/',
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const handler = new RetryHandler(dispatchOptions, {
+      dispatch: client.dispatch.bind(client),
+      handler: {
+        onConnect () {
+          t.ok(true, `The connection was successful: ${x}`)
+        },
+        onHeaders (status, _rawHeaders) {
+          t.strictEqual(status, 503, 'Final response status should be 503')
+          return true
+        },
+        onData (chunk) {
+          chunks.push(chunk)
+          return true
+        },
+        onComplete () {
+          t.strictEqual(Buffer.concat(chunks).toString('utf-8'), 'def', 'The response body should be "def"')
+          t.strictEqual(x, 3, 'The request should have been retried 3 times')
+        },
+        onError (err) {
+          t.fail(err)
+        }
+      }
+    })
+
+    after(async () => {
+      await client.close()
+      server.close()
+      await once(server, 'close')
+    })
+
+    client.dispatch(
+      {
+        method: 'GET',
+        path: '/',
+        headers: {
+          'content-type': 'application/json'
+        }
+      },
+      handler
+    )
   })
 
   await t.completed

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -1661,3 +1661,108 @@ test('Should not throw error if status code is present in noThrowStatusCodes and
 
   await t.completed
 })
+
+test('Should not pass the last RequestRetryError to the retryFn callback when the status code is in noThrowStatusCodes and statusCodes', async t => {
+  // This test verifies that retries occur correctly for:
+  // - Retries are triggered for codes listed in statusCodes.
+  // - No error is thrown on the final attempt for codes in noThrowStatusCodes.
+  // - The last RequestRetryError is not passed to retryFn if the status is in noThrowStatusCodes.
+  // - The request proceeds normally after the last retry attempt.
+
+  t = tspl(t, { plan: 9 })
+
+  const chunks = []
+  let x = 0
+
+  const server = createServer()
+
+  server.on('request', (req, res) => {
+    t.ok(true, 'Request received by server')
+
+    if (x > 1) {
+      t.fail('The request should not have been retried more than 2 times')
+      return
+    }
+
+    res.writeHead(503)
+    res.end('def')
+
+    x += 1
+  })
+
+  const dispatchOptions = {
+    retryOptions: {
+      // works before invoking the retry callback
+      noThrowStatusCodes: [503],
+      statusCodes: [503],
+      maxRetries: 1,
+      retry: (err, ctx, done) => {
+        t.ok(true, `Retry attempt: ${ctx.state.counter}`)
+
+        // Only for doc:
+        if (ctx.state.counter > 1) {
+          t.fail('Should never be here')
+          return
+        }
+
+        if (err.code === 'UND_ERR_REQ_RETRY') {
+          t.strictEqual(err.statusCode, 503, 'The status code should be 503 in the RequestRetryError')
+        }
+
+        // Propositally without condition
+        setTimeout(done, 800)
+      }
+    },
+    method: 'GET',
+    path: '/',
+    headers: {
+      'content-type': 'application/json'
+    }
+  }
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const handler = new RetryHandler(dispatchOptions, {
+      dispatch: client.dispatch.bind(client),
+      handler: {
+        onConnect () {
+          t.ok(true, `The connection was successful: ${x}`)
+        },
+        onHeaders (status, _rawHeaders) {
+          t.strictEqual(status, 503, 'Final response status should be 503')
+          return true
+        },
+        onData (chunk) {
+          chunks.push(chunk)
+          return true
+        },
+        onComplete () {
+          t.strictEqual(Buffer.concat(chunks).toString('utf-8'), 'def', 'The response body should be "def"')
+          t.strictEqual(x, 2, 'The request should have been retried 2 times')
+        },
+        onError (err) {
+          t.fail(err)
+        }
+      }
+    })
+
+    after(async () => {
+      await client.close()
+      server.close()
+      await once(server, 'close')
+    })
+
+    client.dispatch(
+      {
+        method: 'GET',
+        path: '/',
+        headers: {
+          'content-type': 'application/json'
+        }
+      },
+      handler
+    )
+  })
+
+  await t.completed
+})

--- a/types/retry-handler.d.ts
+++ b/types/retry-handler.d.ts
@@ -12,7 +12,7 @@ declare class RetryHandler implements Dispatcher.DispatchHandler {
 }
 
 declare namespace RetryHandler {
-  export type RetryState = { counter: number; }
+  export type RetryState = { counter: number }
 
   export type RetryContext = {
     state: RetryState;
@@ -107,6 +107,21 @@ declare namespace RetryHandler {
      * @default [500, 502, 503, 504, 429],
      */
     statusCodes?: number[];
+
+    /**
+     * List of HTTP status codes that will not trigger a `RequestRetryError` directly in the handler.
+     *
+     * The error will only be thrown if the response status is in `statusCodes` and **not** in `noThrowStatusCodes`,
+     * considering only status codes ≥ 300 and if it is the last attempt.
+     *
+     * On the last attempt (`maxRetries + 1`), if the status is in both lists (`statusCodes` and `noThrowStatusCodes`),
+     * the error **will not** be thrown, allowing the request to proceed normally.
+     *
+     * @type {number[]}
+     * @memberof RetryOptions
+     * @default []
+     */
+    noThrowStatusCodes?: number[];
   }
 
   export interface RetryHandlers {


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/issues/4080

## Rationale
This PR adds the `noThrowStatusCodes` option to the RetryHandler, allowing you to configure an array of HTTP status codes that should not trigger a `RequestRetryError` on the last attempt.

### Expected Behavior
- If the HTTP status code of the response is in `noThrowStatusCodes`, the error will not be thrown (only on the last attempt), allowing the response to be processed normally.
- This option only interferes if the status code is greater than or equal to 300 and is also listed in `statusCodes`.

### Notes on the `retryFn` callback
The last attempt considered is determined by the value of maxRetries. However, if you are using a `retryFn` to manage your own retries, there is an important detail:
- The retryFn is only called when an error occurs in the handler. If no error is thrown, retryFn will not be executed.
- Since `noThrowStatusCodes` prevents the error from being thrown on the last attempt (if the conditions are met), the `retryFn` will not be executed in this situation.
- If `noThrowStatusCodes` is not used, the behavior of the `retryFn` remains unchanged.

## Changes

- Added the `noThrowStatusCodes` option to `RetryHandlerOptions`.
- Added the `noThrowStatusCodes` option to the `retryOpts` of the `RetryHandler`.
- Added the condition to not throw an error on the last attempt if the response status code is in `noThrowStatusCodes`.
- Added tests to ensure that the error is not thrown on the last attempt if the response status code is in `noThrowStatusCodes`.

### Features

```js
  // Ignore last attempt throw error if status code is 503.
  // No ignore last attempt throw error if status code is 500.
  const retryAgent = new RetryAgent({
      noThrowStatusCodes: [503], // <-- Add this option
      statusCodes: [503, 500],
  })
```

### Bug Fixes

### Breaking Changes and Deprecations

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md
