### PR TITLE
fix(websocket/stream): only enqueue parsed messages in WebSocketStream

### DIFF
--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -284,12 +284,6 @@ class WebSocketStream {
       start: (controller) => {
         this.#readableStreamController = controller
       },
-      pull (controller) {
-        let chunk
-        while (controller.desiredSize > 0 && (chunk = response.socket.read()) !== null) {
-          controller.enqueue(chunk)
-        }
-      },
       cancel: (reason) => this.#cancel(reason)
     })
 

--- a/test/websocket/stream/issue-4958.js
+++ b/test/websocket/stream/issue-4958.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+
+const { WebSocketStream } = require('../../..')
+
+// Repro for: opened.readable may include raw socket bytes instead of only message payloads.
+test('websocketstream opened.readable should expose text message payloads only', async (t) => {
+  const server = new WebSocketServer({
+    port: 0,
+    path: '/',
+    perMessageDeflate: false
+  })
+
+  t.after(() => {
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  server.on('connection', (socket) => {
+    socket.send(JSON.stringify({ event: 'Initialize', data: 1010 }))
+    socket.send(JSON.stringify({ event: 'Ready', data: { id: 1010 } }))
+  })
+
+  const url = `ws://127.0.0.1:${server.address().port}/`
+
+  for (let run = 1; run <= 100; run++) {
+    const wss = new WebSocketStream(url)
+    const { readable } = await wss.opened
+    const reader = readable.getReader()
+
+    try {
+      for (let index = 1; index <= 2; index++) {
+        const { done, value } = await reader.read()
+
+        if (done) {
+          break
+        }
+
+        t.assert.strictEqual(
+          typeof value,
+          'string',
+          `run ${run}, chunk ${index}: expected string payload but got ${value?.constructor?.name ?? typeof value}`
+        )
+
+        t.assert.doesNotThrow(
+          () => JSON.parse(value),
+          `run ${run}, chunk ${index}: expected valid JSON text payload`
+        )
+      }
+    } finally {
+      reader.releaseLock()
+      wss.close()
+      await wss.closed.catch(() => {})
+    }
+  }
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

Fixes #4958

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

`WebSocketStream#opened.readable` should only expose parsed WebSocket message payloads.  
Before this change, the stream could also enqueue raw socket bytes, which intermittently produced malformed text data (for example leading `�`) and broke JSON parsing for text frames.

## Changes

<!-- Write a summary or list of changes here -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

- Remove raw-socket enqueue path from `WebSocketStream` readable stream setup.
- Keep readable output sourced from parser message callbacks only.
- Add regression test `test/websocket/stream/issue-4958.js` to reproduce and guard against the issue.


### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

None.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
