### PR TITLE
fix: preserve fetch stack traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,11 +121,33 @@ module.exports.getGlobalDispatcher = getGlobalDispatcher
 
 const fetchImpl = require('./lib/web/fetch').fetch
 
+function appendFetchStackTrace (err, filename) {
+  if (!err || typeof err !== 'object') {
+    return
+  }
+
+  const stack = typeof err.stack === 'string' ? err.stack : ''
+  const normalizedFilename = filename.replace(/\\/g, '/')
+
+  if (stack && (stack.includes(filename) || stack.includes(normalizedFilename))) {
+    return
+  }
+
+  const capture = {}
+  Error.captureStackTrace(capture, appendFetchStackTrace)
+
+  if (!capture.stack) {
+    return
+  }
+
+  const captureLines = capture.stack.split('\n').slice(1).join('\n')
+
+  err.stack = stack ? `${stack}\n${captureLines}` : capture.stack
+}
+
 module.exports.fetch = function fetch (init, options = undefined) {
   return fetchImpl(init, options).catch(err => {
-    if (err && typeof err === 'object') {
-      Error.captureStackTrace(err)
-    }
+    appendFetchStackTrace(err, __filename)
     throw err
   })
 }

--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -18,9 +18,9 @@ test('FETCH: request errors and prints trimmed stack trace', async (t) => {
   } catch (error) {
     const stackLines = error.stack.split('\n')
     t.assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    t.assert.ok(stackLines[1].includes(`${projectFolder}${sep}index.js`))
-    t.assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
-    t.assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
+    t.assert.ok(stackLines.some(line => line.includes(`lib${sep}web${sep}fetch${sep}index.js`)))
+    t.assert.ok(stackLines.some(line => line.includes(`${projectFolder}${sep}index.js`)))
+    t.assert.ok(stackLines.some(line => line.includes(__filename)))
   }
 })
 
@@ -30,8 +30,8 @@ test('FETCH-index: request errors and prints trimmed stack trace', async (t) => 
   } catch (error) {
     const stackLines = error.stack.split('\n')
     t.assert.ok(stackLines[0].includes('TypeError: fetch failed'))
-    t.assert.ok(stackLines[1].includes(`${projectFolder}${sep}index-fetch.js`))
-    t.assert.ok(stackLines[2].includes('at process.processTicksAndRejections'))
-    t.assert.ok(stackLines[3].includes(`at async TestContext.<anonymous> (${__filename}`))
+    t.assert.ok(stackLines.some(line => line.includes(`lib${sep}web${sep}fetch${sep}index.js`)))
+    t.assert.ok(stackLines.some(line => line.includes(`${projectFolder}${sep}index-fetch.js`)))
+    t.assert.ok(stackLines.some(line => line.includes(__filename)))
   }
 })


### PR DESCRIPTION
## Summary
- append caller stack traces for fetch errors without overwriting existing internal stacks
- keep wrapper frames only when missing and avoid duplicate frames
- relax stack trace tests to assert presence of internal fetch frames and caller context

## Testing
- npx borp -p "test/fetch/client-error-stack-trace.js"