### PR TITLE
fix: use latin1 encoding for headers in WrapHandler

### DIFF
--- a/lib/handler/wrap-handler.js
+++ b/lib/handler/wrap-handler.js
@@ -53,7 +53,7 @@ module.exports = class WrapHandler {
   onRequestUpgrade (controller, statusCode, headers, socket) {
     const rawHeaders = []
     for (const [key, val] of Object.entries(headers)) {
-      rawHeaders.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawHeaders.push(Buffer.from(key, 'latin1'), Array.isArray(val) ? val.map(v => Buffer.from(v, 'latin1')) : Buffer.from(val, 'latin1'))
     }
 
     this.#handler.onUpgrade?.(statusCode, rawHeaders, socket)
@@ -62,7 +62,7 @@ module.exports = class WrapHandler {
   onResponseStart (controller, statusCode, headers, statusMessage) {
     const rawHeaders = []
     for (const [key, val] of Object.entries(headers)) {
-      rawHeaders.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawHeaders.push(Buffer.from(key, 'latin1'), Array.isArray(val) ? val.map(v => Buffer.from(v, 'latin1')) : Buffer.from(val, 'latin1'))
     }
 
     if (this.#handler.onHeaders?.(statusCode, rawHeaders, () => controller.resume(), statusMessage) === false) {
@@ -79,7 +79,7 @@ module.exports = class WrapHandler {
   onResponseEnd (controller, trailers) {
     const rawTrailers = []
     for (const [key, val] of Object.entries(trailers)) {
-      rawTrailers.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawTrailers.push(Buffer.from(key, 'latin1'), Array.isArray(val) ? val.map(v => Buffer.from(v, 'latin1')) : Buffer.from(val, 'latin1'))
     }
 
     this.#handler.onComplete?.(rawTrailers)


### PR DESCRIPTION
## Summary

- Fix `WrapHandler` to use Latin1 encoding when converting header strings to Buffers
- Previously used `Buffer.from(val)` which defaults to UTF-8, causing header values with non-ASCII bytes to be incorrectly encoded
- Affects `onRequestUpgrade`, `onResponseStart`, and `onResponseEnd` methods

Fixes #4797

## Test plan

- [x] Verified both repro cases from the issue now work correctly
- [x] All existing unit tests pass (1221 tests)
- [x] Lint passes