### PR TITLE
feat(websocket): expand diagnostics channel payloads

### DIFF
--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -201,6 +201,32 @@ The `handshakeResponse` object contains the HTTP response that upgraded the conn
 
 This information is particularly useful for debugging and monitoring WebSocket connections, as it provides access to the initial HTTP handshake response that established the WebSocket connection.
 
+## `undici:websocket:created`
+
+This message is published when a `WebSocket` instance is created, before the opening handshake is sent.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:websocket:created').subscribe(({ websocket, url }) => {
+  console.log(websocket) // the WebSocket instance
+  console.log(url) // serialized websocket URL
+})
+```
+
+## `undici:websocket:handshakeRequest`
+
+This message is published when the HTTP upgrade request is about to be sent.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:websocket:handshakeRequest').subscribe(({ websocket, request }) => {
+  console.log(websocket) // the WebSocket instance
+  console.log(request.headers) // handshake request headers assembled so far
+})
+```
+
 ## `undici:websocket:close`
 
 This message is published after the connection has closed.
@@ -222,8 +248,52 @@ This message is published if the socket experiences an error.
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('undici:websocket:socket_error').subscribe((error) => {
+diagnosticsChannel.channel('undici:websocket:socket_error').subscribe(({ error, websocket }) => {
   console.log(error)
+  console.log(websocket) // the WebSocket instance, if available
+})
+```
+
+## `undici:websocket:frameSent`
+
+This message is published after a WebSocket frame is written to the socket.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:websocket:frameSent').subscribe(({ websocket, opcode, mask, payloadData }) => {
+  console.log(websocket) // the WebSocket instance
+  console.log(opcode) // RFC 6455 opcode
+  console.log(mask) // true for client-sent frames
+  console.log(payloadData) // unmasked payload bytes
+})
+```
+
+## `undici:websocket:frameReceived`
+
+This message is published after a WebSocket frame is parsed from the socket.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:websocket:frameReceived').subscribe(({ websocket, opcode, mask, payloadData }) => {
+  console.log(websocket) // the WebSocket instance
+  console.log(opcode) // RFC 6455 opcode
+  console.log(mask) // false for server-sent frames
+  console.log(payloadData) // payload bytes as received
+})
+```
+
+## `undici:websocket:frameError`
+
+This message is published when Undici rejects an invalid incoming WebSocket frame.
+
+```js
+import diagnosticsChannel from 'diagnostics_channel'
+
+diagnosticsChannel.channel('undici:websocket:frameError').subscribe(({ websocket, error }) => {
+  console.log(websocket) // the WebSocket instance
+  console.log(error.message)
 })
 ```
 

--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -248,9 +248,8 @@ This message is published if the socket experiences an error.
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('undici:websocket:socket_error').subscribe(({ error, websocket }) => {
+diagnosticsChannel.channel('undici:websocket:socket_error').subscribe((error) => {
   console.log(error)
-  console.log(websocket) // the WebSocket instance, if available
 })
 ```
 

--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -260,10 +260,9 @@ This message is published after a WebSocket frame is written to the socket.
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('undici:websocket:frameSent').subscribe(({ websocket, opcode, mask, payloadData }) => {
+diagnosticsChannel.channel('undici:websocket:frameSent').subscribe(({ websocket, opcode, payloadData }) => {
   console.log(websocket) // the WebSocket instance
   console.log(opcode) // RFC 6455 opcode
-  console.log(mask) // true for client-sent frames
   console.log(payloadData) // unmasked payload bytes
 })
 ```

--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -274,10 +274,9 @@ This message is published after a WebSocket frame is parsed from the socket.
 ```js
 import diagnosticsChannel from 'diagnostics_channel'
 
-diagnosticsChannel.channel('undici:websocket:frameReceived').subscribe(({ websocket, opcode, mask, payloadData }) => {
+diagnosticsChannel.channel('undici:websocket:frameReceived').subscribe(({ websocket, opcode, payloadData }) => {
   console.log(websocket) // the WebSocket instance
   console.log(opcode) // RFC 6455 opcode
-  console.log(mask) // false for server-sent frames
   console.log(payloadData) // payload bytes as received
 })
 ```

--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -22,8 +22,13 @@ const channels = {
   trailers: diagnosticsChannel.channel('undici:request:trailers'),
   error: diagnosticsChannel.channel('undici:request:error'),
   // WebSocket
+  created: diagnosticsChannel.channel('undici:websocket:created'),
+  handshakeRequest: diagnosticsChannel.channel('undici:websocket:handshakeRequest'),
   open: diagnosticsChannel.channel('undici:websocket:open'),
   close: diagnosticsChannel.channel('undici:websocket:close'),
+  frameSent: diagnosticsChannel.channel('undici:websocket:frameSent'),
+  frameReceived: diagnosticsChannel.channel('undici:websocket:frameReceived'),
+  frameError: diagnosticsChannel.channel('undici:websocket:frameError'),
   socketError: diagnosticsChannel.channel('undici:websocket:socket_error'),
   ping: diagnosticsChannel.channel('undici:websocket:ping'),
   pong: diagnosticsChannel.channel('undici:websocket:pong'),
@@ -166,14 +171,26 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
 
   // Check if any of the channels already have subscribers to prevent duplicate subscriptions
   // This can happen when both Node.js built-in undici and undici as a dependency are present
-  if (channels.open.hasSubscribers || channels.close.hasSubscribers ||
-      channels.socketError.hasSubscribers || channels.ping.hasSubscribers ||
-      channels.pong.hasSubscribers) {
+  if (channels.created.hasSubscribers || channels.handshakeRequest.hasSubscribers ||
+      channels.open.hasSubscribers || channels.close.hasSubscribers ||
+      channels.frameSent.hasSubscribers || channels.frameReceived.hasSubscribers ||
+      channels.frameError.hasSubscribers || channels.socketError.hasSubscribers ||
+      channels.ping.hasSubscribers || channels.pong.hasSubscribers) {
     isTrackingWebSocketEvents = true
     return
   }
 
   isTrackingWebSocketEvents = true
+
+  diagnosticsChannel.subscribe('undici:websocket:created',
+    evt => {
+      debugLog('created websocket for %s', evt.url)
+    })
+
+  diagnosticsChannel.subscribe('undici:websocket:handshakeRequest',
+    evt => {
+      debugLog('sending opening handshake for %s', evt.websocket?.url ?? '<unknown>')
+    })
 
   diagnosticsChannel.subscribe('undici:websocket:open',
     evt => {
@@ -194,9 +211,24 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
       )
     })
 
+  diagnosticsChannel.subscribe('undici:websocket:frameSent',
+    evt => {
+      debugLog('frame sent opcode=%d bytes=%d', evt.opcode, evt.payloadData.length)
+    })
+
+  diagnosticsChannel.subscribe('undici:websocket:frameReceived',
+    evt => {
+      debugLog('frame received opcode=%d bytes=%d', evt.opcode, evt.payloadData.length)
+    })
+
+  diagnosticsChannel.subscribe('undici:websocket:frameError',
+    evt => {
+      debugLog('frame errored for %s - %s', evt.websocket?.url ?? '<unknown>', evt.error.message)
+    })
+
   diagnosticsChannel.subscribe('undici:websocket:socket_error',
-    err => {
-      debugLog('connection errored - %s', err.message)
+    evt => {
+      debugLog('connection errored for %s - %s', evt.websocket?.url ?? '<unknown>', evt.error.message)
     })
 
   diagnosticsChannel.subscribe('undici:websocket:ping',

--- a/lib/core/diagnostics.js
+++ b/lib/core/diagnostics.js
@@ -227,8 +227,8 @@ function trackWebSocketEvents (debugLog = websocketDebuglog) {
     })
 
   diagnosticsChannel.subscribe('undici:websocket:socket_error',
-    evt => {
-      debugLog('connection errored for %s - %s', evt.websocket?.url ?? '<unknown>', evt.error.message)
+    err => {
+      debugLog('connection errored - %s', err.message)
     })
 
   diagnosticsChannel.subscribe('undici:websocket:ping',

--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -9,6 +9,7 @@ const { getDecodeSplit } = require('../fetch/util')
 const { WebsocketFrameSend } = require('./frame')
 const assert = require('node:assert')
 const { runtimeFeatures } = require('../../util/runtime-features')
+const { channels } = require('../../core/diagnostics')
 
 const crypto = runtimeFeatures.has('crypto')
   ? require('node:crypto')
@@ -89,6 +90,15 @@ function establishWebSocketConnection (url, protocols, client, handler, options)
 
   // 11. Fetch request with useParallelQueue set to true, and
   //     processResponse given response being these steps:
+  if (channels.handshakeRequest.hasSubscribers) {
+    channels.handshakeRequest.publish({
+      websocket: handler.websocket,
+      request: {
+        headers: request.headersList.entries
+      }
+    })
+  }
+
   const controller = fetching({
     request,
     useParallelQueue: true,

--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -16,6 +16,7 @@ const { failWebsocketConnection } = require('./connection')
 const { WebsocketFrameSend } = require('./frame')
 const { PerMessageDeflate } = require('./permessage-deflate')
 const { MessageSizeExceededError } = require('../../core/errors')
+const { channels } = require('../../core/diagnostics')
 
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -97,11 +98,13 @@ class ByteParser extends Writable {
         const rsv3 = buffer[0] & 0x10
 
         if (!isValidOpcode(opcode)) {
+          this.publishFrameError(new Error('Invalid opcode received'))
           failWebsocketConnection(this.#handler, 1002, 'Invalid opcode received')
           return callback()
         }
 
         if (masked) {
+          this.publishFrameError(new Error('Frame cannot be masked'))
           failWebsocketConnection(this.#handler, 1002, 'Frame cannot be masked')
           return callback()
         }
@@ -116,17 +119,20 @@ class ByteParser extends Writable {
         // WebSocket connection where a PMCE is in use, this bit indicates
         // whether a message is compressed or not.
         if (rsv1 !== 0 && !this.#extensions.has('permessage-deflate')) {
+          this.publishFrameError(new Error('Expected RSV1 to be clear.'))
           failWebsocketConnection(this.#handler, 1002, 'Expected RSV1 to be clear.')
           return
         }
 
         if (rsv2 !== 0 || rsv3 !== 0) {
+          this.publishFrameError(new Error('RSV1, RSV2, RSV3 must be clear'))
           failWebsocketConnection(this.#handler, 1002, 'RSV1, RSV2, RSV3 must be clear')
           return
         }
 
         if (fragmented && !isTextBinaryFrame(opcode)) {
           // Only text and binary frames can be fragmented
+          this.publishFrameError(new Error('Invalid frame type was fragmented.'))
           failWebsocketConnection(this.#handler, 1002, 'Invalid frame type was fragmented.')
           return
         }
@@ -134,12 +140,14 @@ class ByteParser extends Writable {
         // If we are already parsing a text/binary frame and do not receive either
         // a continuation frame or close frame, fail the connection.
         if (isTextBinaryFrame(opcode) && this.#fragments.length > 0) {
+          this.publishFrameError(new Error('Expected continuation frame'))
           failWebsocketConnection(this.#handler, 1002, 'Expected continuation frame')
           return
         }
 
         if (this.#info.fragmented && fragmented) {
           // A fragmented frame can't be fragmented itself
+          this.publishFrameError(new Error('Fragmented frame exceeded 125 bytes.'))
           failWebsocketConnection(this.#handler, 1002, 'Fragmented frame exceeded 125 bytes.')
           return
         }
@@ -147,11 +155,13 @@ class ByteParser extends Writable {
         // "All control frames MUST have a payload length of 125 bytes or less
         // and MUST NOT be fragmented."
         if ((payloadLength > 125 || fragmented) && isControlFrame(opcode)) {
+          this.publishFrameError(new Error('Control frame either too large or fragmented'))
           failWebsocketConnection(this.#handler, 1002, 'Control frame either too large or fragmented')
           return
         }
 
         if (isContinuationFrame(opcode) && this.#fragments.length === 0 && !this.#info.compressed) {
+          this.publishFrameError(new Error('Unexpected continuation frame'))
           failWebsocketConnection(this.#handler, 1002, 'Unexpected continuation frame')
           return
         }
@@ -199,6 +209,7 @@ class ByteParser extends Writable {
         // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/common/globals.h;drc=1946212ac0100668f14eb9e2843bdd846e510a1e;bpv=1;bpt=1;l=1275
         // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/objects/js-array-buffer.h;l=34;drc=1946212ac0100668f14eb9e2843bdd846e510a1e
         if (upper !== 0 || lower > 2 ** 31 - 1) {
+          this.publishFrameError(new Error('Received payload length > 2^31 bytes.'))
           failWebsocketConnection(this.#handler, 1009, 'Received payload length > 2^31 bytes.')
           return
         }
@@ -211,6 +222,15 @@ class ByteParser extends Writable {
         }
 
         const body = this.consume(this.#info.payloadLength)
+
+        if (channels.frameReceived.hasSubscribers) {
+          channels.frameReceived.publish({
+            websocket: this.#handler.websocket,
+            opcode: this.#info.opcode,
+            mask: this.#info.masked,
+            payloadData: Buffer.from(body)
+          })
+        }
 
         if (isControlFrame(this.#info.opcode)) {
           this.#loop = this.parseControlFrame(body)
@@ -231,7 +251,7 @@ class ByteParser extends Writable {
           } else {
             this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
               if (error) {
-                // Use 1009 (Message Too Big) for decompression size limit errors
+                this.publishFrameError(error)
                 const code = error instanceof MessageSizeExceededError ? 1009 : 1007
                 failWebsocketConnection(this.#handler, code, error.message)
                 return
@@ -384,6 +404,7 @@ class ByteParser extends Writable {
 
     if (opcode === opcodes.CLOSE) {
       if (payloadLength === 1) {
+        this.publishFrameError(new Error('Received close frame with a 1-byte body.'))
         failWebsocketConnection(this.#handler, 1002, 'Received close frame with a 1-byte body.')
         return false
       }
@@ -393,6 +414,7 @@ class ByteParser extends Writable {
       if (this.#info.closeInfo.error) {
         const { code, reason } = this.#info.closeInfo
 
+        this.publishFrameError(new Error(reason))
         failWebsocketConnection(this.#handler, code, reason)
         return false
       }
@@ -447,6 +469,17 @@ class ByteParser extends Writable {
 
   get closingInfo () {
     return this.#info.closeInfo
+  }
+
+  publishFrameError (error) {
+    if (!channels.frameError.hasSubscribers) {
+      return
+    }
+
+    channels.frameError.publish({
+      websocket: this.#handler.websocket,
+      error
+    })
   }
 }
 

--- a/lib/web/websocket/receiver.js
+++ b/lib/web/websocket/receiver.js
@@ -98,14 +98,12 @@ class ByteParser extends Writable {
         const rsv3 = buffer[0] & 0x10
 
         if (!isValidOpcode(opcode)) {
-          this.publishFrameError(new Error('Invalid opcode received'))
-          failWebsocketConnection(this.#handler, 1002, 'Invalid opcode received')
+          this.failWebsocketConnection(1002, 'Invalid opcode received')
           return callback()
         }
 
         if (masked) {
-          this.publishFrameError(new Error('Frame cannot be masked'))
-          failWebsocketConnection(this.#handler, 1002, 'Frame cannot be masked')
+          this.failWebsocketConnection(1002, 'Frame cannot be masked')
           return callback()
         }
 
@@ -119,50 +117,43 @@ class ByteParser extends Writable {
         // WebSocket connection where a PMCE is in use, this bit indicates
         // whether a message is compressed or not.
         if (rsv1 !== 0 && !this.#extensions.has('permessage-deflate')) {
-          this.publishFrameError(new Error('Expected RSV1 to be clear.'))
-          failWebsocketConnection(this.#handler, 1002, 'Expected RSV1 to be clear.')
+          this.failWebsocketConnection(1002, 'Expected RSV1 to be clear.')
           return
         }
 
         if (rsv2 !== 0 || rsv3 !== 0) {
-          this.publishFrameError(new Error('RSV1, RSV2, RSV3 must be clear'))
-          failWebsocketConnection(this.#handler, 1002, 'RSV1, RSV2, RSV3 must be clear')
+          this.failWebsocketConnection(1002, 'RSV1, RSV2, RSV3 must be clear')
           return
         }
 
         if (fragmented && !isTextBinaryFrame(opcode)) {
           // Only text and binary frames can be fragmented
-          this.publishFrameError(new Error('Invalid frame type was fragmented.'))
-          failWebsocketConnection(this.#handler, 1002, 'Invalid frame type was fragmented.')
+          this.failWebsocketConnection(1002, 'Invalid frame type was fragmented.')
           return
         }
 
         // If we are already parsing a text/binary frame and do not receive either
         // a continuation frame or close frame, fail the connection.
         if (isTextBinaryFrame(opcode) && this.#fragments.length > 0) {
-          this.publishFrameError(new Error('Expected continuation frame'))
-          failWebsocketConnection(this.#handler, 1002, 'Expected continuation frame')
+          this.failWebsocketConnection(1002, 'Expected continuation frame')
           return
         }
 
         if (this.#info.fragmented && fragmented) {
           // A fragmented frame can't be fragmented itself
-          this.publishFrameError(new Error('Fragmented frame exceeded 125 bytes.'))
-          failWebsocketConnection(this.#handler, 1002, 'Fragmented frame exceeded 125 bytes.')
+          this.failWebsocketConnection(1002, 'Fragmented frame exceeded 125 bytes.')
           return
         }
 
         // "All control frames MUST have a payload length of 125 bytes or less
         // and MUST NOT be fragmented."
         if ((payloadLength > 125 || fragmented) && isControlFrame(opcode)) {
-          this.publishFrameError(new Error('Control frame either too large or fragmented'))
-          failWebsocketConnection(this.#handler, 1002, 'Control frame either too large or fragmented')
+          this.failWebsocketConnection(1002, 'Control frame either too large or fragmented')
           return
         }
 
         if (isContinuationFrame(opcode) && this.#fragments.length === 0 && !this.#info.compressed) {
-          this.publishFrameError(new Error('Unexpected continuation frame'))
-          failWebsocketConnection(this.#handler, 1002, 'Unexpected continuation frame')
+          this.failWebsocketConnection(1002, 'Unexpected continuation frame')
           return
         }
 
@@ -209,8 +200,7 @@ class ByteParser extends Writable {
         // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/common/globals.h;drc=1946212ac0100668f14eb9e2843bdd846e510a1e;bpv=1;bpt=1;l=1275
         // https://source.chromium.org/chromium/chromium/src/+/main:v8/src/objects/js-array-buffer.h;l=34;drc=1946212ac0100668f14eb9e2843bdd846e510a1e
         if (upper !== 0 || lower > 2 ** 31 - 1) {
-          this.publishFrameError(new Error('Received payload length > 2^31 bytes.'))
-          failWebsocketConnection(this.#handler, 1009, 'Received payload length > 2^31 bytes.')
+          this.failWebsocketConnection(1009, 'Received payload length > 2^31 bytes.')
           return
         }
 
@@ -227,7 +217,6 @@ class ByteParser extends Writable {
           channels.frameReceived.publish({
             websocket: this.#handler.websocket,
             opcode: this.#info.opcode,
-            mask: this.#info.masked,
             payloadData: Buffer.from(body)
           })
         }
@@ -251,9 +240,8 @@ class ByteParser extends Writable {
           } else {
             this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
               if (error) {
-                this.publishFrameError(error)
                 const code = error instanceof MessageSizeExceededError ? 1009 : 1007
-                failWebsocketConnection(this.#handler, code, error.message)
+                this.failWebsocketConnection(code, error.message, error)
                 return
               }
 
@@ -404,8 +392,7 @@ class ByteParser extends Writable {
 
     if (opcode === opcodes.CLOSE) {
       if (payloadLength === 1) {
-        this.publishFrameError(new Error('Received close frame with a 1-byte body.'))
-        failWebsocketConnection(this.#handler, 1002, 'Received close frame with a 1-byte body.')
+        this.failWebsocketConnection(1002, 'Received close frame with a 1-byte body.')
         return false
       }
 
@@ -414,8 +401,7 @@ class ByteParser extends Writable {
       if (this.#info.closeInfo.error) {
         const { code, reason } = this.#info.closeInfo
 
-        this.publishFrameError(new Error(reason))
-        failWebsocketConnection(this.#handler, code, reason)
+        this.failWebsocketConnection(code, reason)
         return false
       }
 
@@ -480,6 +466,11 @@ class ByteParser extends Writable {
       websocket: this.#handler.websocket,
       error
     })
+  }
+
+  failWebsocketConnection (code, reason, error = new Error(reason)) {
+    this.publishFrameError(error)
+    failWebsocketConnection(this.#handler, code, reason)
   }
 }
 

--- a/lib/web/websocket/sender.js
+++ b/lib/web/websocket/sender.js
@@ -10,7 +10,7 @@ const { channels } = require('../../core/diagnostics')
  * @property {Promise<void> | null} promise
  * @property {((...args: any[]) => any)} callback
  * @property {Buffer | null} frame
- * @property {boolean} published
+ * @property {{ published: boolean, data: Buffer | ArrayBuffer | ArrayBufferView | null, hint: number }} diagnosticInfo
  */
 
 class SendQueue {
@@ -40,7 +40,7 @@ class SendQueue {
         // TODO(@tsctx): support fast-path for string on running
         if (hint === sendHints.text) {
           // special fast-path for string
-          publishFrame(this.#websocket, opcodes.TEXT, true, item)
+          publishFrame(this.#websocket, opcodes.TEXT, true, item, hint)
           const { 0: head, 1: body } = WebsocketFrameSend.createFastTextFrame(item)
           this.#socket.cork()
           this.#socket.write(head)
@@ -48,7 +48,7 @@ class SendQueue {
           this.#socket.uncork()
         } else {
           // direct writing
-          publishFrame(this.#websocket, hint === sendHints.text ? opcodes.TEXT : opcodes.BINARY, true, toBuffer(item, hint))
+          publishFrame(this.#websocket, hint === sendHints.text ? opcodes.TEXT : opcodes.BINARY, true, item, hint)
           this.#socket.write(createFrame(item, hint), cb)
         }
       } else {
@@ -57,7 +57,11 @@ class SendQueue {
           promise: null,
           callback: cb,
           frame: createFrame(item, hint),
-          published: false
+          diagnosticInfo: {
+            published: false,
+            data: item,
+            hint
+          }
         }
         this.#queue.push(node)
       }
@@ -68,13 +72,17 @@ class SendQueue {
     const node = {
       promise: item.arrayBuffer().then((ab) => {
         node.promise = null
-        publishFrame(this.#websocket, opcodes.BINARY, true, new Uint8Array(ab))
-        node.published = true
+        publishFrame(this.#websocket, opcodes.BINARY, true, ab, hint)
+        node.diagnosticInfo.published = true
         node.frame = createFrame(ab, hint)
       }),
       callback: cb,
       frame: null,
-      published: false
+      diagnosticInfo: {
+        published: false,
+        data: item,
+        hint
+      }
     }
 
     this.#queue.push(node)
@@ -94,8 +102,9 @@ class SendQueue {
         await node.promise
       }
       // write
-      if (node.frame !== null && !node.published) {
-        publishQueuedFrame(this.#websocket, node.frame)
+      if (node.frame !== null && !node.diagnosticInfo.published) {
+        publishQueuedFrame(this.#websocket, node.frame, node.diagnosticInfo)
+        node.diagnosticInfo.published = true
       }
       this.#socket.write(node.frame, node.callback)
       // cleanup
@@ -120,7 +129,7 @@ function toBuffer (data, hint) {
   }
 }
 
-function publishFrame (websocket, opcode, mask, payloadData) {
+function publishFrame (websocket, opcode, mask, data, hint) {
   if (!channels.frameSent.hasSubscribers) {
     return
   }
@@ -129,43 +138,21 @@ function publishFrame (websocket, opcode, mask, payloadData) {
     websocket,
     opcode,
     mask,
-    payloadData: Buffer.from(payloadData)
+    payloadData: Buffer.from(toBuffer(data, hint))
   })
 }
 
-function publishQueuedFrame (websocket, frame) {
+function publishQueuedFrame (websocket, frame, diagnosticInfo) {
   if (!channels.frameSent.hasSubscribers) {
     return
-  }
-
-  const payloadOffset = getPayloadOffset(frame)
-  const payloadData = Buffer.allocUnsafe(frame.length - payloadOffset)
-  const maskKey = frame.subarray(payloadOffset - 4, payloadOffset)
-
-  for (let i = 0; i < payloadData.length; ++i) {
-    payloadData[i] = frame[payloadOffset + i] ^ maskKey[i & 3]
   }
 
   channels.frameSent.publish({
     websocket,
     opcode: frame[0] & 0x0F,
     mask: (frame[1] & 0x80) === 0x80,
-    payloadData
+    payloadData: Buffer.from(toBuffer(diagnosticInfo.data, diagnosticInfo.hint))
   })
-}
-
-function getPayloadOffset (frame) {
-  const payloadLength = frame[1] & 0x7F
-
-  if (payloadLength === 126) {
-    return 8
-  }
-
-  if (payloadLength === 127) {
-    return 14
-  }
-
-  return 6
 }
 
 module.exports = { SendQueue }

--- a/lib/web/websocket/sender.js
+++ b/lib/web/websocket/sender.js
@@ -3,12 +3,14 @@
 const { WebsocketFrameSend } = require('./frame')
 const { opcodes, sendHints } = require('./constants')
 const FixedQueue = require('../../dispatcher/fixed-queue')
+const { channels } = require('../../core/diagnostics')
 
 /**
  * @typedef {object} SendQueueNode
  * @property {Promise<void> | null} promise
  * @property {((...args: any[]) => any)} callback
  * @property {Buffer | null} frame
+ * @property {boolean} published
  */
 
 class SendQueue {
@@ -25,8 +27,11 @@ class SendQueue {
   /** @type {import('node:net').Socket} */
   #socket
 
-  constructor (socket) {
+  #websocket
+
+  constructor (socket, websocket) {
     this.#socket = socket
+    this.#websocket = websocket
   }
 
   add (item, cb, hint) {
@@ -35,6 +40,7 @@ class SendQueue {
         // TODO(@tsctx): support fast-path for string on running
         if (hint === sendHints.text) {
           // special fast-path for string
+          publishFrame(this.#websocket, opcodes.TEXT, true, item)
           const { 0: head, 1: body } = WebsocketFrameSend.createFastTextFrame(item)
           this.#socket.cork()
           this.#socket.write(head)
@@ -42,6 +48,7 @@ class SendQueue {
           this.#socket.uncork()
         } else {
           // direct writing
+          publishFrame(this.#websocket, hint === sendHints.text ? opcodes.TEXT : opcodes.BINARY, true, toBuffer(item, hint))
           this.#socket.write(createFrame(item, hint), cb)
         }
       } else {
@@ -49,7 +56,8 @@ class SendQueue {
         const node = {
           promise: null,
           callback: cb,
-          frame: createFrame(item, hint)
+          frame: createFrame(item, hint),
+          published: false
         }
         this.#queue.push(node)
       }
@@ -60,10 +68,13 @@ class SendQueue {
     const node = {
       promise: item.arrayBuffer().then((ab) => {
         node.promise = null
+        publishFrame(this.#websocket, opcodes.BINARY, true, new Uint8Array(ab))
+        node.published = true
         node.frame = createFrame(ab, hint)
       }),
       callback: cb,
-      frame: null
+      frame: null,
+      published: false
     }
 
     this.#queue.push(node)
@@ -83,6 +94,9 @@ class SendQueue {
         await node.promise
       }
       // write
+      if (node.frame !== null && !node.published) {
+        publishQueuedFrame(this.#websocket, node.frame)
+      }
       this.#socket.write(node.frame, node.callback)
       // cleanup
       node.callback = node.frame = null
@@ -104,6 +118,54 @@ function toBuffer (data, hint) {
     case sendHints.blob:
       return new Uint8Array(data)
   }
+}
+
+function publishFrame (websocket, opcode, mask, payloadData) {
+  if (!channels.frameSent.hasSubscribers) {
+    return
+  }
+
+  channels.frameSent.publish({
+    websocket,
+    opcode,
+    mask,
+    payloadData: Buffer.from(payloadData)
+  })
+}
+
+function publishQueuedFrame (websocket, frame) {
+  if (!channels.frameSent.hasSubscribers) {
+    return
+  }
+
+  const payloadOffset = getPayloadOffset(frame)
+  const payloadData = Buffer.allocUnsafe(frame.length - payloadOffset)
+  const maskKey = frame.subarray(payloadOffset - 4, payloadOffset)
+
+  for (let i = 0; i < payloadData.length; ++i) {
+    payloadData[i] = frame[payloadOffset + i] ^ maskKey[i & 3]
+  }
+
+  channels.frameSent.publish({
+    websocket,
+    opcode: frame[0] & 0x0F,
+    mask: (frame[1] & 0x80) === 0x80,
+    payloadData
+  })
+}
+
+function getPayloadOffset (frame) {
+  const payloadLength = frame[1] & 0x7F
+
+  if (payloadLength === 126) {
+    return 8
+  }
+
+  if (payloadLength === 127) {
+    return 14
+  }
+
+  return 6
 }
 
 module.exports = { SendQueue }

--- a/lib/web/websocket/sender.js
+++ b/lib/web/websocket/sender.js
@@ -48,7 +48,7 @@ class SendQueue {
           this.#socket.uncork()
         } else {
           // direct writing
-          publishFrame(this.#websocket, hint === sendHints.text ? opcodes.TEXT : opcodes.BINARY, true, item, hint)
+          publishFrame(this.#websocket, opcodes.BINARY, true, item, hint)
           this.#socket.write(createFrame(item, hint), cb)
         }
       } else {

--- a/lib/web/websocket/sender.js
+++ b/lib/web/websocket/sender.js
@@ -10,7 +10,7 @@ const { channels } = require('../../core/diagnostics')
  * @property {Promise<void> | null} promise
  * @property {((...args: any[]) => any)} callback
  * @property {Buffer | null} frame
- * @property {{ published: boolean, data: Buffer | ArrayBuffer | ArrayBufferView | null, hint: number }} diagnosticInfo
+ * @property {{ data: Buffer | ArrayBuffer | ArrayBufferView | null, hint: number }} diagnosticInfo
  */
 
 class SendQueue {
@@ -58,7 +58,6 @@ class SendQueue {
           callback: cb,
           frame: createFrame(item, hint),
           diagnosticInfo: {
-            published: false,
             data: item,
             hint
           }
@@ -72,14 +71,12 @@ class SendQueue {
     const node = {
       promise: item.arrayBuffer().then((ab) => {
         node.promise = null
-        publishFrame(this.#websocket, opcodes.BINARY, ab, hint)
-        node.diagnosticInfo.published = true
+        node.diagnosticInfo.data = ab
         node.frame = createFrame(ab, hint)
       }),
       callback: cb,
       frame: null,
       diagnosticInfo: {
-        published: false,
         data: item,
         hint
       }
@@ -102,9 +99,8 @@ class SendQueue {
         await node.promise
       }
       // write
-      if (node.frame !== null && !node.diagnosticInfo.published) {
+      if (node.frame !== null) {
         publishQueuedFrame(this.#websocket, node.frame, node.diagnosticInfo)
-        node.diagnosticInfo.published = true
       }
       this.#socket.write(node.frame, node.callback)
       // cleanup

--- a/lib/web/websocket/sender.js
+++ b/lib/web/websocket/sender.js
@@ -40,7 +40,7 @@ class SendQueue {
         // TODO(@tsctx): support fast-path for string on running
         if (hint === sendHints.text) {
           // special fast-path for string
-          publishFrame(this.#websocket, opcodes.TEXT, true, item, hint)
+          publishFrame(this.#websocket, opcodes.TEXT, item, hint)
           const { 0: head, 1: body } = WebsocketFrameSend.createFastTextFrame(item)
           this.#socket.cork()
           this.#socket.write(head)
@@ -48,7 +48,7 @@ class SendQueue {
           this.#socket.uncork()
         } else {
           // direct writing
-          publishFrame(this.#websocket, opcodes.BINARY, true, item, hint)
+          publishFrame(this.#websocket, opcodes.BINARY, item, hint)
           this.#socket.write(createFrame(item, hint), cb)
         }
       } else {
@@ -72,7 +72,7 @@ class SendQueue {
     const node = {
       promise: item.arrayBuffer().then((ab) => {
         node.promise = null
-        publishFrame(this.#websocket, opcodes.BINARY, true, ab, hint)
+        publishFrame(this.#websocket, opcodes.BINARY, ab, hint)
         node.diagnosticInfo.published = true
         node.frame = createFrame(ab, hint)
       }),
@@ -129,7 +129,7 @@ function toBuffer (data, hint) {
   }
 }
 
-function publishFrame (websocket, opcode, mask, data, hint) {
+function publishFrame (websocket, opcode, data, hint) {
   if (!channels.frameSent.hasSubscribers) {
     return
   }
@@ -137,7 +137,6 @@ function publishFrame (websocket, opcode, mask, data, hint) {
   channels.frameSent.publish({
     websocket,
     opcode,
-    mask,
     payloadData: Buffer.from(toBuffer(data, hint))
   })
 }
@@ -150,7 +149,6 @@ function publishQueuedFrame (websocket, frame, diagnosticInfo) {
   channels.frameSent.publish({
     websocket,
     opcode: frame[0] & 0x0F,
-    mask: (frame[1] & 0x80) === 0x80,
     payloadData: Buffer.from(toBuffer(diagnosticInfo.data, diagnosticInfo.hint))
   })
 }

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -57,7 +57,10 @@ class WebSocketStream {
       this.#handler.readyState = states.CLOSING
 
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(err)
+        channels.socketError.publish({
+          error: err,
+          websocket: undefined
+        })
       }
 
       this.#handler.socket.destroy()

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -57,10 +57,7 @@ class WebSocketStream {
       this.#handler.readyState = states.CLOSING
 
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish({
-          error: err,
-          websocket: undefined
-        })
+        channels.socketError.publish(err)
       }
 
       this.#handler.socket.destroy()

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -36,6 +36,7 @@ const { channels } = require('../../core/diagnostics')
  * @property {() => void} onSocketClose
  * @property {(body: Buffer) => void} onPing
  * @property {(body: Buffer) => void} onPong
+ * @property {WebSocket} [websocket]
  *
  * @property {number} readyState
  * @property {import('stream').Duplex} socket
@@ -75,7 +76,10 @@ class WebSocket extends EventTarget {
       this.#handler.readyState = states.CLOSING
 
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(err)
+        channels.socketError.publish({
+          error: err,
+          websocket: this
+        })
       }
 
       this.#handler.socket.destroy()
@@ -155,6 +159,14 @@ class WebSocket extends EventTarget {
 
     // 5. Set this's url to urlRecord.
     this.#url = new URL(urlRecord.href)
+    this.#handler.websocket = this
+
+    if (channels.created.hasSubscribers) {
+      channels.created.publish({
+        websocket: this,
+        url: URLSerializer(this.#url)
+      })
+    }
 
     // Store options for later use (e.g., maxDecompressedMessageSize)
     this.#options = {
@@ -468,7 +480,7 @@ class WebSocket extends EventTarget {
     parser.on('error', (err) => this.#handler.onParserError(err))
 
     this.#parser = parser
-    this.#sendQueue = new SendQueue(response.socket)
+    this.#sendQueue = new SendQueue(response.socket, this)
 
     // 1. Change the ready state to OPEN (1).
     this.#handler.readyState = states.OPEN

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -76,10 +76,7 @@ class WebSocket extends EventTarget {
       this.#handler.readyState = states.CLOSING
 
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish({
-          error: err,
-          websocket: this
-        })
+        channels.socketError.publish(err)
       }
 
       this.#handler.socket.destroy()

--- a/test/node-test/debug.js
+++ b/test/node-test/debug.js
@@ -12,7 +12,7 @@ const isNode23Plus = process.versions.node.split('.')[0] >= 23
 const isCITGM = !!process.env.CITGM
 
 test('debug#websocket', { skip: !process.versions.icu || isCITGM || isNode23Plus }, async t => {
-  const assert = tspl(t, { plan: 6 })
+  const assert = tspl(t, { plan: 10 })
   const child = spawn(
     process.execPath,
     [
@@ -26,10 +26,13 @@ test('debug#websocket', { skip: !process.versions.icu || isCITGM || isNode23Plus
   )
   const chunks = []
   const assertions = [
+    /(WEBSOCKET [0-9]+:) (created websocket for)/,
+    /(WEBSOCKET [0-9]+:) (sending opening handshake for)/,
     /(WEBSOCKET [0-9]+:) (connecting to)/,
     /(WEBSOCKET [0-9]+:) (connected to)/,
     /(WEBSOCKET [0-9]+:) (sending request)/,
     /(WEBSOCKET [0-9]+:) (connection opened)/,
+    /(WEBSOCKET [0-9]+:) (frame received opcode=8 bytes=9)/,
     /(WEBSOCKET [0-9]+:) (closed connection to)/,
     /^$/
   ]
@@ -41,7 +44,7 @@ test('debug#websocket', { skip: !process.versions.icu || isCITGM || isNode23Plus
   child.stderr.on('end', () => {
     const lines = extractLines(chunks)
     assert.strictEqual(lines.length, assertions.length)
-    for (let i = 1; i < lines.length; i++) {
+    for (let i = 0; i < lines.length; i++) {
       assert.match(lines[i], assertions[i])
     }
   })

--- a/test/types/diagnostics-channel.test-d.ts
+++ b/test/types/diagnostics-channel.test-d.ts
@@ -1,6 +1,6 @@
 import { Socket } from 'node:net'
 import { expectAssignable } from 'tsd'
-import { DiagnosticsChannel, buildConnector } from '../..'
+import { DiagnosticsChannel, WebSocket, buildConnector } from '../..'
 
 const request = {
   origin: '',
@@ -26,6 +26,8 @@ const connectParams = {
   port: '',
   servername: ''
 }
+
+const websocket = {} as InstanceType<typeof WebSocket>
 
 expectAssignable<DiagnosticsChannel.RequestCreateMessage>({ request })
 expectAssignable<DiagnosticsChannel.RequestBodyChunkSentMessage>({ request, chunk: Buffer.from('') })
@@ -72,4 +74,48 @@ expectAssignable<DiagnosticsChannel.ClientConnectErrorMessage>({
     options: buildConnector.Options,
     callback: buildConnector.Callback
   ) => new Socket()
+})
+expectAssignable<DiagnosticsChannel.WebsocketCreatedMessage>({
+  websocket,
+  url: 'ws://localhost:3000'
+})
+expectAssignable<DiagnosticsChannel.WebsocketHandshakeRequestMessage>({
+  websocket,
+  request: {
+    headers: {}
+  }
+})
+expectAssignable<DiagnosticsChannel.WebsocketOpenMessage>({
+  address: {
+    address: '127.0.0.1',
+    family: 'IPv4',
+    port: 3000
+  },
+  protocol: '',
+  extensions: '',
+  websocket,
+  handshakeResponse: {
+    status: 101,
+    statusText: 'Switching Protocols',
+    headers: {}
+  }
+})
+expectAssignable<DiagnosticsChannel.WebsocketCloseMessage>({
+  websocket,
+  code: 1000,
+  reason: ''
+})
+expectAssignable<DiagnosticsChannel.WebsocketFrameMessage>({
+  websocket,
+  opcode: 1,
+  mask: true,
+  payloadData: Buffer.from('')
+})
+expectAssignable<DiagnosticsChannel.WebsocketFrameErrorMessage>({
+  websocket,
+  error: new Error('Error')
+})
+expectAssignable<DiagnosticsChannel.WebsocketSocketErrorMessage>({
+  websocket,
+  error: new Error('Error')
 })

--- a/test/types/diagnostics-channel.test-d.ts
+++ b/test/types/diagnostics-channel.test-d.ts
@@ -115,7 +115,3 @@ expectAssignable<DiagnosticsChannel.WebsocketFrameErrorMessage>({
   websocket,
   error: new Error('Error')
 })
-expectAssignable<DiagnosticsChannel.WebsocketSocketErrorMessage>({
-  websocket,
-  error: new Error('Error')
-})

--- a/test/websocket/diagnostics-channel-created-handshake-request.js
+++ b/test/websocket/diagnostics-channel-created-handshake-request.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const dc = require('node:diagnostics_channel')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+
+test('diagnostics channel - undici:websocket:[created/handshakeRequest]', async (t) => {
+  t.plan(10)
+
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+
+  server.on('upgrade', (request, socket, head) => {
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      ws.close(1000, 'done')
+    })
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const url = `ws://localhost:${server.address().port}`
+  const events = []
+  let createdWebSocket
+  let handshakeWebSocket
+
+  const createdListener = ({ websocket, url: createdUrl }) => {
+    events.push('created')
+    createdWebSocket = websocket
+    t.assert.strictEqual(createdUrl, `${url}/`)
+  }
+
+  const handshakeRequestListener = ({ websocket, request }) => {
+    events.push('handshakeRequest')
+    handshakeWebSocket = websocket
+    t.assert.strictEqual(typeof request, 'object')
+    t.assert.strictEqual(typeof request.headers, 'object')
+    t.assert.strictEqual(request.headers['sec-websocket-version'], '13')
+    t.assert.strictEqual(request.headers['sec-websocket-extensions'], 'permessage-deflate; client_max_window_bits')
+    t.assert.strictEqual(typeof request.headers['sec-websocket-key'], 'string')
+  }
+
+  dc.channel('undici:websocket:created').subscribe(createdListener)
+  dc.channel('undici:websocket:handshakeRequest').subscribe(handshakeRequestListener)
+
+  const ws = new WebSocket(url)
+
+  t.after(() => {
+    dc.channel('undici:websocket:created').unsubscribe(createdListener)
+    dc.channel('undici:websocket:handshakeRequest').unsubscribe(handshakeRequestListener)
+    wss.close()
+    server.close()
+  })
+
+  await once(ws, 'close')
+
+  t.assert.deepStrictEqual(events, ['created', 'handshakeRequest'])
+  t.assert.strictEqual(createdWebSocket, ws)
+  t.assert.strictEqual(handshakeWebSocket, ws)
+  t.assert.strictEqual(ws.url, `${url}/`)
+})

--- a/test/websocket/diagnostics-channel-frame-error.js
+++ b/test/websocket/diagnostics-channel-frame-error.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const dc = require('node:diagnostics_channel')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+const { WebsocketFrameSend } = require('../../lib/web/websocket/frame')
+
+test('diagnostics channel - undici:websocket:frameError', async (t) => {
+  t.plan(3)
+
+  const body = Buffer.allocUnsafe(2)
+  body.writeUInt16BE(1006, 0)
+
+  const frame = new WebsocketFrameSend(body)
+  const buffer = frame.createFrame(0x8)
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (socket) => {
+    socket._socket.write(buffer, () => socket.close())
+  })
+
+  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+  const frameErrorListener = ({ websocket, error }) => {
+    t.assert.strictEqual(websocket, ws)
+    t.assert.strictEqual(error.message, 'Frame cannot be masked')
+  }
+
+  dc.channel('undici:websocket:frameError').subscribe(frameErrorListener)
+
+  t.after(() => {
+    server.close()
+    ws.close()
+    dc.channel('undici:websocket:frameError').unsubscribe(frameErrorListener)
+  })
+
+  await once(ws, 'close')
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)
+})

--- a/test/websocket/diagnostics-channel-frames.js
+++ b/test/websocket/diagnostics-channel-frames.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const dc = require('node:diagnostics_channel')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+const { opcodes } = require('../../lib/web/websocket/constants')
+
+test('diagnostics channel - undici:websocket:[frameSent/frameReceived]', async (t) => {
+  t.plan(8)
+
+  const server = new WebSocketServer({ port: 0 })
+  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+  server.on('connection', (socket) => {
+    socket.on('message', (payload) => {
+      socket.send(payload.toString())
+    })
+  })
+
+  const frameSentListener = ({ websocket, opcode, mask, payloadData }) => {
+    if (opcode !== opcodes.TEXT || payloadData.toString() !== 'hello') {
+      return
+    }
+
+    t.assert.strictEqual(websocket, ws)
+    t.assert.strictEqual(opcode, opcodes.TEXT)
+    t.assert.strictEqual(mask, true)
+    t.assert.strictEqual(payloadData.toString(), 'hello')
+  }
+
+  const frameReceivedListener = ({ websocket, opcode, mask, payloadData }) => {
+    if (opcode !== opcodes.TEXT || payloadData.toString() !== 'hello') {
+      return
+    }
+
+    t.assert.strictEqual(websocket, ws)
+    t.assert.strictEqual(opcode, opcodes.TEXT)
+    t.assert.strictEqual(mask, false)
+    t.assert.strictEqual(payloadData.toString(), 'hello')
+  }
+
+  dc.channel('undici:websocket:frameSent').subscribe(frameSentListener)
+  dc.channel('undici:websocket:frameReceived').subscribe(frameReceivedListener)
+
+  t.after(() => {
+    server.close()
+    ws.close()
+    dc.channel('undici:websocket:frameSent').unsubscribe(frameSentListener)
+    dc.channel('undici:websocket:frameReceived').unsubscribe(frameReceivedListener)
+  })
+
+  await once(ws, 'open')
+  ws.send('hello')
+  await once(ws, 'message')
+})

--- a/test/websocket/diagnostics-channel-frames.js
+++ b/test/websocket/diagnostics-channel-frames.js
@@ -8,7 +8,7 @@ const { WebSocket } = require('../..')
 const { opcodes } = require('../../lib/web/websocket/constants')
 
 test('diagnostics channel - undici:websocket:[frameSent/frameReceived]', async (t) => {
-  t.plan(8)
+  t.plan(6)
 
   const server = new WebSocketServer({ port: 0 })
   const ws = new WebSocket(`ws://localhost:${server.address().port}`)
@@ -26,7 +26,6 @@ test('diagnostics channel - undici:websocket:[frameSent/frameReceived]', async (
 
     t.assert.strictEqual(websocket, ws)
     t.assert.strictEqual(opcode, opcodes.TEXT)
-    t.assert.strictEqual(mask, true)
     t.assert.strictEqual(payloadData.toString(), 'hello')
   }
 
@@ -37,7 +36,6 @@ test('diagnostics channel - undici:websocket:[frameSent/frameReceived]', async (
 
     t.assert.strictEqual(websocket, ws)
     t.assert.strictEqual(opcode, opcodes.TEXT)
-    t.assert.strictEqual(mask, false)
     t.assert.strictEqual(payloadData.toString(), 'hello')
   }
 

--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -4,6 +4,7 @@ import buildConnector from './connector'
 import Dispatcher from './dispatcher'
 
 declare namespace DiagnosticsChannel {
+  type WebSocket = InstanceType<typeof import('./websocket').WebSocket>
   interface Request {
     origin?: string | URL;
     completed: boolean;
@@ -70,5 +71,49 @@ declare namespace DiagnosticsChannel {
     socket: Socket;
     connectParams: ConnectParams;
     connector: Connector;
+  }
+  export interface WebsocketCreatedMessage {
+    websocket: WebSocket;
+    url: string;
+  }
+  export interface WebsocketHandshakeRequestMessage {
+    websocket: WebSocket;
+    request: {
+      headers: Record<string, string>;
+    };
+  }
+  export interface WebsocketOpenMessage {
+    address: {
+      address: string;
+      family: string;
+      port: number;
+    };
+    protocol: string;
+    extensions: string;
+    websocket: WebSocket;
+    handshakeResponse: {
+      status: number;
+      statusText: string;
+      headers: Record<string, string>;
+    };
+  }
+  export interface WebsocketCloseMessage {
+    websocket: WebSocket;
+    code: number;
+    reason: string;
+  }
+  export interface WebsocketFrameMessage {
+    websocket: WebSocket;
+    opcode: number;
+    mask: boolean;
+    payloadData: Buffer;
+  }
+  export interface WebsocketFrameErrorMessage {
+    websocket: WebSocket;
+    error: Error;
+  }
+  export interface WebsocketSocketErrorMessage {
+    websocket?: WebSocket;
+    error: Error;
   }
 }

--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -112,8 +112,4 @@ declare namespace DiagnosticsChannel {
     websocket: WebSocket;
     error: Error;
   }
-  export interface WebsocketSocketErrorMessage {
-    websocket?: WebSocket;
-    error: Error;
-  }
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
Fixes: https://github.com/nodejs/undici/issues/4673
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
I would like to extend the WebSocket events in order to send CDP data.
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes
Introduces undici:websocket:created, undici:websocket:handshakeRequest, frameSent, frameReceived, and frameError coverage.
<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes
N/A
<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
