### PR TITLE
Add missing `close` method to WebSocketStream interface

### DIFF
--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -169,6 +169,8 @@ interface WebSocketStream {
     writable: WritableStream
   }>
   url: string
+
+  close(options?: Partial<WebSocketCloseInfo>): void
 }
 
 export declare const WebSocketStream: {


### PR DESCRIPTION
## This relates to...

- No related issues reported

## Rationale

This adds missing close method to WebSocketStream interface, (see [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/WebSocketStream/close)).

Method is already defined, but missing in interface: https://github.com/nodejs/undici/blob/6cc668d9e24fc23a75b9cdfef5faa0212e4fb29f/lib/web/websocket/stream/websocketstream.js#L185-L198

## Changes

See diff

### Features

N/A if not

### Bug Fixes

N/A

### Breaking Changes and Deprecations

No breaking changes

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [S] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
