### PR TITLE
test: add unexpected disconnect guards to client test files

### DIFF
--- a/test/client-connect.js
+++ b/test/client-connect.js
@@ -29,6 +29,11 @@ test('connect aborted after connect', async (t) => {
     pipelining: 3
   })
   after(() => client.close())
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   client.connect({
     path: '/',

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -41,6 +41,11 @@ test('20 times GET with pipelining 10', async (t) => {
       pipelining: 10
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     for (let i = 0; i < num; i++) {
       makeRequest(i)
@@ -98,6 +103,11 @@ test('A client should enqueue as much as twice its pipelining factor', async (t)
       pipelining: 2
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     for (; sent < 2;) {
       t.ok(client[kSize] <= client.pipelining, 'client is not full')
@@ -148,6 +158,11 @@ test('pipeline 1 is 1 active request', async (t) => {
       pipelining: 1
     })
     after(() => client.destroy())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
     client.request({
       path: '/',
       method: 'GET'
@@ -201,6 +216,11 @@ test('pipelined chunked POST stream', async (t) => {
       pipelining: 2
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     client.request({
       path: '/',
@@ -270,6 +290,11 @@ test('pipelined chunked POST iterator', async (t) => {
       pipelining: 2
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     client.request({
       path: '/',
@@ -393,6 +418,11 @@ test('pipelining non-idempotent', async (t) => {
       pipelining: 2
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     let ended = false
     client.request({
@@ -439,6 +469,11 @@ function pipeliningNonIdempotentWithBody (bodyType) {
         pipelining: 2
       })
       after(() => client.close())
+      client.on('disconnect', () => {
+        if (!client.closed && !client.destroyed) {
+          t.fail('unexpected disconnect')
+        }
+      })
 
       let ended = false
       let reading = false
@@ -747,6 +782,11 @@ test('pipelining blocked', async (t) => {
       pipelining: 10
     })
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
     client.request({
       path: '/',
       method: 'GET',

--- a/test/client-post.js
+++ b/test/client-post.js
@@ -26,6 +26,11 @@ test('request post blob', async (t) => {
 
   const client = new Client(`http://localhost:${server.address().port}`)
   after(client.destroy.bind(client))
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   client.request({
     path: '/',
@@ -62,6 +67,11 @@ test('request post arrayBuffer', async (t) => {
 
   const client = new Client(`http://localhost:${server.address().port}`)
   after(() => client.destroy())
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const buf = Buffer.from('asd')
   const dst = new ArrayBuffer(buf.byteLength)

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -22,6 +22,11 @@ test('stream get', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     const signal = new EE()
     client.stream({
@@ -65,6 +70,11 @@ test('stream promise get', async (t) => {
   server.listen(0, async () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     await client.stream({
       path: '/',
@@ -254,6 +264,11 @@ test('stream waits only for writable side', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     const pt = new PassThrough({ autoDestroy: false })
     client.stream({
@@ -321,6 +336,11 @@ test('stream destroy if not readable', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(client.destroy.bind(client))
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     client.stream({
       path: '/',
@@ -397,6 +417,11 @@ test('stream body without destroy', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(client.destroy.bind(client))
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     client.stream({
       path: '/',
@@ -520,6 +545,11 @@ test('stream abort after complete', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(client.destroy.bind(client))
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     const pt = new PassThrough()
     const signal = new EE()
@@ -580,6 +610,11 @@ test('trailers', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     client.stream({
       path: '/',
@@ -605,6 +640,11 @@ test('stream ignore 1xx', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     let buf = ''
     client.stream({
@@ -637,6 +677,11 @@ test('stream ignore 1xx and use onInfo', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     let buf = ''
     client.stream({
@@ -675,6 +720,11 @@ test('stream backpressure', async (t) => {
   server.listen(0, () => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.close())
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     let buf = ''
     client.stream({
@@ -736,6 +786,11 @@ test('stream needDrain', async (t) => {
     after(() => {
       client.destroy()
     })
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
 
     const dst = new PassThrough()
     dst.pause()
@@ -791,6 +846,11 @@ test('stream legacy needDrain', async (t) => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => {
       client.destroy()
+    })
+    client.on('disconnect', () => {
+      if (!client.closed && !client.destroyed) {
+        t.fail('unexpected disconnect')
+      }
     })
 
     const dst = new PassThrough()


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Relates to https://github.com/nodejs/undici/issues/251

## Rationale

Adds `client.on('disconnect', ...)` guards to tests where a disconnect is unexpected, catching silent reconnections that could mask bugs. Guards check `!client.closed && !client.destroyed` to avoid false failures during teardown. There are some more test cases to cover, but this PR focuses on tests that do not have any disconnect handling.

## Changes

For test cases that did not have a guard-clause for disconnects, the following block is added:

```typescript
    client.on('disconnect', () => {
      if (!client.closed && !client.destroyed) {
        t.fail('unexpected disconnect')
      }
    })
```

Modfied test cases in each file: 
* client-pipelining.js (8)
* client-stream.js (12)
* client-post.js (2)
* client-connect.js (1)

```
 test/client-connect.js    |  5 +++++
 test/client-pipelining.js | 40 ++++++++++++++++++++++++++++++++++++++++
 test/client-post.js       | 10 ++++++++++
 test/client-stream.js     | 60 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 115 insertions(+)
```

Here are the benchmark results from a local run:

```
[bench:run] ┌─────────┬───────────────────────┬─────────┬────────────────────┬────────────┬─────────────────────────┐
[bench:run] │ (index) │ Tests                 │ Samples │ Result             │ Tolerance  │ Difference with slowest │
[bench:run] ├─────────┼───────────────────────┼─────────┼────────────────────┼────────────┼─────────────────────────┤
[bench:run] │ 0       │ 'http - no keepalive' │ 85      │ '4578.17 req/sec'  │ '± 2.97 %' │ '-'                     │
[bench:run] │ 1       │ 'axios'               │ 10      │ '11725.67 req/sec' │ '± 3.00 %' │ '+ 156.12 %'            │
[bench:run] │ 2       │ 'got'                 │ 10      │ '12017.29 req/sec' │ '± 2.82 %' │ '+ 162.49 %'            │
[bench:run] │ 3       │ 'node-fetch'          │ 15      │ '12433.44 req/sec' │ '± 2.88 %' │ '+ 171.58 %'            │
[bench:run] │ 4       │ 'request'             │ 30      │ '13014.85 req/sec' │ '± 2.88 %' │ '+ 184.28 %'            │
[bench:run] │ 5       │ 'undici - fetch'      │ 40      │ '14339.34 req/sec' │ '± 2.96 %' │ '+ 213.21 %'            │
[bench:run] │ 6       │ 'superagent'          │ 10      │ '17800.66 req/sec' │ '± 2.23 %' │ '+ 288.82 %'            │
[bench:run] │ 7       │ 'http - keepalive'    │ 15      │ '19486.13 req/sec' │ '± 2.32 %' │ '+ 325.63 %'            │
[bench:run] │ 8       │ 'undici - pipeline'   │ 30      │ '23147.78 req/sec' │ '± 2.96 %' │ '+ 405.61 %'            │
[bench:run] │ 9       │ 'undici - stream'     │ 10      │ '27177.58 req/sec' │ '± 2.99 %' │ '+ 493.63 %'            │
[bench:run] │ 10      │ 'undici - request'    │ 10      │ '27250.48 req/sec' │ '± 2.84 %' │ '+ 495.23 %'            │
[bench:run] │ 11      │ 'undici - dispatch'   │ 15      │ '29097.65 req/sec' │ '± 2.70 %' │ '+ 535.57 %'            │
[bench:run] └─────────┴───────────────────────┴─────────┴────────────────────┴────────────┴─────────────────────────┘
```

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

None

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [S] Documented (N/A)
- [x] Review ready
- [x] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
