### PR TITLE
fix: eventsource does not reconnect on network error

### DIFF
--- a/lib/web/eventsource/eventsource.js
+++ b/lib/web/eventsource/eventsource.js
@@ -231,12 +231,9 @@ class EventSource extends EventTarget {
 
     // 14. Let processEventSourceEndOfBody given response res be the following step: if res is not a network error, then reestablish the connection.
     const processEventSourceEndOfBody = (response) => {
-      if (isNetworkError(response)) {
-        this.dispatchEvent(new Event('error'))
-        this.close()
+      if (!isNetworkError(response)) {
+        return this.#reconnect()
       }
-
-      this.#reconnect()
     }
 
     // 15. Fetch request, with processResponseEndOfBody set to processEventSourceEndOfBody...

--- a/lib/web/eventsource/util.js
+++ b/lib/web/eventsource/util.js
@@ -26,7 +26,7 @@ function isASCIINumber (value) {
 // https://github.com/nodejs/undici/issues/2664
 function delay (ms) {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms).unref()
+    setTimeout(resolve, ms)
   })
 }
 

--- a/test/node-platform-objects.js
+++ b/test/node-platform-objects.js
@@ -18,16 +18,19 @@ test('unserializable web instances should be uncloneable if node exposes the api
       { Uncloneable: MessageEvent, value: 'dummy event', brand: 'MessageEvent' },
       { Uncloneable: CloseEvent, value: 'dummy event', brand: 'CloseEvent' },
       { Uncloneable: ErrorEvent, value: 'dummy event', brand: 'ErrorEvent' },
-      { Uncloneable: EventSource, value: 'http://localhost', brand: 'EventSource' },
+      { Uncloneable: EventSource, value: 'http://localhost', brand: 'EventSource', doneCb: (entity) => entity.close() },
       { Uncloneable: Headers, brand: 'Headers' },
       { Uncloneable: WebSocket, value: 'http://localhost', brand: 'WebSocket' },
       { Uncloneable: Cache, value: kConstruct, brand: 'Cache' },
       { Uncloneable: CacheStorage, value: kConstruct, brand: 'CacheStorage' }
     ]
     uncloneables.forEach((platformEntity) => {
-      t.throws(() => structuredClone(new platformEntity.Uncloneable(platformEntity.value)),
+      const entity = new platformEntity.Uncloneable(platformEntity.value)
+      t.throws(() => structuredClone(entity),
         DOMException,
         `Cloning ${platformEntity.brand} should throw DOMException`)
+
+      platformEntity.doneCb?.(entity)
     })
   }
 })


### PR DESCRIPTION
To be honest: I am pretty much confused, why we had this regression. In #2665 the setTimeout got replaced with the non promise one, and thus broke the reconnection logic. It seems like setTimeout from timers/promise without reference, still keeps the process running, but the unref`d normal setTimeout results in letting the process die, even though we are still in reconning state.

Also I dont understand anymore why I wrote the close logic into `processEventSourceEndOfBody`.  

So take this PR with a grain of salt.