### PR TITLE
fix(debug): remove extra forward slash in logs

### DIFF
--- a/docs/docs/api/Debug.md
+++ b/docs/docs/api/Debug.md
@@ -14,14 +14,14 @@ NODE_DEBUG=undici node script.js
 UNDICI 16241: connecting to nodejs.org using https:h1
 UNDICI 16241: connecting to nodejs.org using https:h1
 UNDICI 16241: connected to nodejs.org using https:h1
-UNDICI 16241: sending request to GET https://nodejs.org//
-UNDICI 16241: received response to GET https://nodejs.org// - HTTP 307
+UNDICI 16241: sending request to GET https://nodejs.org/
+UNDICI 16241: received response to GET https://nodejs.org/ - HTTP 307
 UNDICI 16241: connecting to nodejs.org using https:h1
-UNDICI 16241: trailers received from GET https://nodejs.org//
+UNDICI 16241: trailers received from GET https://nodejs.org/
 UNDICI 16241: connected to nodejs.org using https:h1
-UNDICI 16241: sending request to GET https://nodejs.org//en
-UNDICI 16241: received response to GET https://nodejs.org//en - HTTP 200
-UNDICI 16241: trailers received from GET https://nodejs.org//en
+UNDICI 16241: sending request to GET https://nodejs.org/en
+UNDICI 16241: received response to GET https://nodejs.org/en - HTTP 200
+UNDICI 16241: trailers received from GET https://nodejs.org/en
 ```
 
 ## `fetch`
@@ -36,14 +36,14 @@ NODE_DEBUG=fetch node script.js
 FETCH 16241: connecting to nodejs.org using https:h1
 FETCH 16241: connecting to nodejs.org using https:h1
 FETCH 16241: connected to nodejs.org using https:h1
-FETCH 16241: sending request to GET https://nodejs.org//
-FETCH 16241: received response to GET https://nodejs.org// - HTTP 307
+FETCH 16241: sending request to GET https://nodejs.org/
+FETCH 16241: received response to GET https://nodejs.org/ - HTTP 307
 FETCH 16241: connecting to nodejs.org using https:h1
-FETCH 16241: trailers received from GET https://nodejs.org//
+FETCH 16241: trailers received from GET https://nodejs.org/
 FETCH 16241: connected to nodejs.org using https:h1
-FETCH 16241: sending request to GET https://nodejs.org//en
-FETCH 16241: received response to GET https://nodejs.org//en - HTTP 200
-FETCH 16241: trailers received from GET https://nodejs.org//en
+FETCH 16241: sending request to GET https://nodejs.org/en
+FETCH 16241: received response to GET https://nodejs.org/en - HTTP 200
+FETCH 16241: trailers received from GET https://nodejs.org/en
 ```
 
 ## `websocket`
@@ -57,6 +57,6 @@ NODE_DEBUG=websocket node script.js
 
 WEBSOCKET 18309: connecting to echo.websocket.org using https:h1
 WEBSOCKET 18309: connected to echo.websocket.org using https:h1
-WEBSOCKET 18309: sending request to GET https://echo.websocket.org//
+WEBSOCKET 18309: sending request to GET https://echo.websocket.org/
 WEBSOCKET 18309: connection opened <ip_address>
 ```

--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -85,7 +85,7 @@ function trackClientEvents (debugLog = undiciDebugLog) {
       const {
         request: { method, path, origin }
       } = evt
-      debugLog('sending request to %s %s/%s', method, origin, path)
+      debugLog('sending request to %s %s%s', method, origin, path)
     })
 }
 
@@ -105,7 +105,7 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
         response: { statusCode }
       } = evt
       debugLog(
-        'received response to %s %s/%s - HTTP %d',
+        'received response to %s %s%s - HTTP %d',
         method,
         origin,
         path,
@@ -118,7 +118,7 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
       const {
         request: { method, path, origin }
       } = evt
-      debugLog('trailers received from %s %s/%s', method, origin, path)
+      debugLog('trailers received from %s %s%s', method, origin, path)
     })
 
   diagnosticsChannel.subscribe('undici:request:error',
@@ -128,7 +128,7 @@ function trackRequestEvents (debugLog = undiciDebugLog) {
         error
       } = evt
       debugLog(
-        'request to %s %s/%s errored - %s',
+        'request to %s %s%s errored - %s',
         method,
         origin,
         path,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

When fixing an issue in a unrelated third-party package that was incorrectly adding an extra forward slash. The node debug logs still contained an extra forward slash which lead me to believe the issue had not been patched in the unrelated third-party package. 

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

When enabling the fetch debug logs, the request contains two forward slashes.

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
