### PR TITLE
fix(header): enable header host to fix mtls for specific case, fix #4034

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1525,7 +1525,11 @@ async function httpNetworkOrCacheFetch (
     }
   }
 
-  httpRequest.headersList.delete('host', true)
+  // Note: per the Fetch spec, Host is a forbidden request-header and should be
+  // deleted here. However, we preserve a user-provided Host header so that
+  // servers requiring a specific Host value (e.g. without port) can be reached.
+  // The Host header is still set automatically by the Client if not provided.
+  // See: https://github.com/nodejs/undici/issues/4034
 
   //    21. If includeCredentials is true, then:
   if (includeCredentials) {

--- a/test/fetch/issue-2318.js
+++ b/test/fetch/issue-2318.js
@@ -6,7 +6,45 @@ const { createServer } = require('node:http')
 const { fetch } = require('../..')
 const { closeServerAsPromise } = require('../utils/node-http')
 
-test('Undici overrides user-provided `Host` header', async (t) => {
+test('Undici preserves user-provided `Host` header', async (t) => {
+  t.plan(1)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers.host, 'www.idk.org')
+
+    res.end()
+  }).listen(0)
+
+  t.after(closeServerAsPromise(server))
+  await once(server, 'listening')
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    headers: {
+      host: 'www.idk.org'
+    }
+  })
+})
+
+test('Undici preserves user-provided `Host` header without port', async (t) => {
+  t.plan(1)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers.host, 'localhost')
+
+    res.end()
+  }).listen(0)
+
+  t.after(closeServerAsPromise(server))
+  await once(server, 'listening')
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    headers: {
+      host: 'localhost'
+    }
+  })
+})
+
+test('Undici sets Host header automatically when not user-provided', async (t) => {
   t.plan(1)
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -18,9 +56,43 @@ test('Undici overrides user-provided `Host` header', async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
+  await fetch(`http://localhost:${server.address().port}`)
+})
+
+test('Undici preserves user-provided `Host` header with custom domain', async (t) => {
+  t.plan(1)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers.host, 'example.com')
+
+    res.end()
+  }).listen(0)
+
+  t.after(closeServerAsPromise(server))
+  await once(server, 'listening')
+
   await fetch(`http://localhost:${server.address().port}`, {
     headers: {
-      host: 'www.idk.org'
+      host: 'example.com'
+    }
+  })
+})
+
+test('Undici preserves user-provided `Host` header with custom domain and port', async (t) => {
+  t.plan(1)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers.host, 'example.com:8080')
+
+    res.end()
+  }).listen(0)
+
+  t.after(closeServerAsPromise(server))
+  await once(server, 'listening')
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    headers: {
+      host: 'example.com:8080'
     }
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

This issue https://github.com/nodejs/undici/issues/4034

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

node-fetch behavior enables to override Host request header, using undici.request also works, but undici.fetch breaks

## Changes

<!-- Write a summary or list of changes here -->

when passing Header Host it will go along the request instead of host:port

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
