### PR TITLE
Feat dns interceptor storage

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1043,7 +1043,7 @@ The `dns` interceptor enables you to cache DNS lookups for a given duration, per
   - The function should return a single record from the records array.
   - By default a simplified version of Round Robin is used.
   - The `records` property can be mutated to store the state of the balancing algorithm.
-- `storage: { size: number, get(origin: string): DNSInterceptorOriginRecords | null, set(origin: string, records: DNSInterceptorOriginRecords | null, options?: { ttl: number }): void, delete(origin: string): void, full(): boolean }` - Custom storage for resolved DNS records
+- `storage: DNSStorage` - Custom storage for resolved DNS records
 
 > The `Dispatcher#options` also gets extended with the options `dns.affinity`, `dns.dualStack`, `dns.lookup` and `dns.pick` which can be used to configure the interceptor at a request-per-request basis.
 
@@ -1057,6 +1057,15 @@ It represents a DNS record.
 It represents a map of DNS IP addresses records for a single origin.
 - `4.ips` - (`DNSInterceptorRecord[] | null`) The IPv4 addresses.
 - `6.ips` - (`DNSInterceptorRecord[] | null`) The IPv6 addresses.
+
+**DNSStorage**
+It represents a storage object for resolved DNS records.
+- `size` - (`number`) current size of the storage.
+- `get` - (`(origin: string) => DNSInterceptorOriginRecords | null`) method to get the records for a given origin.
+- `set` - (`(origin: string, records: DNSInterceptorOriginRecords | null, options: { ttl: number }) => void`) method to set the records for a given origin.
+- `delete` - (`(origin: string) => void`) method to delete records for a given origin.
+- `full` - (`() => boolean`) method to check if the storage is full, if returns `true`, DNS lookup will be skipped in this interceptor and new records will not be stored.
+```ts
 
 **Example - Basic DNS Interceptor**
 

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -402,6 +402,17 @@ module.exports = interceptorOpts => {
     throw new InvalidArgumentError('Invalid pick. Must be a function')
   }
 
+  if (
+    // interceptorOpts?.storage != null &&
+    (typeof interceptorOpts?.storage?.get !== 'function' ||
+      typeof interceptorOpts?.storage?.set !== 'function' ||
+      typeof interceptorOpts?.storage?.full !== 'function' ||
+      typeof interceptorOpts?.storage?.delete !== 'function'
+    )
+  ) {
+    throw new InvalidArgumentError('Invalid storage. Must be a object with methods: { get, set, full, delete }')
+  }
+
   const dualStack = interceptorOpts?.dualStack ?? true
   let affinity
   if (dualStack) {

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -5,6 +5,36 @@ const DecoratorHandler = require('../handler/decorator-handler')
 const { InvalidArgumentError, InformationalError } = require('../core/errors')
 const maxInt = Math.pow(2, 31) - 1
 
+class DNSStorage {
+  #maxItems = 0
+  #records = new Map()
+
+  constructor (opts) {
+    this.#maxItems = opts.maxItems
+  }
+
+  get size () {
+    return this.#records.size
+  }
+
+  get (hostname) {
+    return this.#records.get(hostname) ?? null
+  }
+
+  set (hostname, records) {
+    this.#records.set(hostname, records)
+  }
+
+  delete (hostname) {
+    this.#records.delete(hostname)
+  }
+
+  // Delegate to storage decide can we do more lookups or not
+  full () {
+    return this.size >= this.#maxItems
+  }
+}
+
 class DNSInstance {
   #maxTTL = 0
   #maxItems = 0
@@ -12,7 +42,7 @@ class DNSInstance {
   affinity = null
   lookup = null
   pick = null
-  cache = null
+  storage = null
 
   constructor (opts) {
     this.#maxTTL = opts.maxTTL
@@ -21,18 +51,14 @@ class DNSInstance {
     this.affinity = opts.affinity
     this.lookup = opts.lookup ?? this.#defaultLookup
     this.pick = opts.pick ?? this.#defaultPick
-    this.cache = opts.cache ?? new Map()
-  }
-
-  get full () {
-    return this.cache.size === this.#maxItems
+    this.storage = opts.storage ?? new DNSStorage(opts)
   }
 
   runLookup (origin, opts, cb) {
-    const ips = this.cache.get(origin.hostname)
+    const ips = this.storage.get(origin.hostname)
 
     // If full, we just return the origin
-    if (ips == null && this.full) {
+    if (ips == null && this.storage.full()) {
       cb(null, origin)
       return
     }
@@ -56,7 +82,7 @@ class DNSInstance {
         }
 
         this.setRecords(origin, addresses)
-        const records = this.cache.get(origin.hostname)
+        const records = this.storage.get(origin.hostname)
 
         const ip = this.pick(
           origin,
@@ -90,7 +116,7 @@ class DNSInstance {
 
       // If no IPs we lookup - deleting old records
       if (ip == null) {
-        this.cache.delete(origin.hostname)
+        this.storage.delete(origin.hostname)
         this.runLookup(origin, opts, cb)
         return
       }
@@ -194,7 +220,7 @@ class DNSInstance {
   }
 
   pickFamily (origin, ipFamily) {
-    const records = this.cache.get(origin.hostname)?.records
+    const records = this.storage.get(origin.hostname)?.records
     if (!records) {
       return null
     }
@@ -228,11 +254,13 @@ class DNSInstance {
   setRecords (origin, addresses) {
     const timestamp = Date.now()
     const records = { records: { 4: null, 6: null } }
+    let minTTL = this.#maxTTL
     for (const record of addresses) {
       record.timestamp = timestamp
       if (typeof record.ttl === 'number') {
         // The record TTL is expected to be in ms
         record.ttl = Math.min(record.ttl, this.#maxTTL)
+        minTTL = Math.min(minTTL, record.ttl)
       } else {
         record.ttl = this.#maxTTL
       }
@@ -243,11 +271,12 @@ class DNSInstance {
       records.records[record.family] = familyRecords
     }
 
-    this.cache.set(origin.hostname, records)
+    // We provide a default TTL if external storage will be used without TTL per record-level support
+    this.storage.set(origin.hostname, records, { ttl: minTTL })
   }
 
   deleteRecords (origin) {
-    this.cache.delete(origin.hostname)
+    this.storage.delete(origin.hostname)
   }
 
   getHandler (meta, opts) {

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -403,7 +403,7 @@ module.exports = interceptorOpts => {
   }
 
   if (
-    // interceptorOpts?.storage != null &&
+    interceptorOpts?.storage != null &&
     (typeof interceptorOpts?.storage?.get !== 'function' ||
       typeof interceptorOpts?.storage?.set !== 'function' ||
       typeof interceptorOpts?.storage?.full !== 'function' ||
@@ -427,7 +427,8 @@ module.exports = interceptorOpts => {
     pick: interceptorOpts?.pick ?? null,
     dualStack,
     affinity,
-    maxItems: interceptorOpts?.maxItems ?? Infinity
+    maxItems: interceptorOpts?.maxItems ?? Infinity,
+    storage: interceptorOpts?.storage
   }
 
   const instance = new DNSInstance(opts)

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -8,11 +8,11 @@ const maxInt = Math.pow(2, 31) - 1
 class DNSInstance {
   #maxTTL = 0
   #maxItems = 0
-  #records = new Map()
   dualStack = true
   affinity = null
   lookup = null
   pick = null
+  cache = null
 
   constructor (opts) {
     this.#maxTTL = opts.maxTTL
@@ -21,14 +21,15 @@ class DNSInstance {
     this.affinity = opts.affinity
     this.lookup = opts.lookup ?? this.#defaultLookup
     this.pick = opts.pick ?? this.#defaultPick
+    this.cache = opts.cache ?? new Map()
   }
 
   get full () {
-    return this.#records.size === this.#maxItems
+    return this.cache.size === this.#maxItems
   }
 
   runLookup (origin, opts, cb) {
-    const ips = this.#records.get(origin.hostname)
+    const ips = this.cache.get(origin.hostname)
 
     // If full, we just return the origin
     if (ips == null && this.full) {
@@ -55,7 +56,7 @@ class DNSInstance {
         }
 
         this.setRecords(origin, addresses)
-        const records = this.#records.get(origin.hostname)
+        const records = this.cache.get(origin.hostname)
 
         const ip = this.pick(
           origin,
@@ -89,7 +90,7 @@ class DNSInstance {
 
       // If no IPs we lookup - deleting old records
       if (ip == null) {
-        this.#records.delete(origin.hostname)
+        this.cache.delete(origin.hostname)
         this.runLookup(origin, opts, cb)
         return
       }
@@ -193,7 +194,7 @@ class DNSInstance {
   }
 
   pickFamily (origin, ipFamily) {
-    const records = this.#records.get(origin.hostname)?.records
+    const records = this.cache.get(origin.hostname)?.records
     if (!records) {
       return null
     }
@@ -242,11 +243,11 @@ class DNSInstance {
       records.records[record.family] = familyRecords
     }
 
-    this.#records.set(origin.hostname, records)
+    this.cache.set(origin.hostname, records)
   }
 
   deleteRecords (origin) {
-    this.#records.delete(origin.hostname)
+    this.cache.delete(origin.hostname)
   }
 
   getHandler (meta, opts) {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test:infra": "borp -p \"test/infra/*.js\"",
     "test:interceptors": "borp -p \"test/interceptors/*.js\"",
     "test:jest": "cross-env NODE_V8_COVERAGE= jest",
-    "test:unit": "borp --expose-gc -p \"test/*.js\"",
+    "test:unit": "borp --reporter spec",
     "test:node-fetch": "borp -p \"test/node-fetch/**/*.js\"",
     "test:node-test": "borp -p \"test/node-test/**/*.js\"",
     "test:tdd": "borp --expose-gc -p \"test/*.js\"",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test:infra": "borp -p \"test/infra/*.js\"",
     "test:interceptors": "borp -p \"test/interceptors/*.js\"",
     "test:jest": "cross-env NODE_V8_COVERAGE= jest",
-    "test:unit": "borp --reporter spec",
+    "test:unit": "borp --expose-gc -p \"test/*.js\"",
     "test:node-fetch": "borp -p \"test/node-fetch/**/*.js\"",
     "test:node-test": "borp -p \"test/node-test/**/*.js\"",
     "test:tdd": "borp --expose-gc -p \"test/*.js\"",

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -15,7 +15,7 @@ const { interceptors, Agent } = require('../..')
 const { dns } = interceptors
 
 test('Should validate options', t => {
-  t = tspl(t, { plan: 10 })
+  t = tspl(t, { plan: 11 })
 
   t.throws(() => dns({ dualStack: 'true' }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ dualStack: 0 }), { code: 'UND_ERR_INVALID_ARG' })
@@ -27,6 +27,7 @@ test('Should validate options', t => {
   t.throws(() => dns({ maxItems: -1 }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ lookup: {} }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ pick: [] }), { code: 'UND_ERR_INVALID_ARG' })
+  t.throws(() => dns({ storage: new Map() }), { code: 'UND_ERR_INVALID_ARG' })
 })
 
 test('Should automatically resolve IPs (dual stack)', async t => {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -1802,7 +1802,6 @@ test('Should support external storage', async t => {
       }
     },
     dns({
-      maxItems: Infinity,
       storage,
       lookup: (_origin, _opts, cb) => {
         cb(null, [

--- a/test/types/dns-interceptor.test-d.ts
+++ b/test/types/dns-interceptor.test-d.ts
@@ -1,0 +1,58 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { LookupOptions } from 'node:dns'
+import Interceptors from '../../types/interceptors'
+
+const storage: Interceptors.DNSStorage = {
+  get size (): number {
+    throw new Error('stub')
+  },
+  get (origin: string): Interceptors.DNSInterceptorOriginRecords | null {
+    throw new Error('stub')
+  },
+  set (origin: string, records: Interceptors.DNSInterceptorOriginRecords | null, options: { ttl: number }): void {
+    throw new Error('stub')
+  },
+  delete (origin: string): void {
+    throw new Error('stub')
+  },
+  full (): boolean {
+    throw new Error('stub')
+  }
+}
+
+const lookup: Interceptors.DNSInterceptorOpts['lookup'] = (origin: URL, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: Interceptors.DNSInterceptorRecord[]) => void): void => {
+  throw new Error('stub')
+}
+
+const pick: Interceptors.DNSInterceptorOpts['pick'] = (origin: URL, records: Interceptors.DNSInterceptorOriginRecords, affinity: 4 | 6): Interceptors.DNSInterceptorRecord => {
+  throw new Error('stub')
+}
+
+expectAssignable<Interceptors.DNSInterceptorOpts>({})
+expectAssignable<Interceptors.DNSInterceptorOpts>({ storage })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ maxTTL: 1000 })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ maxItems: 1000 })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ dualStack: true })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ affinity: 4 })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ lookup })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ pick })
+
+expectAssignable<Interceptors.DNSInterceptorRecord>({ address: '127.0.0.1', ttl: 300, family: 4 })
+
+expectAssignable<Interceptors.DNSInterceptorOriginRecords>({ records: { 4: { ips: [{ address: '127.0.0.1', ttl: 300, family: 4 }] }, 6: null } })
+
+expectNotAssignable<Interceptors.DNSInterceptorOpts>({ storage: new Map() })
+expectNotAssignable<Interceptors.DNSInterceptorOpts>({
+  lookup: (origin: string) => {
+    throw new Error('stub')
+  }
+})
+expectNotAssignable<Interceptors.DNSInterceptorOpts>({
+  pick: (origin: string) => {
+    throw new Error('stub')
+  }
+})
+
+expectNotAssignable<Interceptors.DNSInterceptorRecord>({})
+
+expectNotAssignable<Interceptors.DNSInterceptorOriginRecords>({ 4: { ips: [{ address: '127.0.0.1', ttl: 300, family: 4 }] }, 6: null })

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -23,7 +23,7 @@ declare namespace Interceptors {
   export type DNSStorage = {
     size: number
     get(origin: string): DNSInterceptorOriginRecords | null
-    set(origin: string, records: DNSInterceptorOriginRecords | null, options?: { ttl: number }): void
+    set(origin: string, records: DNSInterceptorOriginRecords | null, options: { ttl: number }): void
     delete(origin: string): void
     full(): boolean
   }

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -30,7 +30,7 @@ declare namespace Interceptors {
   export type DNSInterceptorOpts = {
     maxTTL?: number
     maxItems?: number
-    lookup?: (hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void
+    lookup?: (origin: URL, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void
     pick?: (origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord
     dualStack?: boolean
     affinity?: 4 | 6

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -19,7 +19,14 @@ declare namespace Interceptors {
 
   // DNS interceptor
   export type DNSInterceptorRecord = { address: string, ttl: number, family: 4 | 6 }
-  export type DNSInterceptorOriginRecords = { 4: { ips: DNSInterceptorRecord[] } | null, 6: { ips: DNSInterceptorRecord[] } | null }
+  export type DNSInterceptorOriginRecords = { records: { 4: { ips: DNSInterceptorRecord[] } | null, 6: { ips: DNSInterceptorRecord[] } | null } }
+  export type DNSStorage = {
+    size: number
+    get(origin: string): DNSInterceptorOriginRecords | null
+    set(origin: string, records: DNSInterceptorOriginRecords | null, options?: { ttl: number }): void
+    delete(origin: string): void
+    full(): boolean
+  }
   export type DNSInterceptorOpts = {
     maxTTL?: number
     maxItems?: number
@@ -27,6 +34,7 @@ declare namespace Interceptors {
     pick?: (origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord
     dualStack?: boolean
     affinity?: 4 | 6
+    storage?: DNSStorage
   }
 
   export function dump (opts?: DumpInterceptorOpts): Dispatcher.DispatcherComposeInterceptor


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

Alternative implementation for https://github.com/nodejs/undici/pull/4565

Custom `cache` for DNS interceptor allows:
- add custom metrics for DNS cache hit rate monitoring
- use any cache library (`lru-cache`, etc.)

Reference - https://github.com/szmarczak/cacheable-lookup?tab=readme-ov-file#cache

## Changes

Added `cache` parameter for `DNSInstance`

<!-- Write a summary or list of changes here -->

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
