### PR TITLE
refactor errors

### DIFF
--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -10,22 +10,28 @@ import { errors } from 'undici'
 | Error                                | Error Codes                           | Description                                                               |
 | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |
 | `UndiciError`                        | `UND_ERR`                             | all errors below are extended from `UndiciError`.                         |
-| `ConnectTimeoutError`                | `UND_ERR_CONNECT_TIMEOUT`             | socket is destroyed due to connect timeout.                               |
-| `HeadersTimeoutError`                | `UND_ERR_HEADERS_TIMEOUT`             | socket is destroyed due to headers timeout.                               |
-| `HeadersOverflowError`               | `UND_ERR_HEADERS_OVERFLOW`            | socket is destroyed due to headers' max size being exceeded.              |
+| `AbortError`                         | `UND_ERR_ABORT`                       | the operation was aborted.                                                |
+| `BalancedPoolMissingUpstreamError`   | `UND_ERR_BPL_MISSING_UPSTREAM`        | trying to use a balanced pool without upstreams.                          |
 | `BodyTimeoutError`                   | `UND_ERR_BODY_TIMEOUT`                | socket is destroyed due to body timeout.                                  |
+| `ClientClosedError`                  | `UND_ERR_CLOSED`                      | trying to use a closed client.                                            |
+| `ClientDestroyedError`               | `UND_ERR_DESTROYED`                   | trying to use a destroyed client.                                         |
+| `ConnectTimeoutError`                | `UND_ERR_CONNECT_TIMEOUT`             | socket is destroyed due to connect timeout.                               |
+| `HeadersOverflowError`               | `UND_ERR_HEADERS_OVERFLOW`            | socket is destroyed due to headers' max size being exceeded.              |
+| `HeadersTimeoutError`                | `UND_ERR_HEADERS_TIMEOUT`             | socket is destroyed due to headers timeout.                               |
+| `HTTPParserError`                    | `UND_ERR_HTTP_PARSE`                  | there is an error while parsing the HTTP.                                 |
+| `InformationalError`                 | `UND_ERR_INFO`                        | expected error with reason                                                |
 | `InvalidArgumentError`               | `UND_ERR_INVALID_ARG`                 | passed an invalid argument.                                               |
 | `InvalidReturnValueError`            | `UND_ERR_INVALID_RETURN_VALUE`        | returned an invalid value.                                                |
-| `RequestAbortedError`                | `UND_ERR_ABORTED`                     | the request has been aborted by the user                                  |
-| `ClientDestroyedError`               | `UND_ERR_DESTROYED`                   | trying to use a destroyed client.                                         |
-| `ClientClosedError`                  | `UND_ERR_CLOSED`                      | trying to use a closed client.                                            |
-| `SocketError`                        | `UND_ERR_SOCKET`                      | there is an error with the socket.                                        |
+| `MaxOriginsReachedError`             | `UND_ERR_MAX_ORIGINS_REACHED`         | trying to add more origins than allowed.                                  |
 | `NotSupportedError`                  | `UND_ERR_NOT_SUPPORTED`               | encountered unsupported functionality.                                    |
+| `RequestAbortedError`                | `UND_ERR_REQUEST_ABORTED`             | the request has been aborted by the user                                  |
 | `RequestContentLengthMismatchError`  | `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` | request body does not match content-length header                         |
+| `RequestRetryError`                  | `UND_ERR_REQ_RETRY`                   | the request should be retried.                                            |
+| `ResponseError`                      | `UND_ERR_RESPONSE`                    | there is an error with the response.                                      |
 | `ResponseContentLengthMismatchError` | `UND_ERR_RES_CONTENT_LENGTH_MISMATCH` | response body does not match content-length header                        |
-| `InformationalError`                 | `UND_ERR_INFO`                        | expected error with reason                                                |
 | `ResponseExceededMaxSizeError`       | `UND_ERR_RES_EXCEEDED_MAX_SIZE`       | response body exceed the max size allowed                                 |
 | `SecureProxyConnectionError`         | `UND_ERR_PRX_TLS`                     | tls connection to a proxy failed                                          |
+| `SocketError`                        | `UND_ERR_SOCKET`                      | there is an error with the socket.                                        |
 
 Be aware of the possible difference between the global dispatcher version and the actual undici version you might be using. We recommend to avoid the check `instanceof errors.UndiciError` and seek for the `error.code === '<error_code>'` instead to avoid inconsistencies.
 ### `SocketError`

--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -7,7 +7,7 @@ You can find all the error objects inside the `errors` key.
 import { errors } from 'undici'
 ```
 
-| Error                                | Error Codes                           | Description                                                               |
+| Error                                | Error Code                            | Description                                                               |
 | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |
 | `UndiciError`                        | `UND_ERR`                             | all errors below are extended from `UndiciError`.                         |
 | `AbortError`                         | `UND_ERR_ABORT`                       | the operation was aborted.                                                |
@@ -18,7 +18,7 @@ import { errors } from 'undici'
 | `ConnectTimeoutError`                | `UND_ERR_CONNECT_TIMEOUT`             | socket is destroyed due to connect timeout.                               |
 | `HeadersOverflowError`               | `UND_ERR_HEADERS_OVERFLOW`            | socket is destroyed due to headers' max size being exceeded.              |
 | `HeadersTimeoutError`                | `UND_ERR_HEADERS_TIMEOUT`             | socket is destroyed due to headers timeout.                               |
-| `HTTPParserError`                    | `UND_ERR_HTTP_PARSE`                  | there is an error while parsing the HTTP.                                 |
+| `HTTPParserError`                    |                                       | there is an error while parsing the HTTP.                                 |
 | `InformationalError`                 | `UND_ERR_INFO`                        | expected error with reason                                                |
 | `InvalidArgumentError`               | `UND_ERR_INVALID_ARG`                 | passed an invalid argument.                                               |
 | `InvalidReturnValueError`            | `UND_ERR_INVALID_RETURN_VALUE`        | returned an invalid value.                                                |

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -12,7 +12,9 @@ class UndiciError extends Error {
     return instance && instance[kUndiciError] === true
   }
 
-  [kUndiciError] = true
+  get [kUndiciError] () {
+    return true
+  }
 }
 
 const kConnectTimeoutError = Symbol.for('undici.error.UND_ERR_CONNECT_TIMEOUT')
@@ -28,7 +30,9 @@ class ConnectTimeoutError extends UndiciError {
     return instance && instance[kConnectTimeoutError] === true
   }
 
-  [kConnectTimeoutError] = true
+  get [kConnectTimeoutError] () {
+    return true
+  }
 }
 
 const kHeadersTimeoutError = Symbol.for('undici.error.UND_ERR_HEADERS_TIMEOUT')
@@ -44,7 +48,9 @@ class HeadersTimeoutError extends UndiciError {
     return instance && instance[kHeadersTimeoutError] === true
   }
 
-  [kHeadersTimeoutError] = true
+  get [kHeadersTimeoutError] () {
+    return true
+  }
 }
 
 const kHeadersOverflowError = Symbol.for('undici.error.UND_ERR_HEADERS_OVERFLOW')
@@ -60,7 +66,9 @@ class HeadersOverflowError extends UndiciError {
     return instance && instance[kHeadersOverflowError] === true
   }
 
-  [kHeadersOverflowError] = true
+  get [kHeadersOverflowError] () {
+    return true
+  }
 }
 
 const kBodyTimeoutError = Symbol.for('undici.error.UND_ERR_BODY_TIMEOUT')
@@ -76,7 +84,9 @@ class BodyTimeoutError extends UndiciError {
     return instance && instance[kBodyTimeoutError] === true
   }
 
-  [kBodyTimeoutError] = true
+  get [kBodyTimeoutError] () {
+    return true
+  }
 }
 
 const kInvalidArgumentError = Symbol.for('undici.error.UND_ERR_INVALID_ARG')
@@ -92,7 +102,9 @@ class InvalidArgumentError extends UndiciError {
     return instance && instance[kInvalidArgumentError] === true
   }
 
-  [kInvalidArgumentError] = true
+  get [kInvalidArgumentError] () {
+    return true
+  }
 }
 
 const kInvalidReturnValueError = Symbol.for('undici.error.UND_ERR_INVALID_RETURN_VALUE')
@@ -108,7 +120,9 @@ class InvalidReturnValueError extends UndiciError {
     return instance && instance[kInvalidReturnValueError] === true
   }
 
-  [kInvalidReturnValueError] = true
+  get [kInvalidReturnValueError] () {
+    return true
+  }
 }
 
 const kAbortError = Symbol.for('undici.error.UND_ERR_ABORT')
@@ -124,23 +138,27 @@ class AbortError extends UndiciError {
     return instance && instance[kAbortError] === true
   }
 
-  [kAbortError] = true
+  get [kAbortError] () {
+    return true
+  }
 }
 
-const kRequestAbortedError = Symbol.for('undici.error.UND_ERR_ABORTED')
+const kRequestAbortedError = Symbol.for('undici.error.UND_ERR_REQUEST_ABORTED')
 class RequestAbortedError extends AbortError {
   constructor (message) {
     super(message)
-    this.name = 'AbortError'
+    this.name = 'RequestAbortedError'
     this.message = message || 'Request aborted'
-    this.code = 'UND_ERR_ABORTED'
+    this.code = 'UND_ERR_REQUEST_ABORTED'
   }
 
   static [Symbol.hasInstance] (instance) {
     return instance && instance[kRequestAbortedError] === true
   }
 
-  [kRequestAbortedError] = true
+  get [kRequestAbortedError] () {
+    return true
+  }
 }
 
 const kInformationalError = Symbol.for('undici.error.UND_ERR_INFO')
@@ -156,7 +174,9 @@ class InformationalError extends UndiciError {
     return instance && instance[kInformationalError] === true
   }
 
-  [kInformationalError] = true
+  get [kInformationalError] () {
+    return true
+  }
 }
 
 const kRequestContentLengthMismatchError = Symbol.for('undici.error.UND_ERR_REQ_CONTENT_LENGTH_MISMATCH')
@@ -172,7 +192,9 @@ class RequestContentLengthMismatchError extends UndiciError {
     return instance && instance[kRequestContentLengthMismatchError] === true
   }
 
-  [kRequestContentLengthMismatchError] = true
+  get [kRequestContentLengthMismatchError] () {
+    return true
+  }
 }
 
 const kResponseContentLengthMismatchError = Symbol.for('undici.error.UND_ERR_RES_CONTENT_LENGTH_MISMATCH')
@@ -188,7 +210,9 @@ class ResponseContentLengthMismatchError extends UndiciError {
     return instance && instance[kResponseContentLengthMismatchError] === true
   }
 
-  [kResponseContentLengthMismatchError] = true
+  get [kResponseContentLengthMismatchError] () {
+    return true
+  }
 }
 
 const kClientDestroyedError = Symbol.for('undici.error.UND_ERR_DESTROYED')
@@ -204,7 +228,9 @@ class ClientDestroyedError extends UndiciError {
     return instance && instance[kClientDestroyedError] === true
   }
 
-  [kClientDestroyedError] = true
+  get [kClientDestroyedError] () {
+    return true
+  }
 }
 
 const kClientClosedError = Symbol.for('undici.error.UND_ERR_CLOSED')
@@ -220,7 +246,9 @@ class ClientClosedError extends UndiciError {
     return instance && instance[kClientClosedError] === true
   }
 
-  [kClientClosedError] = true
+  get [kClientClosedError] () {
+    return true
+  }
 }
 
 const kSocketError = Symbol.for('undici.error.UND_ERR_SOCKET')
@@ -237,7 +265,9 @@ class SocketError extends UndiciError {
     return instance && instance[kSocketError] === true
   }
 
-  [kSocketError] = true
+  get [kSocketError] () {
+    return true
+  }
 }
 
 const kNotSupportedError = Symbol.for('undici.error.UND_ERR_NOT_SUPPORTED')
@@ -253,14 +283,16 @@ class NotSupportedError extends UndiciError {
     return instance && instance[kNotSupportedError] === true
   }
 
-  [kNotSupportedError] = true
+  get [kNotSupportedError] () {
+    return true
+  }
 }
 
 const kBalancedPoolMissingUpstreamError = Symbol.for('undici.error.UND_ERR_BPL_MISSING_UPSTREAM')
 class BalancedPoolMissingUpstreamError extends UndiciError {
   constructor (message) {
     super(message)
-    this.name = 'MissingUpstreamError'
+    this.name = 'BalancedPoolMissingUpstreamError'
     this.message = message || 'No upstream has been added to the BalancedPool'
     this.code = 'UND_ERR_BPL_MISSING_UPSTREAM'
   }
@@ -269,11 +301,13 @@ class BalancedPoolMissingUpstreamError extends UndiciError {
     return instance && instance[kBalancedPoolMissingUpstreamError] === true
   }
 
-  [kBalancedPoolMissingUpstreamError] = true
+  get [kBalancedPoolMissingUpstreamError] () {
+    return true
+  }
 }
 
 const kHTTPParserError = Symbol.for('undici.error.UND_ERR_HTTP_PARSER')
-class HTTPParserError extends Error {
+class HTTPParserError extends UndiciError {
   constructor (message, code, data) {
     super(message)
     this.name = 'HTTPParserError'
@@ -285,7 +319,9 @@ class HTTPParserError extends Error {
     return instance && instance[kHTTPParserError] === true
   }
 
-  [kHTTPParserError] = true
+  get [kHTTPParserError] () {
+    return true
+  }
 }
 
 const kResponseExceededMaxSizeError = Symbol.for('undici.error.UND_ERR_RES_EXCEEDED_MAX_SIZE')
@@ -301,12 +337,14 @@ class ResponseExceededMaxSizeError extends UndiciError {
     return instance && instance[kResponseExceededMaxSizeError] === true
   }
 
-  [kResponseExceededMaxSizeError] = true
+  get [kResponseExceededMaxSizeError] () {
+    return true
+  }
 }
 
 const kRequestRetryError = Symbol.for('undici.error.UND_ERR_REQ_RETRY')
 class RequestRetryError extends UndiciError {
-  constructor (message, code, { headers, data }) {
+  constructor (message, code, { headers, data } = {}) {
     super(message)
     this.name = 'RequestRetryError'
     this.message = message || 'Request retry error'
@@ -320,12 +358,14 @@ class RequestRetryError extends UndiciError {
     return instance && instance[kRequestRetryError] === true
   }
 
-  [kRequestRetryError] = true
+  get [kRequestRetryError] () {
+    return true
+  }
 }
 
 const kResponseError = Symbol.for('undici.error.UND_ERR_RESPONSE')
 class ResponseError extends UndiciError {
-  constructor (message, code, { headers, body }) {
+  constructor (message, code, { headers, body } = {}) {
     super(message)
     this.name = 'ResponseError'
     this.message = message || 'Response error'
@@ -339,12 +379,19 @@ class ResponseError extends UndiciError {
     return instance && instance[kResponseError] === true
   }
 
-  [kResponseError] = true
+  get [kResponseError] () {
+    return true
+  }
 }
 
 const kSecureProxyConnectionError = Symbol.for('undici.error.UND_ERR_PRX_TLS')
 class SecureProxyConnectionError extends UndiciError {
-  constructor (cause, message, options = {}) {
+  constructor (message, cause, options = {}) {
+    // Fallback because order of arguments changed in a minor release
+    if (typeof message !== 'string') {
+      cause = message
+      message = undefined
+    }
     super(message, { cause, ...options })
     this.name = 'SecureProxyConnectionError'
     this.message = message || 'Secure Proxy Connection failed'
@@ -356,7 +403,9 @@ class SecureProxyConnectionError extends UndiciError {
     return instance && instance[kSecureProxyConnectionError] === true
   }
 
-  [kSecureProxyConnectionError] = true
+  get [kSecureProxyConnectionError] () {
+    return true
+  }
 }
 
 const kMaxOriginsReachedError = Symbol.for('undici.error.UND_ERR_MAX_ORIGINS_REACHED')
@@ -372,7 +421,9 @@ class MaxOriginsReachedError extends UndiciError {
     return instance && instance[kMaxOriginsReachedError] === true
   }
 
-  [kMaxOriginsReachedError] = true
+  get [kMaxOriginsReachedError] () {
+    return true
+  }
 }
 
 module.exports = {

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -344,12 +344,12 @@ class ResponseExceededMaxSizeError extends UndiciError {
 
 const kRequestRetryError = Symbol.for('undici.error.UND_ERR_REQ_RETRY')
 class RequestRetryError extends UndiciError {
-  constructor (message, code, { headers, data } = {}) {
+  constructor (message, statusCode, { headers, data } = {}) {
     super(message)
     this.name = 'RequestRetryError'
     this.message = message || 'Request retry error'
     this.code = 'UND_ERR_REQ_RETRY'
-    this.statusCode = code
+    this.statusCode = statusCode
     this.data = data
     this.headers = headers
   }
@@ -365,12 +365,12 @@ class RequestRetryError extends UndiciError {
 
 const kResponseError = Symbol.for('undici.error.UND_ERR_RESPONSE')
 class ResponseError extends UndiciError {
-  constructor (message, code, { headers, body } = {}) {
+  constructor (message, statusCode, { headers, body } = {}) {
     super(message)
     this.name = 'ResponseError'
     this.message = message || 'Response error'
     this.code = 'UND_ERR_RESPONSE'
-    this.statusCode = code
+    this.statusCode = statusCode
     this.body = body
     this.headers = headers
   }

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -388,15 +388,15 @@ const kSecureProxyConnectionError = Symbol.for('undici.error.UND_ERR_PRX_TLS')
 class SecureProxyConnectionError extends UndiciError {
   constructor (message, cause, options = {}) {
     // Fallback because order of arguments changed in a minor release
-    if (typeof message !== 'string') {
-      cause = message
-      message = undefined
+    if (message instanceof Error) {
+      options.cause = message
+      message = cause
+      cause = undefined
     }
     super(message, { cause, ...options })
     this.name = 'SecureProxyConnectionError'
     this.message = message || 'Secure Proxy Connection failed'
     this.code = 'UND_ERR_PRX_TLS'
-    this.cause = cause
   }
 
   static [Symbol.hasInstance] (instance) {

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -180,7 +180,7 @@ class ProxyAgent extends DispatcherBase {
         } catch (err) {
           if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
             // Throw a custom error to avoid loop in client.js#connect
-            callback(new SecureProxyConnectionError(err))
+            callback(new SecureProxyConnectionError(err.message, err))
           } else {
             callback(err)
           }

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -19,7 +19,9 @@ class MockNotMatchedError extends UndiciError {
     return instance && instance[kMockNotMatchedError] === true
   }
 
-  [kMockNotMatchedError] = true
+  get [kMockNotMatchedError] () {
+    return true
+  }
 }
 
 module.exports = {

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -563,7 +563,7 @@ test('pipeline abort piped res', async (t) => {
       return pipeline(body, pt, () => {})
     })
       .on('error', (err) => {
-        t.strictEqual(err.code, 'UND_ERR_ABORTED')
+        t.strictEqual(err.code, 'UND_ERR_REQUEST_ABORTED')
       })
       .end()
   })

--- a/test/errors.js
+++ b/test/errors.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert')
 const fs = require('node:fs')
+const path = require('node:path')
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test } = require('node:test')
 const typescript = require('typescript')
@@ -46,7 +47,7 @@ const scenarios = [
 assert.strictEqual(scenarios.length, Object.keys(errors).length)
 
 // Read Errors.md and extract the table of errors
-const errorsMd = fs.readFileSync(require.resolve('../docs/docs/api/Errors.md'), 'utf8')
+const errorsMd = fs.readFileSync(path.resolve(__dirname, '..', 'docs', 'docs', 'api', 'Errors.md'), 'utf8')
 const errorsMdTableHead = `| Error                                | Error Code                            | Description                                                               |
 | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |`
 const errorsMdTableStart = errorsMd.indexOf(errorsMdTableHead)
@@ -58,7 +59,7 @@ const errorsTable = errorsMd.slice(errorsMdTableStart + errorsMdTableHead.length
 assert.strictEqual(errorsTable.length, scenarios.length, 'Errors.md should not have more or less documented errors than actual errors')
 
 // Read errors.d.ts and parse it with TypeScript
-const errorsDts = fs.readFileSync(require.resolve('../types/errors.d.ts'), 'utf8')
+const errorsDts = fs.readFileSync(path.resolve(__dirname, '..', 'types', 'errors.d.ts'), 'utf8')
 const errorsSourceFile = typescript.createSourceFile('errors.d.ts', errorsDts, typescript.ScriptTarget.ES2015, /* setParentNodes */ true)
 assert.strictEqual([...errorsSourceFile.identifiers.values()].filter(v => v.endsWith('Error') && v !== 'Error').length, scenarios.length, 'errors.d.ts should not have more or less declared errors than actual errors')
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,69 +1,202 @@
 'use strict'
 
+const assert = require('node:assert')
+const fs = require('node:fs')
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test } = require('node:test')
+const typescript = require('typescript')
 
 const errors = require('../lib/core/errors')
 
-const createScenario = (ErrorClass, defaultMessage, name, code) => ({
-  ErrorClass,
-  defaultMessage,
-  name,
-  code
-})
+const createScenario = (ErrorClass, defaultMessage, name, code) => {
+  return {
+    ErrorClass,
+    defaultMessage,
+    name,
+    code
+  }
+}
 
 const scenarios = [
   createScenario(errors.UndiciError, '', 'UndiciError', 'UND_ERR'),
+  createScenario(errors.AbortError, 'The operation was aborted', 'AbortError', 'UND_ERR_ABORT'),
+  createScenario(errors.BalancedPoolMissingUpstreamError, 'No upstream has been added to the BalancedPool', 'BalancedPoolMissingUpstreamError', 'UND_ERR_BPL_MISSING_UPSTREAM'),
+  createScenario(errors.BodyTimeoutError, 'Body Timeout Error', 'BodyTimeoutError', 'UND_ERR_BODY_TIMEOUT'),
+  createScenario(errors.ClientClosedError, 'The client is closed', 'ClientClosedError', 'UND_ERR_CLOSED'),
+  createScenario(errors.ClientDestroyedError, 'The client is destroyed', 'ClientDestroyedError', 'UND_ERR_DESTROYED'),
   createScenario(errors.ConnectTimeoutError, 'Connect Timeout Error', 'ConnectTimeoutError', 'UND_ERR_CONNECT_TIMEOUT'),
-  createScenario(errors.HeadersTimeoutError, 'Headers Timeout Error', 'HeadersTimeoutError', 'UND_ERR_HEADERS_TIMEOUT'),
   createScenario(errors.HeadersOverflowError, 'Headers Overflow Error', 'HeadersOverflowError', 'UND_ERR_HEADERS_OVERFLOW'),
+  createScenario(errors.HeadersTimeoutError, 'Headers Timeout Error', 'HeadersTimeoutError', 'UND_ERR_HEADERS_TIMEOUT'),
+  createScenario(errors.HTTPParserError, '', 'HTTPParserError', undefined),
+  createScenario(errors.InformationalError, 'Request information', 'InformationalError', 'UND_ERR_INFO'),
   createScenario(errors.InvalidArgumentError, 'Invalid Argument Error', 'InvalidArgumentError', 'UND_ERR_INVALID_ARG'),
   createScenario(errors.InvalidReturnValueError, 'Invalid Return Value Error', 'InvalidReturnValueError', 'UND_ERR_INVALID_RETURN_VALUE'),
-  createScenario(errors.RequestAbortedError, 'Request aborted', 'AbortError', 'UND_ERR_ABORTED'),
-  createScenario(errors.InformationalError, 'Request information', 'InformationalError', 'UND_ERR_INFO'),
-  createScenario(errors.RequestContentLengthMismatchError, 'Request body length does not match content-length header', 'RequestContentLengthMismatchError', 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'),
-  createScenario(errors.ClientDestroyedError, 'The client is destroyed', 'ClientDestroyedError', 'UND_ERR_DESTROYED'),
-  createScenario(errors.ClientClosedError, 'The client is closed', 'ClientClosedError', 'UND_ERR_CLOSED'),
-  createScenario(errors.SocketError, 'Socket error', 'SocketError', 'UND_ERR_SOCKET'),
+  createScenario(errors.MaxOriginsReachedError, 'Maximum allowed origins reached', 'MaxOriginsReachedError', 'UND_ERR_MAX_ORIGINS_REACHED'),
   createScenario(errors.NotSupportedError, 'Not supported error', 'NotSupportedError', 'UND_ERR_NOT_SUPPORTED'),
+  createScenario(errors.RequestAbortedError, 'Request aborted', 'RequestAbortedError', 'UND_ERR_REQUEST_ABORTED'),
+  createScenario(errors.RequestContentLengthMismatchError, 'Request body length does not match content-length header', 'RequestContentLengthMismatchError', 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH'),
+  createScenario(errors.RequestRetryError, 'Request retry error', 'RequestRetryError', 'UND_ERR_REQ_RETRY'),
   createScenario(errors.ResponseContentLengthMismatchError, 'Response body length does not match content-length header', 'ResponseContentLengthMismatchError', 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH'),
-  createScenario(errors.ResponseExceededMaxSizeError, 'Response content exceeded max size', 'ResponseExceededMaxSizeError', 'UND_ERR_RES_EXCEEDED_MAX_SIZE')
+  createScenario(errors.ResponseError, 'Response error', 'ResponseError', 'UND_ERR_RESPONSE'),
+  createScenario(errors.ResponseExceededMaxSizeError, 'Response content exceeded max size', 'ResponseExceededMaxSizeError', 'UND_ERR_RES_EXCEEDED_MAX_SIZE'),
+  createScenario(errors.SecureProxyConnectionError, 'Secure Proxy Connection failed', 'SecureProxyConnectionError', 'UND_ERR_PRX_TLS'),
+  createScenario(errors.SocketError, 'Socket error', 'SocketError', 'UND_ERR_SOCKET')
 ]
 
-scenarios.forEach(scenario => {
-  describe(scenario.name, () => {
-    const SAMPLE_MESSAGE = 'sample message'
+assert.strictEqual(scenarios.length, Object.keys(errors).length)
 
-    const errorWithDefaultMessage = () => new scenario.ErrorClass()
-    const errorWithProvidedMessage = () => new scenario.ErrorClass(SAMPLE_MESSAGE)
+// Read Errors.md and extract the table of errors
+const errorsMd = fs.readFileSync(require.resolve('../docs/docs/api/Errors.md'), 'utf8')
+const errorsMdTableHead = `| Error                                | Error Codes                           | Description                                                               |
+| ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |`
+const errorsMdTableStart = errorsMd.indexOf(errorsMdTableHead)
+assert.notStrictEqual(errorsMdTableStart, -1)
+const errorsMdTableEnd = errorsMd.indexOf('\n\n', errorsMdTableStart)
+assert.notStrictEqual(errorsMdTableEnd, -1)
+const errorsTable = errorsMd.slice(errorsMdTableStart + errorsMdTableHead.length + 1, errorsMdTableEnd).split('\n')
 
+assert.strictEqual(errorsTable.length, scenarios.length, 'Errors.md should not have more or less documented errors than actual errors')
+
+// Read errors.d.ts and parse it with TypeScript
+const errorsDts = fs.readFileSync(require.resolve('../types/errors.d.ts'), 'utf8')
+const errorsSourceFile = typescript.createSourceFile('errors.d.ts', errorsDts, typescript.ScriptTarget.ES2015, /* setParentNodes */ true)
+assert.strictEqual([...errorsSourceFile.identifiers.values()].filter(v => v.endsWith('Error') && v !== 'Error').length, scenarios.length, 'errors.d.ts should not have more or less declared errors than actual errors')
+
+for (const { name, ErrorClass, defaultMessage, code } of scenarios) {
+  describe(name, () => {
     test('should use default message', t => {
       t = tspl(t, { plan: 1 })
 
-      const error = errorWithDefaultMessage()
-
-      t.strictEqual(error.message, scenario.defaultMessage)
+      t.strictEqual(new ErrorClass().message, defaultMessage)
     })
 
     test('should use provided message', t => {
       t = tspl(t, { plan: 1 })
 
-      const error = errorWithProvidedMessage()
-
-      t.strictEqual(error.message, SAMPLE_MESSAGE)
+      t.strictEqual(new ErrorClass('sample message').message, 'sample message')
     })
 
     test('should have proper fields', t => {
       t = tspl(t, { plan: 6 })
-      const errorInstances = [errorWithDefaultMessage(), errorWithProvidedMessage()]
+      const errorInstances = [new ErrorClass(), new ErrorClass('sample message')]
       errorInstances.forEach(error => {
-        t.strictEqual(error.name, scenario.name)
-        t.strictEqual(error.code, scenario.code)
+        t.strictEqual(error.name, name, `name should be ${name}`)
+        t.strictEqual(error.code, code, `code should be ${code}`)
         t.ok(error.stack)
       })
     })
+
+    test('should be instance of Error', t => {
+      t = tspl(t, { plan: 1 })
+
+      t.ok(new ErrorClass() instanceof Error)
+    })
+
+    test('should be instance of UndiciError', t => {
+      t = tspl(t, { plan: 1 })
+
+      t.ok(new ErrorClass() instanceof errors.UndiciError)
+    })
+
+    test('Error-specific-Symbol should not be on the Error-Instance and not be enumerable', t => {
+      t = tspl(t, { plan: 3 })
+
+      const ErrorSymbol = name === 'HTTPParserError'
+        ? Symbol.for('undici.error.UND_ERR_HTTP_PARSER')
+        : Symbol.for(`undici.error.${code}`)
+
+      t.strictEqual(new ErrorClass()[Symbol.for('undici.error.UND_ERR')], true)
+      t.strictEqual(new ErrorClass()[ErrorSymbol], true)
+      t.strictEqual(Object.getOwnPropertySymbols(new ErrorClass()).includes(ErrorSymbol), false)
+    })
+
+    test('should be documented in Errors.md', t => {
+      t = tspl(t, { plan: code !== undefined ? 2 : 1 })
+
+      const errorsTableEntry = errorsTable.find(line => line.includes(`| \`${name}\` `))
+      t.ok(errorsTableEntry, `${name} should be documented in Errors.md`)
+      if (code !== undefined) {
+        t.ok(errorsTableEntry.includes(`| \`${code}\` `), `${name} should have code ${code} documented in Errors.md`)
+      }
+
+      // remove the entry so that we can check at the end if there are undocumented errors
+      const index = errorsTable.indexOf(errorsTableEntry)
+      errorsTable.splice(index, 1)
+    })
+
+    test('should be declared in errors.d.ts', t => {
+      t = tspl(t, { plan: 4 })
+
+      t.strictEqual(errorsSourceFile.identifiers.get(name), name, `${name} should be declared in errors.d.ts`)
+
+      // check if it extends UndiciError, has correct name property and code property
+      let extendsUndiciError = false
+      let typeNameValue
+      let typeCodeValue
+
+      function visit (node) {
+        if (typescript.isClassDeclaration(node) &&
+          node.name &&
+          node.name.text === name) {
+          // Check inheritance
+          if (node.heritageClauses) {
+            node.heritageClauses.forEach(heritageClause => {
+              if (heritageClause.token === typescript.SyntaxKind.ExtendsKeyword) {
+                heritageClause.types.forEach(type => {
+                  if (typescript.isIdentifier(type.expression) &&
+                    type.expression.text === 'UndiciError') {
+                    extendsUndiciError = true
+                  }
+                })
+              }
+            })
+          }
+
+          // Check properties
+          if (node.members) {
+            node.members.forEach(member => {
+              if (typescript.isPropertyDeclaration(member) &&
+                member.name &&
+                typescript.isIdentifier(member.name)) {
+                const propertyName = member.name.text
+
+                // Check name property
+                if (propertyName === 'name' && member.type) {
+                  if (typescript.isLiteralTypeNode(member.type) &&
+                    typescript.isStringLiteral(member.type.literal)) {
+                    typeNameValue = member.type.literal.text
+                  }
+                }
+
+                // Check code property (if code is defined for this error)
+                if (propertyName === 'code' && member.type && code !== undefined) {
+                  if (typescript.isLiteralTypeNode(member.type) &&
+                    typescript.isStringLiteral(member.type.literal)) {
+                    typeCodeValue = member.type.literal.text
+                  }
+                }
+              }
+            })
+          }
+        }
+
+        typescript.forEachChild(node, visit)
+      }
+
+      visit(errorsSourceFile)
+
+      if (name === 'UndiciError') {
+        t.strictEqual(extendsUndiciError, false, 'UndiciError does not extend itself')
+        t.strictEqual(typeNameValue, undefined, 'UndiciError should not have specific name property in errors.d.ts')
+        t.strictEqual(typeCodeValue, undefined, 'UndiciError should not have specific code property in errors.d.ts')
+      } else {
+        t.strictEqual(extendsUndiciError, true, `${name} should extend UndiciError in errors.d.ts`)
+        t.strictEqual(typeNameValue, name, `${name} should have '${name}' as name but got '${typeNameValue}' in errors.d.ts`)
+        t.strictEqual(typeCodeValue, code, `${name} should have ${code}' as code property but got '${typeCodeValue}' in errors.d.ts`)
+      }
+    })
   })
-})
+}
 
 describe('Default HTTPParseError Codes', () => {
   test('code and data should be undefined when not set', t => {

--- a/test/errors.js
+++ b/test/errors.js
@@ -208,3 +208,27 @@ describe('Default HTTPParseError Codes', () => {
     t.strictEqual(error.data, undefined)
   })
 })
+
+describe('SecureProxyConnectionError constructor should be backwards compatible', () => {
+  test('message is first and cause is second parameter', t => {
+    t = tspl(t, { plan: 2 })
+
+    const message = 'message'
+    const cause = new Error('cause error')
+    const error = new errors.SecureProxyConnectionError(message, cause)
+
+    t.strictEqual(error.cause, cause)
+    t.strictEqual(error.message, 'message')
+  })
+
+  test('cause is first and message is second parameter', t => {
+    t = tspl(t, { plan: 2 })
+
+    const message = 'message'
+    const cause = new Error('cause error')
+    const error = new errors.SecureProxyConnectionError(cause, message)
+
+    t.strictEqual(error.cause, cause)
+    t.strictEqual(error.message, 'message')
+  })
+})

--- a/test/errors.js
+++ b/test/errors.js
@@ -48,8 +48,7 @@ assert.strictEqual(scenarios.length, Object.keys(errors).length)
 
 // Read Errors.md and extract the table of errors
 const errorsMd = fs.readFileSync(path.resolve(__dirname, '..', 'docs', 'docs', 'api', 'Errors.md'), 'utf8')
-const errorsMdTableHead = `| Error                                | Error Code                            | Description                                                               |
-| ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |`
+const errorsMdTableHead = '| ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------- |'
 const errorsMdTableStart = errorsMd.indexOf(errorsMdTableHead)
 assert.notStrictEqual(errorsMdTableStart, -1)
 const errorsMdTableEnd = errorsMd.indexOf('\n\n', errorsMdTableStart)

--- a/test/interceptors/dump-interceptor.js
+++ b/test/interceptors/dump-interceptor.js
@@ -494,7 +494,7 @@ test('Should abort if content length grater than max size', async t => {
   })
 
   t.rejects(client.request(requestOptions), {
-    name: 'AbortError',
+    name: 'RequestAbortedError',
     message: 'Response size (2048) larger than maxSize (1024)'
   })
 
@@ -581,7 +581,7 @@ test('Should abort if content length grater than max size (dispatch opts)', asyn
       return await client.request(requestOptions).then(res => res.body.text())
     },
     {
-      name: 'AbortError',
+      name: 'RequestAbortedError',
       message: 'Response size (2048) larger than maxSize (100)'
     }
   )

--- a/test/pool.js
+++ b/test/pool.js
@@ -870,7 +870,7 @@ test('pool request abort in queue', async (t) => {
       method: 'GET',
       signal
     }, (err) => {
-      t.strictEqual(err.code, 'UND_ERR_ABORTED')
+      t.strictEqual(err.code, 'UND_ERR_REQUEST_ABORTED')
     })
     signal.emit('abort')
   })
@@ -917,7 +917,7 @@ test('pool stream abort in queue', async (t) => {
       method: 'GET',
       signal
     }, ({ body }) => body, (err) => {
-      t.strictEqual(err.code, 'UND_ERR_ABORTED')
+      t.strictEqual(err.code, 'UND_ERR_REQUEST_ABORTED')
     })
     signal.emit('abort')
   })
@@ -964,7 +964,7 @@ test('pool pipeline abort in queue', async (t) => {
       method: 'GET',
       signal
     }, ({ body }) => body).end().on('error', (err) => {
-      t.strictEqual(err.code, 'UND_ERR_ABORTED')
+      t.strictEqual(err.code, 'UND_ERR_REQUEST_ABORTED')
     })
     signal.emit('abort')
   })

--- a/test/types/errors.test-d.ts
+++ b/test/types/errors.test-d.ts
@@ -47,8 +47,8 @@ expectAssignable<'UND_ERR_INVALID_RETURN_VALUE'>(new errors.InvalidReturnValueEr
 
 expectAssignable<errors.UndiciError>(new errors.RequestAbortedError())
 expectAssignable<errors.RequestAbortedError>(new errors.RequestAbortedError())
-expectAssignable<'AbortError'>(new errors.RequestAbortedError().name)
-expectAssignable<'UND_ERR_ABORTED'>(new errors.RequestAbortedError().code)
+expectAssignable<'RequestAbortedError'>(new errors.RequestAbortedError().name)
+expectAssignable<'UND_ERR_REQUEST_ABORTED'>(new errors.RequestAbortedError().code)
 
 expectAssignable<errors.UndiciError>(new errors.InformationalError())
 expectAssignable<errors.InformationalError>(new errors.InformationalError())
@@ -88,7 +88,7 @@ expectAssignable<'UND_ERR_NOT_SUPPORTED'>(new errors.NotSupportedError().code)
 
 expectAssignable<errors.UndiciError>(new errors.BalancedPoolMissingUpstreamError())
 expectAssignable<errors.BalancedPoolMissingUpstreamError>(new errors.BalancedPoolMissingUpstreamError())
-expectAssignable<'MissingUpstreamError'>(new errors.BalancedPoolMissingUpstreamError().name)
+expectAssignable<'BalancedPoolMissingUpstreamError'>(new errors.BalancedPoolMissingUpstreamError().name)
 expectAssignable<'UND_ERR_BPL_MISSING_UPSTREAM'>(new errors.BalancedPoolMissingUpstreamError().code)
 
 expectAssignable<errors.UndiciError>(new errors.HTTPParserError())

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -9,6 +9,11 @@ declare namespace Errors {
     code: string
   }
 
+  export class AbortError extends UndiciError {
+    name: 'AbortError'
+    code: 'UND_ERR_ABORT'
+  }
+
   /** Connect timeout error. */
   export class ConnectTimeoutError extends UndiciError {
     name: 'ConnectTimeoutError'
@@ -63,8 +68,8 @@ declare namespace Errors {
 
   /** The request has been aborted by the user. */
   export class RequestAbortedError extends UndiciError {
-    name: 'AbortError'
-    code: 'UND_ERR_ABORTED'
+    name: 'RequestAbortedError'
+    code: 'UND_ERR_REQUEST_ABORTED'
   }
 
   /** Expected error with reason. */
@@ -112,7 +117,7 @@ declare namespace Errors {
 
   /** No upstream has been added to the BalancedPool. */
   export class BalancedPoolMissingUpstreamError extends UndiciError {
-    name: 'MissingUpstreamError'
+    name: 'BalancedPoolMissingUpstreamError'
     code: 'UND_ERR_BPL_MISSING_UPSTREAM'
   }
 
@@ -146,8 +151,8 @@ declare namespace Errors {
 
   export class SecureProxyConnectionError extends UndiciError {
     constructor (
-      cause?: Error,
       message?: string,
+      cause?: Error,
       options?: Record<any, any>
     )
     name: 'SecureProxyConnectionError'


### PR DESCRIPTION
This PR aims to ensure that Errors are properly configured, typed and documented.

### All Errors need to extend from UndiciError

HTTPParserError  now extends properly from UndiciError. 

### Ensure Errors should have message as first parameter

SecureProxyConnectionError had as first parameter cause and not message as error. I switched them and changed the constructor to have a fallback solution. 

### Ensure that name property of Error is name of Error

Changed name property of `BalancedPoolMissingUpstreamError` and `RequestAbortedError` to match this behavior.

### Ensure that code property of Error match accordingly

`RequestAbortedError` had `UND_ERR_ABORTED` as value, this got corrected to `UND_ERR_REQUEST_ABORTED`

This is afaik the only potentially breaking change.

### Ensure that Errors.md contains all Errors

It is ensured that we dont forget to document all Errors in the Errors.md. 

### Ensure that errors.d.ts contains all Errors

It uses typescript to analyze the errors.d.ts file and checks if the errors are having the correct name and code. Also if it is extending from UndiciError if needed.

### Symbol.for(`UND_ERR_${code}`) attribute non-enumerable
All Error specific Symbols are now with getters accessible, making them non-enumerable. 

This avoids that we expose the Symbol when printing the error to the console.

In main you see the Symbol(undici.error.UND_ERR) as a property of the ErrorInstance if you do a `console.log(new UndiciError())`

```sh
UndiciError
    at Object.<anonymous> (/home/aras/workspace/undici/lib/core/errors.js:362:13)
    at Module._compile (node:internal/modules/cjs/loader:1738:14)
    at Object..js (node:internal/modules/cjs/loader:1871:10)
    at Module.load (node:internal/modules/cjs/loader:1470:32)
    at Module._load (node:internal/modules/cjs/loader:1290:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:238:24)
    at Module.require (node:internal/modules/cjs/loader:1493:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/home/aras/workspace/undici/test/errors.js:6:16) {
  code: 'UND_ERR',
  Symbol(undici.error.UND_ERR): true
}
```

When this PR is applied, the Symbol is hidden.

```sh
UndiciError
    at Object.<anonymous> (/home/aras/workspace/undici/lib/core/errors.js:362:13)
    at Module._compile (node:internal/modules/cjs/loader:1738:14)
    at Object..js (node:internal/modules/cjs/loader:1871:10)
    at Module.load (node:internal/modules/cjs/loader:1470:32)
    at Module._load (node:internal/modules/cjs/loader:1290:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:238:24)
    at Module.require (node:internal/modules/cjs/loader:1493:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/home/aras/workspace/undici/test/errors.js:6:16) {
  code: 'UND_ERR'
}
```
