### PR TITLE
perf: use Pool instead of Client in ProxyAgent for HTTP proxy connections

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { kProxy, kClose, kDestroy, kDispatch, kConnector } = require('../core/symbols')
+const { kProxy, kClose, kDestroy, kDispatch } = require('../core/symbols')
 const { URL } = require('node:url')
 const Agent = require('./agent')
 const Pool = require('./pool')
 const DispatcherBase = require('./dispatcher-base')
 const { InvalidArgumentError, RequestAbortedError, SecureProxyConnectionError } = require('../core/errors')
 const buildConnector = require('../core/connect')
-const Client = require('./client')
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -29,6 +28,7 @@ const noop = () => {}
 
 class ProxyClient extends DispatcherBase {
   #client = null
+  #connector = null
   constructor (origin, opts) {
     if (typeof origin === 'string') {
       origin = new URL(origin)
@@ -40,7 +40,9 @@ class ProxyClient extends DispatcherBase {
 
     super()
 
-    this.#client = new Client(origin, opts)
+    // Store the connector for direct socket connections
+    this.#connector = opts?.connect || buildConnector(opts)
+    this.#client = new Pool(origin, opts)
   }
 
   async [kClose] () {
@@ -54,7 +56,7 @@ class ProxyClient extends DispatcherBase {
   async [kDispatch] (opts, handler) {
     const { method, origin } = opts
     if (method === 'CONNECT') {
-      this.#client[kConnector]({
+      this.#connector({
         origin,
         port: opts.port || defaultProtocolPort(opts.protocol),
         path: opts.host,
@@ -121,7 +123,7 @@ class ProxyAgent extends DispatcherBase {
           if (origin.protocol === 'http:') {
             return new ProxyClient(origin, options)
           }
-          return new Client(origin, options)
+          return new Pool(origin, options)
         }
       : undefined
 


### PR DESCRIPTION
## Summary
- Changed ProxyClient to use Pool instead of Client for HTTP proxy connections
- Updated factory function to use Pool for non-tunneling scenarios
- Added proper connector handling for CONNECT methods when tunneling is disabled

## Benefits
- Better connection management through connection pooling
- Improved performance for HTTP proxy scenarios
- Maintains all existing functionality and backward compatibility

## Changes
- `ProxyClient` constructor now uses `new Pool()` instead of `new Client()`
- Added `#connector` field to store raw connector for CONNECT method handling
- Updated factory function fallback to also use Pool
- Cleaned up unused imports (`kConnector`, `Client`)

## Test Plan
- [x] All existing proxy-agent tests pass
- [x] Linting passes
- [x] Both tunneling and non-tunneling scenarios work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)