### PR TITLE
fix: fetch blob with range off-by-one error

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -889,7 +889,7 @@ function schemeFetch (fetchParams) {
 
         // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart,
         //    rangeEnd + 1, and type.
-        const slicedBlob = blob.slice(rangeStart, rangeEnd, type)
+        const slicedBlob = blob.slice(rangeStart, rangeEnd + 1, type)
 
         // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.
         // Note: same reason as mentioned above as to why we use extractBody

--- a/test/fetch/blob-uri.js
+++ b/test/fetch/blob-uri.js
@@ -23,6 +23,19 @@ test('fetching blob: uris', async (t) => {
     t.assert.strictEqual(`${blob.size}`, res.headers.get('Content-Length'))
   })
 
+  await t.test('a range fetch request returns the inclusive byte range', async () => {
+    const res = await fetch(objectURL, {
+      headers: {
+        Range: 'bytes=1-3'
+      }
+    })
+
+    t.assert.strictEqual(res.status, 206)
+    t.assert.strictEqual(await res.text(), blobContents.slice(1, 4))
+    t.assert.strictEqual(res.headers.get('Content-Length'), '3')
+    t.assert.strictEqual(res.headers.get('Content-Range'), `bytes 1-3/${blob.size}`)
+  })
+
   await t.test('non-GET method to blob: fails', async () => {
     try {
       await fetch(objectURL, {


### PR DESCRIPTION
In a range request, the rangeEnd is meant to be inclusive, but undici has a bug in its handling of range requests on blob uri's that misses the last character.

## This relates to...

Fix for https://github.com/nodejs/node/issues/60382

Credit to @severo for discovering this bug.

## Rationale

The [fetch spec](https://fetch.spec.whatwg.org/#concept-scheme-fetch) clearly states that:

> Let slicedBlob be the result of invoking [slice blob](https://w3c.github.io/FileAPI/#slice-blob) given blob, rangeStart, rangeEnd + 1, and type.
> 
> Note: A range header denotes an inclusive byte range, while the [slice blob](https://w3c.github.io/FileAPI/#slice-blob) algorithm input range does not. To use the [slice blob](https://w3c.github.io/FileAPI/#slice-blob) algorithm, we have to increment rangeEnd.

And funny enough, in the undici code the COMMENT is correct but the code is off by one:

```js
        // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart,
        //    rangeEnd + 1, and type.
        const slicedBlob = blob.slice(rangeStart, rangeEnd, type)
```

## Changes

Fixes the off-by-one error in range requests by adding 1 to the rangeEnd slice.

```js
        // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart,
        //    rangeEnd + 1, and type.
        const slicedBlob = blob.slice(rangeStart, rangeEnd + 1, type)
```

Includes a test which fails on master but passes with this fix.

### Features

n/a

### Bug Fixes

Fixes https://github.com/nodejs/node/issues/60382

### Breaking Changes and Deprecations

n/a

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
