### PR TITLE
fix: properly close idle connections in encoding test

### DIFF
--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -49,8 +49,9 @@ describe('content-encoding handling', () => {
     await once(server.listen(0), 'listening')
   })
 
-  after(() => {
-    server.close()
+  after(async () => {
+    server.closeIdleConnections()
+    await new Promise(resolve => server.close(resolve))
   })
 
   test('content-encoding header', async (t) => {
@@ -111,8 +112,9 @@ describe('content-encoding chain limit', () => {
     await once(server.listen(0), 'listening')
   })
 
-  after(() => {
-    server.close()
+  after(async () => {
+    server.closeIdleConnections()
+    await new Promise(resolve => server.close(resolve))
   })
 
   test(`should allow exactly ${MAX_CONTENT_ENCODINGS} content-encodings`, async (t) => {


### PR DESCRIPTION
## Summary
- Fix flaky `test/fetch/encoding.js` test that fails intermittently on macOS with `ECONNRESET` errors
- Changed both `after()` hooks to call `server.closeIdleConnections()` before closing the server
- This ensures idle connections are properly drained rather than abruptly terminated

## Test plan
- [x] Ran encoding tests multiple times locally to verify stability
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)