### PR TITLE
types: document Client and H2CClient option declarations

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -39,7 +39,7 @@ export declare namespace Client {
     socketTimeout?: never;
     /** @deprecated unsupported requestTimeout, use headersTimeout & bodyTimeout instead */
     requestTimeout?: never;
-    /** TODO */
+    /** The timeout for establishing a socket connection, in milliseconds. Use `0` to disable it entirely. Default: `10e3` milliseconds (10s). */
     connectTimeout?: number;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `300e3` milliseconds (300s). */
     bodyTimeout?: number;
@@ -55,7 +55,7 @@ export declare namespace Client {
     keepAliveMaxTimeout?: number;
     /** A number of milliseconds subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuracies caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
     keepAliveTimeoutThreshold?: number;
-    /** TODO */
+    /** An IPC endpoint, either a Unix domain socket or Windows named pipe. Default: `null`. */
     socketPath?: string;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
     pipelining?: number;
@@ -63,13 +63,13 @@ export declare namespace Client {
     tls?: never;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
     strictContentLength?: boolean;
-    /** TODO */
+    /** Maximum number of TLS cached sessions used by the built-in connector. Use `0` to disable TLS session caching. Default: `100`. */
     maxCachedSessions?: number;
-    /** TODO */
+    /** Connector options passed to `buildConnector`, or a custom connector function. Default: `null`. */
     connect?: Partial<buildConnector.BuildOptions> | buildConnector.connector;
-    /** TODO */
+    /** The maximum number of requests to send over a single connection before it is reset. Use `0` to disable this limit. Default: `null`. */
     maxRequestsPerClient?: number;
-    /** TODO */
+    /** Local IP address the socket should connect from. */
     localAddress?: string;
     /** Max response body size in bytes, -1 is disabled */
     maxResponseSize?: number;

--- a/types/h2c-client.d.ts
+++ b/types/h2c-client.d.ts
@@ -32,7 +32,7 @@ export declare namespace H2CClient {
     maxHeaderSize?: number;
     /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `300e3` milliseconds (300s). */
     headersTimeout?: number;
-    /** TODO */
+    /** The timeout for establishing a socket connection, in milliseconds. Use `0` to disable it entirely. Default: `10e3` milliseconds (10s). */
     connectTimeout?: number;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `300e3` milliseconds (300s). */
     bodyTimeout?: number;
@@ -42,19 +42,19 @@ export declare namespace H2CClient {
     keepAliveMaxTimeout?: number;
     /** A number of milliseconds subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuracies caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
     keepAliveTimeoutThreshold?: number;
-    /** TODO */
+    /** An IPC endpoint, either a Unix domain socket or Windows named pipe. Default: `null`. */
     socketPath?: string;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
     pipelining?: number;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
     strictContentLength?: boolean;
-    /** TODO */
+    /** Maximum number of TLS cached sessions used by the built-in connector. Use `0` to disable TLS session caching. Default: `100`. */
     maxCachedSessions?: number;
-    /** TODO */
+    /** Connector options passed to `buildConnector`, or a custom connector function. Default: `null`. */
     connect?: Omit<Partial<buildConnector.BuildOptions>, 'allowH2'> | buildConnector.connector;
-    /** TODO */
+    /** The maximum number of requests to send over a single connection before it is reset. Use `0` to disable this limit. Default: `null`. */
     maxRequestsPerClient?: number;
-    /** TODO */
+    /** Local IP address the socket should connect from. */
     localAddress?: string;
     /** Max response body size in bytes, -1 is disabled */
     maxResponseSize?: number;


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Documentation coverage for the TypeScript declarations in `types/client.d.ts` and `types/h2c-client.d.ts`.

## Rationale

Both declaration files had `/** TODO */` placeholders for public options. Replacing those with real API docs makes the type surface easier to use in editors and keeps the declarations aligned with the documented client options.

## Changes

- Replaced placeholder comments in `types/client.d.ts`
- Replaced placeholder comments in `types/h2c-client.d.ts`
- Added descriptions for:
  - `connectTimeout`
  - `socketPath`
  - `maxCachedSessions`
  - `connect`
  - `maxRequestsPerClient`
  - `localAddress`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
