### PR TITLE
test: fix snapshot testing flaky test

### DIFF
--- a/lib/mock/snapshot-agent.js
+++ b/lib/mock/snapshot-agent.js
@@ -182,39 +182,33 @@ class SnapshotAgent extends MockAgent {
    * Replays a recorded response
    */
   _replaySnapshot (snapshot, handler) {
-    return new Promise((resolve) => {
-      // Simulate the response
-      setImmediate(() => {
-        try {
-          const { response } = snapshot
+    try {
+      const { response } = snapshot
 
-          const controller = {
-            pause () {},
-            resume () {},
-            abort (reason) {
-              this.aborted = true
-              this.reason = reason
-            },
+      const controller = {
+        pause () { },
+        resume () { },
+        abort (reason) {
+          this.aborted = true
+          this.reason = reason
+        },
 
-            aborted: false,
-            paused: false
-          }
+        aborted: false,
+        paused: false
+      }
 
-          handler.onRequestStart(controller)
+      handler.onRequestStart(controller)
 
-          handler.onResponseStart(controller, response.statusCode, response.headers)
+      handler.onResponseStart(controller, response.statusCode, response.headers)
 
-          // Body is always stored as base64 string
-          const body = Buffer.from(response.body, 'base64')
-          handler.onResponseData(controller, body)
+      // Body is always stored as base64 string
+      const body = Buffer.from(response.body, 'base64')
+      handler.onResponseData(controller, body)
 
-          handler.onResponseEnd(controller, response.trailers)
-          resolve()
-        } catch (error) {
-          handler.onError?.(error)
-        }
-      })
-    })
+      handler.onResponseEnd(controller, response.trailers)
+    } catch (error) {
+      handler.onError?.(error)
+    }
   }
 
   /**

--- a/test/snapshot-testing.js
+++ b/test/snapshot-testing.js
@@ -98,8 +98,7 @@ function createSequentialHandler (responses) {
   let callCount = 0
   return (req, res) => {
     res.writeHead(200, { 'content-type': 'text/plain' })
-    res.end(responses[callCount] || responses[responses.length - 1])
-    callCount++
+    res.end(responses[callCount++] || responses[responses.length - 1])
   }
 }
 


### PR DESCRIPTION
@mcollina 

Was there a reason to make _replaySnapshot async? Because it was asyncy it resulted in the flaky behaviour. Basically returning the snapshot was async so it was not ensured which response Body needed to be returned.