### PR TITLE
chore: require node native modules  with `node:`-prefix

### DIFF
--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Writable } = require('stream')
+const { Writable } = require('node:stream')
 const { assertCacheKey, assertCacheValue } = require('../util/cache.js')
 
 let DatabaseSync

--- a/test/client.js
+++ b/test/client.js
@@ -1921,7 +1921,7 @@ test('async iterator early return closes early', async (t) => {
 })
 
 test('async iterator yield unsupported TypedArray', {
-  skip: !!require('stream')._isArrayBufferView
+  skip: !!require('node:stream')._isArrayBufferView
 }, async (t) => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {

--- a/test/fetch/fire-and-forget.js
+++ b/test/fetch/fire-and-forget.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { randomFillSync } = require('node:crypto')
-const { setTimeout: sleep } = require('timers/promises')
+const { setTimeout: sleep } = require('node:timers/promises')
 const { test } = require('node:test')
 const { fetch, Agent, setGlobalDispatcher } = require('../..')
 const { createServer } = require('node:http')

--- a/test/fetch/max-listeners.js
+++ b/test/fetch/max-listeners.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { setMaxListeners, getMaxListeners, defaultMaxListeners } = require('events')
+const { setMaxListeners, getMaxListeners, defaultMaxListeners } = require('node:events')
 const { test } = require('node:test')
 const assert = require('node:assert')
 const { Request } = require('../..')

--- a/test/interceptors/cache-fastimers-fix.js
+++ b/test/interceptors/cache-fastimers-fix.js
@@ -4,8 +4,8 @@ const { test, after } = require('node:test')
 const { strictEqual } = require('node:assert')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
+const { setTimeout: sleep } = require('node:timers/promises')
 const { request, Client, interceptors } = require('../../index')
-const { setTimeout: sleep } = require('timers/promises')
 
 test('revalidates the request when the response is stale', async () => {
   let count = 0


### PR DESCRIPTION
we already use everywhere `node:` prefix, these places should do it too.