### PR TITLE
fix: set messageEvent default origin to `null`

### DIFF
--- a/lib/web/websocket/events.js
+++ b/lib/web/websocket/events.js
@@ -68,7 +68,7 @@ class MessageEvent extends Event {
     bubbles = false,
     cancelable = false,
     data = null,
-    origin = '',
+    origin = null,
     lastEventId = '',
     source = null,
     ports = []
@@ -86,7 +86,7 @@ class MessageEvent extends Event {
     const messageEvent = new MessageEvent(kConstruct, type, init)
     messageEvent.#eventInit = init
     messageEvent.#eventInit.data ??= null
-    messageEvent.#eventInit.origin ??= ''
+    messageEvent.#eventInit.origin ??= null
     messageEvent.#eventInit.lastEventId ??= ''
     messageEvent.#eventInit.source ??= null
     messageEvent.#eventInit.ports ??= []


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

From sepc (https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque)

```
If origin is an opaque origin, then return null.
```

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
