### PR TITLE
fix: MockAgent delayed response with AbortSignal (#4693)

### DIFF
--- a/test/mock-delayed-abort.js
+++ b/test/mock-delayed-abort.js
@@ -1,0 +1,137 @@
+'use strict'
+
+const { test } = require('node:test')
+const { MockAgent, interceptors } = require('..')
+const DecoratorHandler = require('../lib/handler/decorator-handler')
+const { tspl } = require('@matteo.collina/tspl')
+
+test('MockAgent with delayed response and AbortSignal should not cause uncaught errors', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  const agent = new MockAgent()
+  t.after(() => agent.close())
+
+  const mockPool = agent.get('https://example.com')
+  mockPool.intercept({ path: '/test', method: 'GET' })
+    .reply(200, { success: true }, { headers: { 'content-type': 'application/json' } })
+    .delay(100)
+
+  const ac = new AbortController()
+
+  // Abort the request after 10ms
+  setTimeout(() => {
+    ac.abort(new Error('Request aborted'))
+  }, 10)
+
+  try {
+    await agent.request({
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'GET',
+      signal: ac.signal
+    })
+    p.fail('Should have thrown an error')
+  } catch (err) {
+    p.ok(err.message === 'Request aborted' || err.name === 'AbortError', 'Error should be related to abort')
+  }
+
+  // Wait for the delayed response to fire - should not cause any uncaught errors
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  p.ok(true, 'No uncaught errors after delayed response')
+})
+
+test('MockAgent with delayed response and composed interceptor (decompress) should not cause uncaught errors', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  // The decompress interceptor has assertions that fail if onResponseStart is called after onError
+  const agent = new MockAgent().compose(interceptors.decompress())
+  t.after(() => agent.close())
+
+  const mockPool = agent.get('https://example.com')
+  mockPool.intercept({ path: '/test', method: 'GET' })
+    .reply(200, { success: true }, { headers: { 'content-type': 'application/json' } })
+    .delay(100)
+
+  const ac = new AbortController()
+
+  // Abort the request after 10ms
+  setTimeout(() => {
+    ac.abort(new Error('Request aborted'))
+  }, 10)
+
+  try {
+    await agent.request({
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'GET',
+      signal: ac.signal
+    })
+    p.fail('Should have thrown an error')
+  } catch (err) {
+    p.ok(err.message === 'Request aborted' || err.name === 'AbortError', 'Error should be related to abort')
+  }
+
+  // Wait for the delayed response to fire - should not cause any uncaught errors
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  p.ok(true, 'No uncaught errors after delayed response')
+})
+
+test('MockAgent with delayed response and DecoratorHandler should not call onResponseStart after onError', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  class TestDecoratorHandler extends DecoratorHandler {
+    #onErrorCalled = false
+
+    onResponseStart (controller, statusCode, headers, statusMessage) {
+      if (this.#onErrorCalled) {
+        p.fail('onResponseStart should not be called after onError')
+      }
+      return super.onResponseStart(controller, statusCode, headers, statusMessage)
+    }
+
+    onResponseError (controller, err) {
+      this.#onErrorCalled = true
+      return super.onResponseError(controller, err)
+    }
+  }
+
+  const agent = new MockAgent()
+  t.after(() => agent.close())
+
+  const mockPool = agent.get('https://example.com')
+  mockPool.intercept({ path: '/test', method: 'GET' })
+    .reply(200, { success: true }, { headers: { 'content-type': 'application/json' } })
+    .delay(100)
+
+  const ac = new AbortController()
+
+  // Abort the request after 10ms
+  setTimeout(() => {
+    ac.abort(new Error('Request aborted'))
+  }, 10)
+
+  const originalDispatch = agent.dispatch.bind(agent)
+  agent.dispatch = (opts, handler) => {
+    const decoratedHandler = new TestDecoratorHandler(handler)
+    return originalDispatch(opts, decoratedHandler)
+  }
+
+  try {
+    await agent.request({
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'GET',
+      signal: ac.signal
+    })
+    p.fail('Should have thrown an error')
+  } catch (err) {
+    p.ok(err.message === 'Request aborted' || err.name === 'AbortError', 'Error should be related to abort')
+  }
+
+  // Wait for the delayed response to fire
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  p.ok(true, 'Decorator handler invariants maintained')
+})


### PR DESCRIPTION
Fixes #4693

## Problem

When a `MockAgent` had a delayed response (using `.delay()`) and the request was aborted via an `AbortSignal`, the delayed response callback would still fire and attempt to call handler methods (`onHeaders`, `onData`, `onComplete`) even after the handler's `onError` had been called. This violated state invariants expected by handlers like `DecoratorHandler` (used by the decompress interceptor), which has assertions that `onResponseStart` should not be called after `onError`.

This issue was particularly noticeable when using `MockAgent` with interceptors like `decompress`, which would throw an assertion error when receiving a delayed response after abort.

## Solution

Modified `lib/mock/mock-utils.js` in the `mockDispatch` function to:

1. **Track abort state**: Added `aborted` flag and `timer` reference to track if the request has been aborted and the delayed response timer.

2. **Proper `onConnect` handling**: Moved `handler.onConnect?.()` call before scheduling the delayed response so the abort callback can be registered.

3. **Abort callback cleanup**: When the abort callback is invoked:
   - Sets the `aborted` flag
   - Clears the pending `setTimeout` timer if it exists
   - Calls `handler.onError(err)` to notify the handler

4. **Prevent late responses**: The `handleReply` function now checks the `aborted` flag at two points:
   - Before processing (immediately)
   - After async body resolution (for callback-based data)
   
   If aborted, it silently returns without invoking any handler callbacks.

## Tests

Added `test/mock-delayed-abort.js` with three test cases:
1. Basic delayed mock with abort - verifies no uncaught errors
2. Delayed mock with decompress interceptor - verifies the actual use case from the bug report
3. Delayed mock with custom DecoratorHandler - verifies state invariants

All existing tests continue to pass.

## Checklist

- [x] Added tests for the change
- [x] Documentation updated (not needed for bug fix)
- [x] TypeScript types are correct (verified)
- [x] Linting passes
- [x] All tests pass