### PR TITLE
fix: use OR operator in includesCredentials per WHATWG URL Standard

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1439,7 +1439,7 @@ function hasAuthenticationEntry (request) {
  */
 function includesCredentials (url) {
   // A URL includes credentials if its username or password is not the empty string.
-  return !!(url.username && url.password)
+  return !!(url.username || url.password)
 }
 
 /**

--- a/test/fetch/includes-credentials.js
+++ b/test/fetch/includes-credentials.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { test } = require('node:test')
+const { includesCredentials } = require('../../lib/web/fetch/util')
+
+test('includesCredentials returns true for URL with both username and password', () => {
+  const url = new URL('http://user:pass@example.com')
+  require('node:assert').strictEqual(includesCredentials(url), true)
+})
+
+test('includesCredentials returns true for URL with only username', () => {
+  const url = new URL('http://user@example.com')
+  require('node:assert').strictEqual(includesCredentials(url), true)
+})
+
+test('includesCredentials returns true for URL with only password', () => {
+  const url = new URL('http://:pass@example.com')
+  require('node:assert').strictEqual(includesCredentials(url), true)
+})
+
+test('includesCredentials returns false for URL with no credentials', () => {
+  const url = new URL('http://example.com')
+  require('node:assert').strictEqual(includesCredentials(url), false)
+})


### PR DESCRIPTION
## Summary

- Fix logical operator in `includesCredentials()` (`lib/web/fetch/util.js`): `&&` → `||`
- Add unit tests for `includesCredentials()` covering all credential combinations

## Problem

The `includesCredentials()` function uses AND (`&&`) instead of OR (`||`), contradicting both:
1. Its own comment: *"A URL includes credentials if its username **or** password is not the empty string."*
2. [WHATWG URL Standard §4.4](https://url.spec.whatwg.org/#include-credentials): *"A URL includes credentials if its username is not the empty string **or** its password is not the empty string."*

This causes the Authorization header to be silently omitted during authentication retries for URLs with only a username (e.g., `http://apitoken@host`) or only a password (e.g., `http://:secret@host`).

## Fix

```diff
 function includesCredentials (url) {
   // A URL includes credentials if its username or password is not the empty string.
-  return !!(url.username && url.password)
+  return !!(url.username || url.password)
 }
```

## Test plan

- [x] New test: URL with both username and password → `true`
- [x] New test: URL with only username → `true`
- [x] New test: URL with only password → `true`
- [x] New test: URL with no credentials → `false`
- [x] Existing fetch tests pass (no regressions)
- [x] ESLint passes

Fixes: https://github.com/nodejs/undici/issues/4815

Ref: [CWE-480: Use of Incorrect Operator](https://cwe.mitre.org/data/definitions/480.html)