### PR TITLE
docs(snapshot-agent): use RFC 2606 domains in examples

### DIFF
--- a/docs/docs/api/SnapshotAgent.md
+++ b/docs/docs/api/SnapshotAgent.md
@@ -49,7 +49,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Makes real requests and records them
-const response = await fetch('https://api.example.com/users')
+const response = await fetch('https://api.example/users')
 const users = await response.json()
 
 // Save recorded snapshots
@@ -69,7 +69,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Uses recorded response instead of real request
-const response = await fetch('https://api.example.com/users')
+const response = await fetch('https://api.example/users')
 ```
 
 #### Update Mode (`'update'`)
@@ -85,7 +85,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Uses snapshot if exists, otherwise makes real request and records it
-const response = await fetch('https://api.example.com/new-endpoint')
+const response = await fetch('https://api.example/new-endpoint')
 ```
 
 ## Instance Methods
@@ -161,7 +161,7 @@ const agent = new SnapshotAgent({
   snapshotPath: './snapshots.json',
   
   excludeUrls: [
-    'https://analytics.example.com',  // String match
+    'https://analytics.example',  // String match
     /\/api\/v\d+\/health/,           // Regex pattern
     'telemetry'                      // Substring match
   ]
@@ -195,10 +195,10 @@ Handle multiple responses for the same request (similar to nock):
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './sequential.json' })
 
 // First call returns response A
-await fetch('https://api.example.com/random')
+await fetch('https://api.example/random')
 
 // Second call returns response B  
-await fetch('https://api.example.com/random')
+await fetch('https://api.example/random')
 
 await agent.saveSnapshots()
 
@@ -206,13 +206,13 @@ await agent.saveSnapshots()
 const playbackAgent = new SnapshotAgent({ mode: 'playback', snapshotPath: './sequential.json' })
 
 // Returns response A
-const first = await fetch('https://api.example.com/random')
+const first = await fetch('https://api.example/random')
 
 // Returns response B
-const second = await fetch('https://api.example.com/random')
+const second = await fetch('https://api.example/random')
 
 // Third call repeats the last response (B)
-const third = await fetch('https://api.example.com/random')
+const third = await fetch('https://api.example/random')
 ```
 
 ## Managing Snapshots
@@ -296,7 +296,7 @@ agent.clearSnapshots()
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './get-snapshots.json' })
 setGlobalDispatcher(agent)
 
-const response = await fetch('https://jsonplaceholder.typicode.com/posts/1')
+const response = await fetch('https://posts.example/posts/1')
 const post = await response.json()
 
 await agent.saveSnapshots()
@@ -309,7 +309,7 @@ await agent.saveSnapshots()
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './post-snapshots.json' })
 setGlobalDispatcher(agent)
 
-const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+const response = await fetch('https://posts.example/posts', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ title: 'Test Post', body: 'Content' })
@@ -328,7 +328,7 @@ import { SnapshotAgent, request, setGlobalDispatcher } from 'undici'
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './request-snapshots.json' })
 setGlobalDispatcher(agent)
 
-const { statusCode, headers, body } = await request('https://api.example.com/data')
+const { statusCode, headers, body } = await request('https://api.example/data')
 const data = await body.json()
 
 await agent.saveSnapshots()
@@ -354,7 +354,7 @@ test('API integration test', async (t) => {
   t.after(() => setGlobalDispatcher(originalDispatcher))
   
   // This will use recorded data
-  const response = await fetch('https://api.example.com/users')
+  const response = await fetch('https://api.example/users')
   const users = await response.json()
   
   assert(Array.isArray(users))
@@ -405,7 +405,7 @@ Snapshots are stored as JSON with the following structure:
     "snapshot": {
       "request": {
         "method": "GET",
-        "url": "https://api.example.com/users",
+        "url": "https://api.example/users",
         "headers": {
           "authorization": "Bearer token"
         },
@@ -494,7 +494,7 @@ const agent = new SnapshotAgent({
 
 ```javascript
 try {
-  const response = await fetch('https://api.example.com/nonexistent')
+  const response = await fetch('https://api.example/nonexistent')
 } catch (error) {
   if (error.message.includes('No snapshot found')) {
     // Handle missing snapshot
@@ -509,7 +509,7 @@ try {
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './snapshots.json' })
 
 try {
-  const response = await fetch('https://nonexistent-api.example.com/data')
+  const response = await fetch('https://nonexistent-api.example/data')
 } catch (error) {
   // Network errors are not recorded as snapshots
   console.log('Network error:', error.message)
@@ -578,7 +578,7 @@ test('validate snapshot contents', async (t) => {
 **Manual MockAgent:**
 ```javascript
 const mockAgent = new MockAgent()
-const mockPool = mockAgent.get('https://api.example.com')
+const mockPool = mockAgent.get('https://api.example')
 
 mockPool.intercept({
   path: '/users',


### PR DESCRIPTION
## Summary
- replace `example.com`/`jsonplaceholder.typicode.com` URLs in `SnapshotAgent` API docs with RFC 2606-compliant domains
- keep examples semantically identical while avoiding real-world domains

## Validation
- `git diff --check`

Refs #4866
