### PR TITLE
MockAgent.prototype.get support ignoreTrailingSlash option

### DIFF
--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -17,7 +17,8 @@ const {
   kMockAgentAddCallHistoryLog,
   kMockAgentMockCallHistoryInstance,
   kMockAgentAcceptsNonStandardSearchParameters,
-  kMockCallHistoryAddLog
+  kMockCallHistoryAddLog,
+  kIgnoreTrailingSlash
 } = require('./mock-symbols')
 const MockClient = require('./mock-client')
 const MockPool = require('./mock-pool')
@@ -37,6 +38,7 @@ class MockAgent extends Dispatcher {
     this[kIsMockActive] = true
     this[kMockAgentIsCallHistoryEnabled] = mockOptions?.enableCallHistory ?? false
     this[kMockAgentAcceptsNonStandardSearchParameters] = mockOptions?.acceptNonStandardSearchParameters ?? false
+    this[kIgnoreTrailingSlash] = mockOptions?.ignoreTrailingSlash ?? false
 
     // Instantiate Agent and encapsulate
     if (opts?.agent && typeof opts.agent.dispatch !== 'function') {
@@ -54,11 +56,15 @@ class MockAgent extends Dispatcher {
   }
 
   get (origin) {
-    let dispatcher = this[kMockAgentGet](origin)
+    const originKey = this[kIgnoreTrailingSlash]
+      ? origin.replace(/\/$/, '')
+      : origin
+
+    let dispatcher = this[kMockAgentGet](originKey)
 
     if (!dispatcher) {
-      dispatcher = this[kFactory](origin)
-      this[kMockAgentSet](origin, dispatcher)
+      dispatcher = this[kFactory](originKey)
+      this[kMockAgentSet](originKey, dispatcher)
     }
     return dispatcher
   }

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -17,16 +17,11 @@ const {
   kMockAgentAddCallHistoryLog,
   kMockAgentMockCallHistoryInstance,
   kMockAgentAcceptsNonStandardSearchParameters,
-  kMockCallHistoryAddLog,
-  kIgnoreTrailingSlash
+  kMockCallHistoryAddLog
 } = require('./mock-symbols')
 const MockClient = require('./mock-client')
 const MockPool = require('./mock-pool')
-const {
-  matchValue,
-  normalizeSearchParams,
-  buildAndValidateMockOptions
-} = require('./mock-utils')
+const { matchValue, normalizeSearchParams, buildAndValidateMockOptions } = require('./mock-utils')
 const { InvalidArgumentError, UndiciError } = require('../core/errors')
 const Dispatcher = require('../dispatcher/dispatcher')
 const PendingInterceptorsFormatter = require('./pending-interceptors-formatter')
@@ -40,17 +35,12 @@ class MockAgent extends Dispatcher {
 
     this[kNetConnect] = true
     this[kIsMockActive] = true
-    this[kMockAgentIsCallHistoryEnabled] =
-      mockOptions?.enableCallHistory ?? false
-    this[kMockAgentAcceptsNonStandardSearchParameters] =
-      mockOptions?.acceptNonStandardSearchParameters ?? false
-    this[kIgnoreTrailingSlash] = mockOptions?.ignoreTrailingSlash ?? false
+    this[kMockAgentIsCallHistoryEnabled] = mockOptions?.enableCallHistory ?? false
+    this[kMockAgentAcceptsNonStandardSearchParameters] = mockOptions?.acceptNonStandardSearchParameters ?? false
 
     // Instantiate Agent and encapsulate
     if (opts?.agent && typeof opts.agent.dispatch !== 'function') {
-      throw new InvalidArgumentError(
-        'Argument opts.agent must implement Agent'
-      )
+      throw new InvalidArgumentError('Argument opts.agent must implement Agent')
     }
     const agent = opts?.agent ? opts.agent : new Agent(opts)
     this[kAgent] = agent
@@ -64,15 +54,11 @@ class MockAgent extends Dispatcher {
   }
 
   get (origin) {
-    const originKey = this[kIgnoreTrailingSlash]
-      ? origin.replace(/\/$/, '')
-      : origin
-
-    let dispatcher = this[kMockAgentGet](originKey)
+    let dispatcher = this[kMockAgentGet](origin)
 
     if (!dispatcher) {
-      dispatcher = this[kFactory](originKey)
-      this[kMockAgentSet](originKey, dispatcher)
+      dispatcher = this[kFactory](origin)
+      this[kMockAgentSet](origin, dispatcher)
     }
     return dispatcher
   }
@@ -83,17 +69,13 @@ class MockAgent extends Dispatcher {
 
     this[kMockAgentAddCallHistoryLog](opts)
 
-    const acceptNonStandardSearchParameters =
-      this[kMockAgentAcceptsNonStandardSearchParameters]
+    const acceptNonStandardSearchParameters = this[kMockAgentAcceptsNonStandardSearchParameters]
 
     const dispatchOpts = { ...opts }
 
     if (acceptNonStandardSearchParameters && dispatchOpts.path) {
       const [path, searchParams] = dispatchOpts.path.split('?')
-      const normalizedSearchParams = normalizeSearchParams(
-        searchParams,
-        acceptNonStandardSearchParameters
-      )
+      const normalizedSearchParams = normalizeSearchParams(searchParams, acceptNonStandardSearchParameters)
       dispatchOpts.path = `${path}?${normalizedSearchParams}`
     }
 
@@ -115,11 +97,7 @@ class MockAgent extends Dispatcher {
   }
 
   enableNetConnect (matcher) {
-    if (
-      typeof matcher === 'string' ||
-      typeof matcher === 'function' ||
-      matcher instanceof RegExp
-    ) {
+    if (typeof matcher === 'string' || typeof matcher === 'function' || matcher instanceof RegExp) {
       if (Array.isArray(this[kNetConnect])) {
         this[kNetConnect].push(matcher)
       } else {
@@ -128,9 +106,7 @@ class MockAgent extends Dispatcher {
     } else if (typeof matcher === 'undefined') {
       this[kNetConnect] = true
     } else {
-      throw new InvalidArgumentError(
-        'Unsupported matcher. Must be one of String|Function|RegExp.'
-      )
+      throw new InvalidArgumentError('Unsupported matcher. Must be one of String|Function|RegExp.')
     }
   }
 
@@ -209,11 +185,7 @@ class MockAgent extends Dispatcher {
 
     // If we match, create a pool and assign the same dispatches
     for (const [keyMatcher, result] of Array.from(this[kClients])) {
-      if (
-        result &&
-        typeof keyMatcher !== 'string' &&
-        matchValue(keyMatcher, origin)
-      ) {
+      if (result && typeof keyMatcher !== 'string' && matchValue(keyMatcher, origin)) {
         const dispatcher = this[kFactory](origin)
         this[kMockAgentSet](origin, dispatcher)
         dispatcher[kDispatches] = result.dispatcher[kDispatches]
@@ -230,18 +202,11 @@ class MockAgent extends Dispatcher {
     const mockAgentClients = this[kClients]
 
     return Array.from(mockAgentClients.entries())
-      .flatMap(([origin, result]) =>
-        result.dispatcher[kDispatches].map((dispatch) => ({
-          ...dispatch,
-          origin
-        }))
-      )
+      .flatMap(([origin, result]) => result.dispatcher[kDispatches].map(dispatch => ({ ...dispatch, origin })))
       .filter(({ pending }) => pending)
   }
 
-  assertNoPendingInterceptors ({
-    pendingInterceptorsFormatter = new PendingInterceptorsFormatter()
-  } = {}) {
+  assertNoPendingInterceptors ({ pendingInterceptorsFormatter = new PendingInterceptorsFormatter() } = {}) {
     const pending = this.pendingInterceptors()
 
     if (pending.length === 0) {

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -17,11 +17,16 @@ const {
   kMockAgentAddCallHistoryLog,
   kMockAgentMockCallHistoryInstance,
   kMockAgentAcceptsNonStandardSearchParameters,
-  kMockCallHistoryAddLog
+  kMockCallHistoryAddLog,
+  kIgnoreTrailingSlash
 } = require('./mock-symbols')
 const MockClient = require('./mock-client')
 const MockPool = require('./mock-pool')
-const { matchValue, normalizeSearchParams, buildAndValidateMockOptions } = require('./mock-utils')
+const {
+  matchValue,
+  normalizeSearchParams,
+  buildAndValidateMockOptions
+} = require('./mock-utils')
 const { InvalidArgumentError, UndiciError } = require('../core/errors')
 const Dispatcher = require('../dispatcher/dispatcher')
 const PendingInterceptorsFormatter = require('./pending-interceptors-formatter')
@@ -35,12 +40,17 @@ class MockAgent extends Dispatcher {
 
     this[kNetConnect] = true
     this[kIsMockActive] = true
-    this[kMockAgentIsCallHistoryEnabled] = mockOptions?.enableCallHistory ?? false
-    this[kMockAgentAcceptsNonStandardSearchParameters] = mockOptions?.acceptNonStandardSearchParameters ?? false
+    this[kMockAgentIsCallHistoryEnabled] =
+      mockOptions?.enableCallHistory ?? false
+    this[kMockAgentAcceptsNonStandardSearchParameters] =
+      mockOptions?.acceptNonStandardSearchParameters ?? false
+    this[kIgnoreTrailingSlash] = mockOptions?.ignoreTrailingSlash ?? false
 
     // Instantiate Agent and encapsulate
     if (opts?.agent && typeof opts.agent.dispatch !== 'function') {
-      throw new InvalidArgumentError('Argument opts.agent must implement Agent')
+      throw new InvalidArgumentError(
+        'Argument opts.agent must implement Agent'
+      )
     }
     const agent = opts?.agent ? opts.agent : new Agent(opts)
     this[kAgent] = agent
@@ -54,11 +64,15 @@ class MockAgent extends Dispatcher {
   }
 
   get (origin) {
-    let dispatcher = this[kMockAgentGet](origin)
+    const originKey = this[kIgnoreTrailingSlash]
+      ? origin.replace(/\/$/, '')
+      : origin
+
+    let dispatcher = this[kMockAgentGet](originKey)
 
     if (!dispatcher) {
-      dispatcher = this[kFactory](origin)
-      this[kMockAgentSet](origin, dispatcher)
+      dispatcher = this[kFactory](originKey)
+      this[kMockAgentSet](originKey, dispatcher)
     }
     return dispatcher
   }
@@ -69,13 +83,17 @@ class MockAgent extends Dispatcher {
 
     this[kMockAgentAddCallHistoryLog](opts)
 
-    const acceptNonStandardSearchParameters = this[kMockAgentAcceptsNonStandardSearchParameters]
+    const acceptNonStandardSearchParameters =
+      this[kMockAgentAcceptsNonStandardSearchParameters]
 
     const dispatchOpts = { ...opts }
 
     if (acceptNonStandardSearchParameters && dispatchOpts.path) {
       const [path, searchParams] = dispatchOpts.path.split('?')
-      const normalizedSearchParams = normalizeSearchParams(searchParams, acceptNonStandardSearchParameters)
+      const normalizedSearchParams = normalizeSearchParams(
+        searchParams,
+        acceptNonStandardSearchParameters
+      )
       dispatchOpts.path = `${path}?${normalizedSearchParams}`
     }
 
@@ -97,7 +115,11 @@ class MockAgent extends Dispatcher {
   }
 
   enableNetConnect (matcher) {
-    if (typeof matcher === 'string' || typeof matcher === 'function' || matcher instanceof RegExp) {
+    if (
+      typeof matcher === 'string' ||
+      typeof matcher === 'function' ||
+      matcher instanceof RegExp
+    ) {
       if (Array.isArray(this[kNetConnect])) {
         this[kNetConnect].push(matcher)
       } else {
@@ -106,7 +128,9 @@ class MockAgent extends Dispatcher {
     } else if (typeof matcher === 'undefined') {
       this[kNetConnect] = true
     } else {
-      throw new InvalidArgumentError('Unsupported matcher. Must be one of String|Function|RegExp.')
+      throw new InvalidArgumentError(
+        'Unsupported matcher. Must be one of String|Function|RegExp.'
+      )
     }
   }
 
@@ -185,7 +209,11 @@ class MockAgent extends Dispatcher {
 
     // If we match, create a pool and assign the same dispatches
     for (const [keyMatcher, result] of Array.from(this[kClients])) {
-      if (result && typeof keyMatcher !== 'string' && matchValue(keyMatcher, origin)) {
+      if (
+        result &&
+        typeof keyMatcher !== 'string' &&
+        matchValue(keyMatcher, origin)
+      ) {
         const dispatcher = this[kFactory](origin)
         this[kMockAgentSet](origin, dispatcher)
         dispatcher[kDispatches] = result.dispatcher[kDispatches]
@@ -202,11 +230,18 @@ class MockAgent extends Dispatcher {
     const mockAgentClients = this[kClients]
 
     return Array.from(mockAgentClients.entries())
-      .flatMap(([origin, result]) => result.dispatcher[kDispatches].map(dispatch => ({ ...dispatch, origin })))
+      .flatMap(([origin, result]) =>
+        result.dispatcher[kDispatches].map((dispatch) => ({
+          ...dispatch,
+          origin
+        }))
+      )
       .filter(({ pending }) => pending)
   }
 
-  assertNoPendingInterceptors ({ pendingInterceptorsFormatter = new PendingInterceptorsFormatter() } = {}) {
+  assertNoPendingInterceptors ({
+    pendingInterceptorsFormatter = new PendingInterceptorsFormatter()
+  } = {}) {
     const pending = this.pendingInterceptors()
 
     if (pending.length === 0) {

--- a/test/jest/mock-agent.test.js
+++ b/test/jest/mock-agent.test.js
@@ -44,3 +44,26 @@ describe('MockAgent', () => {
     expect(jsonResponse).toEqual({ foo: 'bar' })
   })
 })
+
+describe('MockAgent with ignoreTrailingSlash option', () => {
+  const trailingSlashUrl = 'http://localhost:9999/'
+  const noTrailingSlashUrl = 'http://localhost:9999'
+
+  it('should not remove trailing slash from origin if the option is not enable', async () => {
+    const mockClient = new MockAgent()
+
+    const dispatcherOne = mockClient.get(trailingSlashUrl)
+    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
+
+    expect(dispatcherOne).not.toBe(dispatcherTwo)
+  })
+
+  it('should remove trailing slash from origin if enabled the option', async () => {
+    const mockClient = new MockAgent({ ignoreTrailingSlash: true })
+
+    const dispatcherOne = mockClient.get(trailingSlashUrl)
+    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
+
+    expect(dispatcherOne).toBe(dispatcherTwo)
+  })
+})

--- a/test/jest/mock-agent.test.js
+++ b/test/jest/mock-agent.test.js
@@ -5,7 +5,7 @@ const { getResponse } = require('../../lib/mock/mock-utils')
 
 /* global describe, it, afterEach, expect */
 
-describe('smoking test in jest', () => {
+describe('MockAgent', () => {
   let mockAgent
 
   afterEach(() => {
@@ -21,58 +21,26 @@ describe('smoking test in jest', () => {
     setGlobalDispatcher(mockAgent)
     const mockClient = mockAgent.get(baseUrl)
 
-    mockClient
-      .intercept({
-        path: '/foo?hello=there&see=ya',
-        method: 'POST',
-        body: 'form1=data1&form2=data2'
-      })
-      .reply(
-        200,
-        { foo: 'bar' },
-        {
-          headers: {
-            'content-type': 'application/json'
-          },
-          trailers: { 'Content-MD5': 'test' }
-        }
-      )
+    mockClient.intercept({
+      path: '/foo?hello=there&see=ya',
+      method: 'POST',
+      body: 'form1=data1&form2=data2'
+    }).reply(200, { foo: 'bar' }, {
+      headers: {
+        'content-type': 'application/json'
+      },
+      trailers: { 'Content-MD5': 'test' }
+    })
 
-    const { statusCode, headers, trailers, body } = await request(
-      `${baseUrl}/foo?hello=there&see=ya`,
-      {
-        method: 'POST',
-        body: 'form1=data1&form2=data2'
-      }
-    )
+    const { statusCode, headers, trailers, body } = await request(`${baseUrl}/foo?hello=there&see=ya`, {
+      method: 'POST',
+      body: 'form1=data1&form2=data2'
+    })
     expect(statusCode).toBe(200)
     expect(headers).toEqual({ 'content-type': 'application/json' })
     expect(trailers).toEqual({ 'content-md5': 'test' })
 
     const jsonResponse = JSON.parse(await getResponse(body))
     expect(jsonResponse).toEqual({ foo: 'bar' })
-  })
-})
-
-describe('MockAgent with ignoreTrailingSlash option', () => {
-  const trailingSlashUrl = 'http://localhost:9999/'
-  const noTrailingSlashUrl = 'http://localhost:9999'
-
-  it('should not remove trailing slash from origin if the option is not enable', async () => {
-    const mockClient = new MockAgent()
-
-    const dispatcherOne = mockClient.get(trailingSlashUrl)
-    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
-
-    expect(dispatcherOne).not.toBe(dispatcherTwo)
-  })
-
-  it('should remove trailing slash from origin if enabled the option', async () => {
-    const mockClient = new MockAgent({ ignoreTrailingSlash: true })
-
-    const dispatcherOne = mockClient.get(trailingSlashUrl)
-    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
-
-    expect(dispatcherOne).toBe(dispatcherTwo)
   })
 })

--- a/test/jest/mock-agent.test.js
+++ b/test/jest/mock-agent.test.js
@@ -5,7 +5,7 @@ const { getResponse } = require('../../lib/mock/mock-utils')
 
 /* global describe, it, afterEach, expect */
 
-describe('MockAgent', () => {
+describe('smoking test in jest', () => {
   let mockAgent
 
   afterEach(() => {
@@ -21,26 +21,58 @@ describe('MockAgent', () => {
     setGlobalDispatcher(mockAgent)
     const mockClient = mockAgent.get(baseUrl)
 
-    mockClient.intercept({
-      path: '/foo?hello=there&see=ya',
-      method: 'POST',
-      body: 'form1=data1&form2=data2'
-    }).reply(200, { foo: 'bar' }, {
-      headers: {
-        'content-type': 'application/json'
-      },
-      trailers: { 'Content-MD5': 'test' }
-    })
+    mockClient
+      .intercept({
+        path: '/foo?hello=there&see=ya',
+        method: 'POST',
+        body: 'form1=data1&form2=data2'
+      })
+      .reply(
+        200,
+        { foo: 'bar' },
+        {
+          headers: {
+            'content-type': 'application/json'
+          },
+          trailers: { 'Content-MD5': 'test' }
+        }
+      )
 
-    const { statusCode, headers, trailers, body } = await request(`${baseUrl}/foo?hello=there&see=ya`, {
-      method: 'POST',
-      body: 'form1=data1&form2=data2'
-    })
+    const { statusCode, headers, trailers, body } = await request(
+      `${baseUrl}/foo?hello=there&see=ya`,
+      {
+        method: 'POST',
+        body: 'form1=data1&form2=data2'
+      }
+    )
     expect(statusCode).toBe(200)
     expect(headers).toEqual({ 'content-type': 'application/json' })
     expect(trailers).toEqual({ 'content-md5': 'test' })
 
     const jsonResponse = JSON.parse(await getResponse(body))
     expect(jsonResponse).toEqual({ foo: 'bar' })
+  })
+})
+
+describe('MockAgent with ignoreTrailingSlash option', () => {
+  const trailingSlashUrl = 'http://localhost:9999/'
+  const noTrailingSlashUrl = 'http://localhost:9999'
+
+  it('should not remove trailing slash from origin if the option is not enable', async () => {
+    const mockClient = new MockAgent()
+
+    const dispatcherOne = mockClient.get(trailingSlashUrl)
+    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
+
+    expect(dispatcherOne).not.toBe(dispatcherTwo)
+  })
+
+  it('should remove trailing slash from origin if enabled the option', async () => {
+    const mockClient = new MockAgent({ ignoreTrailingSlash: true })
+
+    const dispatcherOne = mockClient.get(trailingSlashUrl)
+    const dispatcherTwo = mockClient.get(noTrailingSlashUrl)
+
+    expect(dispatcherOne).toBe(dispatcherTwo)
   })
 })


### PR DESCRIPTION
## This relates to...

fix #4342

## Rationale

## Changes

MockAgent.prototype.get now respect the `ignoreTrailingSlash` option.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

### Breaking Changes and Deprecations

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
