### PR TITLE
fix: preserve request statusText and update h2 dispatch tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,8 @@ jobs:
       fail-fast: false
       max-parallel: 0
       matrix:
+        # Node.js 22 is intentionally excluded here: --shared-builtin-undici/undici-path
+        # embedding is only validated for supported/current majors.
         node-version: ['24', '25']
         runs-on: ['ubuntu-latest']
     with:

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -87,7 +87,7 @@ class RequestHandler extends AsyncResource {
     this.context = context
   }
 
-  onResponseStart (controller, statusCode, headers, _statusMessage) {
+  onResponseStart (controller, statusCode, headers, statusText) {
     const { callback, opaque, context, responseHeaders, highWaterMark } = this
 
     const rawHeaders = controller?.rawHeaders
@@ -126,6 +126,7 @@ class RequestHandler extends AsyncResource {
       try {
         this.runInAsyncScope(callback, null, null, {
           statusCode,
+          statusText,
           headers: responseHeaderData,
           trailers: this.trailers,
           opaque,

--- a/lib/dispatcher/dispatcher-base.js
+++ b/lib/dispatcher/dispatcher-base.js
@@ -7,7 +7,6 @@ const {
   InvalidArgumentError
 } = require('../core/errors')
 const { kDestroy, kClose, kClosed, kDestroyed, kDispatch } = require('../core/symbols')
-const Dispatcher1Wrapper = require('./dispatcher1-wrapper')
 
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
@@ -130,7 +129,9 @@ class DispatcherBase extends Dispatcher {
   }
 
   dispatch (opts, handler) {
-    const wrappedHandler = Dispatcher1Wrapper.wrapHandler(handler)
+    if (!handler || typeof handler !== 'object') {
+      throw new InvalidArgumentError('handler must be an object')
+    }
 
     try {
       if (!opts || typeof opts !== 'object') {
@@ -145,13 +146,13 @@ class DispatcherBase extends Dispatcher {
         throw new ClientClosedError()
       }
 
-      return this[kDispatch](opts, wrappedHandler)
+      return this[kDispatch](opts, handler)
     } catch (err) {
-      if (typeof wrappedHandler.onResponseError !== 'function') {
+      if (typeof handler.onResponseError !== 'function') {
         throw err
       }
 
-      wrappedHandler.onResponseError(null, err)
+      handler.onResponseError(null, err)
 
       return false
     }

--- a/lib/dispatcher/dispatcher-base.js
+++ b/lib/dispatcher/dispatcher-base.js
@@ -7,6 +7,7 @@ const {
   InvalidArgumentError
 } = require('../core/errors')
 const { kDestroy, kClose, kClosed, kDestroyed, kDispatch } = require('../core/symbols')
+const Dispatcher1Wrapper = require('./dispatcher1-wrapper')
 
 const kOnDestroyed = Symbol('onDestroyed')
 const kOnClosed = Symbol('onClosed')
@@ -129,9 +130,7 @@ class DispatcherBase extends Dispatcher {
   }
 
   dispatch (opts, handler) {
-    if (!handler || typeof handler !== 'object') {
-      throw new InvalidArgumentError('handler must be an object')
-    }
+    const wrappedHandler = Dispatcher1Wrapper.wrapHandler(handler)
 
     try {
       if (!opts || typeof opts !== 'object') {
@@ -146,13 +145,13 @@ class DispatcherBase extends Dispatcher {
         throw new ClientClosedError()
       }
 
-      return this[kDispatch](opts, handler)
+      return this[kDispatch](opts, wrappedHandler)
     } catch (err) {
-      if (typeof handler.onResponseError !== 'function') {
+      if (typeof wrappedHandler.onResponseError !== 'function') {
         throw err
       }
 
-      handler.onResponseError(null, err)
+      wrappedHandler.onResponseError(null, err)
 
       return false
     }

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -511,19 +511,13 @@ test('Should send http2 PING frames', async t => {
     method: 'PUT',
     body: 'hello'
   }, {
-    onConnect () {
-
-    },
-    onHeaders () {
-      return true
-    },
-    onData () {
-      return true
-    },
-    onComplete (trailers) {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd (_controller, trailers) {
       t.strictEqual(trailers['x-trailer'], 'hello')
     },
-    onError (err) {
+    onResponseError (_controller, err) {
       t.ifError(err)
     }
   })
@@ -588,19 +582,13 @@ test('Should not send http2 PING frames if interval === 0', async t => {
     method: 'PUT',
     body: 'hello'
   }, {
-    onConnect () {
-
-    },
-    onHeaders () {
-      return true
-    },
-    onData () {
-      return true
-    },
-    onComplete (trailers) {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd (_controller, trailers) {
       t.strictEqual(trailers['x-trailer'], 'hello')
     },
-    onError (err) {
+    onResponseError (_controller, err) {
       t.ifError(err)
     }
   })
@@ -666,19 +654,13 @@ test('Should not send http2 PING frames after connection is closed', async t => 
     method: 'PUT',
     body: 'hello'
   }, {
-    onConnect () {
-
-    },
-    onHeaders () {
-      return true
-    },
-    onData () {
-      return true
-    },
-    onComplete (trailers) {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd (_controller, trailers) {
       t.strictEqual(trailers['x-trailer'], 'hello')
     },
-    onError (err) {
+    onResponseError (_controller, err) {
       t.ifError(err)
     }
   })


### PR DESCRIPTION
## Summary
- preserve `statusText` in `request()` callback results
- migrate HTTP/2 ping tests to the v2 dispatch handler API (`onRequestStart`/`onResponse*`)
- keep the CI note clarifying Node.js 22 is excluded only from shared-builtin embedding jobs

## Validation
- source ~/.nvm/nvm.sh && nvm use 22.22.0 && npx borp -p "test/http2-dispatcher.js"
- source ~/.nvm/nvm.sh && nvm use 22.22.0 && npx borp -p "test/request.js"
- npx borp -p "test/http2-dispatcher.js"
- npx borp -p "test/request.js"
- npm run lint