### PR TITLE
fix(cache): check Authorization on request headers per RFC 9111 §3.5

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -135,7 +135,7 @@ class CacheHandler {
     }
 
     const cacheControlDirectives = cacheControlHeader ? parseCacheControlHeader(cacheControlHeader) : {}
-    if (!canCacheResponse(this.#cacheType, statusCode, resHeaders, cacheControlDirectives)) {
+    if (!canCacheResponse(this.#cacheType, statusCode, resHeaders, cacheControlDirectives, this.#cacheKey.headers)) {
       return downstreamOnHeaders()
     }
 
@@ -340,8 +340,9 @@ class CacheHandler {
  * @param {number} statusCode
  * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives} cacheControlDirectives
+ * @param {import('../../types/header.d.ts').IncomingHttpHeaders} [reqHeaders]
  */
-function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirectives) {
+function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirectives, reqHeaders) {
   // Status code must be final and understood.
   if (statusCode < 200 || NOT_UNDERSTOOD_STATUS_CODES.includes(statusCode)) {
     return false
@@ -372,8 +373,16 @@ function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirect
   }
 
   // https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
-  if (resHeaders.authorization) {
-    if (!cacheControlDirectives.public || typeof resHeaders.authorization !== 'string') {
+  if (reqHeaders?.authorization) {
+    if (
+      !cacheControlDirectives.public &&
+      !cacheControlDirectives['s-maxage'] &&
+      !cacheControlDirectives['must-revalidate']
+    ) {
+      return false
+    }
+
+    if (typeof reqHeaders.authorization !== 'string') {
       return false
     }
 

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -2091,4 +2091,196 @@ describe('Cache Interceptor', () => {
       equal(cached.deleteAt, expectedDeleteAt, `deleteAt (${cached.deleteAt}) should be staleAt + 300s (${expectedDeleteAt})`)
     })
   })
+
+  // https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen
+  describe('RFC 9111 §3.5 - Storing Responses to Authenticated Requests', () => {
+    test('caches response when request has Authorization and response has public directive', async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'public, max-age=60')
+        res.end('authenticated')
+      }).listen(0)
+
+      after(() => server.close())
+      await once(server, 'listening')
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(() => client.close())
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          authorization: 'Bearer token123'
+        }
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+    })
+
+    test('caches response when request has Authorization and response has s-maxage directive', async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.setHeader('cache-control', 's-maxage=60')
+        res.end('authenticated')
+      }).listen(0)
+
+      after(() => server.close())
+      await once(server, 'listening')
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(() => client.close())
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          authorization: 'Bearer token123'
+        }
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+    })
+
+    test('caches response when request has Authorization and response has must-revalidate directive', async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'must-revalidate, max-age=60')
+        res.end('authenticated')
+      }).listen(0)
+
+      after(() => server.close())
+      await once(server, 'listening')
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(() => client.close())
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          authorization: 'Bearer token123'
+        }
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+    })
+
+    test('does not cache response when request has Authorization and response only has max-age', async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'max-age=60')
+        res.end('authenticated')
+      }).listen(0)
+
+      after(() => server.close())
+      await once(server, 'listening')
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(() => client.close())
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          authorization: 'Bearer token123'
+        }
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 2)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+    })
+
+    test('does not cache response when request has Authorization and no cache directives', async () => {
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.end('authenticated')
+      }).listen(0)
+
+      after(() => server.close())
+      await once(server, 'listening')
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(() => client.close())
+
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          authorization: 'Bearer token123'
+        }
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+
+      {
+        const res = await client.request(request)
+        equal(requestsToOrigin, 2)
+        strictEqual(await res.body.text(), 'authenticated')
+      }
+    })
+  })
 })


### PR DESCRIPTION
## This relates to...                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                              
[RFC 9111 §3.5 - Storing Responses to Authenticated Requests](https://www.rfc-editor.org/rfc/rfc9111.html#name-storing-responses-to-authen) I believe I've identified a bug within the cacheHandler logic. I was writing some integration tests which were validating the expected RFC 9111 standards when requests with Authorization headers were being incorrectly cached. 
                                                                                                                                                                                            
## Rationale

 `canCacheResponse()` checked `resHeaders.authorization` (response headers) for the Authorization guard. Since `Authorization` is a request header, this check was dead code — shared caches would store responses to authenticated requests regardless of
  directives, violating RFC 9111 §3.5.

## Changes

Thread `reqHeaders` (from `CacheKey.headers`) into `canCacheResponse()` and check request headers instead of response headers for the Authorization guard.

### Features

  N/A

### Bug Fixes

- Check `reqHeaders.authorization` instead of `resHeaders.authorization` in `canCacheResponse()`
- Accept `s-maxage` and `must-revalidate` as permitting directives alongside `public`, per RFC 9111 §3.5
- Add 5 tests covering the Authorization caching matrix:
  - Auth + `public` → cached
  - Auth + `s-maxage` → cached
  - Auth + `must-revalidate` → cached
  - Auth + `max-age` only → not cached
  - Auth + no directives → not cached

### Breaking Changes and Deprecations

Responses to requests containing an `Authorization` header that previously leaked into shared caches (due to the dead-code bug) will now correctly be excluded unless the response carries `public`, `s-maxage`, or `must-revalidate`. This is a correctness fix, not a feature change.

## Benchmarks

```  

  ┌─────────────────────┬─────────┬───────────────────┬───────────┬─────────────────┐                                                                                                                                                                         
  │        Test         │ Samples │      Result       │ Tolerance │ Diff vs slowest │                                                                                                                                                                         
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤                                                                                                                                                                         
  │ http - no keepalive │ 101     │ 3,371.91 req/sec  │ ± 21.07%  │ -               │                                                                                                                                                                         
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤                                                                                                                                                                         
  │ http - keepalive    │ 101     │ 4,090.87 req/sec  │ ± 28.33%  │ + 21.32%        │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ request             │ 101     │ 8,764.62 req/sec  │ ± 6.75%   │ + 159.93%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ got                 │ 101     │ 9,146.79 req/sec  │ ± 4.63%   │ + 171.26%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ axios               │ 101     │ 9,319.81 req/sec  │ ± 4.15%   │ + 176.40%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ node-fetch          │ 101     │ 9,887.99 req/sec  │ ± 5.30%   │ + 193.25%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ undici - fetch      │ 101     │ 10,416.91 req/sec │ ± 7.36%   │ + 208.93%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ superagent          │ 101     │ 11,185.81 req/sec │ ± 3.84%   │ + 231.74%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ undici - dispatch   │ 101     │ 13,091.94 req/sec │ ± 6.11%   │ + 288.26%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ undici - stream     │ 101     │ 13,357.09 req/sec │ ± 6.03%   │ + 296.13%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ undici - request    │ 101     │ 13,727.02 req/sec │ ± 5.51%   │ + 307.10%       │
  ├─────────────────────┼─────────┼───────────────────┼───────────┼─────────────────┤
  │ undici - pipeline   │ 101     │ 13,835.44 req/sec │ ± 3.23%   │ + 310.31%       │
  └─────────────────────┴─────────┴───────────────────┴───────────┴─────────────────┘
```

## Status

  - [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
  - [x] Tested
  - [x] Benchmarked (**optional**)
  - [ ] Documented
  - [x] Review ready
  - [ ] In review
  - [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin