### PR TITLE
Restore cache tests & fix max-age behavior

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -19,7 +19,6 @@ const { AbortError } = require('../core/errors.js')
  * @returns {boolean}
  */
 function needsRevalidation (result, cacheControlDirectives) {
-  console.log(...arguments)
   if (cacheControlDirectives?.['no-cache']) {
     // Always revalidate requests with the no-cache request directive
     return true
@@ -32,7 +31,6 @@ function needsRevalidation (result, cacheControlDirectives) {
 
   const now = Date.now()
   if (now > result.staleAt) {
-    console.log('response is stale')
     // Response is stale
     if (cacheControlDirectives?.['max-stale']) {
       // There's a threshold where we can serve stale responses, let's see if

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -19,6 +19,7 @@ const { AbortError } = require('../core/errors.js')
  * @returns {boolean}
  */
 function needsRevalidation (result, cacheControlDirectives) {
+  console.log(...arguments)
   if (cacheControlDirectives?.['no-cache']) {
     // Always revalidate requests with the no-cache request directive
     return true
@@ -31,6 +32,7 @@ function needsRevalidation (result, cacheControlDirectives) {
 
   const now = Date.now()
   if (now > result.staleAt) {
+    console.log('response is stale')
     // Response is stale
     if (cacheControlDirectives?.['max-stale']) {
       // There's a threshold where we can serve stale responses, let's see if

--- a/test/cache-interceptor/cache-store-test-utils.js
+++ b/test/cache-interceptor/cache-store-test-utils.js
@@ -164,6 +164,87 @@ function cacheStoreTests (CacheStore) {
       equal(await store.get(key), undefined)
     })
 
+    test('a stale request is overwritten', async () => {
+      const clock = FakeTimers.install({
+        shouldClearNativeTimers: true
+      })
+
+      after(() => clock.uninstall())
+
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}
+       */
+      const key = {
+        origin: 'localhost',
+        path: '/',
+        method: 'GET',
+        headers: {}
+      }
+
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheValue}
+       */
+      const value = {
+        statusCode: 200,
+        statusMessage: '',
+        headers: { foo: 'bar' },
+        cacheControlDirectives: {},
+        cachedAt: Date.now(),
+        staleAt: Date.now() + 1000,
+        // deleteAt is different because stale-while-revalidate, stale-if-error, ...
+        deleteAt: Date.now() + 5000
+      }
+
+      const body = [Buffer.from('asd'), Buffer.from('123')]
+
+      const store = new CacheStore()
+
+      // Sanity check
+      equal(store.get(key), undefined)
+
+      {
+        const writable = store.createWriteStream(key, value)
+        notEqual(writable, undefined)
+        writeBody(writable, body)
+      }
+
+      clock.tick(1500)
+
+      {
+        const result = await store.get(structuredClone(key))
+        notEqual(result, undefined)
+        await compareGetResults(result, value, body)
+      }
+
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheValue}
+       */
+      const value2 = {
+        statusCode: 200,
+        statusMessage: '',
+        headers: { foo: 'baz' },
+        cacheControlDirectives: {},
+        cachedAt: Date.now(),
+        staleAt: Date.now() + 1000,
+        // deleteAt is different because stale-while-revalidate, stale-if-error, ...
+        deleteAt: Date.now() + 5000
+      }
+
+      const body2 = [Buffer.from('foo'), Buffer.from('123')]
+
+      {
+        const writable = store.createWriteStream(key, value2)
+        notEqual(writable, undefined)
+        writeBody(writable, body2)
+      }
+
+      {
+        const result = await store.get(structuredClone(key))
+        notEqual(result, undefined)
+        await compareGetResults(result, value2, body2)
+      }
+    })
+
     test('vary directives used to decide which response to use', async () => {
       /**
        * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}

--- a/test/cache-interceptor/cache-tests-worker.mjs
+++ b/test/cache-interceptor/cache-tests-worker.mjs
@@ -50,10 +50,14 @@ if (environment.ignoredTests) {
 const client = new Agent().compose(interceptors.cache(environment.opts))
 setGlobalDispatcher(client)
 
+globalThis.fetch = fetch
+
 // Run the suite
-await runTestSuite(tests, fetch, true, process.env.BASE_URL)
+await runTestSuite(tests, true, process.env.BASE_URL)
 
 let exitCode = 0
+
+const results = getResults()
 
 // Print the results
 const stats = printResults(environment, getResults())
@@ -206,6 +210,10 @@ function printStats (stats) {
     dependencyFailed,
     retried
   } = stats
+
+  if (total < 0) {
+    throw new Error('Total tests cannot be negative')
+  }
 
   console.log(`\n        Total tests: ${total}`)
   console.log(`            ${styleText('gray', 'Skipped')}: ${skipped} (${((skipped / total) * 100).toFixed(1)}%)`)

--- a/test/cache-interceptor/cache-tests-worker.mjs
+++ b/test/cache-interceptor/cache-tests-worker.mjs
@@ -57,8 +57,6 @@ await runTestSuite(tests, true, process.env.BASE_URL)
 
 let exitCode = 0
 
-const results = getResults()
-
 // Print the results
 const stats = printResults(environment, getResults())
 printStats(stats)

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -38,6 +38,8 @@ test('SqliteCacheStore works nicely with multiple stores', async (t) => {
   })
 
   t.after(async () => {
+    storeA.close()
+    storeB.close()
     await rm(sqliteLocation)
   })
 


### PR DESCRIPTION
The cache tests were not being run. Restore them and add a check to prevent this situation to happen again.

Moreover, it fixes a bug in the memory storage that prevented the max-age and expiry directives to work properly.

fixes https://github.com/nodejs/undici/issues/4203