### PR TITLE
Fix misleading cacheByDefault documentation

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1103,7 +1103,7 @@ The `cache` interceptor implements client-side response caching as described in
 
 - `store` - The [`CacheStore`](/docs/docs/api/CacheStore.md) to store and retrieve responses from. Default is [`MemoryCacheStore`](/docs/docs/api/CacheStore.md#memorycachestore).
 - `methods` - The [**safe** HTTP methods](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.1) to cache the response of.
-- `cacheByDefault` - The default expiration time to cache responses by if they don't have an explicit expiration. If this isn't present, responses without explicit expiration will not be cached. Default `undefined`.
+- `cacheByDefault` - The default expiration time to cache responses by if they don't have an explicit expiration and cannot have an heuristic expiry computed. If this isn't present, responses neither with an explicit expiration nor heuristically cacheable will not be cached. Default `undefined`.
 - `type` - The [type of cache](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#types_of_caches) for Undici to act as. Can be `shared` or `private`. Default `shared`. `private` implies privately cacheable responses will be cached and potentially shared with other users of your application.
 
 ## Instance Events


### PR DESCRIPTION
## This relates to...

The `cacheByDefault` states:

> The default expiration time to cache responses by if they don't have an explicit expiration. If this isn't present, responses without explicit expiration will not be cached.

That is wrong. If the response has a `last-modified` header, an heuristic expiry will be used by current Undici code base instead of `cacheByDefault`. If the response is heuristically cacheable, it will be cached even if `cacheByDefault` is undefined.

See

https://github.com/nodejs/undici/blob/4608ef157cc75d5ce3d2802e6949cb865d73146c/lib/handler/cache-handler.js#L346C26-L358

https://github.com/nodejs/undici/blob/4608ef157cc75d5ce3d2802e6949cb865d73146c/lib/handler/cache-handler.js#L115C1-L125C6

## Changes

 - Update `cacheByDefault` about heuristic caching.

### Features

N/A

### Bug Fixes

 - Inaccurate/outdated documentation.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
