### PR TITLE
fix: add guard

### DIFF
--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -117,7 +117,7 @@ class StreamHandler extends AsyncResource {
       const { callback, res, opaque, trailers, abort } = this
 
       this.res = null
-      if (err || !res.readable) {
+      if (err || !res?.readable) {
         util.destroy(res, err)
       }
 


### PR DESCRIPTION
Fixes #4248.

Does this need a test? I feel like a proper test would involve adding the function from #4248, but that would mean also adding JSONStream as a dependency; which feels like a lot for an API that seems likely to be removed. And the change in this PR seems about as safe as could be imagined. @metcoder95 @mcollina 