### PR TITLE
[chore] Update tests to use @sinonjs/fake-timer 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@fastify/busboy": "3.2.0",
     "@matteo.collina/tspl": "^0.2.0",
     "@metcoder95/https-pem": "^1.0.0",
-    "@sinonjs/fake-timers": "^12.0.0",
+    "@sinonjs/fake-timers": "^15.1.1",
     "@types/node": "^22.0.0",
     "abort-controller": "^3.0.0",
     "borp": "^0.20.0",

--- a/test/cache-interceptor/cache-store-test-utils.js
+++ b/test/cache-interceptor/cache-store-test-utils.js
@@ -5,6 +5,7 @@ const { describe, test, after } = require('node:test')
 const { Readable } = require('node:stream')
 const { once } = require('node:events')
 const FakeTimers = require('@sinonjs/fake-timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 /**
  * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheStore} CacheStore
@@ -109,9 +110,7 @@ function cacheStoreTests (CacheStore, options) {
     })
 
     test('returns stale response before deleteAt', options, async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       after(() => clock.uninstall())
 
@@ -167,9 +166,7 @@ function cacheStoreTests (CacheStore, options) {
     })
 
     test('a stale request is overwritten', options, async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       after(() => clock.uninstall())
 

--- a/test/client-keep-alive.js
+++ b/test/client-keep-alive.js
@@ -8,6 +8,7 @@ const { kConnect } = require('../lib/core/symbols')
 const { createServer } = require('node:net')
 const http = require('node:http')
 const FakeTimers = require('@sinonjs/fake-timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('keep-alive header', async (t) => {
   t = tspl(t, { plan: 2 })
@@ -46,7 +47,7 @@ test('keep-alive header', async (t) => {
 test('keep-alive header 0', async (t) => {
   t = tspl(t, { plan: 2 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   after(() => clock.uninstall())
 
   const server = createServer((socket) => {
@@ -151,7 +152,7 @@ test('keep-alive not timeout', async (t) => {
   t = tspl(t, { plan: 2 })
 
   const clock = FakeTimers.install({
-    apis: ['setTimeout']
+    ...fakeTimersOpts
   })
   after(() => clock.uninstall())
 
@@ -193,7 +194,7 @@ test('keep-alive threshold', async (t) => {
   t = tspl(t, { plan: 2 })
 
   const clock = FakeTimers.install({
-    apis: ['setTimeout']
+    ...fakeTimersOpts
   })
   after(() => clock.uninstall())
 
@@ -236,7 +237,7 @@ test('keep-alive max keepalive', async (t) => {
   t = tspl(t, { plan: 2 })
 
   const clock = FakeTimers.install({
-    apis: ['setTimeout']
+    ...fakeTimersOpts
   })
   after(() => clock.uninstall())
 

--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -7,12 +7,13 @@ const { Client } = require('..')
 const { createServer } = require('node:http')
 const FakeTimers = require('@sinonjs/fake-timers')
 const timers = require('../lib/util/timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('multiple reconnect', async (t) => {
   t = tspl(t, { plan: 5 })
 
   let n = 0
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   after(() => clock.uninstall())
 
   const orgTimers = { ...timers }

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -7,6 +7,7 @@ const { createServer } = require('node:http')
 const { Readable } = require('node:stream')
 const FakeTimers = require('@sinonjs/fake-timers')
 const timers = require('../lib/util/timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('refresh timeout on pause', async (t) => {
   t = tspl(t, { plan: 1 })
@@ -52,7 +53,7 @@ test('refresh timeout on pause', async (t) => {
 test('start headers timeout after request body', async (t) => {
   t = tspl(t, { plan: 2 })
 
-  const clock = FakeTimers.install({ shouldClearNativeTimers: true })
+  const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
   after(() => clock.uninstall())
 
   const orgTimers = { ...timers }
@@ -110,7 +111,7 @@ test('start headers timeout after request body', async (t) => {
 test('start headers timeout after async iterator request body', async (t) => {
   t = tspl(t, { plan: 1 })
 
-  const clock = FakeTimers.install({ shouldClearNativeTimers: true })
+  const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
   after(() => clock.uninstall())
 
   const orgTimers = { ...timers }

--- a/test/eventsource/eventsource-connect.js
+++ b/test/eventsource/eventsource-connect.js
@@ -5,6 +5,7 @@ const http = require('node:http')
 const { test, describe, after } = require('node:test')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { EventSource, defaultReconnectionTime } = require('../../lib/web/eventsource/eventsource')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 const { randomInt } = require('node:crypto')
 
 describe('EventSource - sending correct request headers', () => {
@@ -176,7 +177,7 @@ describe('EventSource - received response must have content-type to be text/even
   })
 
   test('should try to connect again if server is unreachable', async (t) => {
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
 
     after(() => clock.uninstall())
     const reconnectionTime = defaultReconnectionTime
@@ -209,7 +210,7 @@ describe('EventSource - received response must have content-type to be text/even
 
   test('should try to connect again if server is unreachable, configure reconnectionTime', async (t) => {
     const reconnectionTime = 1000
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     const domain = 'bad.n' + randomInt(1e10).toString(36) + '.proxy'

--- a/test/eventsource/eventsource-message.js
+++ b/test/eventsource/eventsource-message.js
@@ -5,6 +5,7 @@ const http = require('node:http')
 const { test, describe, after } = require('node:test')
 const { EventSource, defaultReconnectionTime } = require('../../lib/web/eventsource/eventsource')
 const FakeTimers = require('@sinonjs/fake-timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 describe('EventSource - message', () => {
   test('Should not emit a message if only retry field was sent', (t, done) => {
@@ -202,7 +203,7 @@ describe('EventSource - message', () => {
   })
 
   test('Should not emit a custom type message if no data is provided', (t, done) => {
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     t.plan(1)

--- a/test/eventsource/eventsource-reconnect.js
+++ b/test/eventsource/eventsource-reconnect.js
@@ -5,12 +5,13 @@ const http = require('node:http')
 const { test, describe, after } = require('node:test')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { EventSource, defaultReconnectionTime } = require('../../lib/web/eventsource/eventsource')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 describe('EventSource - reconnect', () => {
   test('Should reconnect on connection closed by server', (t, done) => {
     t.plan(1)
 
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -43,7 +44,7 @@ describe('EventSource - reconnect', () => {
 
   test('Should reconnect on with reconnection timeout', (t, done) => {
     t.plan(2)
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -80,7 +81,7 @@ describe('EventSource - reconnect', () => {
 
   test('Should reconnect on with modified reconnection timeout', (t, done) => {
     t.plan(3)
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -119,7 +120,7 @@ describe('EventSource - reconnect', () => {
 
   test('Should reconnect and send lastEventId', async (t) => {
     t.plan(1)
-    const clock = FakeTimers.install()
+    const clock = FakeTimers.install(fakeTimersOpts)
     after(() => clock.uninstall())
 
     let requestCount = 0

--- a/test/fetch/fetch-timeouts.js
+++ b/test/fetch/fetch-timeouts.js
@@ -7,6 +7,7 @@ const timers = require('../../lib/util/timers')
 const { createServer } = require('node:http')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { closeServerAsPromise } = require('../utils/node-http')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('Fetch very long request, timeout overridden so no error', (t, done) => {
   const minutes = 6
@@ -14,7 +15,7 @@ test('Fetch very long request, timeout overridden so no error', (t, done) => {
 
   t.plan(1)
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   t.after(clock.uninstall.bind(clock))
 
   const orgTimers = { ...timers }

--- a/test/interceptors/cache-async-store.js
+++ b/test/interceptors/cache-async-store.js
@@ -9,6 +9,7 @@ const { request, Client, interceptors } = require('../../index')
 const MemoryCacheStore = require('../../lib/cache/memory-cache-store')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { setTimeout } = require('node:timers/promises')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 /**
  * Wraps a MemoryCacheStore to simulate an async remote store:
@@ -49,7 +50,7 @@ class AsyncCacheStore {
 
 describe('cache interceptor with async store', () => {
   test('stale-while-revalidate 304 refreshes cache with async store', async () => {
-    const clock = FakeTimers.install({ now: 1 })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1 })
     after(() => clock.uninstall())
 
     let count200 = 0
@@ -118,7 +119,7 @@ describe('cache interceptor with async store', () => {
   })
 
   test('stale-while-revalidate 200 refreshes cache with async store', async () => {
-    const clock = FakeTimers.install({ now: 1 })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1 })
     after(() => clock.uninstall())
 
     let requestCount = 0
@@ -172,7 +173,7 @@ describe('cache interceptor with async store', () => {
   })
 
   test('null vary values are not sent in revalidation headers', async () => {
-    const clock = FakeTimers.install({ now: 1 })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1 })
     after(() => clock.uninstall())
 
     let revalidationHeaders = null

--- a/test/interceptors/cache-revalidate-stale.js
+++ b/test/interceptors/cache-revalidate-stale.js
@@ -7,11 +7,10 @@ const { once } = require('node:events')
 const { request, Client, interceptors } = require('../../index')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { setTimeout } = require('node:timers/promises')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('revalidates the request when the response is stale', async () => {
-  const clock = FakeTimers.install({
-    now: 1
-  })
+  const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1 })
   after(() => clock.uninstall())
 
   let count = 0
@@ -75,9 +74,7 @@ describe('revalidates the request, handles 304s during stale-while-revalidate', 
   }
 
   async function revalidateTest (useEtag = false) {
-    const clock = FakeTimers.install({
-      now: 1
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1 })
     after(() => clock.uninstall())
 
     let count200 = 0

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -7,6 +7,7 @@ const { equal, strictEqual, notEqual, fail } = require('node:assert')
 const { setTimeout: sleep } = require('node:timers/promises')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { Client, interceptors, cacheStores: { MemoryCacheStore, SqliteCacheStore } } = require('../../index')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 const { makeCacheKey } = require('../../lib/util/cache.js')
 const { runtimeFeatures } = require('../../lib/util/runtime-features.js')
 
@@ -171,9 +172,7 @@ describe('Cache Interceptor', () => {
   })
 
   test('expires caching', async () => {
-    const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
     let requestsToOrigin = 0
     let serverError
@@ -248,9 +247,7 @@ describe('Cache Interceptor', () => {
   })
 
   test('expires caching with Etag', async () => {
-    const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
     let requestsToOrigin = 0
     let serverError
@@ -326,9 +323,7 @@ describe('Cache Interceptor', () => {
   })
 
   test('max-age caching', async () => {
-    const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
     let requestsToOrigin = 0
     let serverError
@@ -390,9 +385,7 @@ describe('Cache Interceptor', () => {
   })
 
   test('vary headers are present in revalidation request', async () => {
-    const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
     let requestsToOrigin = 0
     let revalidationRequests = 0
@@ -669,9 +662,7 @@ describe('Cache Interceptor', () => {
   })
 
   test('stale-if-error (response)', async () => {
-    const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
-    })
+    const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
     let requestsToOrigin = 0
     const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
@@ -751,9 +742,7 @@ describe('Cache Interceptor', () => {
 
   describe('Client-side directives', () => {
     test('max-age', async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       let requestsToOrigin = 0
       const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
@@ -812,9 +801,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('max-stale', async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       let requestsToOrigin = 0
       let revalidationRequests = 0
@@ -885,9 +872,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('min-fresh', async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       let requestsToOrigin = 0
       const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
@@ -1103,9 +1088,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('stale-if-error', async () => {
-      const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
-      })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, shouldClearNativeTimers: true })
 
       let requestsToOrigin = 0
       const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
@@ -1989,7 +1972,7 @@ describe('Cache Interceptor', () => {
 
   describe('determineDeleteAt', () => {
     test('max-age response has deleteAt proportional to freshness lifetime, not 1 year', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1000 })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()
@@ -2101,7 +2084,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('immutable response has deleteAt of ~1 year', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1000 })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()
@@ -2135,7 +2118,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('stale-while-revalidate extends deleteAt beyond staleAt', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ ...fakeTimersOpts, now: 1000 })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -2,6 +2,7 @@
 
 const FakeTimers = require('@sinonjs/fake-timers')
 const { test, after } = require('node:test')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 const { isIP } = require('node:net')
 const { lookup } = require('node:dns')
 const { createServer } = require('node:http')
@@ -626,7 +627,7 @@ test('Should automatically resolve IPs (dual stack disabled - 6)', { skip: !ipv6
 test('Should we handle TTL (4)', async t => {
   t = tspl(t, { plan: 10 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let counter = 0
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })
@@ -729,7 +730,7 @@ test('Should we handle TTL (4)', async t => {
 test('Should we handle TTL (6)', { skip: !ipv6Available }, async t => {
   t = tspl(t, { plan: 10 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let counter = 0
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })
@@ -834,7 +835,7 @@ test('Should we handle TTL (6)', { skip: !ipv6Available }, async t => {
 test('Should set lowest TTL between resolved and option maxTTL', async t => {
   t = tspl(t, { plan: 9 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })
   const requestOptions = {
@@ -1210,7 +1211,7 @@ test('Should use all dns entries (dual stack disabled - 6)', async t => {
 test('Should handle single family resolved (dual stack)', async t => {
   t = tspl(t, { plan: 7 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let counter = 0
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })
@@ -1301,7 +1302,7 @@ test('Should handle single family resolved (dual stack)', async t => {
 test('Should prefer affinity (dual stack - 4)', async t => {
   t = tspl(t, { plan: 10 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let counter = 0
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })
@@ -1403,7 +1404,7 @@ test('Should prefer affinity (dual stack - 4)', async t => {
 test('Should prefer affinity (dual stack - 6)', async t => {
   t = tspl(t, { plan: 10 })
 
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   let counter = 0
   let lookupCounter = 0
   const server = createServer({ joinDuplicateHeaders: true })

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -5,6 +5,7 @@ const { test, after } = require('node:test')
 const { Client, errors } = require('..')
 const { createServer } = require('node:http')
 const FakeTimers = require('@sinonjs/fake-timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
 test('timeout with pipelining 1', async (t) => {
   t = tspl(t, { plan: 9 })
@@ -64,7 +65,7 @@ test('Disable socket timeout', async (t) => {
   t = tspl(t, { plan: 2 })
 
   const server = createServer({ joinDuplicateHeaders: true })
-  const clock = FakeTimers.install()
+  const clock = FakeTimers.install(fakeTimersOpts)
   after(clock.uninstall.bind(clock))
 
   server.once('request', (req, res) => {

--- a/test/timers.js
+++ b/test/timers.js
@@ -3,8 +3,9 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test } = require('node:test')
 const FakeTimers = require('@sinonjs/fake-timers')
+const fakeTimersOpts = { toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'Date', 'hrtime', 'performance', ...(typeof Intl !== 'undefined' ? ['Intl'] : [])] }
 
-const clock = FakeTimers.install()
+const clock = FakeTimers.install(fakeTimersOpts)
 
 const timers = require('../lib/util/timers')
 const { eventLoopBlocker } = require('./utils/event-loop-blocker')


### PR DESCRIPTION
## This relates to...

Just a chore update
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

I'm packaging undici for [Debian](https://www.debian.org), and I need to use the system `@sinonjs/fake-timers`
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

Just some changes in tests to be compliant to `@sinonjs/fake-timers` changes: Since @sinonjs/fake-timers 13, all supported timers are faked by default _(including `process.nextTick` and `queueMicrotask`)_, which breaks Node.js networking in tests. Add toFake to exclude nextTick and queueMicrotask, matching the defaults of fake-timers 12.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
