### PR TITLE
fix: use lazyloaders for runtime feature detection

### DIFF
--- a/lib/util/runtime-features.js
+++ b/lib/util/runtime-features.js
@@ -1,8 +1,15 @@
-// @ts-check
-
 'use strict'
 
 /** @typedef {`node:${string}`} NodeModuleName */
+
+/** @type {Record<NodeModuleName, () => any>} */
+const lazyLoaders = {
+  __proto__: null,
+  'node:crypto': () => require('node:crypto'),
+  'node:sqlite': () => require('node:sqlite'),
+  'node:worker_threads': () => require('node:worker_threads'),
+  'node:zlib': () => require('node:zlib')
+}
 
 /**
  * @param {NodeModuleName} moduleName
@@ -10,7 +17,7 @@
  */
 function detectRuntimeFeatureByNodeModule (moduleName) {
   try {
-    require(moduleName)
+    lazyLoaders[moduleName]()
     return true
   } catch (err) {
     if (err.code !== 'ERR_UNKNOWN_BUILTIN_MODULE') {
@@ -26,7 +33,7 @@ function detectRuntimeFeatureByNodeModule (moduleName) {
  * @returns {boolean}
  */
 function detectRuntimeFeatureByExportedProperty (moduleName, property) {
-  const module = require(moduleName)
+  const module = lazyLoaders[moduleName]()
   return typeof module[property] !== 'undefined'
 }
 
@@ -47,12 +54,17 @@ const features = /** @type {const} */ ([
   ...runtimeFeaturesAsNodeModule,
   ...runtimeFeaturesByExportedProperty
 ])
+
 /** @typedef {typeof features[number]} Feature */
 
+/**
+ * @param {Feature} feature
+ * @returns {boolean}
+ */
 function detectRuntimeFeature (feature) {
-  if (runtimeFeaturesAsNodeModule.includes(feature)) {
+  if (runtimeFeaturesAsNodeModule.includes(/** @type {RuntimeFeatureByNodeModule} */ (feature))) {
     return detectRuntimeFeatureByNodeModule(`node:${feature}`)
-  } else if (runtimeFeaturesByExportedProperty.includes(feature)) {
+  } else if (runtimeFeaturesByExportedProperty.includes(/** @type {RuntimeFeatureByExportedProperty} */ (feature))) {
     const [moduleName, property] = exportedPropertyLookup[feature]
     return detectRuntimeFeatureByExportedProperty(moduleName, property)
   }


### PR DESCRIPTION
as discussed #4555 

use lazyLoader to avoid having a require fn which dynamically loads "any" module.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
