### PR TITLE
fix: Handle FormData body type correctly in RetryAgent retried requests

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -58,6 +58,8 @@ function wrapRequestBody (body) {
     // to determine whether or not it has been disturbed. This is just
     // a workaround.
     return new BodyAsyncIterable(body)
+  } else if (body && isFormDataLike(body)) {
+    return body
   } else if (
     body &&
     typeof body !== 'string' &&

--- a/test/issue-4691.js
+++ b/test/issue-4691.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+
+const { RetryAgent, Client, FormData } = require('..')
+// https://github.com/nodejs/undici/issues/4691
+test('Should retry status code with FormData body', async t => {
+  t = tspl(t, { plan: 2 })
+
+  let counter = 0
+  const server = createServer({ joinDuplicateHeaders: true })
+  const opts = {
+    maxRetries: 5,
+    timeout: 1,
+    timeoutFactor: 1
+  }
+
+  server.on('request', (req, res) => {
+    switch (counter++) {
+      case 0:
+        req.destroy()
+        return
+      case 1:
+        res.writeHead(500)
+        res.end('failed')
+        return
+      case 2:
+        res.writeHead(200)
+        res.end('hello world!')
+        return
+      default:
+        t.fail()
+    }
+  })
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const agent = new RetryAgent(client, opts)
+
+    after(async () => {
+      await agent.close()
+      server.close()
+
+      await once(server, 'close')
+    })
+
+    const formData = new FormData()
+    formData.append('field', 'test string')
+    agent.request({
+      method: 'GET',
+      path: '/',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: formData
+    }).then((res) => {
+      t.equal(res.statusCode, 200)
+      res.body.setEncoding('utf8')
+      let chunks = ''
+      res.body.on('data', chunk => { chunks += chunk })
+      res.body.on('end', () => {
+        t.equal(chunks, 'hello world!')
+      })
+    })
+  })
+
+  await t.completed
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
- https://github.com/nodejs/undici/issues/4691
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
When a RetryAgent request has FormData body, currently since FormData passes `(body && typeof body !== 'string' && !ArrayBuffer.isView(body) && isIterable(body))` it gets converted to BodyAsyncIterable which leads to extractBody() never being called on retried requests. Now FormData body is checked for and returned without manipulation.
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes
Add a new check on the body using the existing isFormDataLike() utility function. Add a new unit test that references the issue number and runs the retry agent with FormData body.
<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes
- https://github.com/nodejs/undici/issues/4691
<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
