### PR TITLE
fix: use `globalThis.require` to require dynamically

### DIFF
--- a/lib/util/runtime-features.js
+++ b/lib/util/runtime-features.js
@@ -10,7 +10,7 @@
  */
 function detectRuntimeFeatureByNodeModule (moduleName) {
   try {
-    require(moduleName)
+    globalThis.require(moduleName)
     return true
   } catch (err) {
     if (err.code !== 'ERR_UNKNOWN_BUILTIN_MODULE') {
@@ -26,7 +26,7 @@ function detectRuntimeFeatureByNodeModule (moduleName) {
  * @returns {boolean}
  */
 function detectRuntimeFeatureByExportedProperty (moduleName, property) {
-  const module = require(moduleName)
+  const module = globalThis.require(moduleName)
   return typeof module[property] !== 'undefined'
 }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to
Optimize the following pr
feat: add runtime feature "detection" https://github.com/nodejs/undici/pull/4545
@mcollina 

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Use `globalThis.require` to dynamically require to avoid dynamic require warnings generated by bundlers such as webpack when packaging undici.  
The final product `bundle.js` does not actually require the corresponding node.js built-in module, resulting in the following error:
```log
WARNING in ./lib/util/runtime-features.js 13:4-23
Critical dependency: the request of a dependency is an expression

Error: Cannot find module 'node:worker_threads'
    webpackEmptyContext() @ internal/deps/undici/undici:10888:10
    detectRuntimeFeatureByExportedProperty() @ internal/deps/undici/undici:8762:43
    detectRuntimeFeature() @ internal/deps/undici/undici:8790:12
    #detectRuntimeFeature() @ internal/deps/undici/undici:8836:20
    RuntimeFeatures.has() @ internal/deps/undici/undici:8816:59
    2480() @ internal/deps/undici/undici:4890:49
    __webpack_require__() @ internal/deps/undici/undici:24322:41
    575() @ internal/deps/undici/undici:832:20
    __webpack_require__() @ internal/deps/undici/undici:24322:41
    8129() @ internal/deps/undici/undici:19837:5 {
  code: 'MODULE_NOT_FOUND'
}
```

caused by 
```js
function detectRuntimeFeatureByNodeModule (moduleName) {
  try {
    __webpack_require__(4839)(moduleName)
    return true
  } catch (err) {
    if (err.code !== 'ERR_UNKNOWN_BUILTIN_MODULE') {
      throw err
    }
    return false
  }
}


/***/ 4839:
/***/ ((module) => {
function webpackEmptyContext(req) {
	var e = new Error("Cannot find module '" + req + "'");
	e.code = 'MODULE_NOT_FOUND';
	throw e;
}
webpackEmptyContext.keys = () => ([]);
webpackEmptyContext.resolve = webpackEmptyContext;
webpackEmptyContext.id = 4839;
module.exports = webpackEmptyContext;
/***/ })
```

## Changes

require -> for static import, processed by bundlers
globalThis.require -> for dynamic import

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

N/A

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
