### PR TITLE
chore: remove zstd and markAsUncloneable feature probes

### DIFF
--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -3,7 +3,6 @@
 const { createInflate, createGunzip, createBrotliDecompress, createZstdDecompress } = require('node:zlib')
 const { pipeline } = require('node:stream')
 const DecoratorHandler = require('../handler/decorator-handler')
-const { runtimeFeatures } = require('../util/runtime-features')
 
 /** @typedef {import('node:stream').Transform} Transform */
 /** @typedef {import('node:stream').Transform} Controller */
@@ -17,7 +16,7 @@ const supportedEncodings = {
   deflate: createInflate,
   compress: createInflate,
   'x-compress': createInflate,
-  ...(runtimeFeatures.has('zstd') ? { zstd: createZstdDecompress } : {})
+  zstd: createZstdDecompress
 }
 
 const defaultSkipStatusCodes = /** @type {const} */ ([204, 304])

--- a/lib/util/runtime-features.js
+++ b/lib/util/runtime-features.js
@@ -6,9 +6,7 @@
 const lazyLoaders = {
   __proto__: null,
   'node:crypto': () => require('node:crypto'),
-  'node:sqlite': () => require('node:sqlite'),
-  'node:worker_threads': () => require('node:worker_threads'),
-  'node:zlib': () => require('node:zlib')
+  'node:sqlite': () => require('node:sqlite')
 }
 
 /**
@@ -27,35 +25,9 @@ function detectRuntimeFeatureByNodeModule (moduleName) {
   }
 }
 
-/**
- * @param {NodeModuleName} moduleName
- * @param {string} property
- * @returns {boolean}
- */
-function detectRuntimeFeatureByExportedProperty (moduleName, property) {
-  const module = lazyLoaders[moduleName]()
-  return typeof module[property] !== 'undefined'
-}
-
-const runtimeFeaturesByExportedProperty = /** @type {const} */ (['markAsUncloneable', 'zstd'])
-
-/** @type {Record<RuntimeFeatureByExportedProperty, [NodeModuleName, string]>} */
-const exportedPropertyLookup = {
-  markAsUncloneable: ['node:worker_threads', 'markAsUncloneable'],
-  zstd: ['node:zlib', 'createZstdDecompress']
-}
-
-/** @typedef {typeof runtimeFeaturesByExportedProperty[number]} RuntimeFeatureByExportedProperty */
-
 const runtimeFeaturesAsNodeModule = /** @type {const} */ (['crypto', 'sqlite'])
 /** @typedef {typeof runtimeFeaturesAsNodeModule[number]} RuntimeFeatureByNodeModule */
-
-const features = /** @type {const} */ ([
-  ...runtimeFeaturesAsNodeModule,
-  ...runtimeFeaturesByExportedProperty
-])
-
-/** @typedef {typeof features[number]} Feature */
+/** @typedef {RuntimeFeatureByNodeModule} Feature */
 
 /**
  * @param {Feature} feature
@@ -64,9 +36,6 @@ const features = /** @type {const} */ ([
 function detectRuntimeFeature (feature) {
   if (runtimeFeaturesAsNodeModule.includes(/** @type {RuntimeFeatureByNodeModule} */ (feature))) {
     return detectRuntimeFeatureByNodeModule(`node:${feature}`)
-  } else if (runtimeFeaturesByExportedProperty.includes(/** @type {RuntimeFeatureByExportedProperty} */ (feature))) {
-    const [moduleName, property] = exportedPropertyLookup[feature]
-    return detectRuntimeFeatureByExportedProperty(moduleName, property)
   }
   throw new TypeError(`unknown feature: ${feature}`)
 }
@@ -101,7 +70,7 @@ class RuntimeFeatures {
    * @param {boolean} value
    */
   set (feature, value) {
-    if (features.includes(feature) === false) {
+    if (runtimeFeaturesAsNodeModule.includes(feature) === false) {
       throw new TypeError(`unknown feature: ${feature}`)
     }
     this.#map.set(feature, value)

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -66,10 +66,6 @@ const { STATUS_CODES } = require('node:http')
 const { bytesMatch } = require('../subresource-integrity/subresource-integrity')
 const { createDeferredPromise } = require('../../util/promise')
 const { isomorphicEncode } = require('../infra')
-const { runtimeFeatures } = require('../../util/runtime-features')
-
-// Node.js v23.8.0+ and v22.15.0+ supports Zstandard
-const hasZstd = runtimeFeatures.has('zstd')
 
 const GET_OR_HEAD = ['GET', 'HEAD']
 
@@ -2251,7 +2247,7 @@ async function httpNetworkFetch (
                     flush: zlib.constants.BROTLI_OPERATION_FLUSH,
                     finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH
                   }))
-                } else if (coding === 'zstd' && hasZstd) {
+                } else if (coding === 'zstd') {
                   decoders.push(zlib.createZstdDecompress({
                     flush: zlib.constants.ZSTD_e_continue,
                     finishFlush: zlib.constants.ZSTD_e_end

--- a/lib/web/webidl/index.js
+++ b/lib/web/webidl/index.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert')
 const { types, inspect } = require('node:util')
-const { runtimeFeatures } = require('../../util/runtime-features')
+const { markAsUncloneable } = require('node:worker_threads')
 
 const UNDEFINED = 1
 const BOOLEAN = 2
@@ -158,9 +158,7 @@ webidl.util.TypeValueToString = function (o) {
   }
 }
 
-webidl.util.markAsUncloneable = runtimeFeatures.has('markAsUncloneable')
-  ? require('node:worker_threads').markAsUncloneable
-  : () => {}
+webidl.util.markAsUncloneable = markAsUncloneable
 
 // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
 webidl.util.ConvertToInt = function (V, bitLength, signedness, flags) {

--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -76,18 +76,16 @@ describe('content-encoding handling', () => {
     t.assert.strictEqual(await response.text(), 'Hello, World!')
   })
 
-  test('should decompress zstandard response',
-    { skip: typeof require('node:zlib').createZstdDecompress !== 'function' },
-    async (t) => {
-      const response = await fetch(`http://localhost:${server.address().port}`, {
-        keepalive: false,
-        headers: { 'accept-encoding': 'zstd' }
-      })
-
-      t.assert.strictEqual(response.headers.get('content-encoding'), 'zstd')
-      t.assert.strictEqual(response.headers.get('content-type'), 'text/plain')
-      t.assert.strictEqual(await response.text(), 'Hello, World!')
+  test('should decompress zstandard response', async (t) => {
+    const response = await fetch(`http://localhost:${server.address().port}`, {
+      keepalive: false,
+      headers: { 'accept-encoding': 'zstd' }
     })
+
+    t.assert.strictEqual(response.headers.get('content-encoding'), 'zstd')
+    t.assert.strictEqual(response.headers.get('content-type'), 'text/plain')
+    t.assert.strictEqual(await response.text(), 'Hello, World!')
+  })
 })
 
 describe('content-encoding chain limit', () => {

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -135,7 +135,7 @@ test('should decompress brotli response', async t => {
   await t.completed
 })
 
-test('should decompress zstd response', { skip: typeof createZstdCompress !== 'function' }, async t => {
+test('should decompress zstd response', async t => {
   t = tspl(t, { plan: 3 })
 
   const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {

--- a/test/node-platform-objects.js
+++ b/test/node-platform-objects.js
@@ -2,35 +2,32 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
-const { markAsUncloneable } = require('node:worker_threads')
 const { Response, Request, FormData, Headers, ErrorEvent, MessageEvent, CloseEvent, EventSource, WebSocket } = require('..')
 const { CacheStorage } = require('../lib/web/cache/cachestorage')
 const { Cache } = require('../lib/web/cache/cache')
 const { kConstruct } = require('../lib/core/symbols')
 
-test('unserializable web instances should be uncloneable if node exposes the api', (t) => {
-  if (markAsUncloneable !== undefined) {
-    t = tspl(t, { plan: 11 })
-    const uncloneables = [
-      { Uncloneable: Response, brand: 'Response' },
-      { Uncloneable: Request, value: 'http://localhost', brand: 'Request' },
-      { Uncloneable: FormData, brand: 'FormData' },
-      { Uncloneable: MessageEvent, value: 'dummy event', brand: 'MessageEvent' },
-      { Uncloneable: CloseEvent, value: 'dummy event', brand: 'CloseEvent' },
-      { Uncloneable: ErrorEvent, value: 'dummy event', brand: 'ErrorEvent' },
-      { Uncloneable: EventSource, value: 'http://localhost', brand: 'EventSource', doneCb: (entity) => entity.close() },
-      { Uncloneable: Headers, brand: 'Headers' },
-      { Uncloneable: WebSocket, value: 'http://localhost', brand: 'WebSocket' },
-      { Uncloneable: Cache, value: kConstruct, brand: 'Cache' },
-      { Uncloneable: CacheStorage, value: kConstruct, brand: 'CacheStorage' }
-    ]
-    uncloneables.forEach((platformEntity) => {
-      const entity = new platformEntity.Uncloneable(platformEntity.value)
-      t.throws(() => structuredClone(entity),
-        DOMException,
-        `Cloning ${platformEntity.brand} should throw DOMException`)
+test('unserializable web instances should be uncloneable', (t) => {
+  t = tspl(t, { plan: 11 })
+  const uncloneables = [
+    { Uncloneable: Response, brand: 'Response' },
+    { Uncloneable: Request, value: 'http://localhost', brand: 'Request' },
+    { Uncloneable: FormData, brand: 'FormData' },
+    { Uncloneable: MessageEvent, value: 'dummy event', brand: 'MessageEvent' },
+    { Uncloneable: CloseEvent, value: 'dummy event', brand: 'CloseEvent' },
+    { Uncloneable: ErrorEvent, value: 'dummy event', brand: 'ErrorEvent' },
+    { Uncloneable: EventSource, value: 'http://localhost', brand: 'EventSource', doneCb: (entity) => entity.close() },
+    { Uncloneable: Headers, brand: 'Headers' },
+    { Uncloneable: WebSocket, value: 'http://localhost', brand: 'WebSocket' },
+    { Uncloneable: Cache, value: kConstruct, brand: 'Cache' },
+    { Uncloneable: CacheStorage, value: kConstruct, brand: 'CacheStorage' }
+  ]
+  uncloneables.forEach((platformEntity) => {
+    const entity = new platformEntity.Uncloneable(platformEntity.value)
+    t.throws(() => structuredClone(entity),
+      DOMException,
+      `Cloning ${platformEntity.brand} should throw DOMException`)
 
-      platformEntity.doneCb?.(entity)
-    })
-  }
+    platformEntity.doneCb?.(entity)
+  })
 })

--- a/types/webidl.d.ts
+++ b/types/webidl.d.ts
@@ -87,7 +87,6 @@ interface WebidlUtil {
 
   /**
    * Mark a value as uncloneable for Node.js.
-   * This is only effective in some newer Node.js versions.
    */
   markAsUncloneable (V: any): void
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Follow-up to raising the minimum supported Node.js version to `>=22.19.0`

## Rationale

Now that `undici` only supports Node.js versions where `node:zlib` exposes zstd support and `node:worker_threads` exposes `markAsUncloneable`, the remaining runtime probes for those APIs are obsolete. Removing them simplifies the code and makes the tests reflect the actual supported runtime matrix.

## Changes

- remove `zstd` and `markAsUncloneable` from the runtime feature probe registry
- make zstd decompression unconditional in fetch and the decompress interceptor
- import `markAsUncloneable` directly in the Web IDL utilities
- update tests to stop conditionally skipping zstd and uncloneable coverage
- remove the outdated type comment implying `markAsUncloneable` is only available on some newer Node.js versions

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

Removes compatibility branches for Node.js versions older than the supported minimum

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
