### PR TITLE
Resolve .localhost to loopback per Fetch spec

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -60,6 +60,7 @@ function isLocalhostPublicSuffix (hostname) {
   return h === 'localhost' || h.endsWith('.localhost')
 }
 
+// https://nodejs.org/download/release/v9.10.1/docs/api/dns.html#dns_dns_lookup_hostname_options_callback
 // Custom DNS lookup that resolves any *.localhost name to loopback addresses
 // Returns both ::1 and 127.0.0.1 when opts.all is true, otherwise
 // respects requested family, defaulting to IPv4 for maximal compatibility.
@@ -71,10 +72,12 @@ function localhostLookup (_host, opts, cb) {
 
   const all = !!(opts && opts.all)
   const family = opts && opts.family
+  const ipv4 = '127.0.0.1'
+  const ipv6 = '::1'
 
   const results = [
-    { address: '::1', family: 6 },
-    { address: '127.0.0.1', family: 4 }
+    { address: ipv6, family: 6 },
+    { address: ipv4, family: 4 }
   ]
 
   if (all) {
@@ -83,16 +86,16 @@ function localhostLookup (_host, opts, cb) {
   }
 
   if (family === 6) {
-    cb(null, '::1', 6)
+    cb(null, ipv6, 6)
     return
   }
   if (family === 4) {
-    cb(null, '127.0.0.1', 4)
+    cb(null, ipv4, 4)
     return
   }
 
   // Default to IPv4 to avoid environments without IPv6
-  cb(null, '127.0.0.1', 4)
+  cb(null, ipv4, 4)
 }
 
 function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, session: customSession, ...opts }) {

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -60,7 +60,7 @@ function isLocalhostPublicSuffix (hostname) {
   return h === 'localhost' || h.endsWith('.localhost')
 }
 
-// https://nodejs.org/download/release/v9.10.1/docs/api/dns.html#dns_dns_lookup_hostname_options_callback
+// https://nodejs.org/download/release/v24.6.0/docs/api/dns.html#dns_dns_lookup_hostname_options_callback
 // Custom DNS lookup that resolves any *.localhost name to loopback addresses
 // Returns both ::1 and 127.0.0.1 when opts.all is true, otherwise
 // respects requested family, defaulting to IPv4 for maximal compatibility.

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -43,6 +43,58 @@ const SessionCache = class WeakSessionCache {
   }
 }
 
+// Implements the relevant part of "resolve an origin" for localhost public suffix
+// https://fetch.spec.whatwg.org/#resolve-an-origin
+function isLocalhostPublicSuffix (hostname) {
+  if (!hostname || typeof hostname !== 'string') {
+    return false
+  }
+
+  // Normalize trailing dot and casing
+  let h = hostname.toLowerCase()
+  if (h[h.length - 1] === '.') {
+    h = h.slice(0, -1)
+  }
+
+  // Exact localhost or any subdomain of .localhost
+  return h === 'localhost' || h.endsWith('.localhost')
+}
+
+// Custom DNS lookup that resolves any *.localhost name to loopback addresses
+// Returns both ::1 and 127.0.0.1 when opts.all is true, otherwise
+// respects requested family, defaulting to IPv4 for maximal compatibility.
+function localhostLookup (_host, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+
+  const all = !!(opts && opts.all)
+  const family = opts && opts.family
+
+  const results = [
+    { address: '::1', family: 6 },
+    { address: '127.0.0.1', family: 4 }
+  ]
+
+  if (all) {
+    cb(null, results)
+    return
+  }
+
+  if (family === 6) {
+    cb(null, '::1', 6)
+    return
+  }
+  if (family === 4) {
+    cb(null, '127.0.0.1', 4)
+    return
+  }
+
+  // Default to IPv4 to avoid environments without IPv6
+  cb(null, '127.0.0.1', 4)
+}
+
 function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, session: customSession, ...opts }) {
   if (maxCachedSessions != null && (!Number.isInteger(maxCachedSessions) || maxCachedSessions < 0)) {
     throw new InvalidArgumentError('maxCachedSessions must be a positive integer or zero')
@@ -67,7 +119,7 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, sess
 
       port = port || 443
 
-      socket = tls.connect({
+      const tlsOptions = {
         highWaterMark: 16384, // TLS in node can't have bigger HWM anyway...
         ...options,
         servername,
@@ -77,7 +129,14 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, sess
         socket: httpSocket, // upgrade socket connection
         port,
         host: hostname
-      })
+      }
+
+      // Spec: If public suffix is localhost, resolve to loopback
+      if (isLocalhostPublicSuffix(hostname)) {
+        tlsOptions.lookup = localhostLookup
+      }
+
+      socket = tls.connect(tlsOptions)
 
       socket
         .on('session', function (session) {
@@ -89,13 +148,20 @@ function buildConnector ({ allowH2, maxCachedSessions, socketPath, timeout, sess
 
       port = port || 80
 
-      socket = net.connect({
+      const netOptions = {
         highWaterMark: 64 * 1024, // Same as nodejs fs streams.
         ...options,
         localAddress,
         port,
         host: hostname
-      })
+      }
+
+      // Spec: If public suffix is localhost, resolve to loopback
+      if (isLocalhostPublicSuffix(hostname)) {
+        netOptions.lookup = localhostLookup
+      }
+
+      socket = net.connect(netOptions)
     }
 
     // Set TCP keep alive options on the socket here instead of in connect() for the case of assigning the socket

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -60,7 +60,7 @@ function isLocalhostPublicSuffix (hostname) {
   return h === 'localhost' || h.endsWith('.localhost')
 }
 
-// https://nodejs.org/download/release/v24.6.0/docs/api/dns.html#dns_dns_lookup_hostname_options_callback
+// https://nodejs.org/api/dns.html#dnslookuphostname-options-callback
 // Custom DNS lookup that resolves any *.localhost name to loopback addresses
 // Returns both ::1 and 127.0.0.1 when opts.all is true, otherwise
 // respects requested family, defaulting to IPv4 for maximal compatibility.

--- a/test/client-localhost-resolution.js
+++ b/test/client-localhost-resolution.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const http = require('node:http')
+const { Client } = require('..')
+
+async function withServer (handler, fn) {
+  const server = http.createServer(handler)
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const { port } = server.address()
+    return await fn({ port })
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+test('core Client resolves subdomains of localhost to loopback', async () => {
+  await withServer((req, res) => {
+    res.statusCode = 200
+    res.setHeader('content-type', 'text/plain')
+    res.end('ok')
+  }, async ({ port }) => {
+    const urls = [
+      `http://sub.localhost:${port}`,
+      `http://sub.localhost.:${port}`,
+      `http://a.b.localhost:${port}`
+    ]
+
+    for (const origin of urls) {
+      const client = new Client(origin)
+      await new Promise((resolve, reject) => {
+        client.request({ path: '/', method: 'GET' }, (err, data) => {
+          if (err) return reject(err)
+          let body = ''
+          data.body.on('data', (chunk) => { body += String(chunk) })
+          data.body.on('end', () => {
+            try {
+              assert.strictEqual(data.statusCode, 200)
+              assert.strictEqual(body, 'ok')
+              client.close(() => resolve())
+            } catch (e) {
+              reject(e)
+            }
+          })
+        })
+      })
+    }
+  })
+})

--- a/test/fetch/localhost-resolution.js
+++ b/test/fetch/localhost-resolution.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const http = require('node:http')
+const { fetch } = require('../..')
+
+async function withServer (handler, fn) {
+  const server = http.createServer(handler)
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const { port } = server.address()
+    return await fn({ port })
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+test('fetch resolves subdomains of localhost to loopback', async (t) => {
+  await withServer((req, res) => {
+    res.statusCode = 200
+    res.setHeader('content-type', 'text/plain')
+    res.end('ok')
+  }, async ({ port }) => {
+    const urls = [
+      `http://sub.localhost:${port}/`,
+      `http://sub.localhost.:${port}/`,
+      `http://a.b.localhost:${port}/`
+    ]
+
+    for (const url of urls) {
+      const resp = await fetch(url)
+      assert.strictEqual(resp.ok, true)
+      assert.strictEqual(resp.status, 200)
+      assert.strictEqual(await resp.text(), 'ok')
+    }
+  })
+})

--- a/test/fetch/localhost-resolution.js
+++ b/test/fetch/localhost-resolution.js
@@ -4,6 +4,7 @@ const { test } = require('node:test')
 const assert = require('node:assert')
 const http = require('node:http')
 const { fetch } = require('../..')
+const diagnosticsChannel = require('node:diagnostics_channel')
 
 async function withServer (handler, fn) {
   const server = http.createServer(handler)
@@ -17,22 +18,40 @@ async function withServer (handler, fn) {
 }
 
 test('fetch resolves subdomains of localhost to loopback', async (t) => {
-  await withServer((req, res) => {
-    res.statusCode = 200
-    res.setHeader('content-type', 'text/plain')
-    res.end('ok')
-  }, async ({ port }) => {
-    const urls = [
-      `http://sub.localhost:${port}/`,
-      `http://sub.localhost.:${port}/`,
-      `http://a.b.localhost:${port}/`
-    ]
+  const connected = diagnosticsChannel.channel('undici:client:connected')
+  const seen = []
+  const onConnected = (evt) => {
+    seen.push({ hostname: evt.connectParams.hostname, address: evt.socket.remoteAddress })
+  }
+  connected.subscribe(onConnected)
+  try {
+    await withServer((req, res) => {
+      res.statusCode = 200
+      res.setHeader('content-type', 'text/plain')
+      res.end('ok')
+    }, async ({ port }) => {
+      const urls = [
+        `http://sub.localhost:${port}/`,
+        `http://sub.localhost.:${port}/`,
+        `http://a.b.localhost:${port}/`
+      ]
 
-    for (const url of urls) {
-      const resp = await fetch(url)
-      assert.strictEqual(resp.ok, true)
-      assert.strictEqual(resp.status, 200)
-      assert.strictEqual(await resp.text(), 'ok')
-    }
-  })
+      for (const url of urls) {
+        const resp = await fetch(url)
+        assert.strictEqual(resp.ok, true)
+        assert.strictEqual(resp.status, 200)
+        assert.strictEqual(await resp.text(), 'ok')
+      }
+
+      assert.strictEqual(seen.length, 3)
+      for (const { address } of seen) {
+        assert.ok(
+          address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1',
+          `expected loopback, got ${address}`
+        )
+      }
+    })
+  } finally {
+    connected.unsubscribe(onConnected)
+  }
 })


### PR DESCRIPTION
## This relates to...
#4391

## Rationale
Align localhost public-suffix resolution with the Fetch spec (Resolving domains -> “resolve an origin”): any `localhost` or `*.localhost` host resolves to loopback.  
Spec: [Fetch 2.5 resolve an origin](https://fetch.spec.whatwg.org/#resolve-an-origin)

## Changes/Fixes
- Add `isLocalhostPublicSuffix(hostname)`
- Inject custom [`lookup`](https://nodejs.org/api/dns.html#dnslookuphostname-options-callback) (`localhostLookup`) for both net and TLS paths to short‑circuit DNS for `.localhost`
- No change for non‑`localhost` hosts or literal IPs


## Status
- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin