### PR TITLE
feat: support username-only proxy authentication in ProxyAgent

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -125,6 +125,8 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = opts.token
     } else if (username && password) {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
+    } else if (username) {
+      this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:`).toString('base64')}`
     }
 
     const connect = buildConnector({ ...opts.proxyTls })

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -362,6 +362,88 @@ test('use proxy-agent to connect through proxy with basic auth in URL', async (t
   proxyAgent.close()
 })
 
+test('use proxy-agent to connect through proxy with username-only auth in URL', async (t) => {
+  t = tspl(t, { plan: 6 })
+  const server = await buildServer()
+  const proxy = await buildProxy()
+
+  const serverUrl = `http://localhost:${server.address().port}`
+  const proxyUrl = new URL(`http://user:@localhost:${proxy.address().port}`)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
+  const parsedOrigin = new URL(serverUrl)
+
+  proxy.authenticate = function (req) {
+    t.ok(true, 'authentication should be called')
+    return req.headers['proxy-authorization'] === `Basic ${Buffer.from('user:').toString('base64')}`
+  }
+  proxy.on('connect', () => {
+    t.fail('proxy tunnel should not be established')
+  })
+
+  server.on('request', (req, res) => {
+    t.strictEqual(req.url, '/hello?foo=bar')
+    t.strictEqual(req.headers.host, parsedOrigin.host, 'should not use proxyUrl as host')
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ hello: 'world' }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await request(serverUrl + '/hello?foo=bar', { dispatcher: proxyAgent })
+  const json = await body.json()
+
+  t.strictEqual(statusCode, 200)
+  t.deepStrictEqual(json, { hello: 'world' })
+  t.strictEqual(headers.connection, 'keep-alive', 'should remain the connection open')
+
+  server.close()
+  proxy.close()
+  proxyAgent.close()
+})
+
+test('use proxy-agent to connect through proxy with username-only auth in URL without colon', async (t) => {
+  t = tspl(t, { plan: 6 })
+  const server = await buildServer()
+  const proxy = await buildProxy()
+
+  const serverUrl = `http://localhost:${server.address().port}`
+  const proxyUrl = new URL(`http://user@localhost:${proxy.address().port}`)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
+  const parsedOrigin = new URL(serverUrl)
+
+  proxy.authenticate = function (req) {
+    t.ok(true, 'authentication should be called')
+    return req.headers['proxy-authorization'] === `Basic ${Buffer.from('user:').toString('base64')}`
+  }
+  proxy.on('connect', () => {
+    t.fail('proxy tunnel should not be established')
+  })
+
+  server.on('request', (req, res) => {
+    t.strictEqual(req.url, '/hello?foo=bar')
+    t.strictEqual(req.headers.host, parsedOrigin.host, 'should not use proxyUrl as host')
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ hello: 'world' }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await request(serverUrl + '/hello?foo=bar', { dispatcher: proxyAgent })
+  const json = await body.json()
+
+  t.strictEqual(statusCode, 200)
+  t.deepStrictEqual(json, { hello: 'world' })
+  t.strictEqual(headers.connection, 'keep-alive', 'should remain the connection open')
+
+  server.close()
+  proxy.close()
+  proxyAgent.close()
+})
+
 test('use proxy-agent to connect through proxy with basic auth in URL with tunneling enabled', async (t) => {
   t = tspl(t, { plan: 7 })
   const server = await buildServer()
@@ -375,6 +457,47 @@ test('use proxy-agent to connect through proxy with basic auth in URL with tunne
   proxy.authenticate = function (req, fn) {
     t.ok(true, 'authentication should be called')
     return req.headers['proxy-authorization'] === `Basic ${Buffer.from('user:pass').toString('base64')}`
+  }
+  proxy.on('connect', () => {
+    t.ok(true, 'proxy should be called')
+  })
+
+  server.on('request', (req, res) => {
+    t.strictEqual(req.url, '/hello?foo=bar')
+    t.strictEqual(req.headers.host, parsedOrigin.host, 'should not use proxyUrl as host')
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ hello: 'world' }))
+  })
+
+  const {
+    statusCode,
+    headers,
+    body
+  } = await request(serverUrl + '/hello?foo=bar', { dispatcher: proxyAgent })
+  const json = await body.json()
+
+  t.strictEqual(statusCode, 200)
+  t.deepStrictEqual(json, { hello: 'world' })
+  t.strictEqual(headers.connection, 'keep-alive', 'should remain the connection open')
+
+  server.close()
+  proxy.close()
+  proxyAgent.close()
+})
+
+test('use proxy-agent to connect through proxy with username-only auth in URL with tunneling enabled', async (t) => {
+  t = tspl(t, { plan: 7 })
+  const server = await buildServer()
+  const proxy = await buildProxy()
+
+  const serverUrl = `http://localhost:${server.address().port}`
+  const proxyUrl = new URL(`http://user:@localhost:${proxy.address().port}`)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
+  const parsedOrigin = new URL(serverUrl)
+
+  proxy.authenticate = function (req) {
+    t.ok(true, 'authentication should be called')
+    return req.headers['proxy-authorization'] === `Basic ${Buffer.from('user:').toString('base64')}`
   }
   proxy.on('connect', () => {
     t.ok(true, 'proxy should be called')


### PR DESCRIPTION
## This relates to...
- https://github.com/nodejs/undici/issues/1674

## Rationale
ProxyAgent already handles proxy URLs with both username and password, but silently skips authentication when only a username is present (e.g., `http://user:@host` or `http://user@host`).

## Changes

### Features
When a proxy URL contains a username but no password, ProxyAgent now generates a `Basic` auth header with the username and an empty password, matching standard HTTP basic auth behavior.

### Bug Fixes
N/A

### Breaking Changes and Deprecations
N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
