### PR TITLE
speed up flaky websocket test

### DIFF
--- a/test/websocket/issue-3697-2399493917.js
+++ b/test/websocket/issue-3697-2399493917.js
@@ -8,7 +8,7 @@ const { tspl } = require('@matteo.collina/tspl')
 test('closing before a connection is established changes readyState', async (t) => {
   const { completed, strictEqual } = tspl(t, { plan: 1 })
 
-  const ws = new WebSocket('wss://example.com/non-existing-url')
+  const ws = new WebSocket('wss://localhost')
   ws.onclose = () => strictEqual(ws.readyState, WebSocket.CLOSED)
 
   await completed


### PR DESCRIPTION
Locally, this makes the test go from >2 seconds to <50ms

I saw it time out in a few places:
https://github.com/nodejs/undici/actions/runs/16346630382/job/46181950819
https://github.com/nodejs/undici/actions/runs/16346630382/job/46181950577