### PR TITLE
chore: add `pnpm-lock.yaml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ typings/
 # lock files
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 
 # IDE files
 .idea


### PR DESCRIPTION
## This relates to...

When I run `pnpm install` it creates a lockfile and I accidentally commit it.

## Rationale

This doesn't happen when I run `yarn install` or `npm install` because they are already ignored. So we should also ignore pnpm lock file.

## Changes

Add `pnpm-lock.yaml` to `.gitignore`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
