### PR TITLE
fix: fix wrong stream canceled up after cloning (v7)

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -354,7 +354,7 @@ function cloneResponse (response) {
   if (response.body != null) {
     newResponse.body = cloneBody(response.body)
 
-    streamRegistry.register(newResponse, new WeakRef(response.body.stream))
+    streamRegistry.register(newResponse, new WeakRef(newResponse.body.stream))
   }
 
   // 4. Return newResponse.

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -297,3 +297,30 @@ test('clone body garbage collection', async () => {
   const cloneBody = ref.deref()
   assert.equal(cloneBody, undefined, 'clone body was not garbage collected')
 })
+
+test('clone body garbage collection should not affect original res', async () => {
+  let ref
+
+  const doFetch = async () => {
+    const res = new Response('hello world')
+
+    // Clone res and consume its body
+    const clone = res.clone()
+    await clone.text()
+    ref = new WeakRef(clone)
+
+    return res
+  }
+
+  const res = await doFetch()
+
+  // wait for garbage collection
+  while (true) {
+    await setImmediate()
+    global.gc()
+    if (!ref.deref()) break
+  }
+
+  await setImmediate()
+  assert.doesNotThrow(() => res.clone(), 'Body has already been consumed')
+})


### PR DESCRIPTION
Pretty much the same as https://github.com/nodejs/undici/pull/4414 but for v7

## This relates to...

- https://github.com/nodejs/undici/pull/3458
- https://github.com/nodejs/undici/issues/4150

## Rationale

The request/stream registered with the finalization registry is mixed up between the clone and the original request.

## Changes

This PR just changes which of the two tee'd streams is associated

### Features

N/A 

### Bug Fixes

N/A 

### Breaking Changes and Deprecations

N/A 

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
