### PR TITLE
Support for capping the total number of connections across all origins

### DIFF
--- a/docs/docs/api/Agent.md
+++ b/docs/docs/api/Agent.md
@@ -19,6 +19,7 @@ Returns: `Agent`
 Extends: [`PoolOptions`](/docs/docs/api/Pool.md#parameter-pooloptions)
 
 * **factory** `(origin: URL, opts: Object) => Dispatcher` - Default: `(origin, opts) => new Pool(origin, opts)`
+* **maxGlobalConnections** `number | null` - Default: `null` - Limits the total number of connections that can be open at one time across all origins. If `null`, no limit is enforced.
 
 ## Instance Properties
 

--- a/docs/docs/api/Client.md
+++ b/docs/docs/api/Client.md
@@ -31,6 +31,7 @@ Returns: `Client`
 * **autoSelectFamilyAttemptTimeout**: `number` - Default: depends on local Node version, on Node 18.13.0 and above is `250`. The amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the `autoSelectFamily` option. See [here](https://nodejs.org/api/net.html#socketconnectoptions-connectlistener) for more details.
 * **allowH2**: `boolean` - Default: `false`. Enables support for H2 if the server has assigned bigger priority to it through ALPN negotiation.
 * **maxConcurrentStreams**: `number` - Default: `100`. Dictates the maximum number of concurrent streams for a single H2 session. It can be overridden by a SETTINGS remote frame.
+* **maxGlobalConnectionsReached**: `Function | null` (optional) - Default: `null` - A function that returns a boolean indicating whether or not a global maximum number of connections has been reached. Requests will be queued while `true`.
 
 > **Notes about HTTP/2**
 > - It only works under TLS connections. h2c is not supported.

--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { InvalidArgumentError } = require('../core/errors')
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
+const { kClients, kConnected, kRunning, kClose, kDestroy, kDispatch, kUrl, kQueue, kResume } = require('../core/symbols')
 const DispatcherBase = require('./dispatcher-base')
 const Pool = require('./pool')
 const Client = require('./client')
@@ -15,7 +15,7 @@ const kFactory = Symbol('factory')
 const kOptions = Symbol('options')
 
 function defaultFactory (origin, opts) {
-  return opts && opts.connections === 1
+  return opts && (opts.connections === 1 || opts.maxGlobalConnections === 1)
     ? new Client(origin, opts)
     : new Pool(origin, opts)
 }
@@ -39,34 +39,71 @@ class Agent extends DispatcherBase {
     this[kOptions] = { ...util.deepClone(options), connect }
     this[kFactory] = factory
     this[kClients] = new Map()
+    this[kQueue] = []
+
+    if (options.maxGlobalConnections != null) {
+      if (!Number.isFinite(options.maxGlobalConnections) || options.maxGlobalConnections <= 0) {
+        throw new InvalidArgumentError('maxGlobalConnections must be a number greater than 0')
+      }
+
+      if (options.connections != null && options.maxGlobalConnections < options.connections) {
+        throw new InvalidArgumentError('maxGlobalConnections must be greater than or equal to connections')
+      }
+    }
+
+    this[kOptions].maxGlobalConnectionsReached = () => {
+      if (options.maxGlobalConnections == null) return false
+      return (this[kConnected] >= options.maxGlobalConnections)
+    }
 
     this[kOnDrain] = (origin, targets) => {
-      this.emit('drain', origin, [this, ...targets])
+      this.emit('drain', origin.origin, [this, ...targets])
     }
 
     this[kOnConnect] = (origin, targets) => {
-      const result = this[kClients].get(origin)
+      const key = origin.origin
+      const result = this[kClients].get(key)
       if (result) {
         result.count += 1
       }
-      this.emit('connect', origin, [this, ...targets])
+      this.emit('connect', key, [this, ...targets])
     }
 
     this[kOnDisconnect] = (origin, targets, err) => {
-      const result = this[kClients].get(origin)
+      const key = origin.origin
+      const result = this[kClients].get(key)
       if (result) {
         result.count -= 1
-        if (result.count <= 0) {
-          this[kClients].delete(origin)
+        if (result.count <= 0 && err?.code !== 'UND_ERR_INFO') {
+          this[kClients].delete(key)
           result.dispatcher.destroy()
         }
       }
-      this.emit('disconnect', origin, [this, ...targets], err)
+      this.emit('disconnect', key, [this, ...targets], err)
+      this[kResume]()
     }
 
     this[kOnConnectionError] = (origin, targets, err) => {
       // TODO: should this decrement result.count here?
-      this.emit('connectionError', origin, [this, ...targets], err)
+      this.emit('connectionError', origin.origin, [this, ...targets], err)
+    }
+  }
+
+  get [kConnected] () {
+    return this[kClients].values().reduce((acc, { count = 0 }) => acc + count, 0)
+  }
+
+  [kResume] () {
+    for (const { dispatcher } of this[kClients].values()) {
+      dispatcher[kResume](true)
+    }
+
+    while (this[kQueue].length > 0 && !this[kOptions].maxGlobalConnectionsReached()) {
+      const { opts, handler } = this[kQueue].shift()
+      const result = this[kDispatch](opts, handler)
+      if (!result) {
+        break
+      }
     }
   }
 
@@ -84,6 +121,11 @@ class Agent extends DispatcherBase {
       key = String(opts.origin)
     } else {
       throw new InvalidArgumentError('opts.origin must be a non-empty string or URL.')
+    }
+
+    if (this[kOptions].maxGlobalConnectionsReached()) {
+      this[kQueue].push({ opts, handler })
+      return false
     }
 
     const result = this[kClients].get(key)

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -58,6 +58,7 @@ const connectH1 = require('./client-h1.js')
 const connectH2 = require('./client-h2.js')
 
 const kClosedResolve = Symbol('kClosedResolve')
+const kMaxGlobalConnectionsReached = Symbol('maxGlobalConnectionsReached')
 
 const getDefaultNodeMaxHeaderSize = http &&
   http.maxHeaderSize &&
@@ -66,7 +67,7 @@ const getDefaultNodeMaxHeaderSize = http &&
   ? () => http.maxHeaderSize
   : () => { throw new InvalidArgumentError('http module not available or http.maxHeaderSize invalid') }
 
-const noop = () => {}
+const noop = () => { }
 
 function getPipelining (client) {
   return client[kPipelining] ?? client[kHTTPContext]?.defaultPipelining ?? 1
@@ -105,6 +106,7 @@ class Client extends DispatcherBase {
     maxResponseSize,
     autoSelectFamily,
     autoSelectFamilyAttemptTimeout,
+    maxGlobalConnectionsReached,
     // h2
     maxConcurrentStreams,
     allowH2
@@ -190,6 +192,10 @@ class Client extends DispatcherBase {
       throw new InvalidArgumentError('autoSelectFamilyAttemptTimeout must be a positive number')
     }
 
+    if (maxGlobalConnectionsReached != null && typeof maxGlobalConnectionsReached !== 'function') {
+      throw new InvalidArgumentError('maxGlobalConnectionsReached must be a function')
+    }
+
     // h2
     if (allowH2 != null && typeof allowH2 !== 'boolean') {
       throw new InvalidArgumentError('allowH2 must be a valid boolean value')
@@ -234,6 +240,7 @@ class Client extends DispatcherBase {
     this[kMaxResponseSize] = maxResponseSize > -1 ? maxResponseSize : -1
     this[kMaxConcurrentStreams] = maxConcurrentStreams != null ? maxConcurrentStreams : 100 // Max peerConcurrentStreams for a Node h2 server
     this[kHTTPContext] = null
+    this[kMaxGlobalConnectionsReached] = maxGlobalConnectionsReached
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -440,6 +447,12 @@ async function connect (client) {
       return
     }
 
+    if (client[kMaxGlobalConnectionsReached] && client[kMaxGlobalConnectionsReached]()) {
+      const err = new InformationalError('Maximum global connections reached')
+      util.destroy(socket.on('error', noop), err)
+      client[kConnecting] = false
+      return
+    }
     assert(socket)
 
     try {

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -13,7 +13,7 @@ const {
   InvalidArgumentError
 } = require('../core/errors')
 const util = require('../core/util')
-const { kUrl } = require('../core/symbols')
+const { kUrl, kResume } = require('../core/symbols')
 const buildConnector = require('../core/connect')
 
 const kOptions = Symbol('options')
@@ -37,6 +37,7 @@ class Pool extends PoolBase {
     autoSelectFamilyAttemptTimeout,
     allowH2,
     clientTtl,
+    maxGlobalConnectionsReached,
     ...options
   } = {}) {
     if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
@@ -67,7 +68,7 @@ class Pool extends PoolBase {
 
     this[kConnections] = connections || null
     this[kUrl] = util.parseOrigin(origin)
-    this[kOptions] = { ...util.deepClone(options), connect, allowH2, clientTtl }
+    this[kOptions] = { ...util.deepClone(options), connect, allowH2, clientTtl, maxGlobalConnectionsReached }
     this[kOptions].interceptors = options.interceptors
       ? { ...options.interceptors }
       : undefined
@@ -94,6 +95,12 @@ class Pool extends PoolBase {
         }
       }
     })
+  }
+
+  [kResume] (sync) {
+    for (const client of this[kClients]) {
+      client[kResume](sync)
+    }
   }
 
   [kGetDispatcher] () {

--- a/test/node-test/agent.js
+++ b/test/node-test/agent.js
@@ -2,6 +2,7 @@
 
 const { describe, test, after } = require('node:test')
 const assert = require('node:assert/strict')
+const { once } = require('node:events')
 const http = require('node:http')
 const { PassThrough } = require('node:stream')
 const { kRunning } = require('../../lib/core/symbols')
@@ -38,6 +39,59 @@ test('Agent', t => {
   const p = tspl(t, { plan: 1 })
 
   p.doesNotThrow(() => new Agent())
+})
+
+test('Agent enforces maxGlobalConnections', async (t) => {
+  const p = tspl(t, { plan: 5 })
+
+  const dispatcher = new Agent({
+    maxGlobalConnections: 1,
+    keepAliveMaxTimeout: 100,
+    keepAliveTimeout: 100
+  })
+  t.after(() => dispatcher.close())
+
+  let connectCount = 0
+  let openConnections = 0
+  dispatcher.on('connect', () => {
+    connectCount++
+    openConnections++
+    p.strictEqual(openConnections, 1, 'Only one connection should be allowed at a time')
+  })
+
+  let disconnectCount = 0
+  const disconnectPromise = new Promise(resolve => {
+    dispatcher.on('disconnect', () => {
+      disconnectCount++
+      openConnections--
+
+      if (disconnectCount === 2) resolve()
+    })
+  })
+
+  const handler = (_req, res) => {
+    setTimeout(() => res.end('ok'), 50)
+  }
+
+  const server1 = http.createServer({ joinDuplicateHeaders: true }, handler)
+  server1.listen(0)
+  await once(server1, 'listening')
+  t.after(closeServerAsPromise(server1))
+
+  const server2 = http.createServer({ joinDuplicateHeaders: true }, handler)
+  server2.listen(0)
+  await once(server2, 'listening')
+  t.after(closeServerAsPromise(server2))
+
+  const req1 = request(`http://localhost:${server1.address().port}`, { dispatcher })
+  const req2 = request(`http://localhost:${server2.address().port}`, { dispatcher })
+
+  await Promise.all([req1, req2, disconnectPromise])
+
+  p.strictEqual(connectCount, 2, 'Connect should happen exactly twice')
+  p.strictEqual(disconnectCount, 2, 'Disconnect should happen exactly twice')
+  p.strictEqual(openConnections, 0, 'No connections should be open any longer')
+  await p.completed
 })
 
 test('agent should call callback after closing internal pools', async (t) => {


### PR DESCRIPTION
Addresses https://github.com/nodejs/undici/issues/3268, but currently only in `Agent`. If maintainers believe the approach is sound, I will happily add support to `BalancedPool` as well.

The general approach:

1. Expose a `maxGlobalConnections` option in `Agent`
2. Add a `maxGlobalConnectionsReached()` function that can be passed down to `Client`
3. If a `Client` attempts to create a new connection when the max has been reached, add the request to the `Client` queue and clean up the socket
4. If an `Agent` attempts to dispatch when the max has been reached, add the request to the (new!) `Agent` queue
5. When `Agent` receives a `disconnect` event, drain requests from its queue until `maxGlobalConnections` is reached or a dispatch returns `false`