### PR TITLE
fetch: remove await, add jsdoc for some body read functions

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -41,7 +41,15 @@ if (hasFinalizationRegistry) {
   })
 }
 
-// https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+/**
+ * Extract a body with type from a byte sequence or BodyInit object
+ *
+ * @param {import('../../../types').BodyInit} object - The BodyInit object to extract from
+ * @param {boolean} [keepalive=false] - If true, indicates that the body
+ * @returns {[{stream: ReadableStream, source: any, length: number | null}, string | null]} - Returns a tuple containing the body and its type
+ *
+ * @see https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+ */
 function extractBody (object, keepalive = false) {
   // 1. Let stream be null.
   let stream = null
@@ -267,7 +275,22 @@ function extractBody (object, keepalive = false) {
   return [body, type]
 }
 
-// https://fetch.spec.whatwg.org/#bodyinit-safely-extract
+/**
+ * @typedef {object} ExtractBodyResult
+ * @property {ReadableStream<Uint8Array<ArrayBuffer>>} stream - The ReadableStream containing the body data
+ * @property {any} source - The original source of the body data
+ * @property {number | null} length - The length of the body data, or null
+ */
+
+/**
+ * Safely extract a body with type from a byte sequence or BodyInit object.
+ *
+ * @param {import('../../../types').BodyInit} object - The BodyInit object to extract from
+ * @param {boolean} [keepalive=false] - If true, indicates that the body
+ * @returns {[ExtractBodyResult, string | null]} - Returns a tuple containing the body and its type
+ *
+ * @see https://fetch.spec.whatwg.org/#bodyinit-safely-extract
+ */
 function safelyExtractBody (object, keepalive = false) {
   // To safely extract a body and a `Content-Type` value from
   // a byte sequence or BodyInit object object, run these steps:
@@ -275,9 +298,7 @@ function safelyExtractBody (object, keepalive = false) {
   // 1. If object is a ReadableStream object, then:
   if (webidl.is.ReadableStream(object)) {
     // Assert: object is neither disturbed nor locked.
-    // istanbul ignore next
     assert(!util.isDisturbed(object), 'The body has already been consumed.')
-    // istanbul ignore next
     assert(!object.locked, 'The stream is locked.')
   }
 

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -754,7 +754,7 @@ async function mainFetch (fetchParams, recursive = false) {
     }
 
     // 4. Fully read response’s body given processBody and processBodyError.
-    await fullyReadBody(response.body, processBody, processBodyError)
+    fullyReadBody(response.body, processBody, processBodyError)
   } else {
     // 21. Otherwise, run fetch finale given fetchParams and response.
     fetchFinale(fetchParams, response)

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1177,6 +1177,11 @@ function iteratorMixin (name, object, kInternalIterator, keyIndex = 0, valueInde
 }
 
 /**
+ * @param {import('./body').ExtractBodyResult} body
+ * @param {(bytes: Uint8Array) => void} processBody
+ * @param {(error: Error) => void} processBodyError
+ * @returns {void}
+ *
  * @see https://fetch.spec.whatwg.org/#body-fully-read
  */
 function fullyReadBody (body, processBody, processBodyError) {
@@ -1191,20 +1196,17 @@ function fullyReadBody (body, processBody, processBodyError) {
   //    with taskDestination.
   const errorSteps = processBodyError
 
+  try {
   // 4. Let reader be the result of getting a reader for body’s stream.
   //    If that threw an exception, then run errorSteps with that
   //    exception and return.
-  let reader
+    const reader = body.stream.getReader()
 
-  try {
-    reader = body.stream.getReader()
+    // 5. Read all bytes from reader, given successSteps and errorSteps.
+    readAllBytes(reader, successSteps, errorSteps)
   } catch (e) {
     errorSteps(e)
-    return
   }
-
-  // 5. Read all bytes from reader, given successSteps and errorSteps.
-  readAllBytes(reader, successSteps, errorSteps)
 }
 
 /**
@@ -1241,15 +1243,16 @@ function isomorphicEncode (input) {
 /**
  * @see https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes
  * @see https://streams.spec.whatwg.org/#read-loop
- * @param {ReadableStreamDefaultReader} reader
+ * @param {ReadableStream<Uint8Array<ArrayBuffer>>} reader
  * @param {(bytes: Uint8Array) => void} successSteps
  * @param {(error: Error) => void} failureSteps
+ * @returns {Promise<void>}
  */
 async function readAllBytes (reader, successSteps, failureSteps) {
-  const bytes = []
-  let byteLength = 0
-
   try {
+    const bytes = []
+    let byteLength = 0
+
     do {
       const { done, value: chunk } = await reader.read()
 


### PR DESCRIPTION
the function `fullyReadBody` is sync, so the await is unnecessary.