### PR TITLE
fix: make error symbols non enumerable

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -12,7 +12,9 @@ class UndiciError extends Error {
     return instance && instance[kUndiciError] === true
   }
 
-  [kUndiciError] = true
+  get [kUndiciError] () {
+    return true
+  }
 }
 
 const kConnectTimeoutError = Symbol.for('undici.error.UND_ERR_CONNECT_TIMEOUT')
@@ -28,7 +30,9 @@ class ConnectTimeoutError extends UndiciError {
     return instance && instance[kConnectTimeoutError] === true
   }
 
-  [kConnectTimeoutError] = true
+  get [kConnectTimeoutError] () {
+    return true
+  }
 }
 
 const kHeadersTimeoutError = Symbol.for('undici.error.UND_ERR_HEADERS_TIMEOUT')
@@ -44,7 +48,9 @@ class HeadersTimeoutError extends UndiciError {
     return instance && instance[kHeadersTimeoutError] === true
   }
 
-  [kHeadersTimeoutError] = true
+  get [kHeadersTimeoutError] () {
+    return true
+  }
 }
 
 const kHeadersOverflowError = Symbol.for('undici.error.UND_ERR_HEADERS_OVERFLOW')
@@ -60,7 +66,9 @@ class HeadersOverflowError extends UndiciError {
     return instance && instance[kHeadersOverflowError] === true
   }
 
-  [kHeadersOverflowError] = true
+  get [kHeadersOverflowError] () {
+    return true
+  }
 }
 
 const kBodyTimeoutError = Symbol.for('undici.error.UND_ERR_BODY_TIMEOUT')
@@ -76,7 +84,9 @@ class BodyTimeoutError extends UndiciError {
     return instance && instance[kBodyTimeoutError] === true
   }
 
-  [kBodyTimeoutError] = true
+  get [kBodyTimeoutError] () {
+    return true
+  }
 }
 
 const kInvalidArgumentError = Symbol.for('undici.error.UND_ERR_INVALID_ARG')
@@ -92,7 +102,9 @@ class InvalidArgumentError extends UndiciError {
     return instance && instance[kInvalidArgumentError] === true
   }
 
-  [kInvalidArgumentError] = true
+  get [kInvalidArgumentError] () {
+    return true
+  }
 }
 
 const kInvalidReturnValueError = Symbol.for('undici.error.UND_ERR_INVALID_RETURN_VALUE')
@@ -108,7 +120,9 @@ class InvalidReturnValueError extends UndiciError {
     return instance && instance[kInvalidReturnValueError] === true
   }
 
-  [kInvalidReturnValueError] = true
+  get [kInvalidReturnValueError] () {
+    return true
+  }
 }
 
 const kAbortError = Symbol.for('undici.error.UND_ERR_ABORT')
@@ -124,7 +138,9 @@ class AbortError extends UndiciError {
     return instance && instance[kAbortError] === true
   }
 
-  [kAbortError] = true
+  get [kAbortError] () {
+    return true
+  }
 }
 
 const kRequestAbortedError = Symbol.for('undici.error.UND_ERR_ABORTED')
@@ -140,7 +156,9 @@ class RequestAbortedError extends AbortError {
     return instance && instance[kRequestAbortedError] === true
   }
 
-  [kRequestAbortedError] = true
+  get [kRequestAbortedError] () {
+    return true
+  }
 }
 
 const kInformationalError = Symbol.for('undici.error.UND_ERR_INFO')
@@ -156,7 +174,9 @@ class InformationalError extends UndiciError {
     return instance && instance[kInformationalError] === true
   }
 
-  [kInformationalError] = true
+  get [kInformationalError] () {
+    return true
+  }
 }
 
 const kRequestContentLengthMismatchError = Symbol.for('undici.error.UND_ERR_REQ_CONTENT_LENGTH_MISMATCH')
@@ -172,7 +192,9 @@ class RequestContentLengthMismatchError extends UndiciError {
     return instance && instance[kRequestContentLengthMismatchError] === true
   }
 
-  [kRequestContentLengthMismatchError] = true
+  get [kRequestContentLengthMismatchError] () {
+    return true
+  }
 }
 
 const kResponseContentLengthMismatchError = Symbol.for('undici.error.UND_ERR_RES_CONTENT_LENGTH_MISMATCH')
@@ -188,7 +210,9 @@ class ResponseContentLengthMismatchError extends UndiciError {
     return instance && instance[kResponseContentLengthMismatchError] === true
   }
 
-  [kResponseContentLengthMismatchError] = true
+  get [kResponseContentLengthMismatchError] () {
+    return true
+  }
 }
 
 const kClientDestroyedError = Symbol.for('undici.error.UND_ERR_DESTROYED')
@@ -204,7 +228,9 @@ class ClientDestroyedError extends UndiciError {
     return instance && instance[kClientDestroyedError] === true
   }
 
-  [kClientDestroyedError] = true
+  get [kClientDestroyedError] () {
+    return true
+  }
 }
 
 const kClientClosedError = Symbol.for('undici.error.UND_ERR_CLOSED')
@@ -220,7 +246,9 @@ class ClientClosedError extends UndiciError {
     return instance && instance[kClientClosedError] === true
   }
 
-  [kClientClosedError] = true
+  get [kClientClosedError] () {
+    return true
+  }
 }
 
 const kSocketError = Symbol.for('undici.error.UND_ERR_SOCKET')
@@ -237,7 +265,9 @@ class SocketError extends UndiciError {
     return instance && instance[kSocketError] === true
   }
 
-  [kSocketError] = true
+  get [kSocketError] () {
+    return true
+  }
 }
 
 const kNotSupportedError = Symbol.for('undici.error.UND_ERR_NOT_SUPPORTED')
@@ -253,7 +283,9 @@ class NotSupportedError extends UndiciError {
     return instance && instance[kNotSupportedError] === true
   }
 
-  [kNotSupportedError] = true
+  get [kNotSupportedError] () {
+    return true
+  }
 }
 
 const kBalancedPoolMissingUpstreamError = Symbol.for('undici.error.UND_ERR_BPL_MISSING_UPSTREAM')
@@ -269,7 +301,9 @@ class BalancedPoolMissingUpstreamError extends UndiciError {
     return instance && instance[kBalancedPoolMissingUpstreamError] === true
   }
 
-  [kBalancedPoolMissingUpstreamError] = true
+  get [kBalancedPoolMissingUpstreamError] () {
+    return true
+  }
 }
 
 const kHTTPParserError = Symbol.for('undici.error.UND_ERR_HTTP_PARSER')
@@ -285,7 +319,9 @@ class HTTPParserError extends Error {
     return instance && instance[kHTTPParserError] === true
   }
 
-  [kHTTPParserError] = true
+  get [kHTTPParserError] () {
+    return true
+  }
 }
 
 const kResponseExceededMaxSizeError = Symbol.for('undici.error.UND_ERR_RES_EXCEEDED_MAX_SIZE')
@@ -301,7 +337,9 @@ class ResponseExceededMaxSizeError extends UndiciError {
     return instance && instance[kResponseExceededMaxSizeError] === true
   }
 
-  [kResponseExceededMaxSizeError] = true
+  get [kResponseExceededMaxSizeError] () {
+    return true
+  }
 }
 
 const kRequestRetryError = Symbol.for('undici.error.UND_ERR_REQ_RETRY')
@@ -320,7 +358,9 @@ class RequestRetryError extends UndiciError {
     return instance && instance[kRequestRetryError] === true
   }
 
-  [kRequestRetryError] = true
+  get [kRequestRetryError] () {
+    return true
+  }
 }
 
 const kResponseError = Symbol.for('undici.error.UND_ERR_RESPONSE')
@@ -339,7 +379,9 @@ class ResponseError extends UndiciError {
     return instance && instance[kResponseError] === true
   }
 
-  [kResponseError] = true
+  get [kResponseError] () {
+    return true
+  }
 }
 
 const kSecureProxyConnectionError = Symbol.for('undici.error.UND_ERR_PRX_TLS')
@@ -356,7 +398,9 @@ class SecureProxyConnectionError extends UndiciError {
     return instance && instance[kSecureProxyConnectionError] === true
   }
 
-  [kSecureProxyConnectionError] = true
+  get [kSecureProxyConnectionError] () {
+    return true
+  }
 }
 
 const kMaxOriginsReachedError = Symbol.for('undici.error.UND_ERR_MAX_ORIGINS_REACHED')
@@ -372,7 +416,9 @@ class MaxOriginsReachedError extends UndiciError {
     return instance && instance[kMaxOriginsReachedError] === true
   }
 
-  [kMaxOriginsReachedError] = true
+  get [kMaxOriginsReachedError] () {
+    return true
+  }
 }
 
 module.exports = {

--- a/lib/mock/mock-errors.js
+++ b/lib/mock/mock-errors.js
@@ -19,7 +19,9 @@ class MockNotMatchedError extends UndiciError {
     return instance && instance[kMockNotMatchedError] === true
   }
 
-  [kMockNotMatchedError] = true
+  get [kMockNotMatchedError] () {
+    return true
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Partial PR #4519 

I fear that people will get their tests fail, because currently the symbols are enumerable.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
