### PR TITLE
poc: what are bytes sequences

### DIFF
--- a/benchmarks/fetch/bytes-match.mjs
+++ b/benchmarks/fetch/bytes-match.mjs
@@ -1,24 +1,25 @@
 import { createHash } from 'node:crypto'
 import { bench, run } from 'mitata'
-import { bytesMatch } from '../../lib/web/fetch/util.js'
+import { bytesMatch, ByteSequence } from '../../lib/web/fetch/util.js'
 
-const body = Buffer.from('Hello world!')
-const validSha256Base64 = `sha256-${createHash('sha256').update(body).digest('base64')}`
-const invalidSha256Base64 = `sha256-${createHash('sha256').update(body).digest('base64')}`
-const validSha256Base64Url = `sha256-${createHash('sha256').update(body).digest('base64url')}`
-const invalidSha256Base64Url = `sha256-${createHash('sha256').update(body).digest('base64url')}`
+const buffer = Buffer.from('Hello world!')
+const bytes = new ByteSequence([buffer])
+const validSha256Base64 = `sha256-${createHash('sha256').update(buffer).digest('base64')}`
+const invalidSha256Base64 = `sha256-${createHash('sha256').update(buffer).digest('base64')}`
+const validSha256Base64Url = `sha256-${createHash('sha256').update(buffer).digest('base64url')}`
+const invalidSha256Base64Url = `sha256-${createHash('sha256').update(buffer).digest('base64url')}`
 
 bench('bytesMatch valid sha256 and base64', () => {
-  bytesMatch(body, validSha256Base64)
+  bytesMatch(bytes, validSha256Base64)
 })
 bench('bytesMatch invalid sha256 and base64', () => {
-  bytesMatch(body, invalidSha256Base64)
+  bytesMatch(bytes, invalidSha256Base64)
 })
 bench('bytesMatch valid sha256 and base64url', () => {
-  bytesMatch(body, validSha256Base64Url)
+  bytesMatch(bytes, validSha256Base64Url)
 })
 bench('bytesMatch invalid sha256 and base64url', () => {
-  bytesMatch(body, invalidSha256Base64Url)
+  bytesMatch(bytes, invalidSha256Base64Url)
 })
 
 await run()

--- a/lib/web/cache/cache.js
+++ b/lib/web/cache/cache.js
@@ -334,7 +334,7 @@ class Cache {
       const reader = stream.getReader()
 
       // 11.3
-      readAllBytes(reader, bodyReadPromise.resolve, bodyReadPromise.reject)
+      readAllBytes(reader, (bytes) => bodyReadPromise.resolve(bytes.toUint8Array()), bodyReadPromise.reject)
     } else {
       bodyReadPromise.resolve(undefined)
     }

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -7,7 +7,8 @@ const {
   createDeferredPromise,
   fullyReadBody,
   extractMimeType,
-  utf8DecodeBytes
+  utf8DecodeBytes,
+  ByteSequence
 } = require('./util')
 const { FormData, setFormDataState } = require('./formdata')
 const { webidl } = require('../webidl')
@@ -333,7 +334,7 @@ function bodyMixinMethods (instance, getInternalState) {
 
         // Return a Blob whose contents are bytes and type attribute
         // is mimeType.
-        return new Blob([bytes], { type: mimeType })
+        return new Blob(bytes, { type: mimeType })
       }, instance, getInternalState)
     },
 
@@ -343,7 +344,7 @@ function bodyMixinMethods (instance, getInternalState) {
       // given a byte sequence bytes: return a new ArrayBuffer
       // whose contents are bytes.
       return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes).buffer
+        return bytes.toArrayBuffer()
       }, instance, getInternalState)
     },
 
@@ -373,7 +374,7 @@ function bodyMixinMethods (instance, getInternalState) {
             case 'multipart/form-data': {
               // 1. ... [long step]
               // 2. If that fails for some reason, then throw a TypeError.
-              const parsed = multipartFormDataParser(value, mimeType)
+              const parsed = multipartFormDataParser(value.toBuffer(false), mimeType)
 
               // 3. Return a new FormData object, appending each entry,
               //    resulting from the parsing operation, to its entry list.
@@ -384,7 +385,7 @@ function bodyMixinMethods (instance, getInternalState) {
             }
             case 'application/x-www-form-urlencoded': {
               // 1. Let entries be the result of parsing bytes.
-              const entries = new URLSearchParams(value.toString())
+              const entries = new URLSearchParams(value.toString(false))
 
               // 2. If entries is failure, then throw a TypeError.
 
@@ -412,7 +413,7 @@ function bodyMixinMethods (instance, getInternalState) {
       // with this and the following step given a byte sequence bytes: return the
       // result of creating a Uint8Array from bytes in this’s relevant realm.
       return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes)
+        return bytes.toUint8Array()
       }, instance, getInternalState)
     }
   }
@@ -465,7 +466,7 @@ async function consumeBody (object, convertBytesToJSValue, instance, getInternal
   // 5. If object’s body is null, then run successSteps with an
   //    empty byte sequence.
   if (state.body == null) {
-    successSteps(Buffer.allocUnsafe(0))
+    successSteps(new ByteSequence())
     return promise.promise
   }
 

--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { bufferToLowerCasedHeaderName } = require('../../core/util')
-const { utf8DecodeBytes } = require('./util')
+const { utf8DecodeBytes, ByteSequence } = require('./util')
 const { HTTP_TOKEN_CODEPOINTS, isomorphicDecode } = require('./data-url')
 const { makeEntry } = require('./formdata')
 const { webidl } = require('../webidl')
@@ -196,7 +196,7 @@ function multipartFormDataParser (input, mimeType) {
       // 5.11. Otherwise:
 
       // 5.11.1. Let value be the UTF-8 decoding without BOM of body.
-      value = utf8DecodeBytes(Buffer.from(body))
+      value = utf8DecodeBytes(new ByteSequence([body]))
     }
 
     // 5.12. Assert: name is a scalar value string and value is either a scalar value string or a File object.

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -747,7 +747,7 @@ async function mainFetch (fetchParams, recursive = false) {
       }
 
       // 2. Set response’s body to bytes as a body.
-      response.body = safelyExtractBody(bytes)[0]
+      response.body = safelyExtractBody(bytes.toUint8Array())[0]
 
       // 3. Run fetch finale given fetchParams and response.
       fetchFinale(fetchParams, response)

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -11,7 +11,14 @@ const assert = require('node:assert')
 const { isUint8Array } = require('node:util/types')
 const { webidl } = require('../webidl')
 
-let supportedHashes = []
+/**
+ * @typedef {('sha256' | 'sha384' | 'sha512')[]} SupportedHashAlgorithm
+ */
+
+/**
+ * @type {SupportedHashAlgorithm}
+ */
+let supportedHashAlgorithms = []
 
 // https://nodejs.org/api/crypto.html#determining-if-crypto-support-is-unavailable
 /** @type {import('crypto')} */
@@ -19,7 +26,7 @@ let crypto
 try {
   crypto = require('node:crypto')
   const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
-  supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
+  supportedHashAlgorithms = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
 /* c8 ignore next 3 */
 } catch {
 
@@ -700,7 +707,7 @@ function isURLPotentiallyTrustworthy (url) {
 
 /**
  * @see https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist
- * @param {Uint8Array} bytes
+ * @param {ByteSequence} bytes
  * @param {string} metadataList
  */
 function bytesMatch (bytes, metadataList) {
@@ -745,7 +752,7 @@ function bytesMatch (bytes, metadataList) {
     // "be liberal with padding". This is annoying, and it's not even in the spec.
 
     // 3. Let actualValue be the result of applying algorithm to bytes.
-    let actualValue = crypto.createHash(algorithm).update(bytes).digest('base64')
+    let actualValue = bytes.hash(algorithm)
 
     if (actualValue[actualValue.length - 1] === '=') {
       if (actualValue[actualValue.length - 2] === '=') {
@@ -809,7 +816,7 @@ function parseMetadata (metadata) {
 
     // 5. If algorithm is a hash function recognized by the user
     //    agent, add the parsed token to result.
-    if (supportedHashes.includes(algorithm)) {
+    if (supportedHashAlgorithms.includes(algorithm)) {
       result.push(parsedToken.groups)
     }
   }
@@ -823,7 +830,7 @@ function parseMetadata (metadata) {
 }
 
 /**
- * @param {{ algo: 'sha256' | 'sha384' | 'sha512' }[]} metadataList
+ * @param {{ algo: SupportedHashAlgorithm }[]} metadataList
  */
 function getStrongestMetadata (metadataList) {
   // Let algorithm be the algo component of the first item in metadataList.
@@ -1242,12 +1249,11 @@ function isomorphicEncode (input) {
  * @see https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes
  * @see https://streams.spec.whatwg.org/#read-loop
  * @param {ReadableStreamDefaultReader} reader
- * @param {(bytes: Uint8Array) => void} successSteps
+ * @param {(bytes: ByteSequence) => void} successSteps
  * @param {(error: Error) => void} failureSteps
  */
 async function readAllBytes (reader, successSteps, failureSteps) {
-  const bytes = []
-  let byteLength = 0
+  const bytes = new ByteSequence()
 
   try {
     do {
@@ -1255,7 +1261,7 @@ async function readAllBytes (reader, successSteps, failureSteps) {
 
       if (done) {
         // 1. Call successSteps with bytes.
-        successSteps(Buffer.concat(bytes, byteLength))
+        successSteps(bytes)
         return
       }
 
@@ -1267,9 +1273,7 @@ async function readAllBytes (reader, successSteps, failureSteps) {
       }
 
       // 2. Append the bytes represented by chunk to bytes.
-      bytes.push(chunk)
-      byteLength += chunk.length
-
+      bytes.append(chunk)
     // 3. Read-loop given reader, bytes, successSteps, and failureSteps.
     } while (true)
   } catch (e) {
@@ -1682,15 +1686,17 @@ function getDecodeSplit (name, list) {
   return gettingDecodingSplitting(value)
 }
 
-const textDecoder = new TextDecoder()
-
 /**
+ * @param {ByteSequence} bytes
+ * @param {boolean} [removeBOM=true] whether to remove the UTF-8 BOM (Byte Order Mark)
  * @see https://encoding.spec.whatwg.org/#utf-8-decode
- * @param {Buffer} buffer
+ * @returns {string} the decoded string
  */
-function utf8DecodeBytes (buffer) {
-  if (buffer.length === 0) {
-    return ''
+function utf8DecodeBytes (bytes, removeBOM = true) {
+  let output = ''
+
+  if (bytes.bytesLength === 0) {
+    return output
   }
 
   // 1. Let buffer be the result of peeking three bytes from
@@ -1698,13 +1704,14 @@ function utf8DecodeBytes (buffer) {
 
   // 2. If buffer is 0xEF 0xBB 0xBF, then read three
   //    bytes from ioQueue. (Do nothing with those bytes.)
-  if (buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
-    buffer = buffer.subarray(3)
-  }
 
   // 3. Process a queue with an instance of UTF-8’s
   //    decoder, ioQueue, output, and "replacement".
-  const output = textDecoder.decode(buffer)
+  const textDecoder = new TextDecoder('UTF-8', { fatal: true, ignoreBOM: removeBOM === false })
+
+  for (let i = 0, il = bytes.length; i < il; ++i) {
+    output += textDecoder.decode(bytes[i], { stream: il - i > 1 })
+  }
 
   // 4. Return output.
   return output
@@ -1727,6 +1734,90 @@ class EnvironmentSettingsObject {
 }
 
 const environmentSettingsObject = new EnvironmentSettingsObject()
+
+function ignoreBOMFromBuffer (buffer) {
+  // 1. If buffer is 0xEF 0xBB 0xBF, then read three bytes from ioQueue.
+  //    (Do nothing with those bytes.)
+  if (buffer.length >= 3 && buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
+    return buffer.slice(3)
+  }
+  return buffer
+}
+
+class ByteSequence extends Array {
+  #bytesLength
+
+  constructor (uint8ArrayArray = []) {
+    super()
+    this.#bytesLength = 0
+
+    for (let i = 0; i < uint8ArrayArray.length; ++i) {
+      if (!isUint8Array(uint8ArrayArray[i])) {
+        throw new TypeError('Expected Uint8Array in ByteSequence constructor')
+      }
+      this.#bytesLength += uint8ArrayArray[i].length
+      this.push(uint8ArrayArray[i])
+    }
+  }
+
+  /**
+   * @param {Uint8Array} chunk
+   */
+  append (chunk) {
+    this.#bytesLength += chunk.length
+    this.push(chunk)
+  }
+
+  /**
+   * @returns {number}
+   */
+  get bytesLength () {
+    return this.#bytesLength
+  }
+
+  /**
+   * @param {SupportedHashAlgorithm} algorithm
+   * @param {string} [encoding='base64']
+   * @returns {string}
+   */
+  hash (algorithm, encoding = 'base64') {
+    const hash = crypto.createHash(algorithm)
+
+    for (const chunk of this) {
+      hash.update(chunk)
+    }
+
+    return hash.digest(encoding)
+  }
+
+  /**
+   * @returns {ArrayBuffer}
+   */
+  toArrayBuffer () {
+    return new Uint8Array(Buffer.concat(this, this.#bytesLength).slice(), 0, this.#bytesLength).buffer
+  }
+
+  toBuffer (ignoreBOM = false) {
+    return ignoreBOM
+      ? ignoreBOMFromBuffer(Buffer.concat(this, this.#bytesLength))
+      : Buffer.concat(this, this.#bytesLength)
+  }
+
+  /**
+   * @returns {Uint8Array}
+   */
+  toUint8Array () {
+    return new Uint8Array(Buffer.concat(this, this.#bytesLength).slice(), 0, this.#bytesLength)
+  }
+
+  /**
+   * @param {boolean} [removeBOM=true]
+   * @returns {string}
+   */
+  toString (removeBOM = true) {
+    return utf8DecodeBytes(this, removeBOM)
+  }
+}
 
 module.exports = {
   isAborted,
@@ -1778,5 +1869,6 @@ module.exports = {
   getDecodeSplit,
   utf8DecodeBytes,
   environmentSettingsObject,
-  isOriginIPPotentiallyTrustworthy
+  isOriginIPPotentiallyTrustworthy,
+  ByteSequence
 }

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createDeferredPromise, environmentSettingsObject } = require('../../fetch/util')
+const { createDeferredPromise, environmentSettingsObject, ByteSequence } = require('../../fetch/util')
 const { states, opcodes, sentCloseFrameState } = require('../constants')
 const { webidl } = require('../../webidl')
 const { getURLRecord, isValidSubprotocol, isEstablished, utf8Decode } = require('../util')
@@ -383,7 +383,7 @@ class WebSocketStream {
     }
 
     // 5. Let reason be the result of applying UTF-8 decode without BOM to the WebSocket connection close reason .
-    const reason = result?.reason == null ? '' : utf8DecodeBytes(Buffer.from(result.reason))
+    const reason = result?.reason == null ? '' : utf8DecodeBytes(new ByteSequence(Buffer.from(result.reason)))
 
     // 6. If the connection was closed cleanly ,
     if (wasClean) {


### PR DESCRIPTION
regarding #4295 by @the-sun-will-rise-tomorrow reported issue with TextDecoder hitting the limit of 512MB i want to discuss the approach in this PR.

In the spec, I actually dont find a strict definition of what a byte sequence actually is. 

It just says: 

> A byte sequence is a sequence of [bytes](https://infra.spec.whatwg.org/#byte), represented as a space-separated sequence of bytes. Byte sequences with bytes in the range 0x20 (SP) to 0x7E (~), inclusive, can alternately be written as a string, but using backticks instead of quotation marks, to avoid confusion with an actual [string](https://infra.spec.whatwg.org/#string).

https://infra.spec.whatwg.org/#byte-sequence

So we have maybe some wiggle room and can define byte sequence matching that definition but have our own internal representation?

So instead of always passing around the a big Uint8Array we just pass around a Byte Sequence object and if needed transform it to a target representation form. 

As @mcollina pointed out the maximum length of a string in v8 can be 1 GB in x64 architecture. There seems to be a limitation in TextDecoder of only 512MB being allowed and not 1GB. So we have actually some kind of arbitrary restriction, despite that we could have  512 MB longer strings?

I did not test it with a 1GB string. But by avoiding to force the TextDecoder to process a huuuge Uint8Array, it should work also in that case. I expect that the chunks have a size of the corresponding specified highWaterMark, so I dont check if the chunks are above the limit and then split it on the fly. Only drawback is, that we have bigger an bigger growing string. 

Well, this is just a poc. Maybe you say, that this is useless. Or maybe it is anyway an anti pattern to load such huuuge payloads? But we should atleast discuss it.

I just wanted to get the tests pass as much as possible. Of course there are still optimizations possible. Potentially I oversaw some bugs for edge cases. 

E.g. A Byte Sequence Object with only one element doesnt need to be run with concat. If bytesLength is smaller than like e.g. 10 mb just use the old logic and reuse a pre instantiated TextDecoder-instance and just concat everything, instead of chunkWise decoding.

And of course this doesnt solve the limitation, that we dont create JSON in a stream, as we need the whole payload to pass it to JSON.

Now I go to lunch ;)