### PR TITLE
chore: remove unused exceptions in try catch blocks

### DIFF
--- a/build/wasm.js
+++ b/build/wasm.js
@@ -69,10 +69,10 @@ if (process.argv[2] === '--docker') {
 }
 
 const hasApk = (function () {
-  try { execSync('command -v apk'); return true } catch (error) { return false }
+  try { execSync('command -v apk'); return true } catch { return false }
 })()
 const hasOptimizer = (function () {
-  try { execSync(`${WASM_OPT} --version`); return true } catch (error) { return false }
+  try { execSync(`${WASM_OPT} --version`); return true } catch { return false }
 })()
 if (hasApk) {
   // Gather information about the tools used for the build

--- a/docs/examples/snapshot-testing.js
+++ b/docs/examples/snapshot-testing.js
@@ -92,7 +92,7 @@ async function basicSnapshotExample () {
       const { unlink } = require('node:fs/promises')
       await unlink(snapshotPath)
       console.log('\n🗑️  Cleaned up temporary snapshot file')
-    } catch (error) {
+    } catch {
       // File might not exist or already be deleted
     }
   }

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -66,7 +66,7 @@ function lazyllhttp () {
   let mod
   try {
     mod = new WebAssembly.Module(require('../llhttp/llhttp_simd-wasm.js'))
-  } catch (e) {
+  } catch {
     /* istanbul ignore next */
 
     // We could check if the error was caused by the simd option not


### PR DESCRIPTION
We can savely remove exception in the `catch (e)` head if we dont process it.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
