### PR TITLE
test: skip flaky encoding test on macos and node20

### DIFF
--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -8,7 +8,9 @@ const { fetch } = require('../..')
 const zlib = require('node:zlib')
 const { closeServerAsPromise } = require('../utils/node-http')
 
-test('content-encoding header is case-iNsENsITIve', async (t) => {
+const skip = process.versions.node.split('.').map(Number)[0] === 20 && process.platform === 'darwin'
+
+test('content-encoding header is case-iNsENsITIve', { skip }, async (t) => {
   const contentCodings = 'GZiP, bR'
   const text = 'Hello, World!'
   const gzipBrotliText = Buffer.from('CxCAH4sIAAAAAAAAA/NIzcnJ11EIzy/KSVEEANDDSuwNAAAAAw==', 'base64')


### PR DESCRIPTION
Lets skip this god forsaken test 

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
