### PR TITLE
fix formdata constructor args mark optional

### DIFF
--- a/lib/web/fetch/formdata.js
+++ b/lib/web/fetch/formdata.js
@@ -9,7 +9,7 @@ const nodeUtil = require('node:util')
 class FormData {
   #state = []
 
-  constructor (form) {
+  constructor (form = undefined) {
     webidl.util.markAsUncloneable(this)
 
     if (form !== undefined) {

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -341,7 +341,7 @@ test('FormData should be compatible with third-party libraries', (t) => {
 })
 
 test('arguments', () => {
-  assert.strictEqual(FormData.prototype.constructor.length, 0)
+  assert.strictEqual(FormData.length, 0)
   assert.strictEqual(FormData.prototype.append.length, 2)
   assert.strictEqual(FormData.prototype.delete.length, 1)
   assert.strictEqual(FormData.prototype.get.length, 1)

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -341,7 +341,7 @@ test('FormData should be compatible with third-party libraries', (t) => {
 })
 
 test('arguments', () => {
-  assert.strictEqual(FormData.constructor.length, 0)
+  assert.strictEqual(FormData.prototype.constructor.length, 0)
   assert.strictEqual(FormData.prototype.append.length, 2)
   assert.strictEqual(FormData.prototype.delete.length, 1)
   assert.strictEqual(FormData.prototype.get.length, 1)

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -341,7 +341,7 @@ test('FormData should be compatible with third-party libraries', (t) => {
 })
 
 test('arguments', () => {
-  assert.strictEqual(FormData.constructor.length, 1)
+  assert.strictEqual(FormData.constructor.length, 0)
   assert.strictEqual(FormData.prototype.append.length, 2)
   assert.strictEqual(FormData.prototype.delete.length, 1)
   assert.strictEqual(FormData.prototype.get.length, 1)


### PR DESCRIPTION
The [FormData](https://xhr.spec.whatwg.org/#dom-formdata) constructor's arguments are all marked as optional in the specification, so let's make them optional.