### PR TITLE
chore: use Object.hasOwn for iterator checks

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -321,7 +321,7 @@ function isIterable (obj) {
  */
 function hasSafeIterator (obj) {
   const prototype = Object.getPrototypeOf(obj)
-  const ownIterator = Object.prototype.hasOwnProperty.call(obj, Symbol.iterator)
+  const ownIterator = Object.hasOwn(obj, Symbol.iterator)
   return ownIterator || (prototype != null && prototype !== Object.prototype && typeof obj[Symbol.iterator] === 'function')
 }
 

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -7,7 +7,7 @@ const maxInt = Math.pow(2, 31) - 1
 
 function hasSafeIterator (headers) {
   const prototype = Object.getPrototypeOf(headers)
-  const ownIterator = Object.prototype.hasOwnProperty.call(headers, Symbol.iterator)
+  const ownIterator = Object.hasOwn(headers, Symbol.iterator)
   return ownIterator || (prototype != null && prototype !== Object.prototype && typeof headers[Symbol.iterator] === 'function')
 }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Use `Object.hasOwn()` instead of `Object.prototype.hasOwnProperty.call()` for the remaining own-property checks in the iterator safety helpers. The repository already uses `Object.hasOwn()` elsewhere, and the current Node engine requirement supports it, so this keeps the codebase more consistent and modern without changing behavior.

## Changes

- Replace `Object.prototype.hasOwnProperty.call(..., Symbol.iterator)` with `Object.hasOwn(..., Symbol.iterator)` in the shared `hasSafeIterator` logic
- Update the corresponding helper in the DNS interceptor to use the same pattern

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
