### PR TITLE
fix: 'no-referrer-when-downgrade' in determineRequestsReferrer  should return referrerURL

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -502,8 +502,8 @@ function determineRequestsReferrer (request) {
       if (isURLPotentiallyTrustworthy(referrerURL) && !isURLPotentiallyTrustworthy(currentURL)) {
         return 'no-referrer'
       }
-      // 2. Return referrerOrigin
-      return referrerOrigin
+      // 2. Return referrerURL.
+      return referrerURL
     }
   }
 }


### PR DESCRIPTION
Implementation error accidently found by sonarjs. Reported a duplicate block. Checked the spec and realized that  'no-referrer-when-downgrade' was not properly implemented.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
