### PR TITLE
fix: ac lost on cloned request (#4068)

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -29,6 +29,7 @@ const assert = require('node:assert')
 const { getMaxListeners, setMaxListeners, defaultMaxListeners } = require('node:events')
 
 const kAbortController = Symbol('abortController')
+const kDependantAbortController = Symbol('dependantAbortController')
 
 const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
   signal.removeEventListener('abort', abort)
@@ -428,6 +429,12 @@ class Request {
         // See, https://github.com/nodejs/undici/issues/1926.
         this[kAbortController] = ac
 
+        // Keep ref to original ac while cloned request is alive.
+        // See, https://github.com/nodejs/undici/issues/4068.
+        if (webidl.is.Request(input) && input[kAbortController]) {
+          this[kDependantAbortController] = input[kAbortController]
+        }
+
         const acRef = new WeakRef(ac)
         const abort = buildAbort(acRef)
 
@@ -790,8 +797,19 @@ class Request {
       )
     }
 
-    // 4. Return clonedRequestObject.
-    return fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    // 4. Construct clonedRequestObject.
+    const req = fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    req[kAbortController] = ac
+
+    // 5. Keep reference of original controller to avoid GC
+    // Keep ref to original ac while cloned request is alive.
+    // See, https://github.com/nodejs/undici/issues/4068.
+    if (this[kAbortController]) {
+      req[kDependantAbortController] = this[kAbortController]
+    }
+
+    // 6. Return cloned request
+    return req
   }
 
   [nodeUtil.inspect.custom] (depth, options) {

--- a/test/fetch/issue-4068.js
+++ b/test/fetch/issue-4068.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { once } = require('node:events')
+const { test, describe } = require('node:test')
+const { fetch, Request } = require('../..')
+const { createServer } = require('node:http')
+
+describe('issue 4068', async () => {
+  test('abort signal for new request', async (t) => {
+    t.plan(2)
+    const server = createServer(() => {}).listen(0)
+    let aborted = false
+
+    t.after(server.close.bind(server))
+
+    const ac = new AbortController()
+    let req = new Request(`http://localhost:${server.address().port}`, {
+      signal: ac.signal
+    })
+
+    req.signal.addEventListener('abort', () => {
+      aborted = true
+    })
+
+    req = new Request(req)
+    setTimeout(() => {
+      global.gc()
+      ac.abort()
+    })
+    await once(server, 'listening')
+    await t.assert.rejects(fetch(req))
+    t.assert.ok(aborted)
+  })
+
+  test('abort signal for cloned request', async (t) => {
+    t.plan(2)
+    const server = createServer(() => {}).listen(0)
+    let aborted = false
+
+    t.after(server.close.bind(server))
+
+    const ac = new AbortController()
+    let req = new Request(`http://localhost:${server.address().port}`, {
+      signal: ac.signal
+    })
+
+    req.signal.addEventListener('abort', () => {
+      aborted = true
+    })
+
+    req = req.clone()
+    setTimeout(() => {
+      global.gc()
+      ac.abort()
+    })
+    await once(server, 'listening')
+    await t.assert.rejects(fetch(req))
+    t.assert.ok(aborted)
+  })
+})


### PR DESCRIPTION
## This relates to #4068

## Changes

This PR fixes an issue where cloning a `Request` caused the cloned instance to lose its `AbortSignal` behavior under certain GC conditions.  
The underlying problem was that the `signal` reference could be garbage-collected prematurely, preventing the abort event from propagating to the cloned request. This resulted in inconsistent abort behavior on the very first request processed after a clone.

The fix ensures the `signal` and its abort listener remain properly retained across clones, restoring consistent abort propagation for cloned `Request` objects.

### Bug Fixes

- Fixed a bug where `Request.clone()` or `new Request(request)`, could drop the associated `AbortSignal` listener during garbage collection.
- Ensured cloned `Request` objects consistently propagate abort events, including during the initial request lifecycle.
