### PR TITLE
test: remove skip check for AbortSignal.timeout, as it exists since node18

### DIFF
--- a/test/fetch/issue-2171.js
+++ b/test/fetch/issue-2171.js
@@ -7,7 +7,7 @@ const { test } = require('node:test')
 const assert = require('node:assert')
 const { closeServerAsPromise } = require('../utils/node-http')
 
-test('error reason is forwarded - issue #2171', { skip: !AbortSignal.timeout }, async (t) => {
+test('error reason is forwarded - issue #2171', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, () => {}).listen(0)
 
   t.after(closeServerAsPromise(server))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
