### PR TITLE
perf: make `client.connect()` sync

### DIFF
--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -381,9 +381,9 @@ function onError (client, err) {
 
 /**
  * @param {Client} client
- * @returns
+ * @returns {void}
  */
-async function connect (client) {
+function connect (client) {
   assert(!client[kConnecting])
   assert(!client[kHTTPContext])
 
@@ -417,26 +417,23 @@ async function connect (client) {
     })
   }
 
-  try {
-    const socket = await new Promise((resolve, reject) => {
-      client[kConnector]({
-        host,
-        hostname,
-        protocol,
-        port,
-        servername: client[kServerName],
-        localAddress: client[kLocalAddress]
-      }, (err, socket) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(socket)
-        }
-      })
-    })
+  client[kConnector]({
+    host,
+    hostname,
+    protocol,
+    port,
+    servername: client[kServerName],
+    localAddress: client[kLocalAddress]
+  }, (err, socket) => {
+    if (err) {
+      handleConnectError(client, err, { host, hostname, protocol, port })
+      client[kResume]()
+      return
+    }
 
     if (client.destroyed) {
       util.destroy(socket.on('error', noop), new ClientDestroyedError())
+      client[kResume]()
       return
     }
 
@@ -448,7 +445,9 @@ async function connect (client) {
         : connectH1(client, socket)
     } catch (err) {
       socket.destroy().on('error', noop)
-      throw err
+      handleConnectError(client, err, { host, hostname, protocol, port })
+      client[kResume]()
+      return
     }
 
     client[kConnecting] = false
@@ -473,44 +472,46 @@ async function connect (client) {
         socket
       })
     }
+
     client.emit('connect', client[kUrl], [client])
-  } catch (err) {
-    if (client.destroyed) {
-      return
-    }
+    client[kResume]()
+  })
+}
 
-    client[kConnecting] = false
-
-    if (channels.connectError.hasSubscribers) {
-      channels.connectError.publish({
-        connectParams: {
-          host,
-          hostname,
-          protocol,
-          port,
-          version: client[kHTTPContext]?.version,
-          servername: client[kServerName],
-          localAddress: client[kLocalAddress]
-        },
-        connector: client[kConnector],
-        error: err
-      })
-    }
-
-    if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
-      assert(client[kRunning] === 0)
-      while (client[kPending] > 0 && client[kQueue][client[kPendingIdx]].servername === client[kServerName]) {
-        const request = client[kQueue][client[kPendingIdx]++]
-        util.errorRequest(client, request, err)
-      }
-    } else {
-      onError(client, err)
-    }
-
-    client.emit('connectionError', client[kUrl], [client], err)
+function handleConnectError (client, err, { host, hostname, protocol, port }) {
+  if (client.destroyed) {
+    return
   }
 
-  client[kResume]()
+  client[kConnecting] = false
+
+  if (channels.connectError.hasSubscribers) {
+    channels.connectError.publish({
+      connectParams: {
+        host,
+        hostname,
+        protocol,
+        port,
+        version: client[kHTTPContext]?.version,
+        servername: client[kServerName],
+        localAddress: client[kLocalAddress]
+      },
+      connector: client[kConnector],
+      error: err
+    })
+  }
+
+  if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
+    assert(client[kRunning] === 0)
+    while (client[kPending] > 0 && client[kQueue][client[kPendingIdx]].servername === client[kServerName]) {
+      const request = client[kQueue][client[kPendingIdx]++]
+      util.errorRequest(client, request, err)
+    }
+  } else {
+    onError(client, err)
+  }
+
+  client.emit('connectionError', client[kUrl], [client], err)
 }
 
 function emitDrain (client) {


### PR DESCRIPTION
Reduces the amount of promises for a simple fetch by 3.