### PR TITLE
fix (websocket): ErrorEvent constructor should convert arguments before passing to `super()`

### DIFF
--- a/lib/web/websocket/events.js
+++ b/lib/web/websocket/events.js
@@ -143,13 +143,13 @@ class ErrorEvent extends Event {
     const prefix = 'ErrorEvent constructor'
     webidl.argumentLengthCheck(arguments, 1, prefix)
 
-    super(type, eventInitDict)
-    webidl.util.markAsUncloneable(this)
-
     type = webidl.converters.DOMString(type, prefix, 'type')
     eventInitDict = webidl.converters.ErrorEventInit(eventInitDict ?? {})
 
+    super(type, eventInitDict)
+
     this.#eventInit = eventInitDict
+    webidl.util.markAsUncloneable(this)
   }
 
   get message () {


### PR DESCRIPTION
Now the order of operations is comparable to CloseEvent and MessageEvent

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
