### PR TITLE
fix: remove useless catch in client-h1.js

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -325,10 +325,6 @@ class Parser {
         currentBufferRef = chunk
         currentParser = this
         ret = llhttp.llhttp_execute(this.ptr, currentBufferPtr, chunk.length)
-        /* eslint-disable-next-line no-useless-catch */
-      } catch (err) {
-        /* istanbul ignore next: difficult to make a test case for */
-        throw err
       } finally {
         currentParser = null
         currentBufferRef = null
@@ -716,6 +712,7 @@ class Parser {
     } else if (!shouldKeepAlive) {
       util.destroy(socket, new InformationalError('reset'))
       return constants.ERROR.PAUSED
+    // eslint-disable-next-line sonarjs/no-duplicated-branches
     } else if (socket[kReset] && client[kRunning] === 0) {
       // Destroy socket once all requests have completed.
       // The request at the tail of the pipeline is the one

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -712,7 +712,6 @@ class Parser {
     } else if (!shouldKeepAlive) {
       util.destroy(socket, new InformationalError('reset'))
       return constants.ERROR.PAUSED
-    // eslint-disable-next-line sonarjs/no-duplicated-branches
     } else if (socket[kReset] && client[kRunning] === 0) {
       // Destroy socket once all requests have completed.
       // The request at the tail of the pipeline is the one


### PR DESCRIPTION
If we just rethrow then we can remove the catch anyway. sonarjs shows useless-catch error

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
