### PR TITLE
WIP: Max total connections support for BalancedPool

### DIFF
--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -10,10 +10,11 @@ const {
   kNeedDrain,
   kAddClient,
   kRemoveClient,
-  kGetDispatcher
+  kGetDispatcher,
+  kQueue
 } = require('./pool-base')
 const Pool = require('./pool')
-const { kUrl } = require('../core/symbols')
+const { kUrl, kConnected, kDispatch, kQueued, kFree } = require('../core/symbols')
 const { parseOrigin } = require('../core/util')
 const kFactory = Symbol('factory')
 
@@ -24,6 +25,8 @@ const kIndex = Symbol('kIndex')
 const kWeight = Symbol('kWeight')
 const kMaxWeightPerServer = Symbol('kMaxWeightPerServer')
 const kErrorPenalty = Symbol('kErrorPenalty')
+const kMaxTotalConnections = Symbol('kMaxTotalConnections')
+const kQueueResume = Symbol('kQueueResume')
 
 /**
  * Calculate the greatest common divisor of two numbers by
@@ -49,9 +52,13 @@ function defaultFactory (origin, opts) {
 }
 
 class BalancedPool extends PoolBase {
-  constructor (upstreams = [], { factory = defaultFactory, ...opts } = {}) {
+  constructor (upstreams = [], { factory = defaultFactory, maxTotalConnections = 0, ...opts } = {}) {
     if (typeof factory !== 'function') {
       throw new InvalidArgumentError('factory must be a function.')
+    }
+
+    if (maxTotalConnections != null && (!Number.isFinite(maxTotalConnections) || maxTotalConnections < 0)) {
+      throw new InvalidArgumentError('invalid maxTotalConnections')
     }
 
     super()
@@ -59,6 +66,7 @@ class BalancedPool extends PoolBase {
     this[kOptions] = opts
     this[kIndex] = -1
     this[kCurrentWeight] = 0
+    this[kMaxTotalConnections] = maxTotalConnections || null
 
     this[kMaxWeightPerServer] = this[kOptions].maxWeightPerServer || 100
     this[kErrorPenalty] = this[kOptions].errorPenalty || 15
@@ -146,6 +154,50 @@ class BalancedPool extends PoolBase {
       .map((p) => p[kUrl].origin)
   }
 
+  get [kFree] () {
+    return this[kClients].map(pool => pool[kFree]).reduce((a, b) => a + b, 0)
+  }
+
+  get [kConnected] () {
+    return this[kClients].map(pool => pool[kConnected]).reduce((a, b) => a + b, 0)
+  }
+
+  [kQueueResume] () {
+    if (!this[kMaxTotalConnections] || this[kQueued] === 0) return
+
+    // process an item from the queue if there are free connections
+    if (this[kConnected] < this[kMaxTotalConnections] || this[kFree] > 0) {
+      const item = this[kQueue].shift()
+      if (item) {
+        this[kQueued]--
+
+        // rather than loop synchronously, run one queue item per event loop
+        // since kConnected and kFree values change during async operations
+        if (this[kQueued] > 0) setTimeout(() => this[kQueueResume](), 0)
+      }
+
+      const { opts, handler } = item
+      const pool = this[kClients].find(pool => pool[kUrl].origin === opts.origin && pool[kFree] > 0)
+      if (pool) {
+        pool.dispatch(opts, handler)
+      } else {
+        this[kQueue].push({ opts, handler })
+        this[kQueued]++
+      }
+    }
+  }
+
+  [kDispatch] (opts, handler) {
+    // wrap handler.onComplete so it triggers kQueueResume after each request completes
+    const { onComplete } = handler
+    handler.onComplete = (...args) => {
+      setTimeout(this[kQueueResume](), 0)
+      if (onComplete) onComplete(...args)
+    }
+
+    return super[kDispatch](opts, handler)
+  }
+
   [kGetDispatcher] () {
     // We validate that pools is greater than 0,
     // otherwise we would have to wait until an upstream
@@ -162,6 +214,10 @@ class BalancedPool extends PoolBase {
 
     if (!dispatcher) {
       return
+    }
+
+    if (this[kMaxTotalConnections] && this[kConnected] >= this[kMaxTotalConnections]) {
+      return false
     }
 
     const allClientsBusy = this[kClients].map(pool => pool[kNeedDrain]).reduce((a, b) => a && b, true)

--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -190,5 +190,6 @@ module.exports = {
   kNeedDrain,
   kAddClient,
   kRemoveClient,
-  kGetDispatcher
+  kGetDispatcher,
+  kQueue
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

https://github.com/nodejs/undici/issues/3268#issuecomment-2833338941

## Rationale

Work in progress on being able to enforce maximum total connections across all origins in a `BalancedPool` and `Agent`.

## Changes

<!-- Write a summary or list of changes here -->

### Features

Exposes `maxTotalConnections` option on `BalancedPool` and `Agent` that ensures the total number of open connections across all origins does not exceed the configured maximum.

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
