### PR TITLE
cache: fix excessive caching and some other lack of caching

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -241,10 +241,13 @@ class CacheHandler {
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives} cacheControlDirectives
  */
 function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirectives) {
-  // Allow caching for status codes 200 and 307 (original behavior)
-  // Also allow caching for other status codes that are heuristically cacheable
-  // when they have explicit cache directives
-  if (statusCode !== 200 && statusCode !== 307 && !HEURISTICALLY_CACHEABLE_STATUS_CODES.includes(statusCode)) {
+  // Status code must be final.
+  if (statusCode < 200) {
+    return false
+  }
+  // Responses with neither status codes that are heuristically cacheable, nor explicit caching directives,
+  // are not cacheable.
+  if (!HEURISTICALLY_CACHEABLE_STATUS_CODES.includes(statusCode) && !cacheControlDirectives && !resHeaders['expires']) {
     return false
   }
 

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -1437,8 +1437,11 @@ describe('Cache Interceptor', () => {
     })
   })
 
+  // Partial list.
   const cacheableStatusCodes = [
     { code: 204, body: '' },
+    { code: 302, body: 'Found' },
+    { code: 307, body: 'Temporary Redirect' },
     { code: 404, body: 'Not Found' },
     { code: 410, body: 'Gone' }
   ]
@@ -1453,7 +1456,7 @@ describe('Cache Interceptor', () => {
         res.end(body)
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://localhost:${server.address().port}`, { maxRedirections: 0 })
         .compose(interceptors.cache())
 
       after(async () => {
@@ -1489,47 +1492,55 @@ describe('Cache Interceptor', () => {
     })
   }
 
-  test('does not cache non-heuristically cacheable error status codes', async () => {
-    let requestsToOrigin = 0
-    const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
-      requestsToOrigin++
-      res.statusCode = 418 // I'm a teapot - not in heuristically cacheable list
-      res.setHeader('cache-control', 'public, max-age=60')
-      res.end('I am a teapot')
-    }).listen(0)
+  // Partial list.
+  const nonHeuristicallyCacheableStatusCodes = [
+    { code: 201, body: 'Created' },
+    { code: 307, body: 'Temporary Redirect' },
+    { code: 418, body: 'I am a teapot' }
+  ]
 
-    const client = new Client(`http://localhost:${server.address().port}`)
-      .compose(interceptors.cache())
+  for (const { code, body } of nonHeuristicallyCacheableStatusCodes) {
+    test(`does not cache non-heuristically cacheable status ${code} without explicit directive`, async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.statusCode = code
+        res.end(body)
+      }).listen(0)
 
-    after(async () => {
-      server.close()
-      await client.close()
+      const client = new Client(`http://localhost:${server.address().port}`, { maxRedirections: 0 })
+        .compose(interceptors.cache({ cacheByDefault: 60 }))
+
+      after(async () => {
+        server.close()
+        await client.close()
+      })
+
+      await once(server, 'listening')
+
+      equal(requestsToOrigin, 0)
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/'
+      }
+
+      // First request should hit the origin
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        equal(res.statusCode, code)
+        strictEqual(await res.body.text(), body)
+      }
+
+      // Second request should also hit the origin (not cached)
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 2) // Should be 2 (not cached)
+        equal(res.statusCode, code)
+        strictEqual(await res.body.text(), body)
+      }
     })
-
-    await once(server, 'listening')
-
-    equal(requestsToOrigin, 0)
-
-    const request = {
-      origin: 'localhost',
-      method: 'GET',
-      path: '/'
-    }
-
-    // First request should hit the origin
-    {
-      const res = await client.request(request)
-      equal(requestsToOrigin, 1)
-      equal(res.statusCode, 418)
-      strictEqual(await res.body.text(), 'I am a teapot')
-    }
-
-    // Second request should also hit the origin (not cached)
-    {
-      const res = await client.request(request)
-      equal(requestsToOrigin, 2) // Should be 2 (not cached)
-      equal(res.statusCode, 418)
-      strictEqual(await res.body.text(), 'I am a teapot')
-    }
-  })
+  }
 })


### PR DESCRIPTION
307 responses must not be cached if they do not have an explicit caching directive.

Final responses with an explicit caching directive can be cached even if their status code is not heuristically cacheable status codes.

## This relates to...

fix part of #4334.
I have yet to check there is the troubles I expect about caching 206 and 304 responses without properly handling their semantic at the cache level.

## Changes

- Cease caching 307 responses without caching directive.
- Cache responses with explicit caching directive regardless of their status being heuristically cacheable.

### Features

N/A

### Bug Fixes

- 307 Temporary Redirect without explicit caching directive should not be cached.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
