### PR TITLE
docs(errors): clarify timeout error codes and related options

### DIFF
--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -27,6 +27,40 @@ import { errors } from 'undici'
 | `ResponseExceededMaxSizeError`       | `UND_ERR_RES_EXCEEDED_MAX_SIZE`       | response body exceed the max size allowed                                 |
 | `SecureProxyConnectionError`         | `UND_ERR_PRX_TLS`                     | tls connection to a proxy failed                                          |
 
+## Timeout-related errors
+
+The timeout errors below are controlled by dispatcher/client options:
+
+| Error code | When it is thrown | Related option |
+| ---------- | ----------------- | -------------- |
+| `UND_ERR_CONNECT_TIMEOUT` | A connection could not be established before the connection timeout elapsed. | [`connect.timeout`](/docs/docs/api/Client.md#parameter-connectoptions) |
+| `UND_ERR_HEADERS_TIMEOUT` | The full response headers were not received before the headers timeout elapsed. | [`headersTimeout`](/docs/docs/api/Client.md#parameter-clientoptions) |
+| `UND_ERR_BODY_TIMEOUT` | While reading the response body, no new data arrived before the body timeout elapsed. | [`bodyTimeout`](/docs/docs/api/Client.md#parameter-clientoptions) |
+| `UND_ERR_SOCKET` | A generic socket-level failure happened (including some timeout-related socket errors). | Inspect `error.socket` and adjust your dispatcher/client socket settings. |
+
+> **Note**: `UND_ERR_SOCKET_TIMEOUT` is not an Undici error code.
+> Socket timeout-like failures are reported as `UND_ERR_SOCKET`.
+
+### Configuring timeouts for `fetch`
+
+If you are using `fetch` (including Node.js built-in `fetch`), configure timeouts
+through the global dispatcher:
+
+```js
+import { Agent, setGlobalDispatcher, fetch } from 'undici'
+
+setGlobalDispatcher(new Agent({
+  connect: { timeout: 10_000 }, // connection phase
+  headersTimeout: 15_000, // wait for response headers
+  bodyTimeout: 30_000 // wait between response body chunks
+}))
+
+await fetch('https://example.com/data')
+```
+
+You can inspect timeout error codes from `error.code` or (for wrapped fetch
+errors) from `error.cause?.code`.
+
 Be aware of the possible difference between the global dispatcher version and the actual undici version you might be using. We recommend to avoid the check `instanceof errors.UndiciError` and seek for the `error.code === '<error_code>'` instead to avoid inconsistencies.
 ### `SocketError`
 

--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -38,9 +38,6 @@ The timeout errors below are controlled by dispatcher/client options:
 | `UND_ERR_BODY_TIMEOUT` | While reading the response body, no new data arrived before the body timeout elapsed. | [`bodyTimeout`](/docs/docs/api/Client.md#parameter-clientoptions) |
 | `UND_ERR_SOCKET` | A generic socket-level failure happened (including some timeout-related socket errors). | Inspect `error.socket` and adjust your dispatcher/client socket settings. |
 
-> **Note**: `UND_ERR_SOCKET_TIMEOUT` is not an Undici error code.
-> Socket timeout-like failures are reported as `UND_ERR_SOCKET`.
-
 ### Configuring timeouts for `fetch`
 
 If you are using `fetch` (including Node.js built-in `fetch`), configure timeouts


### PR DESCRIPTION
## Summary
This improves timeout-related error documentation in `docs/docs/api/Errors.md`.

It adds:
- a dedicated timeout error section that maps codes to when they are thrown
- direct links from each timeout code to the relevant configuration options (`connect.timeout`, `headersTimeout`, `bodyTimeout`)
- a note clarifying that `UND_ERR_SOCKET_TIMEOUT` is not an Undici error code
- a `fetch`-oriented example showing how to configure timeouts via `setGlobalDispatcher`

This is intended to make issues like `UND_ERR_*_TIMEOUT` easier to understand and act on, especially for users coming from `fetch`.

Closes #1865.

## Testing
- Documentation-only change.
- `npm run lint` was attempted locally before dependencies were installed, so eslint was not available in this environment.
