### PR TITLE
fix(fetch): accept global FormData in BodyInit

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -106,7 +106,7 @@ function extractBody (object, keepalive = false) {
   } else if (webidl.is.BufferSource(object)) {
     // Set source to a copy of the bytes held by object.
     source = webidl.util.getCopyOfBytesHeldByBufferSource(object)
-  } else if (webidl.is.FormData(object)) {
+  } else if (util.isFormDataLike(object)) {
     const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -583,7 +583,7 @@ webidl.converters.XMLHttpRequestBodyInit = function (V, prefix, name) {
     return V
   }
 
-  if (webidl.is.FormData(V)) {
+  if (util.isFormDataLike(V)) {
     return V
   }
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -510,6 +510,28 @@ test('post FormData with Blob', (t, done) => {
   })
 })
 
+test('post global FormData', (t, done) => {
+  t.plan(2)
+
+  const body = new globalThis.FormData()
+  body.append('field1', 'asd1')
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.ok(req.headers['content-type']?.startsWith('multipart/form-data; boundary='))
+    req.pipe(res)
+  })
+  t.after(closeServerAsPromise(server))
+
+  server.listen(0, async () => {
+    const res = await fetch(`http://localhost:${server.address().port}`, {
+      method: 'PUT',
+      body
+    })
+    t.assert.ok(/asd1/.test(await res.text()))
+    done()
+  })
+})
+
 test('post FormData with File', (t, done) => {
   t.plan(2)
 

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -301,6 +301,20 @@ test('URLSearchParams body with Headers object - issue #1407', async (t) => {
   t.assert.strictEqual(await request.text(), 'abc=123')
 })
 
+test('constructing Request with global FormData body', async (t) => {
+  const form = new globalThis.FormData()
+  form.set('key', 'value')
+
+  const req = new Request('http://asd', {
+    method: 'POST',
+    body: form
+  })
+
+  const contentType = req.headers.get('content-type').split('=')
+  t.assert.strictEqual(contentType[0], 'multipart/form-data; boundary')
+  t.assert.ok((await req.text()).startsWith(`--${contentType[1]}`))
+})
+
 test('post aborted signal cloned', (t) => {
   t.plan(2)
 

--- a/test/fetch/response.js
+++ b/test/fetch/response.js
@@ -237,6 +237,17 @@ test('Issue#2465', async (t) => {
   t.assert.strictEqual(await response.text(), '[object SharedArrayBuffer]')
 })
 
+test('constructing Response with global FormData body', async (t) => {
+  const form = new globalThis.FormData()
+  form.set('key', 'value')
+
+  const response = new Response(form)
+  const contentType = response.headers.get('content-type').split('=')
+
+  t.assert.strictEqual(contentType[0], 'multipart/form-data; boundary')
+  t.assert.ok((await response.text()).startsWith(`--${contentType[1]}`))
+})
+
 describe('Check the Content-Type of invalid formData', () => {
   test('_application/x-www-form-urlencoded', async (t) => {
     t.plan(1)


### PR DESCRIPTION
## Summary

Fix fetch body handling so `globalThis.FormData` is treated as multipart form data instead of being coerced to `"[object FormData]"`.

## Problem

`fetch()`, `new Request()`, and `new Response()` were using a strict Undici `FormData` brand check in the fetch body conversion path. That rejected compatible global/native `FormData` instances and caused them to fall through to string coercion.

As a result, callers could observe requests being sent with:

- `content-type: text/plain;charset=UTF-8`
- body: `"[object FormData]"`

instead of a proper `multipart/form-data` payload.

## Fix

Replace the strict `webidl.is.FormData(...)` checks in the fetch body conversion path with `util.isFormDataLike(...)`.

This matches the rest of Undici’s cross-realm / third-party FormData handling better and allows compatible global/native `FormData` instances to be encoded as multipart bodies.

## Changes

- update fetch body extraction to accept FormData-like objects
- update `XMLHttpRequestBodyInit` conversion to accept FormData-like objects
- add regression tests covering:
  - `new Request(..., { body: new globalThis.FormData() })`
  - `new Response(new globalThis.FormData())`
  - `fetch(..., { body: new globalThis.FormData() })`

## Testing

Validated with targeted tests:

- `node --test --test-name-pattern="global FormData" test/fetch/request.js test/fetch/response.js test/fetch/client-fetch.js`

Also verified syntax with `node --check` on the touched files.

## Notes

I could reproduce the regression on current `main` / `7.x`. I could not reproduce it locally on `v6.24.1`, even though the issue report mentions that release as well.

Fixes #4918
