### PR TITLE
websocket: provide descriptive error on abnormal closure (fixes #4625)

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -587,7 +587,7 @@ class WebSocket extends EventTarget {
       code = 1006
 
       fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new TypeError(reason)
+        error: new TypeError(reason || 'WebSocket connection closed abnormally')
       })
     }
 

--- a/test/websocket/issue-4625.js
+++ b/test/websocket/issue-4625.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { test } = require('node:test')
+const net = require('node:net')
+const { WebSocket } = require('../..')
+
+// Test for https://github.com/nodejs/undici/issues/4625
+// When WebSocket closes abnormally (code 1006), error message should be descriptive
+test('abnormal closure should have descriptive error message', async (t) => {
+  // Create a raw TCP server that accepts the connection but then abruptly closes
+  const server = net.createServer((socket) => {
+    // Send a valid WebSocket handshake response
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n' +
+            'Upgrade: websocket\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Sec-WebSocket-Accept: invalid\r\n' +
+            '\r\n'
+    )
+    // Immediately destroy the socket to simulate abnormal closure
+    socket.destroy()
+  })
+
+  await new Promise((resolve) => server.listen(0, resolve))
+  const port = server.address().port
+
+  const ws = new WebSocket(`ws://localhost:${port}`)
+
+  await new Promise((resolve) => {
+    ws.addEventListener('error', (event) => {
+      t.assert.ok(event.error instanceof TypeError)
+      t.assert.ok(
+        event.error.message.length > 0,
+        'error message should not be empty'
+      )
+      t.assert.ok(
+        event.error.message.includes('abnormally') ||
+                event.error.message.includes('closed'),
+        'error message should describe the closure'
+      )
+      resolve()
+    })
+  })
+
+  server.close()
+})


### PR DESCRIPTION
## This relates to...

Fixes #4625

## Rationale

When a WebSocket connection closes abnormally (code 1006) without completing the control frame exchange, the error event contained an empty `TypeError` message. This made debugging difficult as the error appeared cryptic with no description of what went wrong.

## Changes

- Modified `lib/web/websocket/websocket.js` line 590 to use a fallback message when `reason` is empty
- Added `test/websocket/issue-4625.js` to verify the fix works for abnormal closures

### Features

N/A

### Bug Fixes

- When WebSocket closes without receiving a close frame (code 1006), the error message now provides a descriptive fallback: "WebSocket connection closed abnormally" instead of an empty string

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin