### PR TITLE
test: fix IPv6 skip check for test/client.js

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -15,7 +15,7 @@ const hasIPv6 = (() => {
   const iFaces = require('node:os').networkInterfaces()
   const re = process.platform === 'win32' ? /Loopback Pseudo-Interface/ : /lo/
   return Object.keys(iFaces).some(
-    (name) => re.test(name) && iFaces[name].some(({ family }) => family === 6)
+    (name) => re.test(name) && iFaces[name].some(({ family }) => family === 'IPv6')
   )
 })()
 
@@ -427,7 +427,7 @@ test('basic head', async (t) => {
 })
 
 test('basic head (IPv6)', { skip: !hasIPv6 }, async (t) => {
-  t = tspl(t, { plan: 15 })
+  t = tspl(t, { plan: 10 })
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/123', req.url)


### PR DESCRIPTION
the skip check was wrong, and deactivating IPv6 test always,even if IPv6 was present

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
