### PR TITLE
fix(types): align Response with DOM fetch types

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -178,6 +178,8 @@ expectType<Promise<Uint8Array>>(response.bytes())
 expectType<Promise<unknown>>(response.json())
 expectType<Promise<string>>(response.text())
 expectType<Response>(response.clone())
+expectAssignable<globalThis.Response>(response)
+expectAssignable<Promise<globalThis.Response>>(fetch(request))
 
 expectType<Request>(new Request('https://example.com', { body: 'Hello, world', duplex: 'half' }))
 expectAssignable<RequestInit>({ duplex: 'half' })

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -60,12 +60,32 @@ export interface SpecIterator<T, TReturn = any, TNext = undefined> {
   next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
 }
 
-export interface SpecIterableIterator<T> extends SpecIterator<T> {
+export interface SpecIteratorObject<T, TReturn = undefined, TNext = unknown> extends SpecIterator<T, TReturn, TNext> {
+  [Symbol.iterator](): SpecIteratorObject<T, TReturn, TNext>;
+  map<U>(callbackfn: (value: T, index: number) => U): SpecIteratorObject<U>;
+  filter<S extends T>(predicate: (value: T, index: number) => value is S): SpecIteratorObject<S>;
+  filter(predicate: (value: T, index: number) => unknown): SpecIteratorObject<T>;
+  take(limit: number): SpecIteratorObject<T>;
+  drop(count: number): SpecIteratorObject<T>;
+  flatMap<U>(callbackfn: (value: T, index: number) => Iterator<U> | Iterable<U>): SpecIteratorObject<U>;
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T): T;
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue: T): T;
+  reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U;
+  toArray(): T[];
+  forEach(callbackfn: (value: T, index: number) => void): void;
+  some(predicate: (value: T, index: number) => unknown): boolean;
+  every(predicate: (value: T, index: number) => unknown): boolean;
+  find<S extends T>(predicate: (value: T, index: number) => value is S): S | undefined;
+  find(predicate: (value: T, index: number) => unknown): T | undefined;
+  readonly [Symbol.toStringTag]: string;
+}
+
+export interface SpecIterableIterator<T> extends SpecIteratorObject<T> {
   [Symbol.iterator](): SpecIterableIterator<T>;
 }
 
 export interface SpecIterable<T> {
-  [Symbol.iterator](): SpecIterator<T>;
+  [Symbol.iterator](): SpecIterableIterator<T>;
 }
 
 export type HeadersInit = [string, string][] | HeaderRecord | Headers

--- a/types/formdata.d.ts
+++ b/types/formdata.d.ts
@@ -4,6 +4,12 @@
 import { File } from 'node:buffer'
 import { SpecIterableIterator } from './fetch'
 
+declare module 'node:buffer' {
+  interface File {
+    readonly [Symbol.toStringTag]: string
+  }
+}
+
 /**
  * A `string` or `File` that represents a single value from a set of `FormData` key-value pairs.
  */


### PR DESCRIPTION
## Summary
- align `SpecIterableIterator` with the iterator-helper surface expected by modern DOM `HeadersIterator` types
- add the missing `File[Symbol.toStringTag]` declaration on `node:buffer` so `Response.formData()` stays structurally compatible
- add a `tsd` regression proving Undici `Response` is assignable to `globalThis.Response`

## Why
Newer TypeScript DOM libs model `Headers.entries()`/`keys()`/`values()` as `HeadersIterator`, which includes iterator helper methods. Undici's `SpecIterableIterator` was missing that surface, so `undici.Response` could not be used where a standard `Response` type was expected. Once that was fixed, `formData()` still diverged because Node's `buffer.File` typing was missing the `Symbol.toStringTag` property that exists at runtime.

## Tests
- `npm run test:typescript`
- `npm run lint`

Fixes #3639
