### PR TITLE
feat: add circuit breaker interceptor

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports.interceptors = {
   dump: require('./lib/interceptor/dump'),
   dns: require('./lib/interceptor/dns'),
   cache: require('./lib/interceptor/cache'),
-  decompress: require('./lib/interceptor/decompress')
+  decompress: require('./lib/interceptor/decompress'),
+  circuitBreaker: require('./lib/interceptor/circuit-breaker')
 }
 
 module.exports.cacheStores = {

--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -421,6 +421,26 @@ class MaxOriginsReachedError extends UndiciError {
   }
 }
 
+const kCircuitBreakerError = Symbol.for('undici.error.UND_ERR_CIRCUIT_BREAKER')
+class CircuitBreakerError extends UndiciError {
+  constructor (message, { state, key }) {
+    super(message)
+    this.name = 'CircuitBreakerError'
+    this.message = message || 'Circuit breaker is open'
+    this.code = 'UND_ERR_CIRCUIT_BREAKER'
+    this.state = state
+    this.key = key
+  }
+
+  static [Symbol.hasInstance] (instance) {
+    return instance && instance[kCircuitBreakerError] === true
+  }
+
+  get [kCircuitBreakerError] () {
+    return true
+  }
+}
+
 module.exports = {
   AbortError,
   HTTPParserError,
@@ -444,5 +464,6 @@ module.exports = {
   RequestRetryError,
   ResponseError,
   SecureProxyConnectionError,
-  MaxOriginsReachedError
+  MaxOriginsReachedError,
+  CircuitBreakerError
 }

--- a/lib/interceptor/circuit-breaker.js
+++ b/lib/interceptor/circuit-breaker.js
@@ -271,6 +271,12 @@ function createCircuitBreakerInterceptor (opts = {}) {
   return dispatch => {
     return function circuitBreakerInterceptor (opts, handler) {
       const key = getKey(opts)
+
+      // If getKey returns null/undefined, bypass circuit breaker
+      if (key == null) {
+        return dispatch(opts, handler)
+      }
+
       const circuit = storage.get(key)
       const now = Date.now()
 

--- a/lib/interceptor/circuit-breaker.js
+++ b/lib/interceptor/circuit-breaker.js
@@ -1,0 +1,330 @@
+'use strict'
+
+const { InvalidArgumentError, CircuitBreakerError } = require('../core/errors')
+const DecoratorHandler = require('../handler/decorator-handler')
+
+// Circuit states
+const STATE_CLOSED = 0
+const STATE_OPEN = 1
+const STATE_HALF_OPEN = 2
+
+// Default error codes that trigger circuit breaker
+const DEFAULT_ERROR_CODES = new Set([
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EAI_AGAIN'
+])
+
+// Default status codes that trigger circuit breaker
+const DEFAULT_STATUS_CODES = new Set([500, 502, 503, 504])
+
+/**
+ * Per-key circuit state tracking.
+ * Uses a simple sliding window counter for fast failure tracking.
+ */
+class CircuitState {
+  constructor () {
+    this.state = STATE_CLOSED
+    this.failureCount = 0
+    this.successCount = 0
+    this.lastFailureTime = 0
+    this.halfOpenRequests = 0
+  }
+
+  reset () {
+    this.state = STATE_CLOSED
+    this.failureCount = 0
+    this.successCount = 0
+    this.lastFailureTime = 0
+    this.halfOpenRequests = 0
+  }
+}
+
+/**
+ * Circuit breaker state storage with automatic cleanup.
+ */
+class CircuitBreakerStorage {
+  #circuits = new Map()
+  #maxSize
+  #cleanupInterval
+  #cleanupTimer = null
+
+  constructor (opts = {}) {
+    this.#maxSize = opts.maxSize ?? 1000
+    this.#cleanupInterval = opts.cleanupInterval ?? 60000
+
+    // Start cleanup timer
+    if (this.#cleanupInterval > 0) {
+      this.#cleanupTimer = setInterval(() => this.#cleanup(), this.#cleanupInterval).unref()
+    }
+  }
+
+  get (key) {
+    let circuit = this.#circuits.get(key)
+    if (!circuit) {
+      // Enforce max size with LRU-like eviction
+      if (this.#circuits.size >= this.#maxSize) {
+        const firstKey = this.#circuits.keys().next().value
+        this.#circuits.delete(firstKey)
+      }
+      circuit = new CircuitState()
+      this.#circuits.set(key, circuit)
+    }
+    return circuit
+  }
+
+  delete (key) {
+    this.#circuits.delete(key)
+  }
+
+  #cleanup () {
+    const now = Date.now()
+    for (const [key, circuit] of this.#circuits) {
+      // Remove circuits that have been closed for a while
+      if (circuit.state === STATE_CLOSED && circuit.failureCount === 0) {
+        this.#circuits.delete(key)
+      } else if (circuit.state === STATE_OPEN && circuit.lastFailureTime > 0) {
+        // Also clean up very old open circuits (stale entries)
+        const age = now - circuit.lastFailureTime
+        if (age > 300000) { // 5 minutes
+          this.#circuits.delete(key)
+        }
+      }
+    }
+  }
+
+  destroy () {
+    if (this.#cleanupTimer) {
+      clearInterval(this.#cleanupTimer)
+      this.#cleanupTimer = null
+    }
+    this.#circuits.clear()
+  }
+
+  get size () {
+    return this.#circuits.size
+  }
+}
+
+class CircuitBreakerHandler extends DecoratorHandler {
+  #circuit
+  #opts
+  #statusCodes
+  #errorCodes
+  #key
+
+  constructor (opts, circuit, key, handler) {
+    super(handler)
+    this.#opts = opts
+    this.#circuit = circuit
+    this.#statusCodes = opts.statusCodes
+    this.#errorCodes = opts.errorCodes
+    this.#key = key
+  }
+
+  onResponseStart (controller, statusCode, headers, statusMessage) {
+    if (this.#statusCodes.has(statusCode)) {
+      this.#recordFailure()
+    } else {
+      this.#recordSuccess()
+    }
+    return super.onResponseStart(controller, statusCode, headers, statusMessage)
+  }
+
+  onResponseEnd (controller, trailers) {
+    return super.onResponseEnd(controller, trailers)
+  }
+
+  onResponseError (controller, err) {
+    const code = err?.code
+    if (code && this.#errorCodes.has(code)) {
+      this.#recordFailure()
+    }
+    return super.onResponseError(controller, err)
+  }
+
+  #recordFailure () {
+    const circuit = this.#circuit
+    circuit.failureCount++
+    circuit.lastFailureTime = Date.now()
+    circuit.successCount = 0
+
+    if (circuit.state === STATE_HALF_OPEN) {
+      // Any failure in half-open immediately opens the circuit
+      circuit.state = STATE_OPEN
+      circuit.halfOpenRequests = 0
+    } else if (circuit.state === STATE_CLOSED) {
+      if (circuit.failureCount >= this.#opts.threshold) {
+        circuit.state = STATE_OPEN
+      }
+    }
+  }
+
+  #recordSuccess () {
+    const circuit = this.#circuit
+
+    if (circuit.state === STATE_HALF_OPEN) {
+      circuit.successCount++
+      circuit.halfOpenRequests = Math.max(0, circuit.halfOpenRequests - 1)
+
+      if (circuit.successCount >= this.#opts.successThreshold) {
+        circuit.reset()
+      }
+    } else if (circuit.state === STATE_CLOSED) {
+      // In closed state, reset failure count on success
+      circuit.failureCount = 0
+    }
+  }
+}
+
+/**
+ * Default key generator - uses origin only for simplicity.
+ * Override with getKey option for route-level granularity.
+ */
+function defaultGetKey (opts) {
+  const origin = typeof opts.origin === 'string' ? opts.origin : opts.origin?.origin
+  return origin || 'unknown'
+}
+
+/**
+ * Creates a circuit breaker interceptor.
+ *
+ * @param {Object} opts Configuration options
+ * @param {number} [opts.threshold=5] Number of failures before opening circuit
+ * @param {number} [opts.timeout=30000] How long circuit stays open (ms)
+ * @param {number} [opts.successThreshold=1] Successes needed in half-open to close
+ * @param {number} [opts.maxHalfOpenRequests=1] Max concurrent requests in half-open
+ * @param {Set|Array} [opts.statusCodes=[500,502,503,504]] Status codes that count as failures
+ * @param {Set|Array} [opts.errorCodes] Error codes that count as failures
+ * @param {Function} [opts.getKey] Function to extract circuit key from request opts
+ * @param {CircuitBreakerStorage} [opts.storage] Custom storage instance
+ * @param {Function} [opts.onStateChange] Callback when circuit state changes
+ */
+function createCircuitBreakerInterceptor (opts = {}) {
+  const {
+    threshold = 5,
+    timeout = 30000,
+    successThreshold = 1,
+    maxHalfOpenRequests = 1,
+    getKey = defaultGetKey,
+    storage = new CircuitBreakerStorage(),
+    onStateChange = null
+  } = opts
+
+  // Validate options
+  if (typeof threshold !== 'number' || threshold < 1) {
+    throw new InvalidArgumentError('threshold must be a positive number')
+  }
+  if (typeof timeout !== 'number' || timeout < 0) {
+    throw new InvalidArgumentError('timeout must be a non-negative number')
+  }
+  if (typeof successThreshold !== 'number' || successThreshold < 1) {
+    throw new InvalidArgumentError('successThreshold must be a positive number')
+  }
+  if (typeof maxHalfOpenRequests !== 'number' || maxHalfOpenRequests < 1) {
+    throw new InvalidArgumentError('maxHalfOpenRequests must be a positive number')
+  }
+  if (typeof getKey !== 'function') {
+    throw new InvalidArgumentError('getKey must be a function')
+  }
+  if (onStateChange != null && typeof onStateChange !== 'function') {
+    throw new InvalidArgumentError('onStateChange must be a function')
+  }
+
+  // Convert arrays to Sets for O(1) lookup
+  let statusCodes = opts.statusCodes
+  if (statusCodes == null) {
+    statusCodes = DEFAULT_STATUS_CODES
+  } else if (Array.isArray(statusCodes)) {
+    statusCodes = new Set(statusCodes)
+  } else if (!(statusCodes instanceof Set)) {
+    throw new InvalidArgumentError('statusCodes must be an array or Set')
+  }
+
+  let errorCodes = opts.errorCodes
+  if (errorCodes == null) {
+    errorCodes = DEFAULT_ERROR_CODES
+  } else if (Array.isArray(errorCodes)) {
+    errorCodes = new Set(errorCodes)
+  } else if (!(errorCodes instanceof Set)) {
+    throw new InvalidArgumentError('errorCodes must be an array or Set')
+  }
+
+  const resolvedOpts = {
+    threshold,
+    timeout,
+    successThreshold,
+    maxHalfOpenRequests,
+    statusCodes,
+    errorCodes
+  }
+
+  return dispatch => {
+    return function circuitBreakerInterceptor (opts, handler) {
+      const key = getKey(opts)
+      const circuit = storage.get(key)
+      const now = Date.now()
+
+      // State machine logic
+      if (circuit.state === STATE_OPEN) {
+        // Check if timeout has elapsed
+        if (now - circuit.lastFailureTime >= timeout) {
+          circuit.state = STATE_HALF_OPEN
+          circuit.halfOpenRequests = 0
+          circuit.successCount = 0
+          if (onStateChange) {
+            onStateChange(key, 'half-open', 'open')
+          }
+        } else {
+          // Fast fail - circuit is open
+          const err = new CircuitBreakerError('Circuit breaker is open', {
+            state: 'open',
+            key
+          })
+          // Use queueMicrotask for async error delivery to match other interceptors
+          queueMicrotask(() => {
+            handler.onResponseError?.(null, err)
+          })
+          return true
+        }
+      }
+
+      if (circuit.state === STATE_HALF_OPEN) {
+        // Check if we've reached max half-open requests
+        if (circuit.halfOpenRequests >= maxHalfOpenRequests) {
+          const err = new CircuitBreakerError('Circuit breaker is half-open (max requests reached)', {
+            state: 'half-open',
+            key
+          })
+          queueMicrotask(() => {
+            handler.onResponseError?.(null, err)
+          })
+          return true
+        }
+        circuit.halfOpenRequests++
+      }
+
+      return dispatch(
+        opts,
+        new CircuitBreakerHandler(resolvedOpts, circuit, key, handler)
+      )
+    }
+  }
+}
+
+// Export state constants for testing/debugging
+createCircuitBreakerInterceptor.STATE_CLOSED = STATE_CLOSED
+createCircuitBreakerInterceptor.STATE_OPEN = STATE_OPEN
+createCircuitBreakerInterceptor.STATE_HALF_OPEN = STATE_HALF_OPEN
+createCircuitBreakerInterceptor.CircuitBreakerStorage = CircuitBreakerStorage
+
+module.exports = createCircuitBreakerInterceptor

--- a/test/interceptors/circuit-breaker.js
+++ b/test/interceptors/circuit-breaker.js
@@ -1,0 +1,630 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { tspl } = require('@matteo.collina/tspl')
+
+const { Agent, interceptors, errors } = require('../..')
+const { circuitBreaker } = interceptors
+const { CircuitBreakerError } = errors
+
+test('circuit breaker - pass through when closed', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createServer((req, res) => {
+    res.writeHead(200)
+    res.end('ok')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({ threshold: 5 }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    origin: `http://localhost:${server.address().port}`,
+    path: '/',
+    method: 'GET'
+  })
+
+  t.equal(response.statusCode, 200)
+  const body = await response.body.text()
+  t.equal(body, 'ok')
+
+  await t.completed
+})
+
+test('circuit breaker - opens after threshold 500s', async t => {
+  t = tspl(t, { plan: 7 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    res.writeHead(500)
+    res.end('error')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 3,
+    timeout: 1000
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // First 3 requests should go through (hitting threshold)
+  for (let i = 0; i < 3; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    t.equal(response.statusCode, 500)
+    await response.body.dump()
+  }
+
+  // 4th request should fail immediately with circuit open
+  try {
+    await client.request({ origin, path: '/', method: 'GET' })
+    t.fail('Should have thrown CircuitBreakerError')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+    t.equal(err.code, 'UND_ERR_CIRCUIT_BREAKER')
+    t.equal(err.state, 'open')
+  }
+
+  // Verify only 3 requests reached the server
+  t.equal(requestCount, 3)
+
+  await t.completed
+})
+
+test('circuit breaker - transitions to half-open after timeout', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    if (requestCount <= 3) {
+      res.writeHead(500)
+      res.end('error')
+    } else {
+      res.writeHead(200)
+      res.end('ok')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 3,
+    timeout: 100 // Short timeout for testing
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Trigger 3 failures to open circuit
+  for (let i = 0; i < 3; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Wait for timeout to elapse
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  // Now circuit should be half-open, request should go through
+  const response = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response.statusCode, 200)
+  await response.body.dump()
+
+  // Circuit should now be closed, more requests should work
+  const response2 = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response2.statusCode, 200)
+  await response2.body.dump()
+
+  t.equal(requestCount, 5)
+
+  await t.completed
+})
+
+test('circuit breaker - re-opens on half-open failure', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    res.writeHead(500)
+    res.end('error')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 100
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Trigger 2 failures to open circuit
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Wait for timeout
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  // Half-open request that fails
+  const response = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response.statusCode, 500)
+  await response.body.dump()
+
+  // Circuit should be open again
+  try {
+    await client.request({ origin, path: '/', method: 'GET' })
+    t.fail('Should have thrown CircuitBreakerError')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+  }
+
+  t.equal(requestCount, 3)
+
+  await t.completed
+})
+
+test('circuit breaker - tracks per origin', async t => {
+  t = tspl(t, { plan: 4 })
+
+  let server1Count = 0
+  let server2Count = 0
+
+  const server1 = createServer((req, res) => {
+    server1Count++
+    res.writeHead(500)
+    res.end('error')
+  })
+
+  const server2 = createServer((req, res) => {
+    server2Count++
+    res.writeHead(200)
+    res.end('ok')
+  })
+
+  server1.listen(0)
+  server2.listen(0)
+  await Promise.all([once(server1, 'listening'), once(server2, 'listening')])
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 1000
+  }))
+
+  after(async () => {
+    await client.close()
+    server1.close()
+    server2.close()
+    await Promise.all([once(server1, 'close'), once(server2, 'close')])
+  })
+
+  const origin1 = `http://localhost:${server1.address().port}`
+  const origin2 = `http://localhost:${server2.address().port}`
+
+  // Fail origin1 circuit
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin: origin1, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // origin1 circuit should be open
+  try {
+    await client.request({ origin: origin1, path: '/', method: 'GET' })
+    t.fail('Should have thrown')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+  }
+
+  // origin2 should still work
+  const response = await client.request({ origin: origin2, path: '/', method: 'GET' })
+  t.equal(response.statusCode, 200)
+  await response.body.dump()
+
+  t.equal(server1Count, 2)
+  t.equal(server2Count, 1)
+
+  await t.completed
+})
+
+test('circuit breaker - custom getKey for route-level', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    if (req.url === '/fail') {
+      res.writeHead(500)
+      res.end('error')
+    } else {
+      res.writeHead(200)
+      res.end('ok')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 1000,
+    getKey: (opts) => `${opts.origin}${opts.path}`
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Fail /fail route
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/fail', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // /fail route circuit should be open
+  try {
+    await client.request({ origin, path: '/fail', method: 'GET' })
+    t.fail('Should have thrown')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+  }
+
+  // /success route should still work
+  const response = await client.request({ origin, path: '/success', method: 'GET' })
+  t.equal(response.statusCode, 200)
+  await response.body.dump()
+
+  t.equal(requestCount, 3)
+
+  await t.completed
+})
+
+test('circuit breaker - custom status codes', async t => {
+  t = tspl(t, { plan: 2 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    res.writeHead(429) // Rate limited
+    res.end('rate limited')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    statusCodes: [429, 503]
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Trigger failures
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Circuit should be open
+  try {
+    await client.request({ origin, path: '/', method: 'GET' })
+    t.fail('Should have thrown')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+  }
+
+  t.equal(requestCount, 2)
+
+  await t.completed
+})
+
+test('circuit breaker - connection errors', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 1000
+  }))
+
+  after(async () => {
+    await client.close()
+  })
+
+  // Non-existent server
+  const origin = 'http://localhost:59999'
+
+  // First 2 connection failures
+  for (let i = 0; i < 2; i++) {
+    try {
+      await client.request({ origin, path: '/', method: 'GET' })
+    } catch (err) {
+      // Connection refused is expected
+    }
+  }
+
+  // Circuit should be open
+  try {
+    await client.request({ origin, path: '/', method: 'GET' })
+    t.fail('Should have thrown CircuitBreakerError')
+  } catch (err) {
+    t.ok(err instanceof CircuitBreakerError)
+    t.equal(err.state, 'open')
+  }
+
+  await t.completed
+})
+
+test('circuit breaker - validates options', async t => {
+  t = tspl(t, { plan: 5 })
+
+  t.throws(() => circuitBreaker({ threshold: 0 }), /threshold must be a positive number/)
+  t.throws(() => circuitBreaker({ threshold: -1 }), /threshold must be a positive number/)
+  t.throws(() => circuitBreaker({ timeout: -1 }), /timeout must be a non-negative number/)
+  t.throws(() => circuitBreaker({ getKey: 'not a function' }), /getKey must be a function/)
+  t.throws(() => circuitBreaker({ statusCodes: 'invalid' }), /statusCodes must be an array or Set/)
+
+  await t.completed
+})
+
+test('circuit breaker - limits half-open concurrent requests', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createServer((req, res) => {
+    res.writeHead(500)
+    res.end('error')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 50,
+    maxHalfOpenRequests: 1
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Open circuit
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Wait for half-open
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Fire two concurrent requests - only one should get through
+  const results = await Promise.allSettled([
+    client.request({ origin, path: '/', method: 'GET' }),
+    client.request({ origin, path: '/', method: 'GET' })
+  ])
+
+  // One should succeed (500), one should fail with circuit breaker error
+  const errorResults = results.filter(r => r.status === 'rejected')
+  const fulfilled = results.filter(r => r.status === 'fulfilled')
+
+  t.equal(errorResults.length, 1)
+  t.equal(fulfilled.length, 1)
+  t.ok(errorResults[0].reason instanceof CircuitBreakerError)
+
+  // Clean up fulfilled response
+  for (const r of fulfilled) {
+    await r.value.body.dump()
+  }
+
+  await t.completed
+})
+
+test('circuit breaker - successThreshold > 1', async t => {
+  t = tspl(t, { plan: 2 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    if (requestCount <= 2) {
+      res.writeHead(500)
+      res.end('error')
+    } else {
+      res.writeHead(200)
+      res.end('ok')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 50,
+    successThreshold: 2,
+    maxHalfOpenRequests: 5
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Open circuit
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Wait for half-open
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // First success in half-open
+  const response1 = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response1.statusCode, 200)
+  await response1.body.dump()
+
+  // Second success - should close circuit
+  const response2 = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response2.statusCode, 200)
+  await response2.body.dump()
+
+  await t.completed
+})
+
+test('circuit breaker - onStateChange callback', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const stateChanges = []
+
+  const server = createServer((req, res) => {
+    res.writeHead(500)
+    res.end('error')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 2,
+    timeout: 50,
+    onStateChange: (key, newState, prevState) => {
+      stateChanges.push({ key, newState, prevState })
+    }
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Trigger failures to open circuit
+  for (let i = 0; i < 2; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Wait for half-open
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // Trigger half-open transition by making a request
+  try {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  } catch (e) {
+    // may fail due to circuit state
+  }
+
+  // Check state changes (at least the half-open transition)
+  t.ok(stateChanges.length >= 1)
+  const halfOpenChange = stateChanges.find(c => c.newState === 'half-open')
+  t.ok(halfOpenChange)
+  t.equal(halfOpenChange.prevState, 'open')
+  t.ok(halfOpenChange.key.includes('localhost'))
+
+  await t.completed
+})
+
+test('circuit breaker - success resets failure count in closed state', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    // Alternate: fail, success, fail, success
+    if (requestCount % 2 === 1) {
+      res.writeHead(500)
+      res.end('error')
+    } else {
+      res.writeHead(200)
+      res.end('ok')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose(circuitBreaker({
+    threshold: 3, // Would need 3 consecutive failures
+    timeout: 1000
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // Do fail-success-fail-success pattern - should never trip circuit
+  for (let i = 0; i < 4; i++) {
+    const response = await client.request({ origin, path: '/', method: 'GET' })
+    await response.body.dump()
+  }
+
+  // Circuit should still be closed - make another request
+  const response = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response.statusCode, 500) // 5th request is fail
+  await response.body.dump()
+
+  // Still not tripped - do one more
+  const response2 = await client.request({ origin, path: '/', method: 'GET' })
+  t.equal(response2.statusCode, 200) // 6th is success
+  await response2.body.dump()
+
+  t.equal(requestCount, 6)
+
+  await t.completed
+})

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -158,4 +158,19 @@ declare namespace Errors {
     name: 'MaxOriginsReachedError'
     code: 'UND_ERR_MAX_ORIGINS_REACHED'
   }
+
+  /** Circuit breaker is open or half-open. */
+  export class CircuitBreakerError extends UndiciError {
+    constructor (
+      message: string,
+      options: {
+        state: 'open' | 'half-open'
+        key: string
+      }
+    )
+    name: 'CircuitBreakerError'
+    code: 'UND_ERR_CIRCUIT_BREAKER'
+    state: 'open' | 'half-open'
+    key: string
+  }
 }


### PR DESCRIPTION
## Summary

Adds a per-host/route circuit breaker interceptor for resilient HTTP client behavior.

### Features
- **Three circuit states**: CLOSED (normal operation), OPEN (fast-fail), HALF_OPEN (testing recovery)
- **Minimal overhead**: Simple counters and timestamps, O(1) Set lookups for status/error codes
- **Per-host/route tracking**: Default tracks by origin, customizable via `getKey` function
- **Configurable failure detection**: HTTP status codes (default: 500, 502, 503, 504) and error codes (timeouts, connection errors)
- **Memory bounded**: Max 1000 circuits by default with LRU-like eviction and automatic cleanup

### Usage

```javascript
import { Agent, interceptors } from 'undici'
const { circuitBreaker } = interceptors

const client = new Agent().compose(circuitBreaker({
  threshold: 5,           // Failures before opening (default: 5)
  timeout: 30000,         // Time circuit stays open in ms (default: 30000)
  successThreshold: 1,    // Successes needed in half-open to close (default: 1)
  maxHalfOpenRequests: 1, // Concurrent requests in half-open (default: 1)
  statusCodes: [500, 502, 503, 504], // HTTP codes counting as failures
  getKey: (opts) => opts.origin,     // Custom key for route-level tracking
  onStateChange: (key, newState, prevState) => {} // State change callback
}))
```

### Files Changed
- `lib/core/errors.js` - Added `CircuitBreakerError` class
- `lib/interceptor/circuit-breaker.js` - New interceptor implementation
- `index.js` - Export circuit breaker interceptor
- `types/errors.d.ts` - TypeScript types for error
- `types/interceptors.d.ts` - TypeScript types for options
- `test/interceptors/circuit-breaker.js` - 13 comprehensive tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)