### PR TITLE
fix: remove deprecated maxRedirections option from types

### DIFF
--- a/test/types/agent.test-d.ts
+++ b/test/types/agent.test-d.ts
@@ -5,7 +5,7 @@ import { URL } from 'url'
 
 expectAssignable<Agent>(new Agent())
 expectAssignable<Agent>(new Agent({}))
-expectAssignable<Agent>(new Agent({ maxRedirections: 1 }))
+expectAssignable<Agent>(new Agent({}))
 expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 
 {
@@ -99,7 +99,7 @@ expectAssignable<Agent>(new Agent({ factory: () => new Dispatcher() }))
 
   // dispatch
   expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
-  expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET', maxRedirections: 1 }, {}))
+  expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(agent.close())

--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -77,7 +77,7 @@ expectAssignable<Client>(
 )
 expectAssignable<Client>(
   new Client('', {
-    maxRedirections: 1
+    maxCachedSessions: 1
   })
 )
 expectAssignable<Client>(

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -46,8 +46,8 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<boolean>(dispatcher.dispatch({ path: '', method: 'CUSTOM' }, {}))
 
   // connect
-  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', maxRedirections: 0 }))
-  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: new URL('http://localhost'), path: '', maxRedirections: 0 }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '' }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: new URL('http://localhost'), path: '' }))
   expectAssignable<void>(dispatcher.connect({ origin: '', path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.ConnectData>(data)
@@ -73,10 +73,10 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: iteratorHeaders }))
 
   // request
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', maxRedirections: 0 }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', maxRedirections: 0, query: {} }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', maxRedirections: 0, query: { pageNum: 1, id: 'abc' } }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', maxRedirections: 0, throwOnError: true }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET' }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', query: {} }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', query: { pageNum: 1, id: 'abc' } }))
+  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', throwOnError: true }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
   expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: 'GET', reset: true }, (err, data) => {
     expectAssignable<Error | null>(err)
@@ -91,7 +91,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<Promise<Dispatcher.ResponseData<{ example: string }>>>(dispatcher.request({ origin: '', path: '', method: 'GET', opaque: { example: '' } }))
 
   // pipeline
-  expectAssignable<Duplex>(dispatcher.pipeline({ origin: '', path: '', method: 'GET', maxRedirections: 0 }, data => {
+  expectAssignable<Duplex>(dispatcher.pipeline({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.PipelineHandlerData>(data)
     return new Readable()
   }))
@@ -114,7 +114,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   }))
 
   // stream
-  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: 'GET', maxRedirections: 0 }, data => {
+  expectAssignable<Promise<Dispatcher.StreamData>>(dispatcher.stream({ origin: '', path: '', method: 'GET' }, data => {
     expectAssignable<Dispatcher.StreamFactoryData>(data)
     return new Writable()
   }))
@@ -170,7 +170,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   }))
 
   // upgrade
-  expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', maxRedirections: 0 }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '' }))
   expectAssignable<void>(dispatcher.upgrade({ path: '' }, (err, data) => {
     expectAssignable<Error | null>(err)
     expectAssignable<Dispatcher.UpgradeData>(data)

--- a/test/types/env-http-proxy-agent.test-d.ts
+++ b/test/types/env-http-proxy-agent.test-d.ts
@@ -94,7 +94,7 @@ expectAssignable<EnvHttpProxyAgent>(new EnvHttpProxyAgent({ httpProxy: 'http://l
 
   // dispatch
   expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
-  expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET', maxRedirections: 1 }, {}))
+  expectAssignable<boolean>(agent.dispatch({ origin: '', path: '', method: 'GET' }, {}))
 
   // close
   expectAssignable<Promise<void>>(agent.close())

--- a/test/types/mock-interceptor.test-d.ts
+++ b/test/types/mock-interceptor.test-d.ts
@@ -52,7 +52,6 @@ expectAssignable<BodyInit | Dispatcher.DispatchOptions['body']>(mockResponseCall
     expectAssignable<MockInterceptor.MockResponseCallbackOptions['headers']>(options.headers)
     expectAssignable<MockInterceptor.MockResponseCallbackOptions['origin']>(options.origin)
     expectAssignable<MockInterceptor.MockResponseCallbackOptions['body']>(options.body)
-    expectAssignable<MockInterceptor.MockResponseCallbackOptions['maxRedirections']>(options.maxRedirections)
     return { statusCode: 200, data: { foo: 'bar' } }
   })
 

--- a/test/types/proxy-agent.test-d.ts
+++ b/test/types/proxy-agent.test-d.ts
@@ -10,7 +10,6 @@ expectAssignable<ProxyAgent>(
     uri: '',
     auth: '',
     token: '',
-    maxRedirections: 1,
     factory: (_origin: URL, opts: Object) => new Agent(opts),
     requestTls: {
       ca: [''],

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -22,14 +22,10 @@ declare namespace Agent {
   export interface Options extends Pool.Options {
     /** Default: `(origin, opts) => new Pool(origin, opts)`. */
     factory?(origin: string | URL, opts: Object): Dispatcher;
-    /** Integer. Default: `0` */
-    maxRedirections?: number;
 
     interceptors?: { Agent?: readonly Dispatcher.DispatchInterceptor[] } & Pool.Options['interceptors']
   }
 
   export interface DispatchOptions extends Dispatcher.DispatchOptions {
-    /** Integer. */
-    maxRedirections?: number;
   }
 }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -71,8 +71,6 @@ export declare namespace Client {
     /** TODO */
     maxCachedSessions?: number;
     /** TODO */
-    maxRedirections?: number;
-    /** TODO */
     connect?: Partial<buildConnector.BuildOptions> | buildConnector.connector;
     /** TODO */
     maxRequestsPerClient?: number;

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -135,8 +135,6 @@ declare namespace Dispatcher {
     signal?: AbortSignal | EventEmitter | null;
     /** This argument parameter is passed through to `ConnectData` */
     opaque?: TOpaque;
-    /** Default: 0 */
-    maxRedirections?: number;
     /** Default: false */
     redirectionLimitReached?: boolean;
     /** Default: `null` */
@@ -147,8 +145,6 @@ declare namespace Dispatcher {
     opaque?: TOpaque;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
-    /** Default: 0 */
-    maxRedirections?: number;
     /** Default: false */
     redirectionLimitReached?: boolean;
     /** Default: `null` */
@@ -172,8 +168,6 @@ declare namespace Dispatcher {
     protocol?: string;
     /** Default: `null` */
     signal?: AbortSignal | EventEmitter | null;
-    /** Default: 0 */
-    maxRedirections?: number;
     /** Default: false */
     redirectionLimitReached?: boolean;
     /** Default: `null` */

--- a/types/h2c-client.d.ts
+++ b/types/h2c-client.d.ts
@@ -51,8 +51,6 @@ export declare namespace H2CClient {
     /** TODO */
     maxCachedSessions?: number;
     /** TODO */
-    maxRedirections?: number;
-    /** TODO */
     connect?: Omit<Partial<buildConnector.BuildOptions>, 'allowH2'> | buildConnector.connector;
     /** TODO */
     maxRequestsPerClient?: number;

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -69,7 +69,6 @@ declare namespace MockInterceptor {
     headers?: Headers | Record<string, string>;
     origin?: string;
     body?: BodyInit | Dispatcher.DispatchOptions['body'] | null;
-    maxRedirections?: number;
   }
 
   export type MockResponseDataHandler<TData extends object = object> = (


### PR DESCRIPTION
## Summary
- Remove deprecated `maxRedirections` option from TypeScript type definitions
- Update type tests to remove usage of the deprecated option
- Preserve `maxRedirections` in redirect interceptor where it's still valid

## Test plan
- [x] TypeScript type checking tests pass (`npm run test:typescript`)
- [x] Linting passes (`npm run lint`)
- All references to `maxRedirections` removed from public API types
- Redirect interceptor functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)