### PR TITLE
test (websocket): speed up test/websocket/issue-2679.js

### DIFF
--- a/test/websocket/issue-2679.js
+++ b/test/websocket/issue-2679.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { test, after } = require('node:test')
 const assert = require('node:assert')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -8,13 +8,15 @@ const { WebSocket } = require('../..')
 
 test('Close without receiving code does not send an invalid payload', async () => {
   const server = new WebSocketServer({ port: 0 })
+  after(() => {
+    server.close()
+    return once(server, 'close')
+  })
 
   await once(server, 'listening')
 
   server.on('connection', (sock, request) => {
-    setTimeout(() => {
-      sock.close()
-    }, 3000)
+    sock.close()
   })
 
   server.on('error', (err) => assert.ifError(err))
@@ -23,7 +25,4 @@ test('Close without receiving code does not send an invalid payload', async () =
   await once(client, 'open')
 
   await once(client, 'close')
-
-  server.close()
-  await once(server, 'close')
 })


### PR DESCRIPTION
The test takes excessively long. i tested against the codebase, which had the bug we test against, and it will still take cover that bug. 

npm run test:websocket will because of this change run on my machine in 1.2 sec instead of 3.8 sec.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
