### PR TITLE
fix(test): remove hardcoded folder name in client-error-stack-trace test

### DIFF
--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const { test } = require('node:test')
-const { sep } = require('node:path')
+const { sep, basename, join } = require('node:path')
 const { fetch, setGlobalDispatcher, Agent } = require('../..')
+
+const projectFolder = basename(join(__dirname, '..', '..'))
 const { fetch: fetchIndex } = require('../../index-fetch')
 
 setGlobalDispatcher(new Agent({
@@ -16,7 +18,7 @@ test('FETCH: request errors and prints trimmed stack trace', async (t) => {
   } catch (error) {
     const stackLines = error.stack.split('\n')
     t.assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    t.assert.ok(stackLines[1].includes(`undici${sep}index.js`))
+    t.assert.ok(stackLines[1].includes(`${projectFolder}${sep}index.js`))
     t.assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
     t.assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }
@@ -28,7 +30,7 @@ test('FETCH-index: request errors and prints trimmed stack trace', async (t) => 
   } catch (error) {
     const stackLines = error.stack.split('\n')
     t.assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    t.assert.ok(stackLines[1].includes(`undici${sep}index-fetch.js`))
+    t.assert.ok(stackLines[1].includes(`${projectFolder}${sep}index-fetch.js`))
     t.assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
     t.assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
   }


### PR DESCRIPTION
## Summary
- Fixed `test/fetch/client-error-stack-trace.js` which was hardcoding `undici` as the expected folder name in stack traces
- The test now dynamically determines the project folder name using `path.basename()`, allowing it to pass when the repo is cloned to a differently-named directory

## Test plan
- [x] Verified the test passes with `npx borp -p "test/fetch/client-error-stack-trace.js"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)