### PR TITLE
fix: avoid setup global dispatcher in advance

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -6,20 +6,34 @@ const globalDispatcher = Symbol.for('undici.globalDispatcher.1')
 const { InvalidArgumentError } = require('./core/errors')
 const Agent = require('./dispatcher/agent')
 
-if (getGlobalDispatcher() === undefined) {
-  setGlobalDispatcher(new Agent())
+let currentDispatcher = null
+
+if (Object.hasOwn(globalThis, globalDispatcher)) {
+  const existing = Reflect.get(globalThis, globalDispatcher)
+  if (existing && typeof existing.dispatch === 'function') {
+    currentDispatcher = existing
+  }
+} else {
+  Object.defineProperty(globalThis, globalDispatcher, {
+    get () {
+      if (currentDispatcher === null) {
+        currentDispatcher = new Agent()
+      }
+      return currentDispatcher
+    },
+    set (agent) {
+      setGlobalDispatcher(agent)
+    },
+    enumerable: false,
+    configurable: false
+  })
 }
 
 function setGlobalDispatcher (agent) {
   if (!agent || typeof agent.dispatch !== 'function') {
     throw new InvalidArgumentError('Argument agent must implement Agent')
   }
-  Object.defineProperty(globalThis, globalDispatcher, {
-    value: agent,
-    writable: true,
-    enumerable: false,
-    configurable: false
-  })
+  currentDispatcher = agent
 }
 
 function getGlobalDispatcher () {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

lazy setup dispatcher so that lazyLoadUndici in node.js core module won't affect the `globalThis`

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

Fixes: https://github.com/nodejs/node/issues/59012

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
