### PR TITLE
return response when receiving 401 instead of network error

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1677,9 +1677,9 @@ async function httpNetworkOrCacheFetch (
       // requestCurrentURL(request).password = TODO
 
       // In browsers, the user will be prompted to enter a username/password before the request
-      // is re-sent. To prevent an infinite 401 loop, return a network error for now.
+      // is re-sent. To prevent an infinite 401 loop, return the response for now.
       // https://github.com/nodejs/undici/pull/4756
-      return makeNetworkError()
+      return response
     }
 
     // 4. Set response to the result of running HTTP-network-or-cache fetch given

--- a/test/fetch/401-statuscode-no-infinite-loop.js
+++ b/test/fetch/401-statuscode-no-infinite-loop.js
@@ -9,18 +9,14 @@ const assert = require('node:assert')
 const { closeServerAsPromise } = require('../utils/node-http')
 
 test('Receiving a 401 status code should not cause infinite retry loop', async (t) => {
-  let requestCount = 0
-
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
-    requestCount++
-    console.log({ requestCount })
     res.statusCode = 401
-    res.setHeader('WWW-Authenticate', 'Basic realm="test"')
     res.end('Unauthorized')
   }).listen(0)
 
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  await assert.rejects(() => fetch(`http://localhost:${server.address().port}`))
+  const response = await fetch(`http://localhost:${server.address().port}`)
+  assert.strictEqual(response.status, 401)
 })


### PR DESCRIPTION
fixes https://github.com/nodejs/undici/issues/4767

it didn't really make sense to throw an error when receiving a 401, did it...