### PR TITLE
fix: prevent duplicate error and close events in WebSocket

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -42,6 +42,7 @@ const { channels } = require('../../core/diagnostics')
  * @property {Set<number>} closeState
  * @property {import('../fetch/index').Fetch} controller
  * @property {boolean} [wasEverConnected=false]
+ * @property {boolean} [closeEventFired=false]
  */
 
 // https://websockets.spec.whatwg.org/#interface-definition
@@ -102,7 +103,8 @@ class WebSocket extends EventTarget {
     socket: null,
     closeState: new Set(),
     controller: null,
-    wasEverConnected: false
+    wasEverConnected: false,
+    closeEventFired: false
   }
 
   #url
@@ -554,6 +556,12 @@ class WebSocket extends EventTarget {
    * @see https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.4
    */
   #onSocketClose () {
+    // Prevent duplicate close events
+    if (this.#handler.closeEventFired) {
+      return
+    }
+    this.#handler.closeEventFired = true
+
     // If the TCP connection was closed after the
     // WebSocket closing handshake was completed, the WebSocket connection
     // is said to have been closed _cleanly_.

--- a/test/websocket/issue-4628.js
+++ b/test/websocket/issue-4628.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test } = require('node:test')
+const { WebSocket } = require('../..')
+
+test('closing before connection is established should only fire error and close events once', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const ws = new WebSocket('wss://example.com/')
+
+  ws.addEventListener('error', () => {
+    t.ok(true, 'error event fired')
+  })
+
+  ws.addEventListener('close', () => {
+    t.ok(true, 'close event fired')
+  })
+
+  // Close immediately before connection is established
+  setTimeout(() => {
+    ws.close()
+  }, 10)
+
+  await t.completed
+})


### PR DESCRIPTION
## Summary

Fixes #4628

When a WebSocket is closed before the connection is established, the `error` and `close` events were being fired twice instead of once.

## Root Cause

The issue was caused by `onSocketClose()` being called multiple times:

1. **First call**: When `ws.close()` is called before connection, it triggers:
   - `closeWebSocketConnection` → `failWebsocketConnection` → `onSocketClose()`
2. **Second call**: The aborted fetch controller returns an error response, which triggers:
   - `failWebsocketConnection` again → `onSocketClose()` again

## Solution

Added a `closeEventFired` flag to the WebSocket handler to prevent duplicate events from being fired.

### Changes

- **`lib/web/websocket/websocket.js`**:
  - Added `closeEventFired` property to the Handler typedef
  - Initialized `closeEventFired: false` in the handler object
  - Added early return check in `#onSocketClose()` to prevent duplicate events

- **`test/websocket/issue-4628.js`**:
  - Added regression test to verify events fire exactly once

## Testing

- ✅ New test case passes
- ✅ All existing websocket tests pass (85 tests)
- ✅ Manual verification with reproduction case from issue

### Before Fix
```
error 3
Closed 3
error 3
Closed 3
```

### After Fix
```
error 3
Closed 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)