### PR TITLE
types: optional `status` in `Response.redirect`

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -207,5 +207,5 @@ export declare class Response extends BodyMixin {
 
   static error (): Response
   static json (data: any, init?: ResponseInit): Response
-  static redirect (url: string | URL, status: ResponseRedirectStatus): Response
+  static redirect (url: string | URL, status?: ResponseRedirectStatus): Response
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static#status

https://github.com/nodejs/undici/blob/7321451d17efb85e79ef975db82489a75aa39085/lib/web/fetch/response.js#L72