### PR TITLE
fix: add ReadableStream to BodyInit

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -23,6 +23,7 @@ export type BodyInit =
   | FormData
   | Iterable<Uint8Array>
   | NodeJS.ArrayBufferView
+  | ReadableStream
   | URLSearchParams
   | null
   | string


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/issues/4401

## Rationale

ReadableStream should be part of BodyInit as part of the MDN standard: https://developer.mozilla.org/en-US/docs/Web/API/Response/Response

## Changes

Added ReadableStream to the BodyInit union type

### Features

N/A

### Bug Fixes

It is now possible to do `new Response(aReadableStream)` without Typescript complaining

### Breaking Changes and Deprecations

None

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
