### PR TITLE
lint: activate n/no-process-exit

### DIFF
--- a/benchmarks/wait.js
+++ b/benchmarks/wait.js
@@ -18,5 +18,5 @@ waitOn({
   timeout: 5000
 }).catch((err) => {
   console.error(err)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/build/wasm.js
+++ b/build/wasm.js
@@ -65,7 +65,7 @@ if (process.argv[2] === '--docker') {
            -t ${WASM_BUILDER_CONTAINER} node build/wasm.js`
   console.log(`> ${cmd}\n\n`)
   execSync(cmd, { stdio: 'inherit' })
-  process.exit(0)
+  process.exit(0) // eslint-disable-line n/no-process-exit
 }
 
 const hasApk = (function () {
@@ -78,8 +78,7 @@ if (hasApk) {
   // Gather information about the tools used for the build
   const buildInfo = execSync('apk info -v').toString()
   if (!buildInfo.includes('wasi-sdk')) {
-    console.log('Failed to generate build environment information')
-    process.exit(-1)
+    throw new Error('Failed to generate build environment information')
   }
   console.log(buildInfo)
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ module.exports = [
   }),
   {
     rules: {
+      'n/no-process-exit': 'error',
       '@stylistic/comma-dangle': ['error', {
         arrays: 'never',
         objects: 'never',

--- a/test/autobahn/client.js
+++ b/test/autobahn/client.js
@@ -48,5 +48,5 @@ ws.addEventListener('close', () => {
 })
 ws.addEventListener('error', (e) => {
   console.error(e.error)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/test/autobahn/report.js
+++ b/test/autobahn/report.js
@@ -103,4 +103,4 @@ console.log('Details:')
 
 console.table(reorderedResult)
 
-process.exit(runFailed ? 1 : 0)
+process.exitCode = runFailed ? 1 : 0

--- a/test/interceptors/dump-interceptor.js
+++ b/test/interceptors/dump-interceptor.js
@@ -8,13 +8,10 @@ const { tspl } = require('@matteo.collina/tspl')
 const { Client, Agent, interceptors } = require('../..')
 const { dump } = interceptors
 
-if (platform() === 'win32') {
-  // TODO: Fix tests on windows
-  console.log('Skipping test on Windows')
-  process.exit(0)
-}
+// TODO: Fix tests on windows
+const skip = platform() === 'win32'
 
-test('Should handle preemptive network error', async t => {
+test('Should handle preemptive network error', { skip }, async t => {
   t = tspl(t, { plan: 4 })
   let offset = 0
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -79,7 +76,7 @@ test('Should handle preemptive network error', async t => {
   await t.completed
 })
 
-test('Should dump on abort', async t => {
+test('Should dump on abort', { skip }, async t => {
   t = tspl(t, { plan: 2 })
   let offset = 0
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -141,7 +138,7 @@ test('Should dump on abort', async t => {
   await t.completed
 })
 
-test('Should dump on already aborted request', async t => {
+test('Should dump on already aborted request', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   let offset = 0
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -202,7 +199,7 @@ test('Should dump on already aborted request', async t => {
   await t.completed
 })
 
-test('Should dump response body up to limit (default)', async t => {
+test('Should dump response body up to limit (default)', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     const buffer = Buffer.alloc(1024 * 1024)
@@ -244,7 +241,7 @@ test('Should dump response body up to limit (default)', async t => {
   await t.completed
 })
 
-test('Should dump response body up to limit and ignore trailers', async t => {
+test('Should dump response body up to limit and ignore trailers', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.writeHead(200, {
@@ -288,7 +285,7 @@ test('Should dump response body up to limit and ignore trailers', async t => {
   await t.completed
 })
 
-test('Should forward common error', async t => {
+test('Should forward common error', { skip }, async t => {
   t = tspl(t, { plan: 1 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.destroy()
@@ -323,7 +320,7 @@ test('Should forward common error', async t => {
   await t.completed
 })
 
-test('Should throw on bad opts', async t => {
+test('Should throw on bad opts', { skip }, async t => {
   t = tspl(t, { plan: 6 })
 
   t.throws(
@@ -421,7 +418,7 @@ test('Should throw on bad opts', async t => {
   )
 })
 
-test('Should dump response body up to limit (opts)', async t => {
+test('Should dump response body up to limit (opts)', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     const buffer = Buffer.alloc(1 * 1024)
@@ -462,7 +459,7 @@ test('Should dump response body up to limit (opts)', async t => {
   await t.completed
 })
 
-test('Should abort if content length grater than max size', async t => {
+test('Should abort if content length grater than max size', { skip }, async t => {
   t = tspl(t, { plan: 1 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     const buffer = Buffer.alloc(2 * 1024)
@@ -501,7 +498,7 @@ test('Should abort if content length grater than max size', async t => {
   await t.completed
 })
 
-test('Should dump response body up to limit (dispatch opts)', async t => {
+test('Should dump response body up to limit (dispatch opts)', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     const buffer = Buffer.alloc(1 * 1024)
@@ -544,7 +541,7 @@ test('Should dump response body up to limit (dispatch opts)', async t => {
   await t.completed
 })
 
-test('Should abort if content length grater than max size (dispatch opts)', async t => {
+test('Should abort if content length grater than max size (dispatch opts)', { skip }, async t => {
   t = tspl(t, { plan: 1 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     const buffer = Buffer.alloc(2 * 1024)

--- a/test/web-platform-tests/runner/test-runner.mjs
+++ b/test/web-platform-tests/runner/test-runner.mjs
@@ -102,9 +102,11 @@ function setupGlobalTestharnessCallbacks () {
     if (process.platform === 'win32') {
       // https://github.com/nodejs/node/issues/56645#issuecomment-3077594952
       setTimeout(() => {
+        // eslint-disable-next-line n/no-process-exit
         process.exit(harnessStatus.status === 0 ? 0 : 1)
       }, 50)
     } else {
+      // eslint-disable-next-line n/no-process-exit
       process.exit(harnessStatus.status === 0 ? 0 : 1)
     }
   })

--- a/test/web-platform-tests/wpt-runner.mjs
+++ b/test/web-platform-tests/wpt-runner.mjs
@@ -428,7 +428,7 @@ async function setup () {
       }
 
       console.log('❌ \x1B[31mSetup incomplete.\x1B[0m')
-      process.exit(1)
+      process.exit(1) // eslint-disable-line n/no-process-exit
     }
   }
 


### PR DESCRIPTION
we used process.exit sometimes in the past to disable test files. We should use skip option and not process.exit

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
