### PR TITLE
docs(eventsource): document connection lifecycle and close usage

### DIFF
--- a/docs/docs/api/EventSource.md
+++ b/docs/docs/api/EventSource.md
@@ -19,6 +19,31 @@ eventSource.onmessage = (event) => {
 }
 ```
 
+## Connection lifecycle (`text/event-stream`)
+
+`EventSource` keeps a long-lived `text/event-stream` connection open and
+automatically reconnects when appropriate.
+
+Call `.close()` when you no longer need events to close the stream and release
+its underlying connection resources:
+
+```mjs
+import { EventSource } from 'undici'
+
+const es = new EventSource('http://localhost:3000/events')
+
+es.onmessage = (event) => {
+  console.log('event:', event.data)
+}
+
+es.onerror = (error) => {
+  console.error('event stream error', error)
+}
+
+// Later, for example on shutdown:
+es.close()
+```
+
 ## Using a custom Dispatcher
 
 undici allows you to set your own Dispatcher in the EventSource constructor.


### PR DESCRIPTION
## Summary
- add a dedicated section describing how `EventSource` manages long-lived `text/event-stream` connections
- document that `.close()` should be called to release connection resources when no longer needed
- add a small example with `onmessage`, `onerror`, and explicit shutdown

Closes #536

## Validation
- `git diff --check`
