### PR TITLE
test: auto-init WPT submodule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,10 @@ Create a commit which includes all of the updated files in lib/llhttp.
 
 ### Steps:
 
+`npm run test:wpt` and `node test/web-platform-tests/wpt-runner.mjs setup` will initialize the WPT submodule automatically when it is missing.
+
+If you want to prepare the checkout explicitly, run:
+
 ```bash
 git submodule update --init --recursive
 ```

--- a/test/web-platform-tests/wpt-runner.mjs
+++ b/test/web-platform-tests/wpt-runner.mjs
@@ -11,17 +11,48 @@ import {
 } from './runner/utils.mjs'
 import * as jsondiffpatch from 'jsondiffpatch'
 
+const REPO_ROOT = join(import.meta.dirname, '..', '..')
 const WPT_DIR = join(import.meta.dirname, 'wpt')
+const WPT_SCRIPT_PATH = join(WPT_DIR, 'wpt')
 const EXPECTATION_PATH = join(import.meta.dirname, 'expectation.json')
 const CA_CERT_PATH = join(import.meta.dirname, 'runner/certs/cacert.pem')
 
 const log = debuglog('UNDICI_WPT')
 
+async function ensureWPTCheckout () {
+  if (existsSync(WPT_SCRIPT_PATH)) {
+    return
+  }
+
+  console.log('WPT checkout missing, attempting to initialize git submodule...')
+
+  const submoduleProc = spawn('git', [
+    'submodule',
+    'update',
+    '--init',
+    '--recursive',
+    '--',
+    'test/web-platform-tests/wpt'
+  ], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit'
+  })
+
+  const submoduleOk = await new Promise(resolve => {
+    submoduleProc.on('exit', code => resolve(code === 0))
+    submoduleProc.on('error', () => resolve(false))
+  })
+
+  if (!submoduleOk || !existsSync(WPT_SCRIPT_PATH)) {
+    throw new Error('WPT checkout is missing. Run `git submodule update --init --recursive test/web-platform-tests/wpt`.')
+  }
+}
+
 async function runWithTestUtil (testFunction) {
   const { promise, resolve, reject } = createDeferredPromise()
 
   console.log('Starting WPT server...')
-  const proc = spawn('python3', ['wpt', 'serve', '--config', '../runner/config.json'], {
+  const proc = spawn('python3', [WPT_SCRIPT_PATH, 'serve', '--config', '../runner/config.json'], {
     cwd: WPT_DIR,
     stdio: 'inherit'
   })
@@ -318,6 +349,8 @@ function generateWPTReport (results, startTime, endTime) {
 async function setup () {
   console.log('Setting up WPT environment...')
 
+  await ensureWPTCheckout()
+
   // Check Python
   const pythonCheck = spawn('python3', ['--version'], { stdio: 'pipe' })
   pythonCheck.stdout.setEncoding('ascii')
@@ -343,7 +376,7 @@ async function setup () {
   const manifestPath = join(WPT_DIR, 'MANIFEST.json')
   if (!existsSync(manifestPath)) {
     console.log('Updating WPT manifest...')
-    const manifestProc = spawn('python3', ['wpt', 'manifest'], {
+    const manifestProc = spawn('python3', [WPT_SCRIPT_PATH, 'manifest'], {
       cwd: WPT_DIR,
       stdio: 'inherit'
     })
@@ -368,7 +401,7 @@ async function setup () {
   const etcHostsConfigured = hostsContent.includes('web-platform.test')
 
   async function setupHostsFile () {
-    const makeHostsProc = spawn('python3', ['wpt', 'make-hosts-file'], {
+    const makeHostsProc = spawn('python3', [WPT_SCRIPT_PATH, 'make-hosts-file'], {
       cwd: WPT_DIR,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -438,6 +471,8 @@ async function setup () {
 }
 
 async function run (filters = []) {
+  await ensureWPTCheckout()
+
   const startTime = Date.now()
   const expectation = getExpectation()
   const tests = discoverTestsToRun(filters, expectation)


### PR DESCRIPTION
## Summary
- auto-init the WPT submodule when missing
- use the resolved WPT script path in the runner
- document the behavior

## Testing
- npm run test:wpt:setup
