### PR TITLE
ci: disable coverage on Node.js 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm run lint
 
   test:
-    name: Test ${{ (matrix.node-version == '24' || matrix.node-version == '25') && matrix.runs-on == 'ubuntu-latest' && 'and Coverage ' || ''}}with Node.js ${{ matrix.node-version }} on ${{ matrix.runs-on }}
+    name: Test ${{ matrix.node-version == '24' && matrix.runs-on == 'ubuntu-latest' && 'and Coverage ' || ''}}with Node.js ${{ matrix.node-version }} on ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       max-parallel: 0
@@ -66,7 +66,8 @@ jobs:
             runs-on: windows-latest
     uses: ./.github/workflows/nodejs.yml
     with:
-      codecov: ${{ (matrix.node-version == '24' || matrix.node-version == '25') && matrix.runs-on == 'ubuntu-latest' }}
+      # Disable coverage on Node.js 25 until https://github.com/nodejs/node/issues/61971 is resolved.
+      codecov: ${{ matrix.node-version == '24' && matrix.runs-on == 'ubuntu-latest' }}
       node-version: ${{ matrix.node-version }}
       runs-on: ${{ matrix.runs-on }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- disable Codecov/coverage collection for the Node.js 25 CI matrix entry
- keep coverage enabled only for Node.js 24 on ubuntu-latest
- add an inline note referencing the upstream issue: https://github.com/nodejs/node/issues/61971

## Testing
- npm run lint
