### PR TITLE
refactor: eliminate eager llhttp promise creation

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -165,11 +165,6 @@ async function lazyllhttp () {
 }
 
 let llhttpInstance = null
-/**
- * @type {Promise<WebAssembly.Instance>|null}
- */
-let llhttpPromise = lazyllhttp()
-llhttpPromise.catch()
 
 /**
  * @type {Parser|null}
@@ -771,8 +766,7 @@ async function connectH1 (client, socket) {
   if (!llhttpInstance) {
     const noop = () => {}
     socket.on('error', noop)
-    llhttpInstance = await llhttpPromise
-    llhttpPromise = null
+    llhttpInstance = await lazyllhttp()
     socket.off('error', noop)
   }
 

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -60,12 +60,12 @@ const removeAllListeners = util.removeAllListeners
 
 let extractBody
 
-async function lazyllhttp () {
+function lazyllhttp () {
   const llhttpWasmData = process.env.JEST_WORKER_ID ? require('../llhttp/llhttp-wasm.js') : undefined
 
   let mod
   try {
-    mod = await WebAssembly.compile(require('../llhttp/llhttp_simd-wasm.js'))
+    mod = new WebAssembly.Module(require('../llhttp/llhttp_simd-wasm.js'))
   } catch (e) {
     /* istanbul ignore next */
 
@@ -73,10 +73,10 @@ async function lazyllhttp () {
     // being enabled, but the occurring of this other error
     // * https://github.com/emscripten-core/emscripten/issues/11495
     // got me to remove that check to avoid breaking Node 12.
-    mod = await WebAssembly.compile(llhttpWasmData || require('../llhttp/llhttp-wasm.js'))
+    mod = new WebAssembly.Module(llhttpWasmData || require('../llhttp/llhttp-wasm.js'))
   }
 
-  return await WebAssembly.instantiate(mod, {
+  return new WebAssembly.Instance(mod, {
     env: {
       /**
        * @param {number} p
@@ -764,10 +764,7 @@ async function connectH1 (client, socket) {
   client[kSocket] = socket
 
   if (!llhttpInstance) {
-    const noop = () => {}
-    socket.on('error', noop)
-    llhttpInstance = await lazyllhttp()
-    socket.off('error', noop)
+    llhttpInstance = lazyllhttp()
   }
 
   if (socket.errored) {


### PR DESCRIPTION
## Summary

- Remove eager promise creation from llhttp WebAssembly module loading
- Make llhttp loading truly lazy by calling `lazyllhttp()` only when needed
- Replace async WebAssembly methods with synchronous constructors
- Eliminate all promise handling from the llhttp loading path

## Changes

This PR makes two key improvements to the llhttp WebAssembly module loading:

1. **Truly lazy loading**: Remove the eager `llhttpPromise = lazyllhttp()` call at module initialization. Instead, call `lazyllhttp()` only when the first HTTP/1.1 connection is established.

2. **Synchronous loading**: Replace `WebAssembly.compile()` and `WebAssembly.instantiate()` with their synchronous counterparts `new WebAssembly.Module()` and `new WebAssembly.Instance()`.

## Benefits

- **No eager promise creation**: Eliminates the need for `.catch()` or `.then(null, noop)` handlers
- **Simpler code**: Removes async/await from the loading path entirely
- **Better performance**: Synchronous WebAssembly loading is typically faster than async
- **Cleaner initialization**: No promise handling at module load time

## Test plan

- [x] Existing tests pass
- [x] Linting passes
- [x] No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.ai/code)