### PR TITLE
fix(fetch): serialize multipart for FormData-like bodies in extractBody

### DIFF
--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -106,7 +106,7 @@ function extractBody (object, keepalive = false) {
   } else if (webidl.is.BufferSource(object)) {
     // Set source to a copy of the bytes held by object.
     source = webidl.util.getCopyOfBytesHeldByBufferSource(object)
-  } else if (webidl.is.FormData(object)) {
+  } else if (webidl.is.FormData(object) || util.isFormDataLike(object)) {
     const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 

--- a/test/fetch/extract-body-node-formdata.js
+++ b/test/fetch/extract-body-node-formdata.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { test } = require('node:test')
+const { extractBody } = require('../../lib/web/fetch/body')
+const { FormData: UndiciFormData, request } = require('../..')
+
+test('extractBody sets multipart content-type for Node global FormData', (t) => {
+  const fd = new globalThis.FormData()
+  fd.append('key', 'value')
+
+  t.assert.strictEqual(fd instanceof UndiciFormData, false)
+
+  const [, contentType] = extractBody(fd)
+  t.assert.ok(contentType != null)
+  t.assert.match(contentType, /^multipart\/form-data; boundary=/)
+})
+
+test('request sends multipart Content-Type for Node global FormData body', async (t) => {
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.match(
+      req.headers['content-type'],
+      /^multipart\/form-data; boundary=/
+    )
+    res.end()
+  }).listen(0)
+
+  t.after(() => server.close())
+  await once(server, 'listening')
+
+  const fd = new globalThis.FormData()
+  fd.append('a', 'b')
+  t.assert.strictEqual(fd instanceof UndiciFormData, false)
+
+  await request(`http://localhost:${server.address().port}`, {
+    method: 'POST',
+    body: fd
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

### Problem

When `undici.request()` is used with **`globalThis.FormData`** (Node’s built-in `FormData`), the HTTP/1 path in `writeH1` treats the body as multipart because `util.isFormDataLike(body)` is true and calls `extractBody()`.

Inside `extractBody`, multipart serialization and the `Content-Type: multipart/form-data; boundary=…` value were only produced when **`webidl.is.FormData(object)`** was true. That assertion is implemented as `instanceof` **undici’s** `FormData` class, not Node’s global constructor.

So **platform `FormData` instances** (and, before this change, any object that matched `isFormDataLike` but not undici’s `FormData`) **did not** take that branch: the returned MIME type stayed `null`, and the client did not add the correct multipart header. That was **inconsistent** with the gate used in `client-h1.js` and broke multipart uploads for callers using the global `FormData`.

### Solution

Widen the `FormData` branch in `extractBody` (`lib/web/fetch/body.js`) so it runs when either:

- **`webidl.is.FormData(object)`** — undici’s `FormData` (Web IDL / spec path), or
- **`util.isFormDataLike(object)`** — same predicate as in `client-h1.js`, including Node’s global `FormData` and other spec-shaped `FormData`-like objects.

No change to the multipart encoding loop; it already iterates entries in a spec-compatible way.

## Changes

<!-- Write a summary or list of changes here -->

### Features

N/A

### Bug Fixes

- Align `extractBody` with `client-h1` so `FormData`-like bodies (including Node’s global `FormData`) get `multipart/form-data` and a generated `boundary`.

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
