### PR TITLE
feat(cache): add origins option for whitelist filtering

### DIFF
--- a/test/types/cache-interceptor.test-d.ts
+++ b/test/types/cache-interceptor.test-d.ts
@@ -21,6 +21,16 @@ expectAssignable<CacheInterceptor.CacheOptions>({ store })
 expectAssignable<CacheInterceptor.CacheOptions>({ methods: [] })
 expectAssignable<CacheInterceptor.CacheOptions>({ store, methods: ['GET'] })
 
+// origins option type tests
+expectAssignable<CacheInterceptor.CacheOptions>({ origins: undefined })
+expectAssignable<CacheInterceptor.CacheOptions>({ origins: [] })
+expectAssignable<CacheInterceptor.CacheOptions>({ origins: ['http://localhost'] })
+expectAssignable<CacheInterceptor.CacheOptions>({ origins: [/localhost/] })
+expectAssignable<CacheInterceptor.CacheOptions>({ origins: ['http://example.com', /localhost/] })
+expectNotAssignable<CacheInterceptor.CacheOptions>({ origins: 'http://localhost' })
+expectNotAssignable<CacheInterceptor.CacheOptions>({ origins: [123] })
+expectNotAssignable<CacheInterceptor.CacheOptions>({ origins: [null] })
+
 expectAssignable<CacheInterceptor.CacheValue>({
   statusCode: 200,
   statusMessage: 'OK',

--- a/types/cache-interceptor.d.ts
+++ b/types/cache-interceptor.d.ts
@@ -39,6 +39,12 @@ declare namespace CacheHandler {
      */
     type?: 'shared' | 'private'
 
+    /**
+     * Array of origins to cache. Only requests to these origins will be cached.
+     * Supports strings (case insensitive) and RegExp patterns.
+     * @default undefined (cache all origins)
+     */
+    origins?: (string | RegExp)[]
   }
 
   export interface CacheControlDirectives {


### PR DESCRIPTION
## Summary

- Add an `origins` option to the cache interceptor that filters which origins can be cached
- Support string matching (case insensitive) and RegExp patterns
- Default behavior (`undefined`) preserves current behavior - cache all origins
- Empty array caches nothing

## Usage

```javascript
interceptors.cache({
  origins: ['localhost', /^api\.example\.com$/]
})
```

## Test plan

- [x] String matching - cache when origin matches
- [x] String matching - skip cache when origin doesn't match
- [x] RegExp matching - cache when origin matches
- [x] RegExp matching - skip cache when origin doesn't match
- [x] Mixed array - cache when any entry matches
- [x] Default behavior - cache all when undefined (backward compatible)
- [x] Empty array - cache nothing
- [x] Validation - throw on invalid types
- [x] Case insensitivity for string matching
- [x] Different hosts are treated as different origins
- [x] TypeScript type tests with tsd