### PR TITLE
fix: max-age=0 and no-cache must be considered "immediately stale"

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -393,9 +393,14 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
 
   const maxAge = cacheControlDirectives['max-age']
   if (maxAge !== undefined) {
-    return maxAge > 0 ? maxAge * 1000 : undefined
+    return maxAge >= 0 ? maxAge * 1000 : undefined
   }
 
+  const noCache = cacheControlDirectives['no-cache']
+  if (noCache !== undefined) {
+    return 0
+  }
+  
   if (typeof resHeaders.expires === 'string') {
     // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.3
     const expiresDate = parseHttpDate(resHeaders.expires)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

https://github.com/nodejs/undici/discussions/4620#discussioncomment-14685096

## Rationale

When server is responding with a max-age=0 or no-cache, Undici does not cache the response and subsequent requests do not include if-none-match or if-modified-since headers.

## Changes

The function determineStaleAt does not take max-age=0 and no-cache into account, returning undefined in both cases: the caller will ignore the response in regard to the cache handling

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A
## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
