### PR TITLE
fix(fetch): handle URL credentials in dispatch path extraction

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2132,9 +2132,12 @@ async function httpNetworkFetch (
     /** @type {import('../../..').Agent} */
     const agent = fetchParams.controller.dispatcher
 
+    const path = url.pathname + url.search
+    const hasTrailingQuestionMark = url.search.length === 0 && url.href[url.href.length - url.hash.length - 1] === '?'
+
     return new Promise((resolve, reject) => agent.dispatch(
       {
-        path: url.href.slice(url.href.indexOf(url.host) + url.host.length, url.hash.length ? -url.hash.length : undefined),
+        path: hasTrailingQuestionMark ? `${path}?` : path,
         origin: url.origin,
         method: request.method,
         body: agent.isMockActive ? request.body && (request.body.source || request.body.stream) : body,

--- a/test/fetch/issue-4897.js
+++ b/test/fetch/issue-4897.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { test } = require('node:test')
+const { fetch } = require('../..')
+
+function createAssertingDispatcher (t, expectedPath) {
+  return {
+    dispatch (opts, handler) {
+      t.assert.strictEqual(opts.path, expectedPath)
+      handler.onError(new Error('stop'))
+      return true
+    }
+  }
+}
+
+async function assertPath (t, url, expectedPath) {
+  const dispatcher = createAssertingDispatcher(t, expectedPath)
+
+  await t.assert.rejects(fetch(url, { dispatcher }), (err) => {
+    t.assert.strictEqual(err.cause?.message, 'stop')
+    return true
+  })
+}
+
+// https://github.com/nodejs/undici/issues/4897
+test('fetch path extraction does not match hostnames inside scheme', async (t) => {
+  const hosts = ['h', 't', 'p', 'ht', 'tp', 'tt']
+
+  for (const scheme of ['http', 'https']) {
+    for (const host of hosts) {
+      await t.test(`${scheme}://${host}/test?a=b#frag`, async (t) => {
+        await assertPath(t, `${scheme}://${host}/test?a=b#frag`, '/test?a=b')
+      })
+    }
+  }
+})

--- a/test/websocket/issue-4889.js
+++ b/test/websocket/issue-4889.js
@@ -1,15 +1,37 @@
+'use strict'
+
 const { test } = require('node:test')
-const http = require('node:http')
-const crypto = require('node:crypto')
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const { WebSocketServer } = require('ws')
+
 const { WebSocket } = require('../..')
-const { createDeferredPromise } = require('../../lib/util/promise')
+const { closeServerAsPromise } = require('../utils/node-http')
 
-test('WebSocket basic auth', (t) => {
-  const server = http.createServer()
+// https://github.com/nodejs/undici/issues/4889
+test('websocket auth retry preserves path when URL contains credentials', async (t) => {
+  const expectedAuth = `Basic ${Buffer.from('user:pass').toString('base64')}`
 
-  server.on('upgrade', (req, socket) => {
-    const auth = req.headers.authorization
-    if (!auth || auth !== `Basic ${Buffer.from('user:pass').toString('base64')}`) {
+  let attempts = 0
+
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+
+  t.after(async () => {
+    for (const client of wss.clients) {
+      client.terminate()
+    }
+
+    await new Promise((resolve) => wss.close(resolve))
+    await closeServerAsPromise(server)()
+  })
+
+  server.on('upgrade', (req, socket, head) => {
+    attempts++
+    t.assert.strictEqual(req.url, '/path')
+
+    if (attempts === 1) {
+      t.assert.strictEqual(req.headers.authorization, undefined)
       socket.write(
         'HTTP/1.1 401 Unauthorized\r\n' +
         'WWW-Authenticate: Basic realm="test"\r\n' +
@@ -20,43 +42,26 @@ test('WebSocket basic auth', (t) => {
       return
     }
 
-    const key = req.headers['sec-websocket-key']
-    const accept = crypto
-      .createHash('sha1')
-      .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
-      .digest('base64')
+    if (attempts === 2) {
+      t.assert.strictEqual(req.headers.authorization, expectedAuth)
+      wss.handleUpgrade(req, socket, head, (websocket) => {
+        wss.emit('connection', websocket, req)
+      })
+      return
+    }
 
-    socket.write(
-      'HTTP/1.1 101 Switching Protocols\r\n' +
-      'Upgrade: websocket\r\n' +
-      'Connection: Upgrade\r\n' +
-      'Sec-WebSocket-Accept: ' + accept + '\r\n' +
-      '\r\n'
-    )
-
-    socket.on('data', () => socket.destroy())
-  }).listen(0)
-
-  const { port } = server.address()
-  const url = `ws://user:pass@127.0.0.1:${port}/path`
-
-  const ws = new WebSocket(url)
-
-  t.after(() => {
-    ws.close()
-    server.close()
+    t.assert.fail(`unexpected upgrade attempt #${attempts}`)
   })
 
-  const promise = createDeferredPromise()
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
 
-  ws.addEventListener('open', () => {
-    promise.resolve()
-    ws.send('h')
+  const ws = new WebSocket(`ws://user:pass@127.0.0.1:${server.address().port}/path`)
+
+  await new Promise((resolve, reject) => {
+    ws.addEventListener('open', resolve, { once: true })
+    ws.addEventListener('error', ({ error }) => reject(error), { once: true })
   })
 
-  ws.addEventListener('error', (e) => {
-    promise.reject(e)
-  })
-
-  return promise.promise
+  t.assert.strictEqual(attempts, 2)
 })


### PR DESCRIPTION
## Summary
- fix fetch dispatch path extraction for URLs that include credentials
- preserve the trailing `?` behavior introduced in #4837
- add a websocket regression test for the 401 challenge/response flow with URL credentials

## Details
Using `url.href.slice(url.origin.length)` breaks when userinfo is present (`user:pass@...`), because `origin` excludes credentials while `href` includes them. That produces an invalid path and prevents dispatch.

This change builds the path from `url.pathname + url.search` and explicitly preserves trailing `?` when present.

## Test plan
- `node --test test/websocket/issue-4889.js`
- `npx borp -p "test/fetch/issue-4836.js"`
- `npx eslint lib/web/fetch/index.js test/websocket/issue-4889.js`

Closes #4889.
