### PR TITLE
feat(websocket): add handshake response info to undici:websocket:open diagnostic event

### DIFF
--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -169,13 +169,37 @@ This message is published after the client has successfully connected to a serve
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('undici:websocket:open').subscribe(({ address, protocol, extensions, websocket }) => {
+diagnosticsChannel.channel('undici:websocket:open').subscribe(({ 
+  address,           // { address: string, family: string, port: number }
+  protocol,          // string - negotiated subprotocol
+  extensions,        // string - negotiated extensions
+  websocket,         // WebSocket - the WebSocket instance
+  handshakeResponse  // object - HTTP response that upgraded the connection
+}) => {
   console.log(address) // address, family, and port
   console.log(protocol) // negotiated subprotocols
   console.log(extensions) // negotiated extensions
   console.log(websocket) // the WebSocket instance
+  
+  // Handshake response details
+  console.log(handshakeResponse.status) // 101 for successful WebSocket upgrade
+  console.log(handshakeResponse.statusText) // 'Switching Protocols'
+  console.log(handshakeResponse.headers) // Object containing response headers
 })
 ```
+
+### Handshake Response Object
+
+The `handshakeResponse` object contains the HTTP response that upgraded the connection to WebSocket:
+
+- `status` (number): The HTTP status code (101 for successful WebSocket upgrade)
+- `statusText` (string): The HTTP status message ('Switching Protocols' for successful upgrade)
+- `headers` (object): The HTTP response headers from the server, including:
+  - `upgrade: 'websocket'`
+  - `connection: 'upgrade'`
+  - `sec-websocket-accept` and other WebSocket-related headers
+
+This information is particularly useful for debugging and monitoring WebSocket connections, as it provides access to the initial HTTP handshake response that established the WebSocket connection.
 
 ## `undici:websocket:close`
 

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -483,22 +483,32 @@ class WebSocket extends EventTarget {
 
     if (channels.open.hasSubscribers) {
       // Convert headers to a plain object for the event
-      const headers = {}
-      for (const [key, value] of response.headersList) {
-        headers[key] = value
-      }
+      const headers = Object.fromEntries(response.headersList.headersMap.entries())
+      if (channels.open.hasSubscribers) {
+        console.log('[IMPL] About to publish undici:websocket:open event', {
+          address: response.socket.address(),
+          protocol: this.#protocol,
+          extensions: this.#extensions,
+          handshakeResponse: {
+            status: response.status,
+            statusText: response.statusText,
+            headers
+          }
+        })
 
-      channels.open.publish({
-        address: response.socket.address(),
-        protocol: this.#protocol,
-        extensions: this.#extensions,
-        websocket: this,
-        handshakeResponse: {
-          status: response.status,
-          statusText: response.statusText,
-          headers
-        }
-      })
+        channels.open.publish({
+          address: response.socket.address(),
+          protocol: this.#protocol,
+          extensions: this.#extensions,
+          websocket: this,
+          handshakeResponse: {
+            status: response.status,
+            statusText: response.statusText,
+            headers
+          }
+        })
+        console.log('[IMPL] Published undici:websocket:open event')
+      }
     }
   }
 

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -483,7 +483,7 @@ class WebSocket extends EventTarget {
 
     if (channels.open.hasSubscribers) {
       // Convert headers to a plain object for the event
-      const headers = Object.fromEntries(response.headersList.headersMap.entries())
+      const headers = response.headersList.entries
       channels.open.publish({
         address: response.socket.address(),
         protocol: this.#protocol,

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -484,31 +484,17 @@ class WebSocket extends EventTarget {
     if (channels.open.hasSubscribers) {
       // Convert headers to a plain object for the event
       const headers = Object.fromEntries(response.headersList.headersMap.entries())
-      if (channels.open.hasSubscribers) {
-        console.log('[IMPL] About to publish undici:websocket:open event', {
-          address: response.socket.address(),
-          protocol: this.#protocol,
-          extensions: this.#extensions,
-          handshakeResponse: {
-            status: response.status,
-            statusText: response.statusText,
-            headers
-          }
-        })
-
-        channels.open.publish({
-          address: response.socket.address(),
-          protocol: this.#protocol,
-          extensions: this.#extensions,
-          websocket: this,
-          handshakeResponse: {
-            status: response.status,
-            statusText: response.statusText,
-            headers
-          }
-        })
-        console.log('[IMPL] Published undici:websocket:open event')
-      }
+      channels.open.publish({
+        address: response.socket.address(),
+        protocol: this.#protocol,
+        extensions: this.#extensions,
+        websocket: this,
+        handshakeResponse: {
+          status: response.status,
+          statusText: response.statusText,
+          headers
+        }
+      })
     }
   }
 

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -482,11 +482,22 @@ class WebSocket extends EventTarget {
     fireEvent('open', this)
 
     if (channels.open.hasSubscribers) {
+      // Convert headers to a plain object for the event
+      const headers = {}
+      for (const [key, value] of response.headersList) {
+        headers[key] = value
+      }
+
       channels.open.publish({
         address: response.socket.address(),
         protocol: this.#protocol,
         extensions: this.#extensions,
-        websocket: this
+        websocket: this,
+        handshakeResponse: {
+          status: response.status,
+          statusText: response.statusText,
+          headers
+        }
       })
     }
   }

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -7,7 +7,7 @@ const { WebSocket } = require('../..')
 const { tspl } = require('@matteo.collina/tspl')
 
 test('diagnostics channel - undici:websocket:open includes handshake response', async (t) => {
-  const { equal, ok, completed } = tspl(t, { plan: 3 })
+  const { equal, ok, completed } = tspl(t, { plan: 11 })
 
   const server = new WebSocketServer({ port: 0 })
   const { port } = server.address()
@@ -35,9 +35,9 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
     ok('connection' in headers, 'connection header should be present')
     ok('sec-websocket-accept' in headers, 'sec-websocket-accept header should be present')
     // Optionally, check values
-    equal(headers.upgrade.value.toLowerCase(), 'websocket', 'upgrade header should be websocket')
-    equal(headers.connection.value.toLowerCase(), 'upgrade', 'connection header should be upgrade')
-    ok(typeof headers['sec-websocket-accept'].value === 'string', 'sec-websocket-accept header should be a string')
+    equal(headers.upgrade.toLowerCase(), 'websocket', 'upgrade header should be websocket')
+    equal(headers.connection.toLowerCase(), 'upgrade', 'connection header should be upgrade')
+    ok(typeof headers['sec-websocket-accept'] === 'string', 'sec-websocket-accept header should be a string')
   }
 
   dc.channel('undici:websocket:open').subscribe(openListener)

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -11,12 +11,18 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
 
   const server = new WebSocketServer({ port: 0 })
   const { port } = server.address()
+  console.log('[TEST] WebSocketServer started on port', port)
 
   server.on('connection', (ws) => {
-    ws.close(1000, 'test')
+    console.log('[TEST] Server: connection established')
+    setTimeout(() => {
+      ws.close(1000, 'test')
+      console.log('[TEST] Server: connection closed')
+    }, 50)
   })
 
   const openListener = (data) => {
+    console.log('[TEST] openListener called:', data)
     // Verify handshake response data
     ok(data.handshakeResponse, 'handshakeResponse should be defined')
     equal(data.handshakeResponse.status, 101, 'status should be 101')
@@ -28,10 +34,12 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
   t.after(() => {
     server.close()
     dc.channel('undici:websocket:open').unsubscribe(openListener)
+    console.log('[TEST] Cleanup complete')
   })
 
   // Create WebSocket connection
   const ws = new WebSocket(`ws://localhost:${port}`)
+  console.log('[TEST] WebSocket client created:', ws.url)
 
   // Ensure connection is created (avoid no-new linting error)
   ws.url // eslint-disable-line no-unused-expressions

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -44,8 +44,8 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
   })
 
   // Create WebSocket connection
-  const ws = new WebSocket(`ws://localhost:${port}`)
-  console.log('[TEST] WebSocket client created:', ws.url)
+  // eslint-disable-next-line no-unused-vars
+  const _ws = new WebSocket(`ws://localhost:${port}`)
 
   await completed
 })

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test } = require('node:test')
+const dc = require('node:diagnostics_channel')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+const { tspl } = require('@matteo.collina/tspl')
+
+test('diagnostics channel - undici:websocket:open includes handshake response', async (t) => {
+  const { equal, ok, completed } = tspl(t, { plan: 3 })
+
+  const server = new WebSocketServer({ port: 0 })
+  const { port } = server.address()
+
+  server.on('connection', (ws) => {
+    ws.close(1000, 'test')
+  })
+
+  const openListener = (data) => {
+    // Verify handshake response data
+    ok(data.handshakeResponse, 'handshakeResponse should be defined')
+    equal(data.handshakeResponse.status, 101, 'status should be 101')
+    equal(data.handshakeResponse.statusText, 'Switching Protocols', 'statusText should be correct')
+  }
+
+  dc.channel('undici:websocket:open').subscribe(openListener)
+
+  t.after(() => {
+    server.close()
+    dc.channel('undici:websocket:open').unsubscribe(openListener)
+  })
+
+  // Create WebSocket connection
+  const ws = new WebSocket(`ws://localhost:${port}`)
+
+  // Ensure connection is created (avoid no-new linting error)
+  ws.url // eslint-disable-line no-unused-expressions
+
+  await completed
+})

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -27,6 +27,17 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
     ok(data.handshakeResponse, 'handshakeResponse should be defined')
     equal(data.handshakeResponse.status, 101, 'status should be 101')
     equal(data.handshakeResponse.statusText, 'Switching Protocols', 'statusText should be correct')
+    // Check handshake response headers
+    const headers = data.handshakeResponse.headers
+    ok(headers, 'headers should be defined')
+    ok(typeof headers === 'object', 'headers should be an object')
+    ok('upgrade' in headers, 'upgrade header should be present')
+    ok('connection' in headers, 'connection header should be present')
+    ok('sec-websocket-accept' in headers, 'sec-websocket-accept header should be present')
+    // Optionally, check values
+    equal(headers.upgrade.value.toLowerCase(), 'websocket', 'upgrade header should be websocket')
+    equal(headers.connection.value.toLowerCase(), 'upgrade', 'connection header should be upgrade')
+    ok(typeof headers['sec-websocket-accept'].value === 'string', 'sec-websocket-accept header should be a string')
   }
 
   dc.channel('undici:websocket:open').subscribe(openListener)
@@ -40,9 +51,6 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
   // Create WebSocket connection
   const ws = new WebSocket(`ws://localhost:${port}`)
   console.log('[TEST] WebSocket client created:', ws.url)
-
-  // Ensure connection is created (avoid no-new linting error)
-  ws.url // eslint-disable-line no-unused-expressions
 
   await completed
 })

--- a/test/websocket/diagnostics-channel-handshake-response.js
+++ b/test/websocket/diagnostics-channel-handshake-response.js
@@ -11,18 +11,14 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
 
   const server = new WebSocketServer({ port: 0 })
   const { port } = server.address()
-  console.log('[TEST] WebSocketServer started on port', port)
 
   server.on('connection', (ws) => {
-    console.log('[TEST] Server: connection established')
     setTimeout(() => {
       ws.close(1000, 'test')
-      console.log('[TEST] Server: connection closed')
     }, 50)
   })
 
   const openListener = (data) => {
-    console.log('[TEST] openListener called:', data)
     // Verify handshake response data
     ok(data.handshakeResponse, 'handshakeResponse should be defined')
     equal(data.handshakeResponse.status, 101, 'status should be 101')
@@ -45,7 +41,6 @@ test('diagnostics channel - undici:websocket:open includes handshake response', 
   t.after(() => {
     server.close()
     dc.channel('undici:websocket:open').unsubscribe(openListener)
-    console.log('[TEST] Cleanup complete')
   })
 
   // Create WebSocket connection


### PR DESCRIPTION


- Add handshakeResponse object to undici:websocket:open diagnostic event
- Include status, statusText, and headers from HTTP handshake response
- Enables Chrome DevTools Protocol Network.webSocketHandshakeResponseReceived support
- Add comprehensive test coverage for handshake response diagnostic data

Fixes #4394


## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [x] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
