### PR TITLE
Clarify the type option of the cache interceptor

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1104,7 +1104,7 @@ The `cache` interceptor implements client-side response caching as described in
 - `store` - The [`CacheStore`](/docs/docs/api/CacheStore.md) to store and retrieve responses from. Default is [`MemoryCacheStore`](/docs/docs/api/CacheStore.md#memorycachestore).
 - `methods` - The [**safe** HTTP methods](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.1) to cache the response of.
 - `cacheByDefault` - The default expiration time to cache responses by if they don't have an explicit expiration. If this isn't present, responses without explicit expiration will not be cached. Default `undefined`.
-- `type` - The type of cache for Undici to act as. Can be `shared` or `private`. Default `shared`.
+- `type` - The type of cache for Undici to act as. Can be `shared` or `private`. Default `shared`. `private` means privately cacheable responses will be cached and potentially shared with other users of your application.
 
 ## Instance Events
 

--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1104,7 +1104,7 @@ The `cache` interceptor implements client-side response caching as described in
 - `store` - The [`CacheStore`](/docs/docs/api/CacheStore.md) to store and retrieve responses from. Default is [`MemoryCacheStore`](/docs/docs/api/CacheStore.md#memorycachestore).
 - `methods` - The [**safe** HTTP methods](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.1) to cache the response of.
 - `cacheByDefault` - The default expiration time to cache responses by if they don't have an explicit expiration. If this isn't present, responses without explicit expiration will not be cached. Default `undefined`.
-- `type` - The type of cache for Undici to act as. Can be `shared` or `private`. Default `shared`. `private` means privately cacheable responses will be cached and potentially shared with other users of your application.
+- `type` - The [type of cache](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#types_of_caches) for Undici to act as. Can be `shared` or `private`. Default `shared`. `private` implies privately cacheable responses will be cached and potentially shared with other users of your application.
 
 ## Instance Events
 


### PR DESCRIPTION
People not knowing well the HTTP cache semantic may misleadingly believe that `private` is a safer choice than `shared`. Add a bit of guidance about the effect of private.

## This relates to...

The `type` option of the cache interceptor, so, HTTP caching of fetches done by Undici.

## Rationale

The `private` `type` option of the cache interceptor causes the Undici HTTP cache to act as a private cache while in most circumstances a Node.js application will be shared between many users. This can lead to private data leakage. Furthermore people not understanding well the HTTP cache semantic may misleadingly think choosing `private` instead of `shared` is safer.

## Changes

Add some guidance about the `private` choice.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

None

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
