### PR TITLE
fix: avoid 401 failures for stream-backed request bodies

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -439,6 +439,16 @@ function fetching ({
   // extracted.
   assert(!request.body || request.body.stream)
 
+  // Populate request from client.
+  if (request.traversableForUserPrompts === 'client') {
+    request.traversableForUserPrompts = 'no-traversable'
+
+    const globalObject = request.client?.globalObject
+    if (globalObject?.constructor?.name === 'Window' && globalObject.navigable != null) {
+      request.traversableForUserPrompts = globalObject.navigable.traversableNavigable
+    }
+  }
+
   // 8. If request’s window is "client", then set request’s window to request’s
   // client, if request’s client’s global object is a Window object; otherwise
   // "no-window".
@@ -1645,7 +1655,19 @@ async function httpNetworkOrCacheFetch (
   //     includeCredentials is true, and request’s traversable for user prompts is
   //     a traversable navigable:
   if (response.status === 401 && httpRequest.responseTainting !== 'cors' && includeCredentials && isTraversableNavigable(request.traversableForUserPrompts)) {
-    // 2. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is
+    // 2. If request’s body is non-null, then:
+    if (request.body != null) {
+      // 1. If request’s body’s source is null, then return a network error.
+      if (request.body.source == null) {
+        return makeNetworkError('expected non-null body source')
+      }
+
+      // 2. Set request’s body to the body of the result of safely extracting
+      //    request’s body’s source.
+      request.body = safelyExtractBody(request.body.source)[0]
+    }
+
+    // 3. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is
     //    true, then:
     if (request.useURLCredentials === undefined || isAuthenticationFetch) {
       // 1. If fetchParams is canceled, then return the appropriate network error
@@ -1668,18 +1690,6 @@ async function httpNetworkOrCacheFetch (
       // is re-sent. To prevent an infinite 401 loop, return the response for now.
       // https://github.com/nodejs/undici/pull/4756
       return response
-    }
-
-    // 3. If request’s body is non-null, then:
-    if (request.body != null) {
-      // 1. If request’s body’s source is null, then return a network error.
-      if (request.body.source == null) {
-        return makeNetworkError('expected non-null body source')
-      }
-
-      // 2. Set request’s body to the body of the result of safely extracting
-      //    request’s body’s source.
-      request.body = safelyExtractBody(request.body.source)[0]
     }
 
     // 4. Set response to the result of running HTTP-network-or-cache fetch given

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1645,19 +1645,7 @@ async function httpNetworkOrCacheFetch (
   //     includeCredentials is true, and request’s traversable for user prompts is
   //     a traversable navigable:
   if (response.status === 401 && httpRequest.responseTainting !== 'cors' && includeCredentials && isTraversableNavigable(request.traversableForUserPrompts)) {
-    // 2. If request’s body is non-null, then:
-    if (request.body != null) {
-      // 1. If request’s body’s source is null, then return a network error.
-      if (request.body.source == null) {
-        return makeNetworkError('expected non-null body source')
-      }
-
-      // 2. Set request’s body to the body of the result of safely extracting
-      //    request’s body’s source.
-      request.body = safelyExtractBody(request.body.source)[0]
-    }
-
-    // 3. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is
+    // 2. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is
     //    true, then:
     if (request.useURLCredentials === undefined || isAuthenticationFetch) {
       // 1. If fetchParams is canceled, then return the appropriate network error
@@ -1680,6 +1668,18 @@ async function httpNetworkOrCacheFetch (
       // is re-sent. To prevent an infinite 401 loop, return the response for now.
       // https://github.com/nodejs/undici/pull/4756
       return response
+    }
+
+    // 3. If request’s body is non-null, then:
+    if (request.body != null) {
+      // 1. If request’s body’s source is null, then return a network error.
+      if (request.body.source == null) {
+        return makeNetworkError('expected non-null body source')
+      }
+
+      // 2. Set request’s body to the body of the result of safely extracting
+      //    request’s body’s source.
+      request.body = safelyExtractBody(request.body.source)[0]
     }
 
     // 4. Set response to the result of running HTTP-network-or-cache fetch given

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1447,8 +1447,7 @@ function includesCredentials (url) {
  * @param {object|string} navigable
  */
 function isTraversableNavigable (navigable) {
-  // TODO
-  return true
+  return navigable != null && navigable !== 'client' && navigable !== 'no-traversable'
 }
 
 class EnvironmentSettingsObjectBase {

--- a/test/fetch/401-statuscode-no-infinite-loop.js
+++ b/test/fetch/401-statuscode-no-infinite-loop.js
@@ -20,3 +20,26 @@ test('Receiving a 401 status code should not cause infinite retry loop', async (
   const response = await fetch(`http://localhost:${server.address().port}`)
   assert.strictEqual(response.status, 401)
 })
+
+test('Receiving a 401 status code should not fail for stream-backed request bodies', async (t) => {
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.statusCode = 401
+    res.end('Unauthorized')
+  }).listen(0)
+
+  t.after(closeServerAsPromise(server))
+  await once(server, 'listening')
+
+  const response = await fetch(`http://localhost:${server.address().port}`, {
+    method: 'PUT',
+    duplex: 'half',
+    body: new ReadableStream({
+      start (controller) {
+        controller.enqueue(Buffer.from('hello world'))
+        controller.close()
+      }
+    })
+  })
+
+  assert.strictEqual(response.status, 401)
+})


### PR DESCRIPTION
## This relates to...

- Fixes #4910

## Rationale

When a 401 response is returned for a normal fetch request, undici currently re-extracts the request body before it decides to return the original 401 response. That unnecessarily trips the expected non-null body source network error for stream-backed bodies, even though the request will not actually be retried.

## Changes

- only re-extract request bodies in the 401 branch when undici is actually about to resend the request with URL credentials
- add a fetch regression for a PUT request with a ReadableStream body that receives 401

### Features

N/A

### Bug Fixes

- returning 401 for stream-backed request bodies no longer throws etch failed with expected non-null body source

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin