### PR TITLE
Run the gc() in long-lived-abort-controller test

### DIFF
--- a/test/fetch/long-lived-abort-controller.js
+++ b/test/fetch/long-lived-abort-controller.js
@@ -39,6 +39,9 @@ test('long-lived-abort-controller', async (t) => {
 
     // drain body
     await res.text()
+
+    // eslint-disable-next-line no-undef
+    gc()
   }
 
   t.assert.strictEqual(emittedWarning, '')


### PR DESCRIPTION
Alternative to https://github.com/nodejs/undici/pull/4636.