### PR TITLE
fix(handler): preserve latin1 header encoding in WrapHandler

### DIFF
--- a/lib/handler/wrap-handler.js
+++ b/lib/handler/wrap-handler.js
@@ -57,7 +57,7 @@ module.exports = class WrapHandler {
   onRequestUpgrade (controller, statusCode, headers, socket) {
     const rawHeaders = []
     for (const [key, val] of Object.entries(headers)) {
-      rawHeaders.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawHeaders.push(Buffer.from(key, 'latin1'), toRawHeaderValue(val))
     }
 
     this.#handler.onUpgrade?.(statusCode, rawHeaders, socket)
@@ -66,7 +66,7 @@ module.exports = class WrapHandler {
   onResponseStart (controller, statusCode, headers, statusMessage) {
     const rawHeaders = []
     for (const [key, val] of Object.entries(headers)) {
-      rawHeaders.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawHeaders.push(Buffer.from(key, 'latin1'), toRawHeaderValue(val))
     }
 
     if (this.#handler.onHeaders?.(statusCode, rawHeaders, () => controller.resume(), statusMessage) === false) {
@@ -83,7 +83,7 @@ module.exports = class WrapHandler {
   onResponseEnd (controller, trailers) {
     const rawTrailers = []
     for (const [key, val] of Object.entries(trailers)) {
-      rawTrailers.push(Buffer.from(key), Array.isArray(val) ? val.map(v => Buffer.from(v)) : Buffer.from(val))
+      rawTrailers.push(Buffer.from(key, 'latin1'), toRawHeaderValue(val))
     }
 
     this.#handler.onComplete?.(rawTrailers)
@@ -96,4 +96,10 @@ module.exports = class WrapHandler {
 
     this.#handler.onError?.(err)
   }
+}
+
+function toRawHeaderValue (value) {
+  return Array.isArray(value)
+    ? value.map((item) => Buffer.from(item, 'latin1'))
+    : Buffer.from(value, 'latin1')
 }

--- a/test/issue-3934.js
+++ b/test/issue-3934.js
@@ -30,3 +30,27 @@ test('WrapHandler works with multiple header values', async (t) => {
 
   assert.deepStrictEqual(headers['set-cookie'], ['a', 'b', 'c'])
 })
+
+// https://github.com/nodejs/undici/issues/4797
+test('WrapHandler preserves latin1 header bytes', async (t) => {
+  const expected = Buffer.from([0xE2, 0x80, 0xA6]).toString('latin1')
+
+  const server = createServer({ joinDuplicateHeaders: true }, async (_req, res) => {
+    res.writeHead(200, {
+      'x-test': expected
+    })
+    res.end()
+  }).listen(0)
+
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  const agent = new Agent()
+  const retryAgent = new RetryAgent(agent)
+
+  const {
+    headers
+  } = await request(`http://localhost:${server.address().port}`, { dispatcher: retryAgent })
+
+  assert.strictEqual(headers['x-test'], expected)
+})


### PR DESCRIPTION
## Summary
Fixes `WrapHandler` header/trailer conversion to preserve latin1/isomorphic byte semantics when bridging new handler API -> old handler API.

Today `WrapHandler` uses `Buffer.from(value)` (utf-8 default), which can corrupt non-ASCII header bytes when the old API later reads as latin1.

## What changed
- Use latin1 encoding when converting wrapped header keys/values to raw buffers in:
  - `onRequestUpgrade`
  - `onResponseStart`
  - `onResponseEnd`
- Added a helper to centralize raw header value conversion.
- Added regression coverage in `test/issue-3934.js`:
  - `WrapHandler preserves latin1 header bytes`

## Validation
- `node --test test/issue-3934.js`
- `npm run lint`

Fixes #4797.
