### PR TITLE
fix: remove support for non-real Blob objects

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -85,23 +85,9 @@ function isStream (obj) {
 /**
  * @param {*} object
  * @returns {object is Blob}
- * based on https://github.com/node-fetch/fetch-blob/blob/8ab587d34080de94140b54f07168451e7d0b655e/index.js#L229-L241 (MIT License)
  */
 function isBlobLike (object) {
-  if (object === null) {
-    return false
-  } else if (object instanceof Blob) {
-    return true
-  } else if (typeof object !== 'object') {
-    return false
-  } else {
-    const sTag = object[Symbol.toStringTag]
-
-    return (sTag === 'Blob' || sTag === 'File') && (
-      ('stream' in object && typeof object.stream === 'function') ||
-      ('arrayBuffer' in object && typeof object.arrayBuffer === 'function')
-    )
-  }
+  return object instanceof Blob
 }
 
 /**

--- a/test/node-test/validations.js
+++ b/test/node-test/validations.js
@@ -7,7 +7,7 @@ const { tspl } = require('@matteo.collina/tspl')
 
 test('validations', async t => {
   let client
-  const p = tspl(t, { plan: 10 })
+  const p = tspl(t, { plan: 12 })
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.setHeader('content-type', 'text/plain')
@@ -50,6 +50,18 @@ test('validations', async t => {
       })
 
       client.request({ path: '/', method: 'POST', body: { hello: 'world' } }, (err, res) => {
+        p.equal(err.code, 'UND_ERR_INVALID_ARG')
+        p.equal(err.message, 'body must be a string, a Buffer, a Readable stream, an iterable, or an async iterable')
+      })
+
+      client.request({
+        path: '/',
+        method: 'POST',
+        body: {
+          [Symbol.toStringTag]: 'Blob',
+          arrayBuffer: () => {}
+        }
+      }, (err, res) => {
         p.equal(err.code, 'UND_ERR_INVALID_ARG')
         p.equal(err.message, 'body must be a string, a Buffer, a Readable stream, an iterable, or an async iterable')
       })

--- a/test/util.js
+++ b/test/util.js
@@ -30,7 +30,7 @@ describe('isBlobLike', () => {
       [Symbol.toStringTag]: 'Blob',
       stream: () => { }
     }
-    strictEqual(isBlobLike(blobLikeStream), true)
+    strictEqual(isBlobLike(blobLikeStream), false)
   })
 
   test('fileLikeStream', () => {
@@ -38,7 +38,7 @@ describe('isBlobLike', () => {
       stream: () => { },
       [Symbol.toStringTag]: 'File'
     }
-    strictEqual(isBlobLike(fileLikeStream), true)
+    strictEqual(isBlobLike(fileLikeStream), false)
   })
 
   test('fileLikeArrayBuffer', () => {
@@ -46,7 +46,7 @@ describe('isBlobLike', () => {
       [Symbol.toStringTag]: 'Blob',
       arrayBuffer: () => { }
     }
-    strictEqual(isBlobLike(blobLikeArrayBuffer), true)
+    strictEqual(isBlobLike(blobLikeArrayBuffer), false)
   })
 
   test('blobLikeArrayBuffer', () => {
@@ -54,7 +54,7 @@ describe('isBlobLike', () => {
       [Symbol.toStringTag]: 'File',
       arrayBuffer: () => { }
     }
-    strictEqual(isBlobLike(fileLikeArrayBuffer), true)
+    strictEqual(isBlobLike(fileLikeArrayBuffer), false)
   })
 
   test('string', () => {


### PR DESCRIPTION
## Description
- restrict `isBlobLike()` to real `Blob` instances
- stop accepting `Blob`/`File` lookalikes based on `Symbol.toStringTag`
- add regression coverage for fake blob-like values in util and request validation tests

## Testing
- `npx borp -p "test/util.js"`
- `node --test test/node-test/validations.js`
