### PR TITLE
fix(env-http-proxy-agent): assume http for schema-less proxy env vars

### DIFF
--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -10,8 +10,8 @@ const DEFAULT_PORTS = {
   'https:': 443
 }
 
-function normalizeProxyURI (proxy) {
-  return /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(proxy) ? proxy : `http://${proxy}`
+function normalizeProxyURI (proxy, defaultScheme = 'http://') {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(proxy) ? proxy : `${defaultScheme}${proxy}`
 }
 
 class EnvHttpProxyAgent extends DispatcherBase {
@@ -29,14 +29,14 @@ class EnvHttpProxyAgent extends DispatcherBase {
 
     const HTTP_PROXY = httpProxy ?? process.env.http_proxy ?? process.env.HTTP_PROXY
     if (HTTP_PROXY) {
-      this[kHttpProxyAgent] = new ProxyAgent({ ...agentOpts, uri: normalizeProxyURI(HTTP_PROXY) })
+      this[kHttpProxyAgent] = new ProxyAgent({ ...agentOpts, uri: normalizeProxyURI(HTTP_PROXY, 'http://') })
     } else {
       this[kHttpProxyAgent] = this[kNoProxyAgent]
     }
 
     const HTTPS_PROXY = httpsProxy ?? process.env.https_proxy ?? process.env.HTTPS_PROXY
     if (HTTPS_PROXY) {
-      this[kHttpsProxyAgent] = new ProxyAgent({ ...agentOpts, uri: normalizeProxyURI(HTTPS_PROXY) })
+      this[kHttpsProxyAgent] = new ProxyAgent({ ...agentOpts, uri: normalizeProxyURI(HTTPS_PROXY, 'https://') })
     } else {
       this[kHttpsProxyAgent] = this[kHttpProxyAgent]
     }

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -53,13 +53,13 @@ test('creates separate proxy agent for http and https when http_proxy and https_
   return dispatcher.close()
 })
 
-test('assumes http scheme for schema-less proxy env vars', async (t) => {
+test('assumes protocol-specific scheme for schema-less proxy env vars', async (t) => {
   t = tspl(t, { plan: 2 })
   process.env.http_proxy = 'localhost:8080'
   process.env.https_proxy = 'localhost:8443'
   const dispatcher = new EnvHttpProxyAgent()
   t.equal(dispatcher[kHttpProxyAgent][kProxy].uri, 'http://localhost:8080/')
-  t.equal(dispatcher[kHttpsProxyAgent][kProxy].uri, 'http://localhost:8443/')
+  t.equal(dispatcher[kHttpsProxyAgent][kProxy].uri, 'https://localhost:8443/')
   return dispatcher.close()
 })
 


### PR DESCRIPTION
## Summary
- assume an `http://` scheme when `HTTP_PROXY` / `HTTPS_PROXY` values are provided without a URL scheme
- keep existing behavior unchanged for already well-formed proxy URLs
- add coverage for schema-less proxy environment variables in `EnvHttpProxyAgent` tests

## Testing
- node --test test/env-http-proxy-agent.js

Closes #4736