### PR TITLE
types: add TOpaque to client connect options

### DIFF
--- a/test/types/client.test-d.ts
+++ b/test/types/client.test-d.ts
@@ -319,4 +319,15 @@ expectAssignable<Client>(
   expectType<number>(client.stats.pending)
   expectType<number>(client.stats.running)
   expectType<number>(client.stats.size)
+
+  // opaque
+  expectType<Promise<Dispatcher.ConnectData<number>>>(
+    client.connect({ opaque: 123, path: '' })
+  )
+  expectType<Promise<Dispatcher.ConnectData<null>>>(
+    client.connect({ path: '' })
+  )
+  expectType<Promise<Dispatcher.ConnectData<{ foo: string }>>>(
+    client.connect({ opaque: { foo: 'bar' }, path: '' })
+  )
 }

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -3,7 +3,7 @@ import Dispatcher from './dispatcher'
 import buildConnector from './connector'
 import TClientStats from './client-stats'
 
-type ClientConnectOptions = Omit<Dispatcher.ConnectOptions, 'origin'>
+type ClientConnectOptions<TOpaque = null> = Omit<Dispatcher.ConnectOptions<TOpaque>, 'origin'>
 
 /**
  * A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection. Pipelining is disabled by default.
@@ -20,12 +20,12 @@ export class Client extends Dispatcher {
   readonly stats: TClientStats
 
   // Override dispatcher APIs.
-  override connect (
-    options: ClientConnectOptions
-  ): Promise<Dispatcher.ConnectData>
-  override connect (
-    options: ClientConnectOptions,
-    callback: (err: Error | null, data: Dispatcher.ConnectData) => void
+  override connect<TOpaque = null> (
+    options: ClientConnectOptions<TOpaque>
+  ): Promise<Dispatcher.ConnectData<TOpaque>>
+  override connect<TOpaque = null> (
+    options: ClientConnectOptions<TOpaque>,
+    callback: (err: Error | null, data: Dispatcher.ConnectData<TOpaque>) => void
   ): void
 }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

![](https://github.com/user-attachments/assets/c8afe9d9-07a9-4d80-a374-079d8a4f3c1d)
<!-- Write a summary or list of changes here -->
Add generic `TOpaque` typing to `ClientConnectOptions` and `Client.connect()` overloads to fix the TypeScript error.

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
