### PR TITLE
test (pool.js): fix flakyness of clientTtl  test

### DIFF
--- a/test/pool.js
+++ b/test/pool.js
@@ -579,11 +579,9 @@ test('pool connect', async (t) => {
 })
 
 test('pool connect with clientTtl specified', async (t) => {
-  t = tspl(t, { plan: 1 })
+  t = tspl(t, { plan: 3 })
 
-  const server = createServer({ joinDuplicateHeaders: true }, (c) => {
-    t.fail()
-  })
+  const server = createServer({ joinDuplicateHeaders: true }, t.fail)
   server.on('connect', (req, socket, firstBodyChunk) => {
     socket.write('HTTP/1.1 200 Connection established\r\n\r\n')
 
@@ -607,7 +605,7 @@ test('pool connect with clientTtl specified', async (t) => {
       path: '/'
     })
 
-    t.strictEqual(socket.closed, false)
+    t.strictEqual(socket.closed, false, 'client not closed yet')
 
     let recvData = ''
     socket.on('data', (d) => {
@@ -619,10 +617,12 @@ test('pool connect with clientTtl specified', async (t) => {
     })
 
     socket.write('Body')
-    socket.end()
+    await new Promise((resolve, reject) => socket.end((e) => e ? reject(e) : resolve()))
+
+    t.strictEqual(socket.closed, false, 'client not closed yet')
 
     await new Promise(resolve => setTimeout(resolve, 10))
-    t.strictEqual(socket.closed, true)
+    t.strictEqual(socket.closed, true, 'client closed after ttl')
   })
 
   await t.completed


### PR DESCRIPTION
I could reproduce it locally on my linux machine, by putting the failing test in a for loop and running it 1e3 times. 

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
