### PR TITLE
fix(pool): add useH2c option support for multiple connections

### DIFF
--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -36,6 +36,7 @@ class Pool extends PoolBase {
     autoSelectFamily,
     autoSelectFamilyAttemptTimeout,
     allowH2,
+    useH2c,
     clientTtl,
     ...options
   } = {}) {
@@ -56,6 +57,7 @@ class Pool extends PoolBase {
         ...tls,
         maxCachedSessions,
         allowH2,
+        useH2c,
         socketPath,
         timeout: connectTimeout,
         ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
@@ -67,7 +69,7 @@ class Pool extends PoolBase {
 
     this[kConnections] = connections || null
     this[kUrl] = util.parseOrigin(origin)
-    this[kOptions] = { ...util.deepClone(options), connect, allowH2, clientTtl }
+    this[kOptions] = { ...util.deepClone(options), connect, allowH2, useH2c, clientTtl }
     this[kOptions].interceptors = options.interceptors
       ? { ...options.interceptors }
       : undefined


### PR DESCRIPTION






## This relates to...
#4737

## Rationale

The Pool class was not passing the useH2c option to buildConnector and kOptions, causing HTTPParserError when using Agent with useH2c and connections > 1.

## Changes


This fix ensures that:
- useH2c is extracted from constructor parameters
- useH2c is passed to buildConnector for proper connection setup
- useH2c is included in kOptions for client instances


### Features
 N/A

### Bug Fixes
Fixes issue with h2c (HTTP/2 Cleartext) failing on second connection when Pool creates multiple Client instances.

### Breaking Changes and Deprecations
Before: connections > 1 with useH2c caused HTTP/1.1 parser to receive
        HTTP/2 binary frames, resulting in protocol mismatch error
After:  All connections properly use HTTP/2 cleartext protocol

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
