### PR TITLE
fix: handle undefined __filename in bundled environments

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -4,6 +4,10 @@ const { getGlobalDispatcher, setGlobalDispatcher } = require('./lib/global')
 const EnvHttpProxyAgent = require('./lib/dispatcher/env-http-proxy-agent')
 const fetchImpl = require('./lib/web/fetch').fetch
 
+// Capture __filename at module load time for stack trace augmentation.
+// This may be undefined when bundled in environments like Node.js internals.
+const currentFilename = typeof __filename !== 'undefined' ? __filename : undefined
+
 function appendFetchStackTrace (err, filename) {
   if (!err || typeof err !== 'object') {
     return
@@ -30,7 +34,11 @@ function appendFetchStackTrace (err, filename) {
 
 module.exports.fetch = function fetch (init, options = undefined) {
   return fetchImpl(init, options).catch(err => {
-    appendFetchStackTrace(err, __filename)
+    if (currentFilename) {
+      appendFetchStackTrace(err, currentFilename)
+    } else if (err && typeof err === 'object') {
+      Error.captureStackTrace(err, module.exports.fetch)
+    }
     throw err
   })
 }

--- a/index.js
+++ b/index.js
@@ -121,6 +121,10 @@ module.exports.getGlobalDispatcher = getGlobalDispatcher
 
 const fetchImpl = require('./lib/web/fetch').fetch
 
+// Capture __filename at module load time for stack trace augmentation.
+// This may be undefined when bundled in environments like Node.js internals.
+const currentFilename = typeof __filename !== 'undefined' ? __filename : undefined
+
 function appendFetchStackTrace (err, filename) {
   if (!err || typeof err !== 'object') {
     return
@@ -147,7 +151,11 @@ function appendFetchStackTrace (err, filename) {
 
 module.exports.fetch = function fetch (init, options = undefined) {
   return fetchImpl(init, options).catch(err => {
-    appendFetchStackTrace(err, __filename)
+    if (currentFilename) {
+      appendFetchStackTrace(err, currentFilename)
+    } else if (err && typeof err === 'object') {
+      Error.captureStackTrace(err, module.exports.fetch)
+    }
     throw err
   })
 }


### PR DESCRIPTION
## Summary

When undici is bundled inside Node.js as an internal module, `__filename` is not defined. This causes a `ReferenceError` when `fetch()` fails, which swallows the original error and replaces it with the ReferenceError, making `err.cause` undefined.

This was introduced in #4778.

## The Problem

The code added in #4778:
```javascript
module.exports.fetch = function fetch (init, options = undefined) {
  return fetchImpl(init, options).catch(err => {
    appendFetchStackTrace(err, __filename)  // __filename is undefined!
    throw err
  })
}
```

When bundled in Node.js internals, `__filename` is not available, causing:
```
ReferenceError: __filename is not defined
```

This error is thrown inside the `.catch()` handler, replacing the original fetch error. As a result, `err.cause` becomes `undefined` instead of containing the actual error.

## The Fix

1. Safely capture `__filename` at module load time, defaulting to `undefined` if not available
2. Use the new stack trace augmentation when `__filename` is available  
3. Fall back to the original `Error.captureStackTrace(err)` behavior when `__filename` is not available

## Testing

- Verified undici's stack trace tests still pass: `npx borp -p "test/fetch/client-error-stack-trace.js"`
- Verified Node.js tests pass with the fix:
  - `test-permission-net-fetch.js`
  - `test-tls-set-default-ca-certificates-append-fetch.mjs`
  - `test-tls-set-default-ca-certificates-reset-fetch.mjs`

Refs: nodejs/node#61683, nodejs/node#61679