### PR TITLE
wpt: properly handle write permissions errors in wpt-runner setup

### DIFF
--- a/test/web-platform-tests/wpt-runner.mjs
+++ b/test/web-platform-tests/wpt-runner.mjs
@@ -407,11 +407,18 @@ async function setup () {
         `The WPT require certain entries to be present in your ${hostsPath} file. Should these be configured automatically? (y/n): `,
         resolve
       )
-    }).finally(() => rl.close())
+    }).finally(() => rl.close()).then((a) => a.trim().toLowerCase())
 
-    if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
-      await setupHostsFile()
-    } else {
+    let hostsModified = false
+    if (answer === 'y' || answer === 'yes') {
+      try {
+        await setupHostsFile()
+        hostsModified = true
+      } catch (err) {
+        console.error('❌ \x1B[31mAutomatic configuration failed.\x1B[0m')
+      }
+    }
+    if (!hostsModified) {
       console.log('Please configure hosts file manually:')
       console.log(`cd ${WPT_DIR}`)
       if (process.platform === 'win32') {
@@ -419,6 +426,9 @@ async function setup () {
       } else {
         console.log('python3 wpt make-hosts-file | sudo tee -a /etc/hosts')
       }
+
+      console.log('❌ \x1B[31mSetup incomplete.\x1B[0m')
+      process.exit(1)
     }
   }
 


### PR DESCRIPTION
@KhafraDev 

Wanted to setup the wpt runner locally. didnt work properly. ofc you need sudo right to write /etc/hosts. So instead of failling with a EACCESS error, now you get clear instructions what to do. 

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
