### PR TITLE
fix: native WebSocket over H2 server after undici import

### DIFF
--- a/lib/dispatcher/dispatcher1-wrapper.js
+++ b/lib/dispatcher/dispatcher1-wrapper.js
@@ -86,9 +86,9 @@ class Dispatcher1Wrapper extends Dispatcher {
   }
 
   dispatch (opts, handler) {
-    // Legacy (v1) consumers lack the H2 WebSocket fallback
-    // (dispatchWithProtocolPreference) so force HTTP/1.1 for upgrades.
-    if (opts.upgrade) {
+    // Legacy (v1) consumers do not support HTTP/2, so force HTTP/1.1.
+    // See https://github.com/nodejs/undici/issues/4989
+    if (opts.allowH2 !== false) {
       opts = { ...opts, allowH2: false }
     }
 

--- a/test/websocket/issue-4989.js
+++ b/test/websocket/issue-4989.js
@@ -19,6 +19,10 @@ const { tspl } = require('@matteo.collina/tspl')
 const { WebSocketServer } = require('ws')
 const { key, cert } = require('@metcoder95/https-pem')
 
+// Self-signed certs require this since native WebSocket uses the
+// bundled dispatcher which has no rejectUnauthorized override.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
 // Importing undici sets the global dispatcher — this is what triggers the bug.
 require('../..')
 


### PR DESCRIPTION
Importing undici v8 overwrites the legacy global dispatcher
(Symbol.for('undici.globalDispatcher.1')) used by Node.js's bundled
undici. The new Agent defaults to allowH2: true, causing ALPN to
negotiate h2. Undici v8's fetch has a fallback
(dispatchWithProtocolPreference) that retries with HTTP/1.1 when
Extended CONNECT is unavailable, but the bundled undici does not.

Fix Dispatcher1Wrapper.dispatch() to force allowH2: false for legacy consumers that cannot handle the H2 WebSocket fallback.

Fixes: https://github.com/nodejs/undici/issues/4989