### PR TITLE
docs(dispatcher): use RFC 2606 domains in interceptor examples

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -962,7 +962,7 @@ It accepts the same arguments as the [`RedirectHandler` constructor](/docs/docs/
 const { Client, interceptors } = require("undici");
 const { redirect } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   redirect({ maxRedirections: 3, throwOnMaxRedirects: true })
 );
 client.request({ path: "/" })
@@ -980,7 +980,7 @@ It accepts the same arguments as the [`RetryHandler` constructor](/docs/docs/api
 const { Client, interceptors } = require("undici");
 const { retry } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   retry({
     maxRetries: 3,
     minTimeout: 1000,
@@ -1006,7 +1006,7 @@ The `dump` interceptor enables you to dump the response body from a request upon
 const { Client, interceptors } = require("undici");
 const { dump } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   dump({
     maxSize: 1024,
   })
@@ -1132,7 +1132,7 @@ The `responseError` interceptor throws an error for responses with status code e
 const { Client, interceptors } = require("undici");
 const { responseError } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   responseError()
 );
 
@@ -1160,7 +1160,7 @@ The `decompress` interceptor automatically decompresses response bodies that are
 const { Client, interceptors } = require("undici");
 const { decompress } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   decompress()
 );
 
@@ -1177,7 +1177,7 @@ const response = await client.request({
 const { Client, interceptors } = require("undici");
 const { decompress } = interceptors;
 
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   decompress({
     skipErrorResponses: false, // Decompress 5xx responses
     skipStatusCodes: [204, 304, 201] // Skip these status codes
@@ -1231,12 +1231,12 @@ const { Client, interceptors } = require("undici");
 const { deduplicate, cache } = interceptors;
 
 // Deduplicate only
-const client = new Client("http://example.com").compose(
+const client = new Client("http://service.example").compose(
   deduplicate()
 );
 
 // Deduplicate with caching
-const clientWithCache = new Client("http://example.com").compose(
+const clientWithCache = new Client("http://service.example").compose(
   deduplicate(),
   cache()
 );


### PR DESCRIPTION
## What
- replace `http://example.com` with `http://service.example` in Dispatcher interceptor examples
- keep sample semantics unchanged while using RFC 2606-reserved domains

## Why
Issue #4866 asks to avoid non-RFC2606 examples in docs/tests. This updates the Dispatcher docs section to use a reserved `.example` domain.

## Validation
- `git diff --check`

Partially addresses #4866.
