### PR TITLE
test: fix flaky http2-dispatcher test

### DIFF
--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -145,17 +145,25 @@ test('Dispatcher#Connect', async t => {
     })
     after(() => forward.close())
 
-    const response = await forward.request({
-      path: '/',
-      method: 'POST',
-      body: stream,
-      headers: {
-        'x-my-header': headers['x-my-header']
-      }
-    })
+    try {
+      const response = await forward.request({
+        path: '/',
+        method: 'POST',
+        body: stream,
+        headers: {
+          'x-my-header': headers['x-my-header']
+        }
+      })
 
-    stream.respond({ ':status': 200, 'x-my-header': response.headers['x-my-header'] })
-    response.body.pipe(stream)
+      stream.respond({ ':status': 200, 'x-my-header': response.headers['x-my-header'] })
+      pipeline(response.body, stream, (err) => {
+        if (err) {
+          stream.destroy(err)
+        }
+      })
+    } catch (err) {
+      stream.destroy(err)
+    }
   })
 
   server.on('stream', (stream, headers) => {


### PR DESCRIPTION
## Summary

Fixed flaky `Dispatcher#Connect` test in `test/http2-dispatcher.js` that was intermittently failing with `ERR_HTTP2_STREAM_ERROR` and timing out.

## Problem

The test was using `response.body.pipe(stream)` without proper error handling. When HTTP/2 streams encountered errors (like `NGHTTP2_INTERNAL_ERROR`), they became uncaught exceptions, causing random test failures and timeouts.

## Solution

- Replaced `.pipe()` with `pipeline()` for proper error handling
- Added try-catch block around the forward request
- Properly destroys streams on errors to prevent hanging connections

## Test Plan

- ✅ Ran test 20+ times consecutively - all passed
- ✅ Pre-commit hooks passed (eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)