### PR TITLE
fix: forward onResponseStarted through WrapHandler and UnwrapHandler

### DIFF
--- a/lib/handler/unwrap-handler.js
+++ b/lib/handler/unwrap-handler.js
@@ -67,6 +67,10 @@ module.exports = class UnwrapHandler {
     this.#handler.onRequestStart?.(this.#controller, context)
   }
 
+  onResponseStarted () {
+    return this.#handler.onResponseStarted?.()
+  }
+
   onUpgrade (statusCode, rawHeaders, socket) {
     this.#handler.onRequestUpgrade?.(this.#controller, statusCode, parseHeaders(rawHeaders), socket)
   }

--- a/lib/handler/wrap-handler.js
+++ b/lib/handler/wrap-handler.js
@@ -20,6 +20,10 @@ module.exports = class WrapHandler {
     return this.#handler.onConnect?.(abort, context)
   }
 
+  onResponseStarted () {
+    return this.#handler.onResponseStarted?.()
+  }
+
   onHeaders (statusCode, rawHeaders, resume, statusMessage) {
     return this.#handler.onHeaders?.(statusCode, rawHeaders, resume, statusMessage)
   }


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

When `fetch()` goes through a dispatcher with composed interceptors, the handler is wrapped by `WrapHandler` and then unwrapped by `UnwrapHandler`. The `onResponseStarted` callback (which sets `timingInfo.finalNetworkResponseStartTime`) was not forwarded by either class, causing `PerformanceResourceTiming.responseStart` to always be `0`.

## Changes

### Features

N/A

### Bug Fixes

- Added `onResponseStarted()` forwarding to `WrapHandler` (Unwrap Interface section)
- Added `onResponseStarted()` forwarding to `UnwrapHandler`

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin