### PR TITLE
feat(dispatcher/env-http-proxy-agent): strip leading dot and asterisk

### DIFF
--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -258,10 +258,10 @@ describe('no_proxy', () => {
     t.ok(await doesNotProxy('http://example:80'))
     t.ok(await doesNotProxy('http://example:0'))
     t.ok(await doesNotProxy('http://example:1337'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example'))
+    t.ok(await doesNotProxy('http://sub.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://a.b.example'))
+    t.ok(await doesNotProxy('http://a.b.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://host/example'))
     return dispatcher.close()
   })
@@ -273,10 +273,10 @@ describe('no_proxy', () => {
     t.ok(await doesNotProxy('http://example:80'))
     t.ok(await doesNotProxy('http://example:0'))
     t.ok(await doesNotProxy('http://example:1337'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example'))
+    t.ok(await doesNotProxy('http://sub.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://a.b.example'))
+    t.ok(await doesNotProxy('http://a.b.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://host/example'))
     return dispatcher.close()
   })
@@ -290,24 +290,25 @@ describe('no_proxy', () => {
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:0'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:1337'))
     t.ok(await doesNotProxy('http://sub.example'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://no.sub.example'))
+    t.ok(await doesNotProxy('http://no.sub.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub-example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.sub'))
     return dispatcher.close()
   })
 
   test('host + port', async (t) => {
-    t = tspl(t, { plan: 12 })
+    t = tspl(t, { plan: 13 })
     process.env.no_proxy = 'example:80, localhost:3000'
-    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(12)
+    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(13)
     t.ok(await doesNotProxy('http://example'))
     t.ok(await doesNotProxy('http://example:80'))
+    t.ok(await doesNotProxy('http://sub.example:80'))
     t.ok(await doesNotProxy('http://example:0'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:1337'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example'))
+    t.ok(await doesNotProxy('http://sub.example'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://a.b.example'))
+    t.ok(await doesNotProxy('http://a.b.example'))
     t.ok(await doesNotProxy('http://localhost:3000/'))
     t.ok(await doesNotProxy('https://localhost:3000/'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://localhost:3001/'))
@@ -315,52 +316,48 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
-  test('host suffix', async (t) => {
+  test('host suffix - leading dot stripped', async (t) => {
     t = tspl(t, { plan: 9 })
     process.env.no_proxy = '.example'
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(9)
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:80'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:1337'))
-    t.ok(await doesNotProxy('http://sub.example'))
-    t.ok(await doesNotProxy('http://sub.example:80'))
-    t.ok(await doesNotProxy('http://sub.example:1337'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await doesNotProxy('http://a.b.example'))
-    return dispatcher.close()
-  })
-
-  test('host suffix with *.', async (t) => {
-    t = tspl(t, { plan: 9 })
-    process.env.no_proxy = '*.example'
-    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(9)
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:80'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:1337'))
-    t.ok(await doesNotProxy('http://sub.example'))
-    t.ok(await doesNotProxy('http://sub.example:80'))
-    t.ok(await doesNotProxy('http://sub.example:1337'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await doesNotProxy('http://a.b.example'))
-    return dispatcher.close()
-  })
-
-  test('substring suffix', async (t) => {
-    t = tspl(t, { plan: 10 })
-    process.env.no_proxy = '*example'
-    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(10)
     t.ok(await doesNotProxy('http://example'))
     t.ok(await doesNotProxy('http://example:80'))
     t.ok(await doesNotProxy('http://example:1337'))
     t.ok(await doesNotProxy('http://sub.example'))
     t.ok(await doesNotProxy('http://sub.example:80'))
     t.ok(await doesNotProxy('http://sub.example:1337'))
-    t.ok(await doesNotProxy('http://prefexample'))
-    t.ok(await doesNotProxy('http://a.b.example'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://host/example'))
+    t.ok(await doesNotProxy('http://a.b.example'))
+    return dispatcher.close()
+  })
+
+  test('host suffix with *. - leading dot with asterisk stripped', async (t) => {
+    t = tspl(t, { plan: 9 })
+    process.env.no_proxy = '*.example'
+    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(9)
+    t.ok(await doesNotProxy('http://example'))
+    t.ok(await doesNotProxy('http://example:80'))
+    t.ok(await doesNotProxy('http://example:1337'))
+    t.ok(await doesNotProxy('http://sub.example'))
+    t.ok(await doesNotProxy('http://sub.example:80'))
+    t.ok(await doesNotProxy('http://sub.example:1337'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.no'))
+    t.ok(await doesNotProxy('http://a.b.example'))
+    return dispatcher.close()
+  })
+
+  test('substring suffix are NOT supported', async (t) => {
+    t = tspl(t, { plan: 6 })
+    process.env.no_proxy = '*example'
+    const { dispatcher, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(6)
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://prefexample'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://x.prefexample'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://a.b.example'))
     return dispatcher.close()
   })
 
@@ -442,11 +439,11 @@ describe('no_proxy', () => {
 
   test('prefers lowercase over uppercase', async (t) => {
     t = tspl(t, { plan: 2 })
-    process.env.NO_PROXY = 'sub.example.com'
+    process.env.NO_PROXY = 'another.com'
     process.env.no_proxy = 'example.com'
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(6)
     t.ok(await doesNotProxy('http://example.com'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example.com'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://another.com'))
     return dispatcher.close()
   })
 
@@ -464,10 +461,10 @@ describe('no_proxy', () => {
     process.env.no_proxy = 'example.com'
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(4)
     t.ok(await doesNotProxy('http://example.com'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example.com'))
-    process.env.no_proxy = 'sub.example.com'
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://another.com'))
+    process.env.no_proxy = 'another.com'
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example.com'))
-    t.ok(await doesNotProxy('http://sub.example.com'))
+    t.ok(await doesNotProxy('http://another.com'))
     return dispatcher.close()
   })
 
@@ -475,10 +472,10 @@ describe('no_proxy', () => {
     t = tspl(t, { plan: 4 })
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(4, { noProxy: 'example.com' })
     t.ok(await doesNotProxy('http://example.com'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example.com'))
-    process.env.no_proxy = 'sub.example.com'
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://another.com'))
+    process.env.no_proxy = 'another.com'
     t.ok(await doesNotProxy('http://example.com'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://sub.example.com'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://another.com'))
     return dispatcher.close()
   })
 })


### PR DESCRIPTION
## This relates to...

https://github.com/nodejs/undici/discussions/4618

## Rationale

`no_proxy` matching logic changes related to current behaviour in `curl`, `deno` and this specification - https://about.gitlab.com/blog/we-need-to-talk-no-proxy/

## Changes

- strip leading dot, so `no_proxy=.example.com` is equivalent to `no_proxy=example.com`
- strip leading asterisk with dot, so `no_proxy=*.example.com` is equivalent to `no_proxy=example.com`
- drop support for substring suffix (this syntax is not specified anywhere), so `no_proxy=*example` is equivalent to `no_proxy=""` or the absence of a `no_proxy` variable

### Breaking Changes and Deprecations

Сhanges in the current Merge Request can be considered as breaking.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
