### PR TITLE
fix: handle schema-less HTTP_PROXY env vars

### DIFF
--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -10,6 +10,14 @@ const DEFAULT_PORTS = {
   'https:': 443
 }
 
+// Prepend http:// to proxy URLs without a scheme (matches Go's httpproxy behavior)
+function normalizeProxyUrl (proxyUrl) {
+  if (proxyUrl && !proxyUrl.startsWith('http://') && !proxyUrl.startsWith('https://')) {
+    return 'http://' + proxyUrl
+  }
+  return proxyUrl
+}
+
 class EnvHttpProxyAgent extends DispatcherBase {
   #noProxyValue = null
   #noProxyEntries = null
@@ -23,14 +31,14 @@ class EnvHttpProxyAgent extends DispatcherBase {
 
     this[kNoProxyAgent] = new Agent(agentOpts)
 
-    const HTTP_PROXY = httpProxy ?? process.env.http_proxy ?? process.env.HTTP_PROXY
+    const HTTP_PROXY = normalizeProxyUrl(httpProxy ?? process.env.http_proxy ?? process.env.HTTP_PROXY)
     if (HTTP_PROXY) {
       this[kHttpProxyAgent] = new ProxyAgent({ ...agentOpts, uri: HTTP_PROXY })
     } else {
       this[kHttpProxyAgent] = this[kNoProxyAgent]
     }
 
-    const HTTPS_PROXY = httpsProxy ?? process.env.https_proxy ?? process.env.HTTPS_PROXY
+    const HTTPS_PROXY = normalizeProxyUrl(httpsProxy ?? process.env.https_proxy ?? process.env.HTTPS_PROXY)
     if (HTTPS_PROXY) {
       this[kHttpsProxyAgent] = new ProxyAgent({ ...agentOpts, uri: HTTPS_PROXY })
     } else {

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -67,6 +67,33 @@ test('handles uppercase HTTP_PROXY and HTTPS_PROXY', async (t) => {
   return dispatcher.close()
 })
 
+test('handles schema-less HTTP_PROXY by assuming http://', async (t) => {
+  t = tspl(t, { plan: 2 })
+  process.env.HTTP_PROXY = 'localhost:8080'
+  const dispatcher = new EnvHttpProxyAgent()
+  t.ok(dispatcher[kHttpProxyAgent] instanceof ProxyAgent)
+  t.equal(dispatcher[kHttpProxyAgent][kProxy].uri, 'http://localhost:8080/')
+  return dispatcher.close()
+})
+
+test('handles schema-less HTTPS_PROXY by assuming http://', async (t) => {
+  t = tspl(t, { plan: 2 })
+  process.env.HTTPS_PROXY = 'localhost:8443'
+  const dispatcher = new EnvHttpProxyAgent()
+  t.ok(dispatcher[kHttpsProxyAgent] instanceof ProxyAgent)
+  t.equal(dispatcher[kHttpsProxyAgent][kProxy].uri, 'http://localhost:8443/')
+  return dispatcher.close()
+})
+
+test('preserves explicit https:// schema in proxy URL', async (t) => {
+  t = tspl(t, { plan: 2 })
+  process.env.HTTP_PROXY = 'https://secure-proxy.example.com:8080'
+  const dispatcher = new EnvHttpProxyAgent()
+  t.ok(dispatcher[kHttpProxyAgent] instanceof ProxyAgent)
+  t.equal(dispatcher[kHttpProxyAgent][kProxy].uri, 'https://secure-proxy.example.com:8080/')
+  return dispatcher.close()
+})
+
 test('accepts httpProxy and httpsProxy options', async (t) => {
   t = tspl(t, { plan: 6 })
   const opts = {


### PR DESCRIPTION
## This relates to...

Fixes #4736

## Rationale

When HTTP_PROXY or HTTPS_PROXY is set without a URL scheme (e.g., localhost:8080 instead of http://localhost:8080), the EnvHttpProxyAgent fails. This PR adds automatic http:// prefix for schema-less proxy URLs, matching Go's httpproxy behavior.

## Changes

Added normalizeProxyUrl() helper function in lib/dispatcher/env-http-proxy-agent.js. Also added tests in test/env-http-proxy-agent.js.

### Features

N/A

### Bug Fixes

- Schema-less proxy URLs now work by assuming http:// protocol

### Breaking Changes and Deprecations

None. This is additive behavior - existing URLs with explicit schemes are unchanged.

## Status

- [x] I have read and agreed to the Developer's Certificate of Origin
- [x] Tested
- [ ] Benchmarked (optional)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready