### PR TITLE
test: remove obsolete nodeMajor/nodeMinor util exports

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -12,8 +12,6 @@ const { InvalidArgumentError, ConnectTimeoutError } = require('./errors')
 const { headerNameLowerCasedRecord } = require('./constants')
 const { tree } = require('./tree')
 
-const [nodeMajor, nodeMinor] = process.versions.node.split('.', 2).map(v => Number(v))
-
 class BodyAsyncIterable {
   constructor (body) {
     this[kBody] = body
@@ -989,8 +987,6 @@ module.exports = {
   normalizedMethodRecords,
   isValidPort,
   isHttpOrHttpsPrefixed,
-  nodeMajor,
-  nodeMinor,
   safeHTTPMethods: Object.freeze(['GET', 'HEAD', 'OPTIONS', 'TRACE']),
   wrapRequestBody,
   setupConnectTimeout,

--- a/test/mock-interceptor-unused-assertions.js
+++ b/test/mock-interceptor-unused-assertions.js
@@ -3,11 +3,6 @@
 const { test, beforeEach, afterEach } = require('node:test')
 const { MockAgent, setGlobalDispatcher } = require('..')
 const PendingInterceptorsFormatter = require('../lib/mock/pending-interceptors-formatter')
-const util = require('../lib/core/util')
-
-// Since Node.js v21 `console.table` rows are aligned to the left
-// https://github.com/nodejs/node/pull/50135
-const tableRowsAlignedToLeft = util.nodeMajor >= 21 || (util.nodeMajor === 20 && util.nodeMinor >= 11)
 
 // `console.table` treats emoji as two character widths for cell width determination
 const Y = process.versions.icu ? '✅' : 'Y '
@@ -51,23 +46,13 @@ test('1 pending interceptor', t => {
     mockAgentWithOneInterceptor().assertNoPendingInterceptors({ pendingInterceptorsFormatter })
     t.assert.fail('Should have thrown')
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, tableRowsAlignedToLeft
-      ? `
+    t.assert.deepStrictEqual(err.message, `
 1 interceptor is pending:
 
 ┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
 │ (index) │ Method │ Origin                │ Path │ Status code │ Persistent │ Invocations │ Remaining │
 ├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
 │ 0       │ 'GET'  │ 'https://example.com' │ '/'  │ 200         │ '${N}'       │ 0           │ 1         │
-└─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
-`.trim()
-      : `
-1 interceptor is pending:
-
-┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
-│ (index) │ Method │        Origin         │ Path │ Status code │ Persistent │ Invocations │ Remaining │
-├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
-│    0    │ 'GET'  │ 'https://example.com' │ '/'  │     200     │    '${N}'    │      0      │     1     │
 └─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
 `.trim())
   }
@@ -84,8 +69,7 @@ test('2 pending interceptors', t => {
   try {
     withTwoInterceptors.assertNoPendingInterceptors({ pendingInterceptorsFormatter })
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, tableRowsAlignedToLeft
-      ? `
+    t.assert.deepStrictEqual(err.message, `
 2 interceptors are pending:
 
 ┌─────────┬────────┬──────────────────────────┬──────────────┬─────────────┬────────────┬─────────────┬───────────┐
@@ -93,16 +77,6 @@ test('2 pending interceptors', t => {
 ├─────────┼────────┼──────────────────────────┼──────────────┼─────────────┼────────────┼─────────────┼───────────┤
 │ 0       │ 'GET'  │ 'https://example.com'    │ '/'          │ 200         │ '${N}'       │ 0           │ 1         │
 │ 1       │ 'GET'  │ 'https://localhost:9999' │ '/some/path' │ 204         │ '${N}'       │ 0           │ 1         │
-└─────────┴────────┴──────────────────────────┴──────────────┴─────────────┴────────────┴─────────────┴───────────┘
-`.trim()
-      : `
-2 interceptors are pending:
-
-┌─────────┬────────┬──────────────────────────┬──────────────┬─────────────┬────────────┬─────────────┬───────────┐
-│ (index) │ Method │          Origin          │     Path     │ Status code │ Persistent │ Invocations │ Remaining │
-├─────────┼────────┼──────────────────────────┼──────────────┼─────────────┼────────────┼─────────────┼───────────┤
-│    0    │ 'GET'  │  'https://example.com'   │     '/'      │     200     │    '${N}'    │      0      │     1     │
-│    1    │ 'GET'  │ 'https://localhost:9999' │ '/some/path' │     204     │    '${N}'    │      0      │     1     │
 └─────────┴────────┴──────────────────────────┴──────────────┴─────────────┴────────────┴─────────────┴───────────┘
 `.trim())
   }
@@ -160,8 +134,7 @@ test('Variations of persist(), times(), and pending status', async t => {
     agent.assertNoPendingInterceptors({ pendingInterceptorsFormatter })
     t.assert.fail('Should have thrown')
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, tableRowsAlignedToLeft
-      ? `
+    t.assert.deepStrictEqual(err.message, `
 4 interceptors are pending:
 
 ┌─────────┬────────┬──────────────────────────┬──────────────────────┬─────────────┬────────────┬─────────────┬───────────┐
@@ -171,18 +144,6 @@ test('Variations of persist(), times(), and pending status', async t => {
 │ 1       │ 'GET'  │ 'https://localhost:9999' │ '/persistent/unused' │ 200         │ '${Y}'       │ 0           │ Infinity  │
 │ 2       │ 'GET'  │ 'https://localhost:9999' │ '/times/partial'     │ 200         │ '${N}'       │ 1           │ 4         │
 │ 3       │ 'GET'  │ 'https://localhost:9999' │ '/times/unused'      │ 200         │ '${N}'       │ 0           │ 2         │
-└─────────┴────────┴──────────────────────────┴──────────────────────┴─────────────┴────────────┴─────────────┴───────────┘
-`.trim()
-      : `
-4 interceptors are pending:
-
-┌─────────┬────────┬──────────────────────────┬──────────────────────┬─────────────┬────────────┬─────────────┬───────────┐
-│ (index) │ Method │          Origin          │         Path         │ Status code │ Persistent │ Invocations │ Remaining │
-├─────────┼────────┼──────────────────────────┼──────────────────────┼─────────────┼────────────┼─────────────┼───────────┤
-│    0    │ 'GET'  │  'https://example.com'   │         '/'          │     200     │    '${N}'    │      0      │     1     │
-│    1    │ 'GET'  │ 'https://localhost:9999' │ '/persistent/unused' │     200     │    '${Y}'    │      0      │ Infinity  │
-│    2    │ 'GET'  │ 'https://localhost:9999' │   '/times/partial'   │     200     │    '${N}'    │      1      │     4     │
-│    3    │ 'GET'  │ 'https://localhost:9999' │   '/times/unused'    │     200     │    '${N}'    │      0      │     2     │
 └─────────┴────────┴──────────────────────────┴──────────────────────┴─────────────┴────────────┴─────────────┴───────────┘
 `.trim())
   }
@@ -225,23 +186,13 @@ test('defaults to rendering output with terminal color when process.env.CI is un
     mockAgentWithOneInterceptor().assertNoPendingInterceptors()
     t.assert.fail('Should have thrown')
   } catch (err) {
-    t.assert.deepStrictEqual(err.message, tableRowsAlignedToLeft
-      ? `
+    t.assert.deepStrictEqual(err.message, `
 1 interceptor is pending:
 
 ┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
 │ (index) │ Method │ Origin                │ Path │ Status code │ Persistent │ Invocations │ Remaining │
 ├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
 │ 0       │ \u001b[32m'GET'\u001b[39m  │ \u001b[32m'https://example.com'\u001b[39m │ \u001b[32m'/'\u001b[39m  │ \u001b[33m200\u001b[39m         │ \u001b[32m'${N}'\u001b[39m       │ \u001b[33m0\u001b[39m           │ \u001b[33m1\u001b[39m         │
-└─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
-`.trim()
-      : `
-1 interceptor is pending:
-
-┌─────────┬────────┬───────────────────────┬──────┬─────────────┬────────────┬─────────────┬───────────┐
-│ (index) │ Method │        Origin         │ Path │ Status code │ Persistent │ Invocations │ Remaining │
-├─────────┼────────┼───────────────────────┼──────┼─────────────┼────────────┼─────────────┼───────────┤
-│    0    │ \u001b[32m'GET'\u001b[39m  │ \u001b[32m'https://example.com'\u001b[39m │ \u001b[32m'/'\u001b[39m  │     \u001b[33m200\u001b[39m     │    \u001b[32m'${N}'\u001b[39m    │      \u001b[33m0\u001b[39m      │     \u001b[33m1\u001b[39m     │
 └─────────┴────────┴───────────────────────┴──────┴─────────────┴────────────┴─────────────┴───────────┘
 `.trim())
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Undici now supports Node.js `>=22.19.0`, so the exported `nodeMajor`/`nodeMinor` helpers are obsolete. The only remaining usage was a test-only branch for old `console.table` formatting behavior.

## Changes

- Remove `nodeMajor` and `nodeMinor` from `lib/core/util.js`
- Simplify `test/mock-interceptor-unused-assertions.js` to assume the Node 22+ `console.table` layout
- Drop the now-unused `util` import and version-gated snapshot branches from that test

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
