### PR TITLE
fix: remove async on `[kClose]` and `[kDestroy]`, only return Promise

### DIFF
--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -110,24 +110,24 @@ class Agent extends DispatcherBase {
     return dispatcher.dispatch(opts, handler)
   }
 
-  async [kClose] () {
+  [kClose] () {
     const closePromises = []
     for (const { dispatcher } of this[kClients].values()) {
       closePromises.push(dispatcher.close())
     }
     this[kClients].clear()
 
-    await Promise.all(closePromises)
+    return Promise.all(closePromises)
   }
 
-  async [kDestroy] (err) {
+  [kDestroy] (err) {
     const destroyPromises = []
     for (const { dispatcher } of this[kClients].values()) {
       destroyPromises.push(dispatcher.destroy(err))
     }
     this[kClients].clear()
 
-    await Promise.all(destroyPromises)
+    return Promise.all(destroyPromises)
   }
 
   get stats () {

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -760,7 +760,7 @@ function onParserTimeout (parser) {
  * @param {import('net').Socket} socket
  * @returns
  */
-async function connectH1 (client, socket) {
+function connectH1 (client, socket) {
   client[kSocket] = socket
 
   if (!llhttpInstance) {

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -77,7 +77,7 @@ function parseH2Headers (headers) {
   return result
 }
 
-async function connectH2 (client, socket) {
+function connectH2 (client, socket) {
   client[kSocket] = socket
 
   const session = http2.connect(client[kUrl], {

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -317,7 +317,7 @@ class Client extends DispatcherBase {
     return this[kNeedDrain] < 2
   }
 
-  async [kClose] () {
+  [kClose] () {
     // TODO: for H2 we need to gracefully flush the remaining enqueued
     // request and close each stream.
     return new Promise((resolve) => {
@@ -329,7 +329,7 @@ class Client extends DispatcherBase {
     })
   }
 
-  async [kDestroy] (err) {
+  [kDestroy] (err) {
     return new Promise((resolve) => {
       const requests = this[kQueue].splice(this[kPendingIdx])
       for (let i = 0; i < requests.length; i++) {
@@ -444,8 +444,8 @@ async function connect (client) {
 
     try {
       client[kHTTPContext] = socket.alpnProtocol === 'h2'
-        ? await connectH2(client, socket)
-        : await connectH1(client, socket)
+        ? connectH2(client, socket)
+        : connectH1(client, socket)
     } catch (err) {
       socket.destroy().on('error', noop)
       throw err

--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -46,24 +46,20 @@ class EnvHttpProxyAgent extends DispatcherBase {
     return agent.dispatch(opts, handler)
   }
 
-  async [kClose] () {
-    await this[kNoProxyAgent].close()
-    if (!this[kHttpProxyAgent][kClosed]) {
-      await this[kHttpProxyAgent].close()
-    }
-    if (!this[kHttpsProxyAgent][kClosed]) {
-      await this[kHttpsProxyAgent].close()
-    }
+  [kClose] () {
+    return Promise.all([
+      this[kNoProxyAgent].close(),
+      !this[kHttpProxyAgent][kClosed] && this[kHttpProxyAgent].close(),
+      !this[kHttpsProxyAgent][kClosed] && this[kHttpsProxyAgent].close()
+    ])
   }
 
-  async [kDestroy] (err) {
-    await this[kNoProxyAgent].destroy(err)
-    if (!this[kHttpProxyAgent][kDestroyed]) {
-      await this[kHttpProxyAgent].destroy(err)
-    }
-    if (!this[kHttpsProxyAgent][kDestroyed]) {
-      await this[kHttpsProxyAgent].destroy(err)
-    }
+  [kDestroy] (err) {
+    return Promise.all([
+      this[kNoProxyAgent].destroy(err),
+      !this[kHttpProxyAgent][kDestroyed] && this[kHttpProxyAgent].destroy(err),
+      !this[kHttpsProxyAgent][kDestroyed] && this[kHttpsProxyAgent].destroy(err)
+    ])
   }
 
   #getProxyAgentForUrl (url) {

--- a/lib/dispatcher/h2c-client.js
+++ b/lib/dispatcher/h2c-client.js
@@ -110,12 +110,12 @@ class H2CClient extends DispatcherBase {
     return this.#client.dispatch(opts, handler)
   }
 
-  async [kClose] () {
-    await this.#client.close()
+  [kClose] () {
+    return this.#client.close()
   }
 
-  async [kDestroy] () {
-    await this.#client.destroy()
+  [kDestroy] () {
+    return this.#client.destroy()
   }
 }
 

--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -108,17 +108,17 @@ class PoolBase extends DispatcherBase {
     return new PoolStats(this)
   }
 
-  async [kClose] () {
+  [kClose] () {
     if (this[kQueue].isEmpty()) {
-      await Promise.all(this[kClients].map(c => c.close()))
+      return Promise.all(this[kClients].map(c => c.close()))
     } else {
-      await new Promise((resolve) => {
+      return new Promise((resolve) => {
         this[kClosedResolve] = resolve
       })
     }
   }
 
-  async [kDestroy] (err) {
+  [kDestroy] (err) {
     while (true) {
       const item = this[kQueue].shift()
       if (!item) {
@@ -127,7 +127,7 @@ class PoolBase extends DispatcherBase {
       item.handler.onError(err)
     }
 
-    await Promise.all(this[kClients].map(c => c.destroy(err)))
+    return Promise.all(this[kClients].map(c => c.destroy(err)))
   }
 
   [kDispatch] (opts, handler) {

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -80,11 +80,11 @@ class Http1ProxyWrapper extends DispatcherBase {
     return this.#client[kDispatch](opts, handler)
   }
 
-  async [kClose] () {
+  [kClose] () {
     return this.#client.close()
   }
 
-  async [kDestroy] (err) {
+  [kDestroy] (err) {
     return this.#client.destroy(err)
   }
 }
@@ -220,14 +220,18 @@ class ProxyAgent extends DispatcherBase {
     }
   }
 
-  async [kClose] () {
-    await this[kAgent].close()
-    await this[kClient].close()
+  [kClose] () {
+    return Promise.all([
+      this[kAgent].close(),
+      this[kClient].close()
+    ])
   }
 
-  async [kDestroy] () {
-    await this[kAgent].destroy()
-    await this[kClient].destroy()
+  [kDestroy] () {
+    return Promise.all([
+      this[kAgent].destroy(),
+      this[kClient].destroy()
+    ])
   }
 }
 


### PR DESCRIPTION
We anyway expect that kClose and kDestroy wont error, when we call them in DispatcherBase. Also we dont want them in the stacktrace.

Also reduces the created promises for a fetch by 2