### PR TITLE
fix: cacheStores types and usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ console.log('trailers', trailers)
 Undici provides a powerful HTTP caching interceptor that follows HTTP caching best practices. Here's how to use it:
 
 ```js
-import { fetch, Agent, interceptors } from 'undici';
+import { fetch, Agent, interceptors, cacheStores } from 'undici';
 
 // Create a client with cache interceptor
 const client = new Agent().compose(interceptors.cache({
   // Optional: Configure cache store (defaults to MemoryCacheStore)
-  store: new interceptors.cacheStores.MemoryCacheStore({
+  store: new cacheStores.MemoryCacheStore({
     maxSize: 100 * 1024 * 1024, // 100MB
     maxCount: 1000,
     maxEntrySize: 5 * 1024 * 1024 // 5MB

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -11,9 +11,11 @@ import Undici, {
   Request,
   FormData,
   SnapshotAgent,
-  install
+  install,
+  cacheStores
 } from '../..'
 import Dispatcher from '../../types/dispatcher'
+import CacheInterceptor from '../../types/cache-interceptor'
 
 expectAssignable<Pool>(new Undici.Pool('', {}))
 expectAssignable<Client>(new Undici.Client('', {}))
@@ -30,6 +32,10 @@ expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.re
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.retry())
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.decompress())
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.cache())
+expectAssignable<CacheInterceptor.CacheStore>(new Undici.cacheStores.MemoryCacheStore())
+expectAssignable<CacheInterceptor.CacheStore>(new Undici.cacheStores.SqliteCacheStore())
+expectAssignable<CacheInterceptor.CacheStore>(new cacheStores.MemoryCacheStore())
+expectAssignable<CacheInterceptor.CacheStore>(new cacheStores.SqliteCacheStore())
 
 const dispatcher = new Dispatcher()
 const handler: Dispatcher.DispatchHandler = {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,12 @@ import RetryAgent from './retry-agent'
 import { request, pipeline, stream, connect, upgrade } from './api'
 import interceptors from './interceptors'
 
+import CacheInterceptor from './cache-interceptor'
+declare const cacheStores: {
+  MemoryCacheStore: typeof CacheInterceptor.MemoryCacheStore;
+  SqliteCacheStore: typeof CacheInterceptor.SqliteCacheStore;
+}
+
 export * from './util'
 export * from './cookies'
 export * from './eventsource'
@@ -36,7 +42,7 @@ export { Interceptable } from './mock-interceptor'
 
 declare function globalThisInstall (): void
 
-export { Dispatcher, BalancedPool, Pool, Client, buildConnector, errors, Agent, request, stream, pipeline, connect, upgrade, setGlobalDispatcher, getGlobalDispatcher, setGlobalOrigin, getGlobalOrigin, interceptors, MockClient, MockPool, MockAgent, SnapshotAgent, MockCallHistory, MockCallHistoryLog, mockErrors, ProxyAgent, EnvHttpProxyAgent, RedirectHandler, DecoratorHandler, RetryHandler, RetryAgent, H2CClient, globalThisInstall as install }
+export { Dispatcher, BalancedPool, Pool, Client, buildConnector, errors, Agent, request, stream, pipeline, connect, upgrade, setGlobalDispatcher, getGlobalDispatcher, setGlobalOrigin, getGlobalOrigin, interceptors, cacheStores, MockClient, MockPool, MockAgent, SnapshotAgent, MockCallHistory, MockCallHistoryLog, mockErrors, ProxyAgent, EnvHttpProxyAgent, RedirectHandler, DecoratorHandler, RetryHandler, RetryAgent, H2CClient, globalThisInstall as install }
 export default Undici
 
 declare namespace Undici {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

1. Cannot use cacheStores in typescript directly (works with `Undici` facade)
2. Misleading README pointing to `interceptors.cacheStores`

## Changes

1. Added a `cacheStores` export 
4. README usage 

### Features

<!-- List the new features here (if applicable), or write N/A if not -->
N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->
Missing export for `cacheStores`

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
