### PR TITLE
types: use MessagePort instance type in MessageEvent

### DIFF
--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -96,16 +96,16 @@ interface MessageEventInit<T = any> extends EventInit {
   data?: T
   lastEventId?: string
   origin?: string
-  ports?: (typeof MessagePort)[]
-  source?: typeof MessagePort | null
+  ports?: MessagePort[]
+  source?: MessagePort | null
 }
 
 interface MessageEvent<T = any> extends Event {
   readonly data: T
   readonly lastEventId: string
   readonly origin: string
-  readonly ports: ReadonlyArray<typeof MessagePort>
-  readonly source: typeof MessagePort | null
+  readonly ports: readonly MessagePort[]
+  readonly source: MessagePort | null
   initMessageEvent(
     type: string,
     bubbles?: boolean,
@@ -113,8 +113,8 @@ interface MessageEvent<T = any> extends Event {
     data?: any,
     origin?: string,
     lastEventId?: string,
-    source?: typeof MessagePort | null,
-    ports?: (typeof MessagePort)[]
+    source?: MessagePort | null,
+    ports?: MessagePort[]
   ): void;
 }
 


### PR DESCRIPTION
These previously mistakenly used the constructor type. Doesn't appear to be any similar errors elsewhere.