### PR TITLE
fix(interceptor): preserve tuple headers in dns interceptor

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -5,6 +5,12 @@ const DecoratorHandler = require('../handler/decorator-handler')
 const { InvalidArgumentError, InformationalError } = require('../core/errors')
 const maxInt = Math.pow(2, 31) - 1
 
+function hasSafeIterator (headers) {
+  const prototype = Object.getPrototypeOf(headers)
+  const ownIterator = Object.prototype.hasOwnProperty.call(headers, Symbol.iterator)
+  return ownIterator || (prototype != null && prototype !== Object.prototype && typeof headers[Symbol.iterator] === 'function')
+}
+
 function isHostHeader (key) {
   return typeof key === 'string' && key.toLowerCase() === 'host'
 }
@@ -19,6 +25,19 @@ function normalizeHeaders (headers) {
       return headers
     }
 
+    const normalized = []
+    for (const header of headers) {
+      if (Array.isArray(header) && header.length === 2) {
+        normalized.push(header[0], header[1])
+      } else {
+        normalized.push(header)
+      }
+    }
+
+    return normalized
+  }
+
+  if (typeof headers === 'object' && hasSafeIterator(headers)) {
     const normalized = []
     for (const header of headers) {
       if (Array.isArray(header) && header.length === 2) {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -2088,6 +2088,57 @@ test('#4444 - Should preserve tuple-style headers', async t => {
   t.equal(await response.body.text(), 'hello world!')
 })
 
+test('#4444 - Should preserve iterable headers', async t => {
+  t = tspl(t, { plan: 5 })
+
+  const server = createServer({ joinDuplicateHeaders: true })
+
+  server.on('request', (req, res) => {
+    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    t.equal(req.headers.foo, 'bar')
+    t.equal(req.headers['0'], undefined)
+
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+
+  await once(server, 'listening')
+
+  const client = new Agent().compose([
+    dns({
+      lookup: (_origin, _opts, cb) => {
+        cb(null, [
+          {
+            address: '::1',
+            family: 6
+          },
+          {
+            address: '127.0.0.1',
+            family: 4
+          }
+        ])
+      }
+    })
+  ])
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const response = await request(`http://localhost:${server.address().port}`, {
+    dispatcher: client,
+    headers: new Map([['foo', 'bar']])
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+})
+
 test('#3951 - Should handle lookup errors correctly', async t => {
   const suite = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
## Summary
- preserve non-object header shapes when the dns interceptor injects the host header
- normalize tuple/iterable header inputs into flat key/value arrays before redispatching
- apply the same host-header handling on DNS fallback retries (other IP family)

## Why
`interceptors.dns()` currently rewrites headers with object spread. For tuple-style headers (for example `[ ['foo', 'bar'] ]`) this can produce malformed headers (`'0': 'foo, bar'`) and break requests in composed interceptor flows.

## Tests
- added `#4444 - Should preserve tuple-style headers` in `test/interceptors/dns.js`
- `node --test test/interceptors/dns.js`
- `npm run lint`

Fixes #4444
