### PR TITLE
fix: use commit hash when generating release (#4757)

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -65,4 +65,5 @@ jobs:
           script: |
             const defaultBranch = "${{ github.event.repository.default_branch }}"
             const versionTag = "v${{ steps.bump.outputs.version }}"
-            await require('./scripts/release').generatePr({ github, context, defaultBranch, versionTag })
+            const commitHash = "${{ github.sha }}"
+            await require('./scripts/release').generatePr({ github, context, defaultBranch, versionTag, commitHash })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,4 +94,5 @@ jobs:
           script: |
             const defaultBranch = "${{ github.event.repository.default_branch }}"
             const versionTag = "${{ needs.determine-release-version.outputs.release-version }}"
-            await require('./scripts/release').release({ github, context, defaultBranch, versionTag })
+            const commitHash = "${{ github.sha }}"
+            await require('./scripts/release').release({ github, context, defaultBranch, versionTag, commitHash })

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,7 +2,7 @@
 
 // Called from .github/workflows
 
-const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBranch }) => {
+const generateReleaseNotes = async ({ github, owner, repo, versionTag, commitHash }) => {
   const { data: releases } = await github.rest.repos.listReleases({
     owner,
     repo
@@ -14,7 +14,7 @@ const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBr
     owner,
     repo,
     tag_name: versionTag,
-    target_commitish: defaultBranch,
+    target_commitish: commitHash,
     previous_tag_name: previousRelease?.tag_name
   })
 
@@ -25,9 +25,9 @@ const generateReleaseNotes = async ({ github, owner, repo, versionTag, defaultBr
   return bodyWithoutReleasePr
 }
 
-const generatePr = async ({ github, context, defaultBranch, versionTag }) => {
+const generatePr = async ({ github, context, defaultBranch, versionTag, commitHash }) => {
   const { owner, repo } = context.repo
-  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, defaultBranch })
+  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, commitHash })
 
   await github.rest.pulls.create({
     owner,
@@ -39,15 +39,15 @@ const generatePr = async ({ github, context, defaultBranch, versionTag }) => {
   })
 }
 
-const release = async ({ github, context, defaultBranch, versionTag }) => {
+const release = async ({ github, context, versionTag, commitHash }) => {
   const { owner, repo } = context.repo
-  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, defaultBranch })
+  const releaseNotes = await generateReleaseNotes({ github, owner, repo, versionTag, commitHash })
 
   await github.rest.repos.createRelease({
     owner,
     repo,
     tag_name: versionTag,
-    target_commitish: defaultBranch,
+    target_commitish: commitHash,
     name: versionTag,
     body: releaseNotes,
     draft: false,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

https://github.com/nodejs/undici/issues/4757

## Rationale

By using the commit hash there is no longer a race condition that could result in the GitHub tag/release being applied to a different commit than was published to NPM.

## Changes

Passed the commit hash that triggered the workflow to release scripts so that the commit hash can be used instead of the branch to create the release and release notes.

### Features

N/A

### Bug Fixes

https://github.com/nodejs/undici/issues/4757

### Breaking Changes and Deprecations

No

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
