### PR TITLE
fix: EnvHttpProxyAgent.Options should accept ProxyAgent.Options

### DIFF
--- a/types/env-http-proxy-agent.d.ts
+++ b/types/env-http-proxy-agent.d.ts
@@ -1,4 +1,5 @@
 import Agent from './agent'
+import ProxyAgent from './proxy-agent'
 import Dispatcher from './dispatcher'
 
 export default EnvHttpProxyAgent
@@ -10,7 +11,7 @@ declare class EnvHttpProxyAgent extends Dispatcher {
 }
 
 declare namespace EnvHttpProxyAgent {
-  export interface Options extends Agent.Options {
+  export interface Options extends Omit<ProxyAgent.Options, 'uri'> {
     /** Overrides the value of the HTTP_PROXY environment variable  */
     httpProxy?: string;
     /** Overrides the value of the HTTPS_PROXY environment variable  */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## Rationale

`EnvHttpProxyAgent.Options` extends from `Agent.Options`, so it's not possible to pass `ProxyAgent.Options` such as `requestTls` to the `EnvHttpProxyAgent` constructor.

## Changes

`EnvHttpProxyAgent.Options` extends `Omit<ProxyAgent.Options, 'uri'>`.
`uri` is omitted, because it's provided by `EnvHttpProxyAgent`.

### Features

N/A

### Bug Fixes

It's not possible to pass `requestTls` (and others) to the `EnvHttpProxyAgent` constructor.

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [s] Tested
- [s] Benchmarked (**optional**)
- [s] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
