### PR TITLE
Ensure conflicting flat headers in HTTP/2 are combined correctly

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -300,6 +300,8 @@ function writeH2 (client, request) {
           headers[key] = val[i]
         }
       }
+    } else if (headers[key]) {
+      headers[key] += `,${val}`
     } else {
       headers[key] = val
     }

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -295,13 +295,13 @@ function writeH2 (client, request) {
     if (Array.isArray(val)) {
       for (let i = 0; i < val.length; i++) {
         if (headers[key]) {
-          headers[key] += `,${val[i]}`
+          headers[key] += `, ${val[i]}`
         } else {
           headers[key] = val[i]
         }
       }
     } else if (headers[key]) {
-      headers[key] += `,${val}`
+      headers[key] += `, ${val}`
     } else {
       headers[key] = val
     }

--- a/test/http2.js
+++ b/test/http2.js
@@ -126,7 +126,8 @@ test('Should support H2 connection (headers as array)', async t => {
 
   server.on('stream', (stream, headers) => {
     t.strictEqual(headers['x-my-header'], 'foo')
-    t.strictEqual(headers['x-my-drink'], 'coffee,tea')
+    t.strictEqual(headers['x-my-drink'], 'coffee,tea,water')
+    t.strictEqual(headers['x-other'], 'value')
     t.strictEqual(headers[':method'], 'GET')
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
@@ -146,14 +147,19 @@ test('Should support H2 connection (headers as array)', async t => {
     allowH2: true
   })
 
-  t = tspl(t, { plan: 7 })
+  t = tspl(t, { plan: 8 })
   after(() => server.close())
   after(() => client.close())
 
   const response = await client.request({
     path: '/',
     method: 'GET',
-    headers: ['x-my-header', 'foo', 'x-my-drink', ['coffee', 'tea']]
+    headers: [
+      'x-my-header', 'foo',
+      'x-my-drink', ['coffee', 'tea'],
+      'x-my-drink', 'water',
+      'x-other', 'value'
+    ]
   })
 
   response.body.on('data', chunk => {

--- a/test/http2.js
+++ b/test/http2.js
@@ -125,8 +125,8 @@ test('Should support H2 connection (headers as array)', async t => {
   const server = createSecureServer(pem)
 
   server.on('stream', (stream, headers) => {
-    t.strictEqual(headers['x-my-header'], 'foo')
-    t.strictEqual(headers['x-my-drink'], 'coffee,tea,water')
+    t.strictEqual(headers['x-my-header'], 'foo, bar')
+    t.strictEqual(headers['x-my-drink'], 'coffee, tea, water')
     t.strictEqual(headers['x-other'], 'value')
     t.strictEqual(headers[':method'], 'GET')
     stream.respond({
@@ -158,6 +158,7 @@ test('Should support H2 connection (headers as array)', async t => {
       'x-my-header', 'foo',
       'x-my-drink', ['coffee', 'tea'],
       'x-my-drink', 'water',
+      'X-My-Header', 'bar',
       'x-other', 'value'
     ]
   })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

When passing a flat header array and using HTTP/2, duplicate keys were discarded and lost unexpectedly.

In addition, the value-combining formatting (effectively `join(',')`) for explicitly array-valued headers in HTTP/2 didn't quite match the formatting for both Undici HTTP/1 or for Node HTTP/2's value-combining behaviour for headers that differ only by case (both of which do `join(', ')` - i.e. with whitespace) which was a bit weird.

## Rationale

```js
const client = new undici.Client('https://testserver.host', { allowH2: true })

client.request({
  method: 'GET',
  path: '/anything',
  headers: ['a', 'b', 'a', 'c']
}).then(async (response) => {
  console.log(await response.body.text())
})
```

The response shows what the server receives: headers including `a: c` but without `a: b` (all but the last header value is lost).

The header array-to-object logic ignored duplicate keys like this.

Regarding the formatting:

* In Undici HTTP/1, `{ 'a': ['b', 'c'] }` is sent as `a: b, c` (whitespace)
* In Node built-in HTTP/2, `{ 'a': 'b', 'A': 'c' }` is sent as `a: b, c` (whitespace)
* In Undici HTTP/2, until now, `{ 'a': ['b', 'c'] }` was sent as `a: b,c` (no whitespace)

(I'm not claiming this formatting is particularly important, but I would've had to reproduce the inconsistency in the tests, and it's nicer to tidy it up & make these headers a bit more readable en route).

Once https://github.com/nodejs/node/pull/57917 is released (e.g. Node v24) we will be able to skip this entirely, and pass raw headers as-is directly to Node's HTTP/2 APIs, so these headers won't be combined at all - but that will have to wait until later, and will only apply for Node versions including that change anyway.

## Changes

N/A

### Features

N/A

### Bug Fixes

* Duplicate keys in HTTP/2 flat header arrays are now combined correctly, not discarded
* Multi-valued HTTP/2 header values which are combined now include whitespace, for consistency with HTTP/1 and Node itself.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
