### PR TITLE
fix: recover BalancedPool after equal-weight outage state

### DIFF
--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -156,7 +156,7 @@ class BalancedPool extends PoolBase {
       .map((p) => p[kUrl].origin)
   }
 
-  [kGetDispatcher] () {
+  [kGetDispatcher] (peek = false) {
     // We validate that pools is greater than 0,
     // otherwise we would have to wait until an upstream
     // is added, which might never happen.
@@ -174,6 +174,10 @@ class BalancedPool extends PoolBase {
       return
     }
 
+    if (peek) {
+      return dispatcher
+    }
+
     const allClientsBusy = this[kClients].map(pool => pool[kNeedDrain]).reduce((a, b) => a && b, true)
 
     if (allClientsBusy) {
@@ -182,7 +186,18 @@ class BalancedPool extends PoolBase {
 
     let counter = 0
 
-    let maxWeightIndex = this[kClients].findIndex(pool => !pool[kNeedDrain])
+    let maxWeightIndex = -1
+
+    for (let i = 0; i < this[kClients].length; i++) {
+      const pool = this[kClients][i]
+
+      if (
+        !pool[kNeedDrain] &&
+        (maxWeightIndex === -1 || pool[kWeight] > this[kClients][maxWeightIndex][kWeight])
+      ) {
+        maxWeightIndex = i
+      }
+    }
 
     while (counter++ < this[kClients].length) {
       this[kIndex] = (this[kIndex] + 1) % this[kClients].length
@@ -199,7 +214,7 @@ class BalancedPool extends PoolBase {
         this[kCurrentWeight] = this[kCurrentWeight] - this[kGreatestCommonDivisor]
 
         if (this[kCurrentWeight] <= 0) {
-          this[kCurrentWeight] = this[kMaxWeightPerServer]
+          this[kCurrentWeight] = this[kClients][maxWeightIndex][kWeight]
         }
       }
       if (pool[kWeight] >= this[kCurrentWeight] && (!pool[kNeedDrain])) {

--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -162,7 +162,7 @@ class PoolBase extends DispatcherBase {
       this[kQueued]++
     } else if (!dispatcher.dispatch(opts, handler)) {
       dispatcher[kNeedDrain] = true
-      this[kNeedDrain] = !this[kGetDispatcher]()
+      this[kNeedDrain] = !this[kGetDispatcher](true)
     }
 
     return !this[kNeedDrain]

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -96,7 +96,7 @@ class Pool extends PoolBase {
     })
   }
 
-  [kGetDispatcher] () {
+  [kGetDispatcher] (peek = false) {
     const clientTtlOption = this[kOptions].clientTtl
     for (const client of this[kClients]) {
       // check ttl of client and if it's stale, remove it from the pool
@@ -108,6 +108,10 @@ class Pool extends PoolBase {
     }
 
     if (!this[kConnections] || this[kClients].length < this[kConnections]) {
+      if (peek) {
+        return true
+      }
+
       const dispatcher = this[kFactory](this[kUrl], this[kOptions])
       this[kAddClient](dispatcher)
       return dispatcher

--- a/lib/dispatcher/round-robin-pool.js
+++ b/lib/dispatcher/round-robin-pool.js
@@ -93,12 +93,16 @@ class RoundRobinPool extends PoolBase {
     })
   }
 
-  [kGetDispatcher] () {
+  [kGetDispatcher] (peek = false) {
     const clientTtlOption = this[kOptions].clientTtl
     const clientsLength = this[kClients].length
 
     // If we have no clients yet, create one
     if (clientsLength === 0) {
+      if (peek) {
+        return true
+      }
+
       const dispatcher = this[kFactory](this[kUrl], this[kOptions])
       this[kAddClient](dispatcher)
       return dispatcher
@@ -127,6 +131,10 @@ class RoundRobinPool extends PoolBase {
 
     // All clients are busy, create a new one if we haven't reached the limit
     if (!this[kConnections] || clientsLength < this[kConnections]) {
+      if (peek) {
+        return true
+      }
+
       const dispatcher = this[kFactory](this[kUrl], this[kOptions])
       this[kAddClient](dispatcher)
       return dispatcher


### PR DESCRIPTION
## Summary
- fix `BalancedPool` weighted round-robin recovery after outages when all upstream weights reach the minimum value
- avoid mutating scheduler state during dispatcher availability probes by adding a non-mutating `peek` mode to `kGetDispatcher` callers
- add a regression test that reproduces the 2-upstream outage/recovery scenario from #4839

## Details
When two upstreams both degrade to weight `1`, `BalancedPool` could repeatedly select the same failed upstream and never probe the healthy one during recovery.

This was caused by two interactions:
1. stateful dispatcher selection was being invoked for a "can dispatch?" probe in `PoolBase`, advancing scheduler state unexpectedly
2. weighted round-robin weight reset used `maxWeightPerServer` instead of the current max available upstream weight

## Testing
- `npx borp -p "test/node-test/balanced-pool.js"`
- `npx borp -p "test/pool.js" -p "test/round-robin-pool.js"`
- `npm run lint`

Closes: #4839
