### PR TITLE
ci: skip Node.js 20 tests on Windows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,6 +63,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        exclude:
+          - node-version: 20
+            runs-on: windows-latest
     uses: ./.github/workflows/test.yml
     with:
       node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Exclude Node.js 20 on Windows from the CI test matrix to avoid known compatibility issues

## Test plan
- Verify that CI still runs tests for Node.js 20 on Ubuntu and macOS
- Verify that Windows tests still run for Node.js 22 and 24
- Check that the overall test coverage remains adequate

🤖 Generated with [Claude Code](https://claude.ai/code)