### PR TITLE
fix(test): client wasm compatible with clang 22

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2169,10 +2169,10 @@ async function httpNetworkFetch (
             headersList,
             body: decoders.length
               ? pipeline(this.body, ...decoders, (err) => {
-                  if (err) {
-                    this.onError(err)
-                  }
-                }).on('error', onError)
+                if (err) {
+                  this.onError(err)
+                }
+              }).on('error', onError)
               : this.body.on('error', onError)
           })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes #4668

## Rationale

The test used a strict `deepStrictEqual` on the full exports list, which fails when clang >= 22 exports `__stack_pointer` as a global symbol.

This will make the test also more "future-proof" in case of future export additions.

## Changes
Changed the assertion to check that each required export is present, without failing on unexpected compiler-internal symbols. 
<!-- Write a summary or list of changes here -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
