### PR TITLE
webidl: remove fallback for USVString

### DIFF
--- a/lib/web/webidl/index.js
+++ b/lib/web/webidl/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { types, inspect, toUSVString } = require('node:util')
+const { types, inspect } = require('node:util')
 const { markAsUncloneable } = require('node:worker_threads')
 
 const UNDEFINED = 1
@@ -495,21 +495,16 @@ webidl.nullableConverter = function (converter) {
   }
 }
 
-webidl.is.USVString = (() => {
-  if (typeof String.prototype.isWellFormed === 'function') {
-    /**
-     * @param {*} value
-     * @returns {boolean}
-     */
-    return (value) => typeof value === 'string' && value.isWellFormed()
-  } else {
-    /**
-     * @param {*} value
-     * @returns {boolean}
-     */
-    return (value) => typeof value === 'string' && value === toUSVString(value)
-  }
-})()
+/**
+ * @param {*} value
+ * @returns {boolean}
+ */
+webidl.is.USVString = function (value) {
+  return (
+    typeof value === 'string' &&
+    value.isWellFormed()
+  )
+}
 
 webidl.is.ReadableStream = webidl.util.MakeTypeAssertion(ReadableStream)
 webidl.is.Blob = webidl.util.MakeTypeAssertion(Blob)
@@ -572,23 +567,18 @@ webidl.converters.ByteString = function (V, prefix, argument) {
   return x
 }
 
-// https://webidl.spec.whatwg.org/#es-USVString
-// TODO: rewrite this so we can control the errors thrown
-webidl.converters.USVString = (() => {
-  if (typeof String.prototype.toWellFormed === 'function') {
-    /**
-     * @param {string} value
-     * @returns {string}
-     */
-    return (value) => `${value}`.toWellFormed()
-  } else {
-    /**
-     * @param {string} value
-     * @returns {string}
-     */
-    return toUSVString
+/**
+ * @param {unknown} value
+ * @returns {string}
+ * @see https://webidl.spec.whatwg.org/#es-USVString
+ */
+webidl.converters.USVString = function (value) {
+  // TODO: rewrite this so we can control the errors thrown
+  if (typeof value === 'string') {
+    return value.toWellFormed()
   }
-})()
+  return `${value}`.toWellFormed()
+}
 
 // https://webidl.spec.whatwg.org/#es-boolean
 webidl.converters.boolean = function (V) {


### PR DESCRIPTION
According to @KhafraDev we dont need the fallback solutions for USVString, since node 20