### PR TITLE
feat: expose statusText in request() ResponseData

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -476,6 +476,7 @@ The `RequestOptions.method` property should not be value `'CONNECT'`.
 #### Parameter: `ResponseData`
 
 * **statusCode** `number`
+* **statusText** `string` - The status message from the response (e.g., "OK", "Not Found").
 * **headers** `Record<string, string | string[]>` - Note that all header keys are lower-cased, e.g. `content-type`.
 * **body** `stream.Readable` which also implements [the body mixin from the Fetch Standard](https://fetch.spec.whatwg.org/#body-mixin).
 * **trailers** `Record<string, string>` - This object starts out
@@ -517,7 +518,7 @@ await once(server, 'listening')
 const client = new Client(`http://localhost:${server.address().port}`)
 
 try {
-  const { body, headers, statusCode, trailers } = await client.request({
+  const { body, headers, statusCode, statusText, trailers } = await client.request({
     path: '/',
     method: 'GET'
   })

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -121,6 +121,7 @@ class RequestHandler extends AsyncResource {
       try {
         this.runInAsyncScope(callback, null, null, {
           statusCode,
+          statusText: statusMessage,
           headers,
           trailers: this.trailers,
           opaque,

--- a/test/request.js
+++ b/test/request.js
@@ -468,3 +468,29 @@ describe('Should include headers from iterable objects', scope => {
     })
   })
 })
+
+test('request should include statusText in response', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createServer((req, res) => {
+    res.writeHead(200, 'Custom Status Text', { 'content-type': 'text/plain' })
+    res.end('hello')
+  })
+
+  after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+
+  await new Promise((resolve) => server.listen(0, resolve))
+
+  const { statusText, body } = await request({
+    method: 'GET',
+    origin: `http://localhost:${server.address().port}`,
+    path: '/'
+  })
+
+  t.strictEqual(statusText, 'Custom Status Text')
+  await body.dump()
+  t.ok('request completed')
+})

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -181,6 +181,7 @@ declare namespace Dispatcher {
   }
   export interface ResponseData<TOpaque = null> {
     statusCode: number;
+    statusText: string;
     headers: IncomingHttpHeaders;
     body: BodyReadable & BodyMixin;
     trailers: Record<string, string>;


### PR DESCRIPTION
Fixes: https://github.com/nodejs/undici/issues/4783

## This relates to...

#4783

## Rationale

Although status text is already captured by the HTTP parser and passed through the request chain via `onHeaders(statusCode, rawHeaders, resume, statusMessage)`, it was being dropped and not exposed in the `ResponseData` returned by `request()`. This makes it difficult for libraries like jsdom that need access to the status text for web platform API compatibility.

Although status text is kind of a useless feature, and so I understand the desire to omit it, the cost of passing this along is minor, and most consumers can ignore it, so I wanted to propose that we keep passing it.

## Changes

Expose `statusMessage` (received from the parser) as `statusText` in the `ResponseData` object returned by `request()`.

### Features

- Added `statusText` property to `ResponseData` returned by `request()`

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

## Point for discussion

`statusText` or `statusMessage`? Undici uses both internally. Fetch uses `statusText`. Node.js uses `statusMessage`. I'm fine either way.