### PR TITLE
fix: buildAndValidateMockOptions should always get an object passed and always return an object

### DIFF
--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -29,16 +29,16 @@ const PendingInterceptorsFormatter = require('./pending-interceptors-formatter')
 const { MockCallHistory } = require('./mock-call-history')
 
 class MockAgent extends Dispatcher {
-  constructor (opts) {
+  constructor (opts = {}) {
     super(opts)
 
     const mockOptions = buildAndValidateMockOptions(opts)
 
     this[kNetConnect] = true
     this[kIsMockActive] = true
-    this[kMockAgentIsCallHistoryEnabled] = mockOptions?.enableCallHistory ?? false
-    this[kMockAgentAcceptsNonStandardSearchParameters] = mockOptions?.acceptNonStandardSearchParameters ?? false
-    this[kIgnoreTrailingSlash] = mockOptions?.ignoreTrailingSlash ?? false
+    this[kMockAgentIsCallHistoryEnabled] = mockOptions.enableCallHistory ?? false
+    this[kMockAgentAcceptsNonStandardSearchParameters] = mockOptions.acceptNonStandardSearchParameters ?? false
+    this[kIgnoreTrailingSlash] = mockOptions.ignoreTrailingSlash ?? false
 
     // Instantiate Agent and encapsulate
     if (opts?.agent && typeof opts.agent.dispatch !== 'function') {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -398,19 +398,21 @@ function checkNetConnect (netConnect, origin) {
 }
 
 function buildAndValidateMockOptions (opts) {
-  if (opts) {
-    const { agent, ...mockOptions } = opts
+  const { agent, ...mockOptions } = opts
 
-    if ('enableCallHistory' in mockOptions && typeof mockOptions.enableCallHistory !== 'boolean') {
-      throw new InvalidArgumentError('options.enableCallHistory must to be a boolean')
-    }
-
-    if ('acceptNonStandardSearchParameters' in mockOptions && typeof mockOptions.acceptNonStandardSearchParameters !== 'boolean') {
-      throw new InvalidArgumentError('options.acceptNonStandardSearchParameters must to be a boolean')
-    }
-
-    return mockOptions
+  if ('enableCallHistory' in mockOptions && typeof mockOptions.enableCallHistory !== 'boolean') {
+    throw new InvalidArgumentError('options.enableCallHistory must to be a boolean')
   }
+
+  if ('acceptNonStandardSearchParameters' in mockOptions && typeof mockOptions.acceptNonStandardSearchParameters !== 'boolean') {
+    throw new InvalidArgumentError('options.acceptNonStandardSearchParameters must to be a boolean')
+  }
+
+  if ('ignoreTrailingSlash' in mockOptions && typeof mockOptions.ignoreTrailingSlash !== 'boolean') {
+    throw new InvalidArgumentError('options.ignoreTrailingSlash must to be a boolean')
+  }
+
+  return mockOptions
 }
 
 module.exports = {


### PR DESCRIPTION
removes a sonarjs/no-inconsistent-returns code smell

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
