### PR TITLE
Fix error handling in MockPool example

### DIFF
--- a/docs/docs/api/MockPool.md
+++ b/docs/docs/api/MockPool.md
@@ -323,7 +323,8 @@ try {
     method: 'GET'
   })
 } catch (error) {
-  console.error(error) // Error: kaboom
+  console.error(error) // TypeError: fetch failed
+  console.error(error.cause) // Error: kaboom
 }
 ```
 


### PR DESCRIPTION
Update error handling in the MockPool example to reflect the correct error type and provide additional error context.