### PR TITLE
docs: use RFC 2606 reserved domains across all documentation

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1265,10 +1265,10 @@ const client = new Agent().compose(interceptors.cache({
 setGlobalDispatcher(client)
 
 // First request goes to the network and is cached when cache headers allow it.
-const first = await fetch('https://example.com/data')
+const first = await fetch('https://service.example/data')
 
 // Second request can be served from cache according to RFC9111 rules.
-const second = await fetch('https://example.com/data')
+const second = await fetch('https://service.example/data')
 ```
 
 ##### `Deduplicate Interceptor`
@@ -1375,7 +1375,7 @@ Response headers will derive a `host` from the `url` of the [Client](/docs/docs/
   'content-length': '123',
   'content-type': 'text/plain',
   connection: 'keep-alive',
-  host: 'mysite.com',
+  host: 'mysite.example',
   accept: '*/*'
 }
 ```
@@ -1387,7 +1387,7 @@ Response headers will derive a `host` from the `url` of the [Client](/docs/docs/
   'content-length', '123',
   'content-type', 'text/plain',
   'connection', 'keep-alive',
-  'host', 'mysite.com',
+  'host', 'mysite.example',
   'accept', '*/*'
 ]
 ```
@@ -1399,7 +1399,7 @@ new Headers({
   'content-length': '123',
   'content-type': 'text/plain',
   connection: 'keep-alive',
-  host: 'mysite.com',
+  host: 'mysite.example',
   accept: '*/*'
 })
 ```
@@ -1409,7 +1409,7 @@ new Map([
   ['content-length', '123'],
   ['content-type', 'text/plain'],
   ['connection', 'keep-alive'],
-  ['host', 'mysite.com'],
+  ['host', 'mysite.example'],
   ['accept', '*/*']
 ])
 ```
@@ -1420,7 +1420,7 @@ or
     yield ['content-length', '123']
     yield ['content-type', 'text/plain']
     yield ['connection', 'keep-alive']
-    yield ['host', 'mysite.com']
+    yield ['host', 'mysite.example']
     yield ['accept', '*/*']
   }
 }

--- a/docs/docs/api/GlobalInstallation.md
+++ b/docs/docs/api/GlobalInstallation.md
@@ -15,15 +15,15 @@ import { install } from 'undici'
 install()
 
 // Now you can use fetch classes globally without importing
-const response = await fetch('https://api.example.com/data')
+const response = await fetch('https://api.service.example/data')
 const data = await response.json()
 
 // All classes are available globally:
 const headers = new Headers([['content-type', 'application/json']])
-const request = new Request('https://example.com')
+const request = new Request('https://service.example')
 const formData = new FormData()
-const ws = new WebSocket('wss://example.com')
-const eventSource = new EventSource('https://example.com/events')
+const ws = new WebSocket('wss://service.example')
+const eventSource = new EventSource('https://service.example/events')
 ```
 
 ## Installed Classes
@@ -53,7 +53,7 @@ These two patterns are safe:
 ```js
 // Built-in globals from Node.js
 const body = new FormData()
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -66,7 +66,7 @@ import { install } from 'undici'
 install()
 
 const body = new FormData()
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -81,7 +81,7 @@ If you do not want to install globals, import both from `undici` instead:
 import { fetch, FormData } from 'undici'
 
 const body = new FormData()
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -113,7 +113,7 @@ if (typeof globalThis.fetch === 'undefined') {
 }
 
 // Now fetch is guaranteed to be available
-const response = await fetch('https://api.example.com')
+const response = await fetch('https://api.service.example')
 ```
 
 ## Example: Testing Environment
@@ -126,7 +126,7 @@ install()
 
 // Now all tests use undici's implementations
 test('fetch API test', async () => {
-  const response = await fetch('https://example.com')
+  const response = await fetch('https://service.example')
   expect(response).toBeInstanceOf(Response)
 })
 ```

--- a/docs/docs/api/MockAgent.md
+++ b/docs/docs/api/MockAgent.md
@@ -191,11 +191,11 @@ agent.disableNetConnect();
 setGlobalDispatcher(agent);
 describe('Test', () => {
   it('200', async () => {
-    const mockAgent = agent.get('http://test.com');
+    const mockAgent = agent.get('http://test.example');
     // your test
   });
   it('200', async () => {
-    const mockAgent = agent.get('http://testing.com');
+    const mockAgent = agent.get('http://testing.example');
     // your test
   });
 });
@@ -397,7 +397,7 @@ setGlobalDispatcher(mockAgent)
 
 mockAgent.enableNetConnect()
 
-await request('http://example.com')
+await request('http://service.example')
 // A real request is made
 ```
 
@@ -409,13 +409,13 @@ import { MockAgent, setGlobalDispatcher, request } from 'undici'
 const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
-mockAgent.enableNetConnect('example-1.com')
-mockAgent.enableNetConnect('example-2.com:8080')
+mockAgent.enableNetConnect('example-1.example')
+mockAgent.enableNetConnect('example-2.example:8080')
 
-await request('http://example-1.com')
+await request('http://example-1.example')
 // A real request is made
 
-await request('http://example-2.com:8080')
+await request('http://example-2.example:8080')
 // A real request is made
 
 await request('http://example-3.com')
@@ -430,9 +430,9 @@ import { MockAgent, setGlobalDispatcher, request } from 'undici'
 const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
-mockAgent.enableNetConnect(new RegExp('example.com'))
+mockAgent.enableNetConnect(new RegExp('service.example'))
 
-await request('http://example.com')
+await request('http://service.example')
 // A real request is made
 ```
 
@@ -444,9 +444,9 @@ import { MockAgent, setGlobalDispatcher, request } from 'undici'
 const mockAgent = new MockAgent()
 setGlobalDispatcher(mockAgent)
 
-mockAgent.enableNetConnect((value) => value === 'example.com')
+mockAgent.enableNetConnect((value) => value === 'service.example')
 
-await request('http://example.com')
+await request('http://service.example')
 // A real request is made
 ```
 
@@ -465,7 +465,7 @@ const mockAgent = new MockAgent()
 
 mockAgent.disableNetConnect()
 
-await request('http://example.com')
+await request('http://service.example')
 // Will throw
 ```
 
@@ -486,7 +486,7 @@ const agent = new MockAgent()
 agent.disableNetConnect()
 
 agent
-  .get('https://example.com')
+  .get('https://service.example')
   .intercept({ method: 'GET', path: '/' })
   .reply(200)
 
@@ -509,7 +509,7 @@ const pendingInterceptors = agent.pendingInterceptors()
 //       headers: {},
 //       trailers: {}
 //     },
-//     origin: 'https://example.com'
+//     origin: 'https://service.example'
 //   }
 // ]
 ```
@@ -529,7 +529,7 @@ const agent = new MockAgent()
 agent.disableNetConnect()
 
 agent
-  .get('https://example.com')
+  .get('https://service.example')
   .intercept({ method: 'GET', path: '/' })
   .reply(200)
 
@@ -541,7 +541,7 @@ agent.assertNoPendingInterceptors()
 // ┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
 // │ (index) │ Method │        Origin         │ Path │ Status code │ Persistent │ Invocations │ Remaining │
 // ├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
-// │    0    │ 'GET'  │ 'https://example.com' │ '/'  │     200     │    '❌'    │      0      │     1     │
+// │    0    │ 'GET'  │ 'https://service.example' │ '/'  │     200     │    '❌'    │      0      │     1     │
 // └─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
 ```
 
@@ -557,7 +557,7 @@ import { MockAgent, setGlobalDispatcher, request } from 'undici'
 const mockAgent = new MockAgent({ enableCallHistory: true })
 setGlobalDispatcher(mockAgent)
 
-await request('http://example.com', { query: { item: 1 }})
+await request('http://service.example', { query: { item: 1 }})
 
 mockAgent.getCallHistory()?.firstCall()
 // Returns
@@ -565,12 +565,12 @@ mockAgent.getCallHistory()?.firstCall()
 //   body: undefined,
 //   headers: undefined,
 //   method: 'GET',
-//   origin: 'http://example.com',
-//   fullUrl: 'http://example.com/?item=1',
+//   origin: 'http://service.example',
+//   fullUrl: 'http://service.example/?item=1',
 //   path: '/',
 //   searchParams: { item: '1' },
 //   protocol: 'http:',
-//   host: 'example.com',
+//   host: 'service.example',
 //   port: ''
 // }
 ```

--- a/docs/docs/api/MockPool.md
+++ b/docs/docs/api/MockPool.md
@@ -127,7 +127,7 @@ mockPool.intercept({
   method: 'GET',
   headers: {
     'User-Agent': 'undici',
-    Host: 'example.com'
+    Host: 'service.example'
   }
 }).reply(200, ({ headers }) => ({ message: headers.get('message') }))
 
@@ -160,7 +160,7 @@ mockPool.intercept({
   method: 'GET',
   headers: {
     'User-Agent': 'undici',
-    Host: 'example.com'
+    Host: 'service.example'
   }
 }).reply(({ headers }) => ({ statusCode: 200, data: { message: headers.get('message') }})))
 
@@ -231,7 +231,7 @@ mockPool.intercept({
   body: 'form1=data1&form2=data2',
   headers: {
     'User-Agent': 'undici',
-    Host: 'example.com'
+    Host: 'service.example'
   }
 }).reply(200, { foo: 'bar' }, {
   headers: { 'content-type': 'application/json' },
@@ -249,7 +249,7 @@ const {
     headers: {
       foo: 'bar',
       'User-Agent': 'undici',
-      Host: 'example.com'
+      Host: 'service.example'
     }
   })
 
@@ -279,7 +279,7 @@ mockPool.intercept({
   body: (value) => value === 'form=data',
   headers: {
     'User-Agent': 'undici',
-    Host: /^example.com$/
+    Host: /^service.example$/
   }
 }).reply(200, 'foo')
 
@@ -292,7 +292,7 @@ const {
   headers: {
     foo: 'bar',
     'User-Agent': 'undici',
-    Host: 'example.com'
+    Host: 'service.example'
   }
 })
 

--- a/docs/docs/api/ProxyAgent.md
+++ b/docs/docs/api/ProxyAgent.md
@@ -181,7 +181,7 @@ proxyServer.listen(8000, () => {
 // Define and use the ProxyAgent
 const proxyAgent = new ProxyAgent('http://localhost:8000');
 
-const response = await fetch('http://example.com', {
+const response = await fetch('http://service.example', {
   dispatcher: proxyAgent,
   method: 'GET',
 });
@@ -203,7 +203,7 @@ import { ProxyAgent, fetch } from 'undici';
 const proxyAgent = new ProxyAgent('https://secure.proxy.server');
 
 // Make a request to an HTTPS endpoint via the proxy
-const response = await fetch('https://secure.endpoint.com/api/data', {
+const response = await fetch('https://secure.endpoint.example/api/data', {
   dispatcher: proxyAgent,
   method: 'GET',
 });
@@ -224,6 +224,6 @@ const proxyAgent = new ProxyAgent('http://localhost:8000');
 setGlobalDispatcher(proxyAgent);
 
 // Make requests without specifying the dispatcher
-const response = await fetch('http://example.com');
+const response = await fetch('http://service.example');
 console.log('Response status:', response.status);
 console.log('Response data:', await response.text());

--- a/docs/docs/api/RetryAgent.md
+++ b/docs/docs/api/RetryAgent.md
@@ -41,7 +41,7 @@ const agent = new RetryAgent(new Agent())
 
 const res = await agent.request({
   method: 'GET',
-  origin: 'http://example.com',
+  origin: 'http://service.example',
   path: '/',
 })
 console.log(res.statusCode)

--- a/docs/docs/api/SnapshotAgent.md
+++ b/docs/docs/api/SnapshotAgent.md
@@ -49,7 +49,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Makes real requests and records them
-const response = await fetch('https://api.example.com/users')
+const response = await fetch('https://api.service.example/users')
 const users = await response.json()
 
 // Save recorded snapshots
@@ -69,7 +69,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Uses recorded response instead of real request
-const response = await fetch('https://api.example.com/users')
+const response = await fetch('https://api.service.example/users')
 ```
 
 #### Update Mode (`'update'`)
@@ -85,7 +85,7 @@ const agent = new SnapshotAgent({
 setGlobalDispatcher(agent)
 
 // Uses snapshot if exists, otherwise makes real request and records it
-const response = await fetch('https://api.example.com/new-endpoint')
+const response = await fetch('https://api.service.example/new-endpoint')
 ```
 
 ## Instance Methods
@@ -161,7 +161,7 @@ const agent = new SnapshotAgent({
   snapshotPath: './snapshots.json',
   
   excludeUrls: [
-    'https://analytics.example.com',  // String match
+    'https://analytics.service.example',  // String match
     /\/api\/v\d+\/health/,           // Regex pattern
     'telemetry'                      // Substring match
   ]
@@ -195,10 +195,10 @@ Handle multiple responses for the same request (similar to nock):
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './sequential.json' })
 
 // First call returns response A
-await fetch('https://api.example.com/random')
+await fetch('https://api.service.example/random')
 
 // Second call returns response B  
-await fetch('https://api.example.com/random')
+await fetch('https://api.service.example/random')
 
 await agent.saveSnapshots()
 
@@ -206,13 +206,13 @@ await agent.saveSnapshots()
 const playbackAgent = new SnapshotAgent({ mode: 'playback', snapshotPath: './sequential.json' })
 
 // Returns response A
-const first = await fetch('https://api.example.com/random')
+const first = await fetch('https://api.service.example/random')
 
 // Returns response B
-const second = await fetch('https://api.example.com/random')
+const second = await fetch('https://api.service.example/random')
 
 // Third call repeats the last response (B)
-const third = await fetch('https://api.example.com/random')
+const third = await fetch('https://api.service.example/random')
 ```
 
 ## Managing Snapshots
@@ -328,7 +328,7 @@ import { SnapshotAgent, request, setGlobalDispatcher } from 'undici'
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './request-snapshots.json' })
 setGlobalDispatcher(agent)
 
-const { statusCode, headers, body } = await request('https://api.example.com/data')
+const { statusCode, headers, body } = await request('https://api.service.example/data')
 const data = await body.json()
 
 await agent.saveSnapshots()
@@ -354,7 +354,7 @@ test('API integration test', async (t) => {
   t.after(() => setGlobalDispatcher(originalDispatcher))
   
   // This will use recorded data
-  const response = await fetch('https://api.example.com/users')
+  const response = await fetch('https://api.service.example/users')
   const users = await response.json()
   
   assert(Array.isArray(users))
@@ -405,7 +405,7 @@ Snapshots are stored as JSON with the following structure:
     "snapshot": {
       "request": {
         "method": "GET",
-        "url": "https://api.example.com/users",
+        "url": "https://api.service.example/users",
         "headers": {
           "authorization": "Bearer token"
         },
@@ -494,7 +494,7 @@ const agent = new SnapshotAgent({
 
 ```javascript
 try {
-  const response = await fetch('https://api.example.com/nonexistent')
+  const response = await fetch('https://api.service.example/nonexistent')
 } catch (error) {
   if (error.message.includes('No snapshot found')) {
     // Handle missing snapshot
@@ -509,7 +509,7 @@ try {
 const agent = new SnapshotAgent({ mode: 'record', snapshotPath: './snapshots.json' })
 
 try {
-  const response = await fetch('https://nonexistent-api.example.com/data')
+  const response = await fetch('https://nonexistent-api.service.example/data')
 } catch (error) {
   // Network errors are not recorded as snapshots
   console.log('Network error:', error.message)
@@ -578,7 +578,7 @@ test('validate snapshot contents', async (t) => {
 **Manual MockAgent:**
 ```javascript
 const mockAgent = new MockAgent()
-const mockPool = mockAgent.get('https://api.example.com')
+const mockPool = mockAgent.get('https://api.service.example')
 
 mockPool.intercept({
   path: '/users',

--- a/docs/docs/api/Socks5ProxyAgent.md
+++ b/docs/docs/api/Socks5ProxyAgent.md
@@ -119,7 +119,7 @@ import { Socks5ProxyAgent, request } from 'undici'
 
 const socks5Proxy = new Socks5ProxyAgent('socks5://localhost:1080')
 
-const response = await request('https://api.example.com/data', {
+const response = await request('https://api.service.example/data', {
   dispatcher: socks5Proxy,
   method: 'GET'
 })
@@ -158,9 +158,9 @@ const socks5Proxy = new Socks5ProxyAgent('socks5://localhost:1080', {
 
 // Multiple requests will reuse connections through the SOCKS5 tunnel
 const responses = await Promise.all([
-  request('http://api.example.com/endpoint1', { dispatcher: socks5Proxy }),
-  request('http://api.example.com/endpoint2', { dispatcher: socks5Proxy }),
-  request('http://api.example.com/endpoint3', { dispatcher: socks5Proxy })
+  request('http://api.service.example/endpoint1', { dispatcher: socks5Proxy }),
+  request('http://api.service.example/endpoint2', { dispatcher: socks5Proxy }),
+  request('http://api.service.example/endpoint3', { dispatcher: socks5Proxy })
 ])
 
 console.log('All requests completed through the same SOCKS5 proxy')

--- a/docs/docs/best-practices/crawling.md
+++ b/docs/docs/best-practices/crawling.md
@@ -29,7 +29,7 @@ const headers = {
   'User-Agent': 'AcmeCo Crawler - acme.co - contact@acme.co'
 }
 
-const res = await fetch('https://example.com', { headers })
+const res = await fetch('https://service.example', { headers })
 ```
 
 ## Best Practices for Crawlers

--- a/docs/docs/best-practices/undici-vs-builtin-fetch.md
+++ b/docs/docs/best-practices/undici-vs-builtin-fetch.md
@@ -33,7 +33,7 @@ const body = new FormData()
 body.set('name', 'some')
 body.set('someOtherProperty', '8000')
 
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -48,7 +48,7 @@ const body = new FormData()
 body.set('name', 'some')
 body.set('someOtherProperty', '8000')
 
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -68,7 +68,7 @@ const body = new FormData()
 body.set('name', 'some')
 body.set('someOtherProperty', '8000')
 
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -86,7 +86,7 @@ import { fetch } from 'undici'
 
 const body = new FormData()
 
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -97,7 +97,7 @@ import { FormData } from 'undici'
 
 const body = new FormData()
 
-await fetch('https://example.com', {
+await fetch('https://service.example', {
   method: 'POST',
   body
 })
@@ -135,7 +135,7 @@ provide lower-level control and significantly better performance than `fetch`:
 ```js
 import { request } from 'undici';
 
-const { statusCode, headers, body } = await request('https://example.com');
+const { statusCode, headers, body } = await request('https://service.example');
 const data = await body.json();
 ```
 
@@ -148,7 +148,7 @@ and concurrency limits:
 ```js
 import { Pool } from 'undici';
 
-const pool = new Pool('https://example.com', { connections: 10 });
+const pool = new Pool('https://service.example', { connections: 10 });
 const { body } = await pool.request({ path: '/', method: 'GET' });
 ```
 
@@ -163,8 +163,8 @@ programmatic control through the dispatcher API:
 ```js
 import { ProxyAgent, fetch } from 'undici';
 
-const proxyAgent = new ProxyAgent('https://my-proxy.example.com:8080');
-const response = await fetch('https://example.com', { dispatcher: proxyAgent });
+const proxyAgent = new ProxyAgent('https://my-proxy.service.example:8080');
+const response = await fetch('https://service.example', { dispatcher: proxyAgent });
 ```
 
 ### Testing and mocking
@@ -178,7 +178,7 @@ import { MockAgent, setGlobalDispatcher, fetch } from 'undici';
 const mockAgent = new MockAgent();
 setGlobalDispatcher(mockAgent);
 
-const pool = mockAgent.get('https://example.com');
+const pool = mockAgent.get('https://service.example');
 pool.intercept({ path: '/api' }).reply(200, { message: 'mocked' });
 ```
 


### PR DESCRIPTION
## Summary

Replaces non-reserved domain names with [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) reserved `.example` TLD domains across all remaining documentation files, following the convention established in #4873.

## Changes

| Before | After |
|--------|-------|
| `example.com` | `service.example` |
| `example.org` | `service.example` |
| `mysite.com` | `mysite.example` |
| `secure.endpoint.com` | `secure.endpoint.example` |
| `test.com` | `test.example` |
| `testing.com` | `testing.example` |
| `example-1.com` | `example-1.example` |
| `example-2.com` | `example-2.example` |

### Updated files (10)

- `Dispatcher.md` — `mysite.com` header examples
- `GlobalInstallation.md` — fetch/WebSocket/EventSource examples
- `MockAgent.md` — mock intercept/enableNetConnect examples
- `MockPool.md` — mock pool host headers
- `ProxyAgent.md` — proxy fetch examples
- `RetryAgent.md` — retry origin example
- `SnapshotAgent.md` — snapshot API examples
- `Socks5ProxyAgent.md` — SOCKS5 proxy examples
- `best-practices/crawling.md` — crawling example
- `best-practices/undici-vs-builtin-fetch.md` — comparison examples

### Preserved as-is

- `jsonplaceholder.typicode.com` — real API used for live examples
- `echo.websocket.org` — real WebSocket echo service
- External documentation links (MDN, WHATWG, IETF, etc.)

Partially addresses #4866.