### PR TITLE
websocketstream: close readablestream properly

### DIFF
--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -388,7 +388,7 @@ class WebSocketStream {
     // 6. If the connection was closed cleanly ,
     if (wasClean) {
       // 6.1. Close stream ’s readable stream .
-      this.#readableStream.cancel().catch(() => {})
+      this.#readableStreamController.close()
 
       // 6.2. Error stream ’s writable stream with an " InvalidStateError " DOMException indicating that a closed WebSocketStream cannot be written to.
       if (!this.#writableStream.locked) {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:tdd:node-test": "borp -p \"test/node-test/**/*.js\" -w",
     "test:typescript": "tsd && tsc test/imports/undici-import.ts --typeRoots ./types --noEmit && tsc ./types/*.d.ts --noEmit --typeRoots ./types",
     "test:webidl": "borp -p \"test/webidl/*.js\"",
-    "test:websocket": "borp -p \"test/websocket/*.js\"",
+    "test:websocket": "borp -p \"test/websocket/**/*.js\"",
     "test:websocket:autobahn": "node test/autobahn/client.js",
     "test:websocket:autobahn:report": "node test/autobahn/report.js",
     "test:wpt": "node test/wpt/start-fetch.mjs && node test/wpt/start-mimesniff.mjs && node test/wpt/start-xhr.mjs && node test/wpt/start-websockets.mjs && node test/wpt/start-cacheStorage.mjs && node test/wpt/start-eventsource.mjs",

--- a/test/websocket/stream/readable-closed-after-close.js
+++ b/test/websocket/stream/readable-closed-after-close.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+const { WebSocketStream } = require('../../..')
+
+// https://github.com/ricea/websocketstream-explainer/issues/25
+test('ReadableStream is closed properly', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  const wss = new WebSocketStream(`ws://localhost:${server.address().port}`)
+
+  t.after(() => server.close())
+
+  const { readable, writable } = await wss.opened
+
+  const writer = writable.getWriter()
+  const reader = readable.getReader()
+
+  await writer.close()
+  await writer.closed
+
+  await Promise.allSettled([reader.closed, writer.closed])
+})

--- a/test/wpt/status/websockets.status.json
+++ b/test/wpt/status/websockets.status.json
@@ -7,10 +7,9 @@
           "backpressure should be applied to sent messages"
         ]
       },
-      "remote-close.any.js": {
-        "note": "Deno also fails this test",
+      "backpressure-receive.any.js": {
         "fail": [
-          "close with unwritten data should not be considered clean"
+          "backpressure should be applied to received messages"
         ]
       },
       "abort.any.js": {


### PR DESCRIPTION
https://github.com/ricea/websocketstream-explainer/issues/25

In the test added, `reader.closed` would hang forever because readablestream.cancel() would always throw due to the stream being locked from the getReader().