### PR TITLE
fix: onParserTimeout potentially accessing undefined

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -735,8 +735,13 @@ class Parser {
   }
 }
 
-function onParserTimeout (parser) {
-  const { socket, timeoutType, client, paused } = parser.deref()
+function onParserTimeout (parserWeakRef) {
+  const parser = parserWeakRef.deref()
+  if (!parser) {
+    return
+  }
+
+  const { socket, timeoutType, client, paused } = parser
 
   if (timeoutType === TIMEOUT_HEADERS) {
     if (!socket[kWriting] || socket.writableNeedDrain || client[kRunning] > 1) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->
- Fixes #4755 

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

In cases where onParserTimeout is called with a weak reference that has
already been collected it was throwing an error like:

    Cannot destructure property 'socket' of 'parser.deref(...)' as it is
    undefined

As specified in the issue as I couldn't find a way to trigger it without a time mock framework replacing `clearTimeout` with a NOP so i'm not sure it qualifies as a bug.

(And also why I didn't include tests, but it should be triggerable by manually changing the global `clearTimeout`)

It's more akin to a potential type error (In an untyped language 😉) but I feel that checking for undefined here would make for a bit better code, and make it resistant against mocking of the global timers.

Fell free to close the PR and issue if it's considered too trivial or risky.

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->
N/A

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->
N/A

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
