### PR TITLE
feat: add new `acceptNonStandardSearchParameters` MockAgent option

### DIFF
--- a/docs/docs/api/MockAgent.md
+++ b/docs/docs/api/MockAgent.md
@@ -20,6 +20,8 @@ Extends: [`AgentOptions`](/docs/docs/api/Agent.md#parameter-agentoptions)
 
 * **ignoreTrailingSlash** `boolean` (optional) - Default: `false` - set the default value for `ignoreTrailingSlash` for interceptors.
 
+* **acceptNonStandardSearchParameters** `boolean` (optional) - Default: `false` - set to `true` if the matcher should also accept non standard search parameters such as multi-value items specified with `[]` (e.g. `param[]=1&param[]=2&param[]=3`) and multi-value items which values are comma separated (e.g. `param=1,2,3`).
+
 ### Example - Basic MockAgent instantiation
 
 This will instantiate the MockAgent. It will not do anything until registered as the agent to use with requests and mock interceptions are added.

--- a/lib/mock/mock-symbols.js
+++ b/lib/mock/mock-symbols.js
@@ -26,5 +26,6 @@ module.exports = {
   kMockAgentRegisterCallHistory: Symbol('mock agent register mock call history'),
   kMockAgentAddCallHistoryLog: Symbol('mock agent add call history log'),
   kMockAgentIsCallHistoryEnabled: Symbol('mock agent is call history enabled'),
+  kMockAgentAcceptsNonStandardSearchParameters: Symbol('mock agent accepts non standard search parameters'),
   kMockCallHistoryAddLog: Symbol('mock call history add log')
 }

--- a/test/types/mock-agent.test-d.ts
+++ b/test/types/mock-agent.test-d.ts
@@ -95,3 +95,12 @@ expectType<MockAgent>(new MockAgent({
 expectType<MockAgent>(new MockAgent({
   agent: new RetryAgent(new Agent())
 }))
+expectType<MockAgent>(new MockAgent({
+  acceptNonStandardSearchParameters: true
+}))
+expectType<MockAgent>(new MockAgent({
+  acceptNonStandardSearchParameters: false
+}))
+expectType<MockAgent>(new MockAgent({
+  acceptNonStandardSearchParameters: undefined
+}))

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -59,6 +59,9 @@ declare namespace MockAgent {
     /** Ignore trailing slashes in the path */
     ignoreTrailingSlash?: boolean;
 
+    /** Accept URLs with search parameters using non standard syntaxes. default false */
+    acceptNonStandardSearchParameters?: boolean;
+
     /** Enable call history. you can either call MockAgent.enableCallHistory(). default false */
     enableCallHistory?: boolean
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->
 
This PR adds a new `acceptNonStandardSearchParameters` option to make
instances of `MockAgent` accept search parameters specified
using non-standard syntaxes such as multi-value items specified with `[]`
(e.g. `param[]=1&param[]=2&param[]=3`) and multi-value items which values
are comma separated (e.g. `param=1,2,3`) 

With these changes `MockAgent` instances can be enabled to intercept requests
such as `https://example.com/qux-c?arraykey[]=a&arraykey[]=b`, etc...

## Changes

<!-- Write a summary or list of changes here -->

MockAgents created with the `acceptNonStandardSearchParameters` "normalize" requests such as `https://example.com/qux-c?arraykey[]=a&arraykey[]=b` into ones like
`https://example.com/qux-c?arraykey=a&arraykey=b` so that they can then be handled normally

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

N/A

### Bug Fixes

Fixes https://github.com/nodejs/undici/issues/4146

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

None

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

___

> [!Note]
> My implementation supports the case of array values having `[]` (e.g. `a[]=1,a[]=2,a[]=3`) and also different array values separated by commas (e.g. `a=1,2,3`) and that's pretty much it, it could potentially support other syntaxes like the JSON API and Bitbucket API mentioned in https://medium.com/raml-api/arrays-in-query-params-33189628fa68, but that feels to me like quite an overkill right now. I am thinking that probably the cases I am adding support for now should cover most use cases anyways and if the extra ones will be needed in the future (someone opening an issue, etc...) they can always be incrementally added as needed on top of my changes :thinking: 
