### PR TITLE
ci: test shared-builtin only on Node.js 24 and 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
       fail-fast: false
       max-parallel: 0
       matrix:
-        node-version: ['20', '22', '24', '25']
+        node-version: ['24', '25']
         runs-on: ['ubuntu-latest']
     with:
       node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Remove Node.js 20 and 22 from the `test-shared-builtin` CI job matrix
- Only test the `--shared-builtin-undici/undici-path` flag on Node.js 24 and 25

## Reason
Node.js 20 and 22 bundle undici 6, while this repository is undici 7. When compiled with `--shared-builtin-undici/undici-path` pointing to undici 7, the API incompatibility causes `ERR_INTERNAL_ASSERTION` during process initialization.

Node.js 24 and 25 bundle undici 7 and work correctly with this flag.