### PR TITLE
eventsource: also test for minimum time in reconnectionTime tests

### DIFF
--- a/test/eventsource/eventsource-connect.js
+++ b/test/eventsource/eventsource-connect.js
@@ -203,6 +203,7 @@ describe('EventSource - received response must have content-type to be text/even
 
     eventSourceInstance.close()
 
+    assert.strictEqual(end - start > (2.9 * reconnectionTime), true)
     assert.strictEqual(end - start < (3.5 * reconnectionTime), true)
   })
 
@@ -226,6 +227,7 @@ describe('EventSource - received response must have content-type to be text/even
 
     eventSourceInstance.close()
 
+    assert.strictEqual(end - start > (2.9 * reconnectionTime), true)
     assert.strictEqual(end - start < (3.5 * reconnectionTime), true)
   })
 })


### PR DESCRIPTION
This just ensures that the test is also covering the case, that the reconnection does not happen really "fast"