### PR TITLE
fix: queue WebSocket error/close events when closing CONNECTING socket

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -315,10 +315,11 @@ function failWebsocketConnection (handler, code, reason, cause) {
   handler.controller.abort()
 
   if (isConnecting(handler.readyState)) {
-    // If the connection was not established, we must still emit an 'error' and 'close' events.
-    // Per the spec, these events must be queued (fired asynchronously), not dispatched
-    // synchronously during the close() call.
-    queueMicrotask(() => handler.onSocketClose())
+    // If the connection was not established, we must still emit 'error' and 'close' events.
+    // Per spec, these must be queued as a task (not microtask), so they fire
+    // asynchronously after close() returns.
+    // @see https://websockets.spec.whatwg.org/#feedback-from-the-protocol
+    setTimeout(() => handler.onSocketClose(), 0)
   } else if (handler.socket?.destroyed === false) {
     handler.socket.destroy()
   }


### PR DESCRIPTION
When `close()` is called on a WebSocket that's still in the CONNECTING state, `failWebsocketConnection` calls `handler.onSocketClose()` synchronously, which fires the error and close events during the `close()` call itself. The spec says these should be queued as tasks and fire asynchronously after `close()` returns.

This wraps the `onSocketClose()` call in `queueMicrotask()` for the CONNECTING state path so events fire after close() returns, matching browser behavior.

**Before:**
```
Calling close()...
error event fired, closeReturned = false    <-- wrong
close event fired, closeReturned = false    <-- wrong
```

**After:**
```
Calling close()...
close() returned, closeReturned = true
error event fired, closeReturned = true     <-- correct
close event fired, closeReturned = true     <-- correct
```

Relevant WPTs:
- `websockets/interfaces/WebSocket/close/close-connecting.html`
- `websockets/interfaces/WebSocket/close/close-connecting-async.any.js`

Fixes #4741