### PR TITLE
fix: set finalizer only for fetch responses

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -242,7 +242,8 @@ class Response {
     const clonedResponse = cloneResponse(this.#state)
 
     // Note: To re-register because of a new stream.
-    if (this.#state.body?.stream) {
+    // Don't set finalizers other than for fetch responses.
+    if (this.#state.urlList.length !== 0 && this.#state.body?.stream) {
       streamRegistry.register(this, new WeakRef(this.#state.body.stream))
     }
 

--- a/test/fetch/fire-and-forget.js
+++ b/test/fetch/fire-and-forget.js
@@ -46,6 +46,42 @@ test('test finalizer cloned response', async () => {
   await response.arrayBuffer() // check consume body
 })
 
+// https://github.com/nodejs/undici/pull/4803
+test('should not call cancel() during GC (new Response)', async () => {
+  if (!hasGC) {
+    throw new Error('gc is not available. Run with \'--expose-gc\'.')
+  }
+
+  let response = new Response(new ReadableStream({
+    start () {},
+
+    pull (ctrl) {
+      ctrl.enqueue(new Uint8Array([72, 101, 108, 108, 111])) // Hello
+    },
+
+    cancel () {
+      throw new Error('should be unreachable')
+    }
+  }))
+
+  let cloned = response.clone()
+
+  const body = response.body
+
+  await nextTick()
+  cloned.body.cancel()
+
+  cloned = null
+  response = null
+
+  await nextTick()
+  // eslint-disable-next-line no-undef
+  gc()
+
+  await nextTick(); // handle 'uncaughtException' event
+  (function () {})(body) // save a reference without triggering linter warnings
+})
+
 test('does not need the body to be consumed to continue', { timeout: 180_000 }, async (t) => {
   if (!hasGC) {
     throw new Error('gc is not available. Run with \'--expose-gc\'.')


### PR DESCRIPTION
Follow up of https://github.com/nodejs/undici/pull/4713#issuecomment-3708065839
I found that I was overlooking this part.
In the past, I added a finalizer after cloning all responses. However, doing so on unfetched responses resulted in unreachable code, making it inefficient.