### PR TITLE
docs: fix syntax highlighting in WebSocket.md

### DIFF
--- a/docs/docs/api/WebSocket.md
+++ b/docs/docs/api/WebSocket.md
@@ -15,7 +15,7 @@ Arguments:
 
 This example will not work in browsers or other platforms that don't allow passing an object.
 
-```mjs
+```js
 import { WebSocket, ProxyAgent } from 'undici'
 
 const proxyAgent = new ProxyAgent('my.proxy.server')
@@ -28,7 +28,7 @@ const ws = new WebSocket('wss://echo.websocket.events', {
 
 If you do not need a custom Dispatcher, it's recommended to use the following pattern:
 
-```mjs
+```js
 import { WebSocket } from 'undici'
 
 const ws = new WebSocket('wss://echo.websocket.events', ['echo', 'chat'])
@@ -44,7 +44,7 @@ const ws = new WebSocket('wss://echo.websocket.events', ['echo', 'chat'])
 
 This example will not work in browsers or other platforms that don't allow passing an object.
 
-```mjs
+```js
 import { Agent } from 'undici'
 
 const agent = new Agent({ allowH2: true })


### PR DESCRIPTION
Updated code block syntax highlighting from 'mjs' to 'js' so that syntax highlighting works.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Syntax highlighting was broken - all the code was one color

https://undici.nodejs.org/#/docs/api/WebSocket

## Changes

Fixes syntax highlighting for the code snippets on Websocket.md


### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
