### PR TITLE
docs: clarify UndiciHeaders validation guidance

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1304,6 +1304,10 @@ Header arguments such as `options.headers` in [`Client.dispatch`](/docs/docs/api
 * As an iterable that can encompass `Headers`, `Map`, or a custom iterator returning key-value pairs.
 Keys are lowercase and values are not modified.
 
+Undici validates header syntax at the protocol level (for example, invalid header names and invalid control characters in string values), but it does not sanitize untrusted application input. Validate and sanitize any user-provided header names and values before passing them to Undici to prevent header/body injection vulnerabilities.
+
+When using the array header format (`string[]`), Undici processes only indexed elements. Additional properties assigned to the array object are ignored.
+
 Response headers will derive a `host` from the `url` of the [Client](/docs/docs/api/Client.md#class-client) instance if no `host` header was previously specified.
 
 ### Example 1 - Object


### PR DESCRIPTION
## Summary\n- clarify that Undici performs protocol-level header syntax validation\n- document that callers must validate and sanitize user-provided header names and values\n- document that in the string[] header format, only indexed array elements are processed and extra array object properties are ignored\n\n## Testing\n- npm run lint