### PR TITLE
webidl: fix existing and add missing buffer source converters

### DIFF
--- a/lib/web/webidl/index.js
+++ b/lib/web/webidl/index.js
@@ -310,6 +310,21 @@ webidl.util.Stringify = function (V) {
   }
 }
 
+webidl.util.IsResizableArrayBuffer = function (V) {
+  if (types.isArrayBuffer(V)) {
+    return V.resizable
+  }
+
+  if (types.isSharedArrayBuffer(V)) {
+    return V.growable
+  }
+
+  throw webidl.errors.exception({
+    header: 'IsResizableArrayBuffer',
+    message: `"${webidl.util.Stringify(V)}" is not an array buffer.`
+  })
+}
+
 // https://webidl.spec.whatwg.org/#es-sequence
 webidl.sequenceConverter = function (converter) {
   return (V, prefix, argument, Iterable) => {
@@ -638,14 +653,15 @@ webidl.converters['unsigned short'] = function (V, prefix, argument, opts) {
 
 // https://webidl.spec.whatwg.org/#idl-ArrayBuffer
 webidl.converters.ArrayBuffer = function (V, prefix, argument, opts) {
-  // 1. If Type(V) is not Object, or V does not have an
+  // 1. If V is not an Object, or V does not have an
   //    [[ArrayBufferData]] internal slot, then throw a
   //    TypeError.
+  // 2. If IsSharedArrayBuffer(V) is true, then throw a
+  //    TypeError.
   // see: https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-instances
-  // see: https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-instances
   if (
     webidl.util.Type(V) !== OBJECT ||
-    !types.isAnyArrayBuffer(V)
+    !types.isArrayBuffer(V)
   ) {
     throw webidl.errors.conversionFailed({
       prefix,
@@ -654,25 +670,14 @@ webidl.converters.ArrayBuffer = function (V, prefix, argument, opts) {
     })
   }
 
-  // 2. If the conversion is not to an IDL type associated
-  //    with the [AllowShared] extended attribute, and
-  //    IsSharedArrayBuffer(V) is true, then throw a
-  //    TypeError.
-  if (opts?.allowShared === false && types.isSharedArrayBuffer(V)) {
-    throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'SharedArrayBuffer is not allowed.'
-    })
-  }
-
   // 3. If the conversion is not to an IDL type associated
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V) is true, then throw a
   //    TypeError.
-  if (V.resizable || V.growable) {
+  if (!opts?.allowResizable && webidl.util.IsResizableArrayBuffer(V)) {
     throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'Received a resizable ArrayBuffer.'
+      header: prefix,
+      message: `${argument} cannot be a resizable ArrayBuffer.`
     })
   }
 
@@ -681,7 +686,43 @@ webidl.converters.ArrayBuffer = function (V, prefix, argument, opts) {
   return V
 }
 
-webidl.converters.TypedArray = function (V, T, prefix, name, opts) {
+// https://webidl.spec.whatwg.org/#idl-SharedArrayBuffer
+webidl.converters.SharedArrayBuffer = function (V, prefix, argument, opts) {
+  // 1. If V is not an Object, or V does not have an
+  //    [[ArrayBufferData]] internal slot, then throw a
+  //    TypeError.
+  // 2. If IsSharedArrayBuffer(V) is false, then throw a
+  //    TypeError.
+  // see: https://tc39.es/ecma262/#sec-properties-of-the-sharedarraybuffer-instances
+  if (
+    webidl.util.Type(V) !== OBJECT ||
+    !types.isSharedArrayBuffer(V)
+  ) {
+    throw webidl.errors.conversionFailed({
+      prefix,
+      argument: `${argument} ("${webidl.util.Stringify(V)}")`,
+      types: ['SharedArrayBuffer']
+    })
+  }
+
+  // 3. If the conversion is not to an IDL type associated
+  //    with the [AllowResizable] extended attribute, and
+  //    IsResizableArrayBuffer(V) is true, then throw a
+  //    TypeError.
+  if (!opts?.allowResizable && webidl.util.IsResizableArrayBuffer(V)) {
+    throw webidl.errors.exception({
+      header: prefix,
+      message: `${argument} cannot be a resizable SharedArrayBuffer.`
+    })
+  }
+
+  // 4. Return the IDL SharedArrayBuffer value that is a
+  //    reference to the same object as V.
+  return V
+}
+
+// https://webidl.spec.whatwg.org/#dfn-typed-array-type
+webidl.converters.TypedArray = function (V, T, prefix, argument, opts) {
   // 1. Let T be the IDL type V is being converted to.
 
   // 2. If Type(V) is not Object, or V does not have a
@@ -694,7 +735,7 @@ webidl.converters.TypedArray = function (V, T, prefix, name, opts) {
   ) {
     throw webidl.errors.conversionFailed({
       prefix,
-      argument: `${name} ("${webidl.util.Stringify(V)}")`,
+      argument: `${argument} ("${webidl.util.Stringify(V)}")`,
       types: [T.name]
     })
   }
@@ -703,10 +744,10 @@ webidl.converters.TypedArray = function (V, T, prefix, name, opts) {
   //    with the [AllowShared] extended attribute, and
   //    IsSharedArrayBuffer(V.[[ViewedArrayBuffer]]) is
   //    true, then throw a TypeError.
-  if (opts?.allowShared === false && types.isSharedArrayBuffer(V.buffer)) {
+  if (!opts?.allowShared && types.isSharedArrayBuffer(V.buffer)) {
     throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'SharedArrayBuffer is not allowed.'
+      header: prefix,
+      message: `${argument} cannot be a view on a shared array buffer.`
     })
   }
 
@@ -714,10 +755,10 @@ webidl.converters.TypedArray = function (V, T, prefix, name, opts) {
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
   //    true, then throw a TypeError.
-  if (V.buffer.resizable || V.buffer.growable) {
+  if (!opts?.allowResizable && webidl.util.IsResizableArrayBuffer(V.buffer)) {
     throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'Received a resizable ArrayBuffer.'
+      header: prefix,
+      message: `${argument} cannot be a view on a resizable array buffer.`
     })
   }
 
@@ -726,13 +767,15 @@ webidl.converters.TypedArray = function (V, T, prefix, name, opts) {
   return V
 }
 
-webidl.converters.DataView = function (V, prefix, name, opts) {
+// https://webidl.spec.whatwg.org/#idl-DataView
+webidl.converters.DataView = function (V, prefix, argument, opts) {
   // 1. If Type(V) is not Object, or V does not have a
   //    [[DataView]] internal slot, then throw a TypeError.
   if (webidl.util.Type(V) !== OBJECT || !types.isDataView(V)) {
-    throw webidl.errors.exception({
-      header: prefix,
-      message: `${name} is not a DataView.`
+    throw webidl.errors.conversionFailed({
+      prefix,
+      argument: `${argument} ("${webidl.util.Stringify(V)}")`,
+      types: ['DataView']
     })
   }
 
@@ -740,10 +783,10 @@ webidl.converters.DataView = function (V, prefix, name, opts) {
   //    with the [AllowShared] extended attribute, and
   //    IsSharedArrayBuffer(V.[[ViewedArrayBuffer]]) is true,
   //    then throw a TypeError.
-  if (opts?.allowShared === false && types.isSharedArrayBuffer(V.buffer)) {
+  if (!opts?.allowShared && types.isSharedArrayBuffer(V.buffer)) {
     throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'SharedArrayBuffer is not allowed.'
+      header: prefix,
+      message: `${argument} cannot be a view on a shared array buffer.`
     })
   }
 
@@ -751,16 +794,98 @@ webidl.converters.DataView = function (V, prefix, name, opts) {
   //    with the [AllowResizable] extended attribute, and
   //    IsResizableArrayBuffer(V.[[ViewedArrayBuffer]]) is
   //    true, then throw a TypeError.
-  if (V.buffer.resizable || V.buffer.growable) {
+  if (!opts?.allowResizable && webidl.util.IsResizableArrayBuffer(V.buffer)) {
     throw webidl.errors.exception({
-      header: 'ArrayBuffer',
-      message: 'Received a resizable ArrayBuffer.'
+      header: prefix,
+      message: `${argument} cannot be a view on a resizable array buffer.`
     })
   }
 
   // 4. Return the IDL DataView value that is a reference
   //    to the same object as V.
   return V
+}
+
+// https://webidl.spec.whatwg.org/#ArrayBufferView
+webidl.converters.ArrayBufferView = function (V, prefix, argument, opts) {
+  if (
+    webidl.util.Type(V) !== OBJECT ||
+    !types.isArrayBufferView(V)
+  ) {
+    throw webidl.errors.conversionFailed({
+      prefix,
+      argument: `${argument} ("${webidl.util.Stringify(V)}")`,
+      types: ['ArrayBufferView']
+    })
+  }
+
+  if (!opts?.allowShared && types.isSharedArrayBuffer(V.buffer)) {
+    throw webidl.errors.exception({
+      header: prefix,
+      message: `${argument} cannot be a view on a shared array buffer.`
+    })
+  }
+
+  if (!opts?.allowResizable && webidl.util.IsResizableArrayBuffer(V.buffer)) {
+    throw webidl.errors.exception({
+      header: prefix,
+      message: `${argument} cannot be a view on a resizable array buffer.`
+    })
+  }
+
+  return V
+}
+
+// https://webidl.spec.whatwg.org/#BufferSource
+webidl.converters.BufferSource = function (V, prefix, argument, opts) {
+  if (types.isArrayBuffer(V)) {
+    return webidl.converters.ArrayBuffer(V, prefix, argument, opts)
+  }
+
+  if (types.isArrayBufferView(V)) {
+    return webidl.converters.ArrayBufferView(V, prefix, argument, {
+      ...opts,
+      allowShared: false
+    })
+  }
+
+  // Make this explicit for easier debugging
+  if (types.isSharedArrayBuffer(V)) {
+    throw webidl.errors.exception({
+      header: prefix,
+      message: `${argument} cannot be a SharedArrayBuffer.`
+    })
+  }
+
+  throw webidl.errors.conversionFailed({
+    prefix,
+    argument: `${argument} ("${webidl.util.Stringify(V)}")`,
+    types: ['ArrayBuffer', 'ArrayBufferView']
+  })
+}
+
+// https://webidl.spec.whatwg.org/#AllowSharedBufferSource
+webidl.converters.AllowSharedBufferSource = function (V, prefix, argument, opts) {
+  if (types.isArrayBuffer(V)) {
+    return webidl.converters.ArrayBuffer(V, prefix, argument, opts)
+  }
+
+  if (types.isSharedArrayBuffer(V)) {
+    return webidl.converters.SharedArrayBuffer(V, prefix, argument, opts)
+  }
+
+  if (types.isArrayBufferView(V)) {
+    return webidl.converters.ArrayBufferView(V, prefix, argument, {
+      ...opts,
+      allowShared: true
+    })
+  }
+
+  throw webidl.errors.conversionFailed({
+    prefix,
+    argument: `${argument} ("${webidl.util.Stringify(V)}")`,
+    types: ['ArrayBuffer', 'SharedArrayBuffer', 'ArrayBufferView']
+  })
 }
 
 webidl.converters['sequence<ByteString>'] = webidl.sequenceConverter(

--- a/test/webidl/converters.js
+++ b/test/webidl/converters.js
@@ -123,82 +123,270 @@ describe('webidl.dictionaryConverter', () => {
   })
 })
 
-test('ArrayBuffer', () => {
-  assert.throws(() => {
-    webidl.converters.ArrayBuffer(true, 'converter', 'converter')
-  }, TypeError)
+describe('buffer source converters', () => {
+  test('ArrayBuffer', () => {
+    assert.throws(() => {
+      webidl.converters.ArrayBuffer(true, 'converter', 'converter')
+    }, TypeError)
 
-  assert.throws(() => {
-    webidl.converters.ArrayBuffer({}, 'converter', 'converter')
-  }, TypeError)
+    assert.throws(() => {
+      webidl.converters.ArrayBuffer({}, 'converter', 'converter')
+    }, TypeError)
 
-  assert.throws(() => {
-    const sab = new SharedArrayBuffer(1024)
-    webidl.converters.ArrayBuffer(sab, 'converter', 'converter', { allowShared: false })
-  }, TypeError)
-
-  assert.doesNotThrow(() => {
-    const sab = new SharedArrayBuffer(1024)
-    webidl.converters.ArrayBuffer(sab, 'converter', 'converter')
-  })
-
-  assert.doesNotThrow(() => {
-    const ab = new ArrayBuffer(8)
-    webidl.converters.ArrayBuffer(ab, 'converter', 'converter')
-  })
-})
-
-test('TypedArray', () => {
-  assert.throws(() => {
-    webidl.converters.TypedArray(3, 'converter', 'converter')
-  }, TypeError)
-
-  assert.throws(() => {
-    webidl.converters.TypedArray({}, 'converter', 'converter')
-  }, TypeError)
-
-  assert.throws(() => {
-    const uint8 = new Uint8Array([1, 2, 3])
-    Object.defineProperty(uint8, 'buffer', {
-      get () {
-        return new SharedArrayBuffer(8)
-      }
+    assert.doesNotThrow(() => {
+      webidl.converters.ArrayBuffer(new ArrayBuffer(8), 'converter', 'converter')
     })
 
-    webidl.converters.TypedArray(uint8, Uint8Array, 'converter', 'converter', {
-      allowShared: false
-    })
-  }, TypeError)
-})
+    assert.throws(() => {
+      webidl.converters.ArrayBuffer(new SharedArrayBuffer(64), 'converter', 'converter')
+    }, TypeError)
 
-test('DataView', () => {
-  assert.throws(() => {
-    webidl.converters.DataView(3, 'converter', 'converter')
-  }, TypeError)
-
-  assert.throws(() => {
-    webidl.converters.DataView({}, 'converter', 'converter')
-  }, TypeError)
-
-  assert.throws(() => {
-    const buffer = new ArrayBuffer(16)
-    const view = new DataView(buffer, 0)
-
-    Object.defineProperty(view, 'buffer', {
-      get () {
-        return new SharedArrayBuffer(8)
-      }
+    assert.throws(() => {
+      webidl.converters.ArrayBuffer(
+        new ArrayBuffer(16, { maxByteLength: 64 }),
+        'converter',
+        'converter'
+      )
     })
 
-    webidl.converters.DataView(view, 'converter', 'converter', {
-      allowShared: false
+    assert.doesNotThrow(() => {
+      webidl.converters.ArrayBuffer(
+        new ArrayBuffer(16, { maxByteLength: 64 }),
+        'converter',
+        'converter',
+        { allowResizable: true }
+      )
     })
   })
 
-  const buffer = new ArrayBuffer(16)
-  const view = new DataView(buffer, 0)
+  test('SharedArrayBuffer', () => {
+    assert.throws(() => {
+      webidl.converters.SharedArrayBuffer(true, 'converter', 'converter')
+    }, TypeError)
 
-  assert.equal(webidl.converters.DataView(view, 'converter', 'converter'), view)
+    assert.throws(() => {
+      webidl.converters.SharedArrayBuffer({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.SharedArrayBuffer(new SharedArrayBuffer(8), 'converter', 'converter')
+    })
+
+    assert.throws(() => {
+      webidl.converters.SharedArrayBuffer(new ArrayBuffer(64), 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.SharedArrayBuffer(
+        new SharedArrayBuffer(16, { maxByteLength: 64 }),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.SharedArrayBuffer(
+        new SharedArrayBuffer(16, { maxByteLength: 64 }),
+        'converter',
+        'converter',
+        { allowResizable: true }
+      )
+    })
+  })
+
+  test('TypedArray', () => {
+    assert.throws(() => {
+      webidl.converters.TypedArray(3, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.TypedArray({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.TypedArray(new Uint8Array(), Uint8Array, 'converter', 'converter')
+    })
+
+    assert.throws(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new SharedArrayBuffer(16)),
+        Uint8Array,
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new SharedArrayBuffer(16)),
+        Uint8Array,
+        'converter',
+        'converter',
+        { allowShared: true }
+      )
+    })
+
+    assert.throws(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new ArrayBuffer(16, { maxByteLength: 32 })),
+        Uint8Array,
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new ArrayBuffer(16, { maxByteLength: 32 })),
+        Uint8Array,
+        'converter',
+        'converter',
+        { allowResizable: true }
+      )
+    })
+
+    assert.throws(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new SharedArrayBuffer(16, { maxByteLength: 32 })),
+        Uint8Array,
+        'converter',
+        'converter',
+        { allowResizable: true }
+      )
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new SharedArrayBuffer(16, { maxByteLength: 32 })),
+        Uint8Array,
+        'converter',
+        'converter',
+        { allowShared: true }
+      )
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.TypedArray(
+        new Uint8Array(new SharedArrayBuffer(16, { maxByteLength: 32 })),
+        Uint8Array,
+        'converter',
+        'converter',
+        { allowResizable: true, allowShared: true }
+      )
+    })
+  })
+
+  test('DataView', () => {
+    assert.throws(() => {
+      webidl.converters.DataView(3, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.DataView({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.DataView(new Uint8Array(), 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.DataView(new DataView(new ArrayBuffer(8)), 'converter', 'converter')
+    })
+
+    assert.throws(() => {
+      webidl.converters.DataView(
+        new DataView(new SharedArrayBuffer(16)),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.DataView(
+        new DataView(new ArrayBuffer(16, { maxByteLength: 64 })),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+  })
+
+  test('ArrayBufferView', () => {
+    assert.throws(() => {
+      webidl.converters.ArrayBufferView(3, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.ArrayBufferView({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.ArrayBufferView(new Uint8Array(), 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.ArrayBufferView(new DataView(new ArrayBuffer(8)), 'converter', 'converter')
+    })
+
+    assert.throws(() => {
+      webidl.converters.ArrayBufferView(
+        new Uint8Array(new SharedArrayBuffer(16)),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.ArrayBufferView(
+        new Float32Array(new ArrayBuffer(16, { maxByteLength: 64 })),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+  })
+
+  test('BufferSource', () => {
+    assert.throws(() => {
+      webidl.converters.BufferSource(3, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.BufferSource({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.BufferSource(new SharedArrayBuffer(16), 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.BufferSource(
+        new Uint8Array(new SharedArrayBuffer(16)),
+        'converter',
+        'converter'
+      )
+    }, TypeError)
+  })
+
+  test('AllowSharedBufferSource', () => {
+    assert.throws(() => {
+      webidl.converters.AllowSharedBufferSource(3, 'converter', 'converter')
+    }, TypeError)
+
+    assert.throws(() => {
+      webidl.converters.AllowSharedBufferSource({}, 'converter', 'converter')
+    }, TypeError)
+
+    assert.doesNotThrow(() => {
+      webidl.converters.AllowSharedBufferSource(new SharedArrayBuffer(16), 'converter', 'converter')
+    })
+
+    assert.doesNotThrow(() => {
+      webidl.converters.AllowSharedBufferSource(
+        new Uint8Array(new SharedArrayBuffer(16)),
+        'converter',
+        'converter'
+      )
+    })
+  })
 })
 
 test('ByteString', () => {

--- a/types/webidl.d.ts
+++ b/types/webidl.d.ts
@@ -94,6 +94,8 @@ interface WebidlUtil {
    * This is only effective in some newer Node.js versions.
    */
   markAsUncloneable (V: any): void
+
+  IsResizableArrayBuffer (V: ArrayBufferLike): boolean
 }
 
 interface WebidlConverters {
@@ -147,34 +149,82 @@ interface WebidlConverters {
   /**
    * @see https://webidl.spec.whatwg.org/#idl-ArrayBuffer
    */
-  ArrayBuffer (V: unknown): ArrayBufferLike
-  ArrayBuffer (V: unknown, opts: { allowShared: false }): ArrayBuffer
+  ArrayBuffer (
+    V: unknown,
+    prefix: string,
+    argument: string,
+    options?: { allowResizable: boolean }
+  ): ArrayBuffer
+
+  /**
+   * @see https://webidl.spec.whatwg.org/#idl-SharedArrayBuffer
+   */
+  SharedArrayBuffer (
+    V: unknown,
+    prefix: string,
+    argument: string,
+    options?: { allowResizable: boolean }
+  ): SharedArrayBuffer
 
   /**
    * @see https://webidl.spec.whatwg.org/#es-buffer-source-types
    */
   TypedArray (
     V: unknown,
-    TypedArray: NodeJS.TypedArray | ArrayBufferLike
-  ): NodeJS.TypedArray | ArrayBufferLike
-  TypedArray (
-    V: unknown,
-    TypedArray: NodeJS.TypedArray | ArrayBufferLike,
-    opts?: { allowShared: false }
-  ): NodeJS.TypedArray | ArrayBuffer
+    T: new () => NodeJS.TypedArray,
+    prefix: string,
+    argument: string,
+    opts?: {
+      allowResizable: boolean
+      allowShared: boolean
+    }
+  ): NodeJS.TypedArray
 
   /**
    * @see https://webidl.spec.whatwg.org/#es-buffer-source-types
    */
-  DataView (V: unknown, opts?: { allowShared: boolean }): DataView
+  DataView (
+    V: unknown,
+    prefix: string,
+    argument: string,
+    opts?: {
+      allowResizable: boolean
+      allowShared: boolean
+    }
+  ): DataView
+
+  /**
+   * @see https://webidl.spec.whatwg.org/#es-buffer-source-types
+   */
+  ArrayBufferView (
+    V: unknown,
+    prefix: string,
+    argument: string,
+    opts?: {
+      allowResizable: boolean
+      allowShared: boolean
+    }
+  ): NodeJS.ArrayBufferView
 
   /**
    * @see https://webidl.spec.whatwg.org/#BufferSource
    */
   BufferSource (
     V: unknown,
-    opts?: { allowShared: boolean }
-  ): NodeJS.TypedArray | ArrayBufferLike | DataView
+    prefix: string,
+    argument: string,
+    opts?: { allowResizable: boolean }
+  ): ArrayBuffer | NodeJS.ArrayBufferView
+
+  /**
+   * @see https://webidl.spec.whatwg.org/#AllowSharedBufferSource
+   */
+  AllowSharedBufferSource (
+    V: unknown,
+    prefix: string,
+    argument: string,
+    opts?: { allowResizable: boolean }
+  ): ArrayBuffer | SharedArrayBuffer | NodeJS.ArrayBufferView
 
   ['sequence<ByteString>']: SequenceConverter<string>
 


### PR DESCRIPTION
## This relates to...

Aims to provide support for a resolution for #4495.

## Rationale

Factors contributing to the specification divergence for fetch/websockets as detailed in the linked issue are:
- the required buffer source converters are missing;
- the existing buffer source converters are not used within the codebase;
- those that do exist are out-of-date with the IDL standard.

## Changes

Changes to existing converters:
- `ArrayBuffer` used to convert to either `ArrayBuffer` or `ArrayBuffer | SharedArrayBuffer`, depending on the presence or absence of the `[AllowShared]` attribute. Subsequent changes to the standard have separated these out into separate IDL types, and so this converter has been split into two.
- The `ArrayBuffer` and `SharedArrayBuffer` converters correctly handle the presence or absence of the `[AllowResizable]` attribute.
- The remaining buffer source converters correctly handle the presence or absence of the `[AllowShared]` and `[AllowResizable]` attributes.

New converters:
- `ArrayBufferView`
- `BufferSource`
- `AllowSharedBufferSource`

### Breaking Changes and Deprecations

As mentioned, this does not affect the current behaviour of undici web APIs, as they do not use these converters at present.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
