### PR TITLE
fix: memory leak in Agent

### DIFF
--- a/test/issue-4244.js
+++ b/test/issue-4244.js
@@ -1,0 +1,62 @@
+const { test, describe } = require('node:test')
+const assert = require('node:assert')
+const { createServer } = require('node:http')
+const { request, Agent, Pool } = require('..')
+
+// https://github.com/nodejs/undici/issues/4424
+describe('Agent should close inactive clients', () => {
+  test('without active connections', async (t) => {
+    const server = createServer({ keepAliveTimeout: 0 }, async (_req, res) => {
+      res.setHeader('connection', 'close')
+      res.writeHead(200)
+      res.end('ok')
+    }).listen(0)
+
+    t.after(() => server.close())
+
+    let p
+    const agent = new Agent({
+      factory: (origin, opts) => {
+        const pool = new Pool(origin, opts)
+        let _resolve, _reject
+        p = new Promise((resolve, reject) => {
+          _resolve = resolve
+          _reject = reject
+        })
+        pool.on('disconnect', () => {
+          setImmediate(() => pool.destroyed ? _resolve() : _reject(new Error('client not destroyed')))
+        })
+        return pool
+      }
+    })
+    const { statusCode } = await request(`http://localhost:${server.address().port}`, { dispatcher: agent })
+    assert.equal(statusCode, 200)
+
+    await p
+  })
+
+  test('in case of connection error', async (t) => {
+    let p
+    const agent = new Agent({
+      factory: (origin, opts) => {
+        const pool = new Pool(origin, opts)
+        let _resolve, _reject
+        p = new Promise((resolve, reject) => {
+          _resolve = resolve
+          _reject = reject
+        })
+        pool.on('connectionError', () => {
+          setImmediate(() => pool.destroyed ? _resolve() : _reject(new Error('client not destroyed')))
+        })
+        return pool
+      }
+    })
+    try {
+      await request('http://localhost:0', { dispatcher: agent })
+    } catch (_) {
+      // ignore
+    }
+
+    await p
+  })
+})


### PR DESCRIPTION
## This relates to...

#4424

## Changes

Instead of using `origin` from the `connect` and `disconnect` events, track client using the original key.

### Features

N/A

### Bug Fixes

#4424

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
