### PR TITLE
Fix AbortSignal cancellation for delayed MockAgent responses

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -313,12 +313,28 @@ function mockDispatch (opts, handler) {
   }
 
   // Handle the request with a delay if necessary
+  const signal = opts.signal
+
   if (typeof delay === 'number' && delay > 0) {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
+      if (signal?.aborted) return
       handleReply(this[kDispatches])
     }, delay)
+
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timeout)
+        return true
+      }
+
+      signal.addEventListener('abort', () => {
+        clearTimeout(timeout)
+      }, { once: true })
+    }
   } else {
-    handleReply(this[kDispatches])
+    if (!signal?.aborted) {
+      handleReply(this[kDispatches])
+    }
   }
 
   function handleReply (mockDispatches, _data = data) {


### PR DESCRIPTION
# This relates to...

N/A

# Rationale

Delayed mock responses created using MockAgent continued executing even after a request was aborted via AbortSignal, which does not match real undici request cancellation behavior.

# Changes

Added AbortSignal handling to the delayed mock dispatch logic to ensure scheduled responses are cancelled when a request is aborted.

# Features

N/A

# Bug Fixes

- Fixed delayed MockAgent responses executing after AbortSignal cancellation by clearing scheduled timers on abort.

# Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready
