### PR TITLE
fix: force HTTP/1.1 for upgrade requests when H2 is enabled by default

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -52,7 +52,7 @@ function buildConnector ({ allowH2, useH2c, maxCachedSessions, socketPath, timeo
   const sessionCache = new SessionCache(maxCachedSessions == null ? 100 : maxCachedSessions)
   timeout = timeout == null ? 10e3 : timeout
   allowH2 = allowH2 != null ? allowH2 : true
-  return function connect ({ hostname, host, protocol, port, servername, localAddress, httpSocket }, callback) {
+  return function connect ({ hostname, host, protocol, port, servername, localAddress, httpSocket, allowH2: overrideAllowH2 }, callback) {
     let socket
     if (protocol === 'https:') {
       if (!tls) {
@@ -67,13 +67,15 @@ function buildConnector ({ allowH2, useH2c, maxCachedSessions, socketPath, timeo
 
       port = port || 443
 
+      const useH2ForConnection = overrideAllowH2 !== undefined ? overrideAllowH2 : allowH2
+
       socket = tls.connect({
         highWaterMark: 16384, // TLS in node can't have bigger HWM anyway...
         ...options,
         servername,
         session,
         localAddress,
-        ALPNProtocols: allowH2 ? ['http/1.1', 'h2'] : ['http/1.1'],
+        ALPNProtocols: useH2ForConnection ? ['http/1.1', 'h2'] : ['http/1.1'],
         socket: httpSocket, // upgrade socket connection
         port,
         host: hostname

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -452,13 +452,19 @@ function connect (client) {
     })
   }
 
+  // If the next pending request needs an HTTP upgrade (e.g. WebSocket),
+  // force HTTP/1.1 since HTTP upgrades are not supported over H2.
+  const request = client[kQueue][client[kPendingIdx]]
+  const needsUpgrade = request?.upgrade != null
+
   client[kConnector]({
     host,
     hostname,
     protocol,
     port,
     servername: client[kServerName],
-    localAddress: client[kLocalAddress]
+    localAddress: client[kLocalAddress],
+    ...(needsUpgrade ? { allowH2: false } : undefined)
   }, (err, socket) => {
     if (err) {
       handleConnectError(client, err, { host, hostname, protocol, port })


### PR DESCRIPTION
Since allowH2 defaults to true, TLS connections negotiate H2 via ALPN. This breaks WebSocket upgrades to servers that don't support the Extended CONNECT protocol (RFC 8441), such as HTTP/2 servers with allowHTTP1: true.

When the next pending request has an upgrade option (e.g. WebSocket), pass allowH2: false to the connector to force HTTP/1.1 negotiation.

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->