### PR TITLE
fetch: remove promise in exported fetch

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -4,8 +4,8 @@ const { getGlobalDispatcher, setGlobalDispatcher } = require('./lib/global')
 const EnvHttpProxyAgent = require('./lib/dispatcher/env-http-proxy-agent')
 const fetchImpl = require('./lib/web/fetch').fetch
 
-module.exports.fetch = function fetch (resource, init = undefined) {
-  return fetchImpl(resource, init).catch((err) => {
+module.exports.fetch = function fetch (init, options = undefined) {
+  return fetchImpl(init, options).catch(err => {
     if (err && typeof err === 'object') {
       Error.captureStackTrace(err)
     }

--- a/index.js
+++ b/index.js
@@ -117,16 +117,14 @@ module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
 const fetchImpl = require('./lib/web/fetch').fetch
-module.exports.fetch = async function fetch (init, options = undefined) {
-  try {
-    return await fetchImpl(init, options)
-  } catch (err) {
+
+module.exports.fetch = function fetch (init, options = undefined) {
+  return fetchImpl(init, options).catch(err => {
     if (err && typeof err === 'object') {
       Error.captureStackTrace(err)
     }
-
     throw err
-  }
+  })
 }
 module.exports.Headers = require('./lib/web/fetch/headers').Headers
 module.exports.Response = require('./lib/web/fetch/response').Response

--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -14,7 +14,11 @@ test('FETCH: request errors and prints trimmed stack trace', async (t) => {
   try {
     await fetch('http://a.com')
   } catch (error) {
-    assert.ok(error.stack.includes(`at async TestContext.<anonymous> (${__filename}`))
+    const stackLines = error.stack.split('\n')
+    assert.ok(stackLines[0].includes('TypeError: fetch failed'))
+    assert.ok(stackLines[1].includes('undici/index.js'))
+    assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
+    assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }
 })
 
@@ -22,6 +26,10 @@ test('FETCH-index: request errors and prints trimmed stack trace', async (t) => 
   try {
     await fetchIndex('http://a.com')
   } catch (error) {
-    assert.ok(error.stack.includes(`at async TestContext.<anonymous> (${__filename}`))
+    const stackLines = error.stack.split('\n')
+    assert.ok(stackLines[0].includes('TypeError: fetch failed'))
+    assert.ok(stackLines[1].includes('undici/index-fetch.js'))
+    assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
+    assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }
 })

--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -2,6 +2,7 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert')
+const { sep } = require('node:path')
 const { fetch, setGlobalDispatcher, Agent } = require('../..')
 const { fetch: fetchIndex } = require('../../index-fetch')
 
@@ -16,7 +17,7 @@ test('FETCH: request errors and prints trimmed stack trace', async (t) => {
   } catch (error) {
     const stackLines = error.stack.split('\n')
     assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    assert.ok(stackLines[1].includes('undici/index.js'))
+    assert.ok(stackLines[1].includes(`undici${sep}index.js`))
     assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
     assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }
@@ -28,7 +29,7 @@ test('FETCH-index: request errors and prints trimmed stack trace', async (t) => 
   } catch (error) {
     const stackLines = error.stack.split('\n')
     assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    assert.ok(stackLines[1].includes('undici/index-fetch.js'))
+    assert.ok(stackLines[1].includes(`undici${sep}index-fetch.js`))
     assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
     assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }


### PR DESCRIPTION
This PR avoids one additional promise in success cases in the exported fetch wrapper.