### PR TITLE
fix: Use correct `Dispatcher.RequestOptions`

### DIFF
--- a/docs/docs/api/RetryAgent.md
+++ b/docs/docs/api/RetryAgent.md
@@ -40,7 +40,11 @@ import { Agent, RetryAgent } from 'undici'
 
 const agent = new RetryAgent(new Agent())
 
-const res = await agent.request('http://example.com')
+const res = await agent.request({
+  method: 'GET',
+  origin: 'http://example.com',
+  path: '/',
+})
 console.log(res.statusCode)
 console.log(await res.body.text())
 ```


### PR DESCRIPTION
## This relates to...
Code example over [here](https://undici.nodejs.org/#/docs/api/RetryAgent?id=new-retryagentdispatcher-options) is currently incorrect:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/35313d54-8678-4449-b58b-1eb8558a4fd5" />

Function `agent.request()` does not take `string` but `Dispatcher.RequestOptions`


## Changes
I've updated the code example with expected `Dispatcher.RequestOptions` props.


## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
