### PR TITLE
docs: clarify Node.js version support in LTS table

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,11 +622,11 @@ and `undici.Agent`) which will enable the family autoselection algorithm when es
 
 Undici aligns with the Node.js LTS schedule. The following table shows the supported versions:
 
-| Version | Node.js     | End of Life |
-|---------|-------------|-------------|
-| 5.x     | v18.x       | 2024-04-30  |
-| 6.x     | v20.x v22.x | 2026-04-30  |
-| 7.x     | v24.x       | 2027-04-30  |
+| Undici Version | Bundled in Node.js | Node.js Versions Supported | End of Life |
+|----------------|-------------------|----------------------------|-------------|
+| v5.x           | v18.x              | ≥14.0 (tested: 14, 16, 18) | 2024-04-30  |
+| v6.x           | v20.x, v22.x       | ≥18.17 (tested: 18, 20, 21, 22) | 2026-04-30  |
+| v7.x           | v24.x              | ≥20.18.1 (tested: 20, 22, 24) | 2027-04-30  |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -624,9 +624,9 @@ Undici aligns with the Node.js LTS schedule. The following table shows the suppo
 
 | Undici Version | Bundled in Node.js | Node.js Versions Supported | End of Life |
 |----------------|-------------------|----------------------------|-------------|
-| v5.x           | v18.x              | ≥14.0 (tested: 14, 16, 18) | 2024-04-30  |
-| v6.x           | v20.x, v22.x       | ≥18.17 (tested: 18, 20, 21, 22) | 2026-04-30  |
-| v7.x           | v24.x              | ≥20.18.1 (tested: 20, 22, 24) | 2027-04-30  |
+| 5.x           | 18.x              | ≥14.0 (tested: 14, 16, 18) | 2024-04-30  |
+| 6.x           | 20.x, 22.x       | ≥18.17 (tested: 18, 20, 21, 22) | 2026-04-30  |
+| 7.x           | 24.x              | ≥20.18.1 (tested: 20, 22, 24) | 2027-04-30  |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Clarify the Long Term Support table to separate bundled Node.js versions from full version support range
- Add column showing which Node.js versions bundle each Undici version  
- Add column showing minimum required and tested Node.js versions
- Makes it clear that v5.x supports Node.js ≥14.0 despite being bundled in v18.x

## Test plan
- [x] Documentation change only, no code changes required
- [x] Verified information by checking GitHub Actions matrices and package.json engines fields across version branches

🤖 Generated with [Claude Code](https://claude.ai/code)