### PR TITLE
chore: jsdoc use `@returns` everywhere

### DIFF
--- a/lib/core/tree.js
+++ b/lib/core/tree.js
@@ -86,7 +86,7 @@ class TstNode {
 
   /**
    * @param {Uint8Array} key
-   * @return {TstNode | null}
+   * @returns {TstNode | null}
    */
   search (key) {
     const keylength = key.length

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -32,7 +32,7 @@ function makeCacheKey (opts) {
 
 /**
  * @param {Record<string, string[] | string>}
- * @return {Record<string, string[] | string>}
+ * @returns {Record<string, string[] | string>}
  */
 function normaliseHeaders (opts) {
   let headers


### PR DESCRIPTION
Is it already hacktober? LOL

We have 200 places where we use `@returns` and only two places where we use `@return`