### PR TITLE
feat(ProxyAgent) improve Curl-y behavior in HTTP->HTTP Proxy connections (#4180)

### DIFF
--- a/docs/docs/api/ProxyAgent.md
+++ b/docs/docs/api/ProxyAgent.md
@@ -27,7 +27,7 @@ For detailed information on the parsing process and potential validation errors,
 * **clientFactory** `(origin: URL, opts: Object) => Dispatcher` (optional) - Default: `(origin, opts) => new Pool(origin, opts)`
 * **requestTls** `BuildOptions` (optional) - Options object passed when creating the underlying socket via the connector builder for the request. It extends from [`Client#ConnectOptions`](/docs/docs/api/Client.md#parameter-connectoptions).
 * **proxyTls** `BuildOptions` (optional) - Options object passed when creating the underlying socket via the connector builder for the proxy server. It extends from [`Client#ConnectOptions`](/docs/docs/api/Client.md#parameter-connectoptions).
-* **proxyTunnel** `boolean` (optional) - By default, ProxyAgent will request that the Proxy facilitate a tunnel between the endpoint and the agent. Setting `proxyTunnel` to false avoids issuing a CONNECT extension, and includes the endpoint domain and path in each request.
+* **proxyTunnel** `boolean` (optional) - For connections involving secure protocols, Undici will always establish a tunnel via the HTTP2  CONNECT extension. If proxyTunnel is set to true, this will occur for unsecured proxy/endpoint connections as well. Currently, there is no way to facilitate HTTP1 IP tunneling as described in https://www.rfc-editor.org/rfc/rfc9484.html#name-http-11-request. If proxyTunnel is set to false (the default), ProxyAgent connections where both the Proxy and Endpoint are unsecured will issue all requests to the Proxy, and prefix the endpoint request path with the endpoint origin address.
 
 Examples:
 

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -244,7 +244,7 @@ test('use proxy-agent to connect through proxy using path with params', async (t
 
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
 
   proxy.on('connect', () => {
@@ -316,7 +316,7 @@ test('use proxy-agent to connect through proxy with basic auth in URL', async (t
 
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = new URL(`http://user:pass@localhost:${proxy.address().port}`)
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
 
   proxy.authenticate = function (req, fn) {
@@ -400,7 +400,8 @@ test('use proxy-agent with auth', async (t) => {
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     auth: Buffer.from('user:pass').toString('base64'),
-    uri: proxyUrl
+    uri: proxyUrl,
+    proxyTunnel: false
   })
   const parsedOrigin = new URL(serverUrl)
 
@@ -489,7 +490,8 @@ test('use proxy-agent with token', async (t) => {
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     token: `Bearer ${Buffer.from('user:pass').toString('base64')}`,
-    uri: proxyUrl
+    uri: proxyUrl,
+    proxyTunnel: false
   })
   const parsedOrigin = new URL(serverUrl)
 
@@ -578,6 +580,7 @@ test('use proxy-agent with custom headers', async (t) => {
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
+    proxyTunnel: false,
     headers: {
       'User-Agent': 'Foobar/1.0.0'
     }
@@ -702,7 +705,7 @@ test('use proxy-agent with setGlobalDispatcher', async (t) => {
 
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
   setGlobalDispatcher(proxyAgent)
 
@@ -786,7 +789,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623', async
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   setGlobalDispatcher(proxyAgent)
 
   after(() => setGlobalDispatcher(defaultDispatcher))
@@ -896,7 +899,7 @@ test('should throw when proxy does not return 200', async (t) => {
     return false
   }
 
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   try {
     await request(serverUrl, { dispatcher: proxyAgent })
     t.fail()


### PR DESCRIPTION
This refactors the way the legacy unsecured behaviour is implemented, by wrapping the Proxy client in a wrapper which rewrites requests, and handles errors. This will also insert authentication headers in each request.

CURRENTLY:

For nonsecure channels, clients allocated by the pool all delegate to the proxy client, and reuse the same HttpContext. This is probably not a good thing, but at least in cases where only one request is performed at a time, it seems harmless enough. In order to make this ready to land, this probably needs to handle simultaneous concurrent requests and have a test for that.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
