### PR TITLE
fix: replace finished() with writable lifecycle tracking

### DIFF
--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -1,13 +1,60 @@
 'use strict'
 
 const assert = require('node:assert')
-const { finished } = require('node:stream')
 const { AsyncResource } = require('node:async_hooks')
 const { InvalidArgumentError, InvalidReturnValueError } = require('../core/errors')
 const util = require('../core/util')
 const { addSignal, removeSignal } = require('./abort-signal')
 
 function noop () {}
+
+function getWritableError (stream) {
+  return stream.errored ?? stream.writableErrored ?? stream._writableState?.errored
+}
+
+function createPrematureCloseError () {
+  const err = new Error('Premature close')
+  err.code = 'ERR_STREAM_PREMATURE_CLOSE'
+  return err
+}
+
+function trackWritableLifecycle (stream, callback) {
+  let done = false
+
+  const cleanup = () => {
+    stream.removeListener('close', onClose)
+    stream.removeListener('error', onError)
+    stream.removeListener('finish', onFinish)
+  }
+
+  const finish = (err, fromErrorEvent = false) => {
+    if (done) {
+      return
+    }
+
+    done = true
+    cleanup()
+    callback(err, fromErrorEvent)
+  }
+
+  const onClose = () => {
+    const err = getWritableError(stream)
+    finish(err ?? (!stream.writableFinished ? createPrematureCloseError() : undefined))
+  }
+
+  const onError = (err) => finish(err, true)
+  const onFinish = () => finish()
+
+  stream.on('close', onClose)
+  stream.on('error', onError)
+  stream.on('finish', onFinish)
+
+  if (stream.closed) {
+    process.nextTick(onClose)
+  } else if (stream.writableFinished) {
+    process.nextTick(onFinish)
+  }
+}
 
 class StreamHandler extends AsyncResource {
   constructor (opts, factory, callback) {
@@ -117,20 +164,19 @@ class StreamHandler extends AsyncResource {
       throw new InvalidReturnValueError('expected Writable')
     }
 
-    // TODO: Avoid finished. It registers an unnecessary amount of listeners.
-    finished(res, { readable: false }, (err) => {
+    trackWritableLifecycle(res, (err, fromErrorEvent) => {
       const { callback, res, opaque, trailers, abort } = this
 
       this.res = null
       if (err || !res?.readable) {
-        util.destroy(res, err)
+        util.destroy(res, fromErrorEvent ? undefined : err)
       }
 
       this.callback = null
       this.runInAsyncScope(callback, null, err || null, { opaque, trailers })
 
       if (err) {
-        abort()
+        abort(err)
       }
     })
 

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -157,6 +157,38 @@ test('stream GET destroy res', async (t) => {
   await t.completed
 })
 
+test('stream GET destroy res without error', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.write('hello')
+    setImmediate(() => {
+      res.end(' world')
+    })
+  })
+  after(() => server.close())
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(() => client.close())
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, () => {
+      const pt = new PassThrough()
+      pt.on('data', () => {
+        pt.destroy()
+      })
+      return pt
+    }, (err) => {
+      t.strictEqual(err.code, 'ERR_STREAM_PREMATURE_CLOSE')
+    })
+  })
+
+  await t.completed
+})
+
 test('stream GET remote destroy', async (t) => {
   t = tspl(t, { plan: 4 })
 
@@ -277,6 +309,33 @@ test('stream waits only for writable side', async (t) => {
     }, () => pt, (err) => {
       t.ifError(err)
       t.strictEqual(pt.destroyed, false)
+    })
+  })
+
+  await t.completed
+})
+
+test('stream accepts already finished writable', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.end()
+  })
+  after(() => server.close())
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(() => client.close())
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, () => {
+      const pt = new PassThrough({ autoDestroy: false })
+      pt.end()
+      return pt
+    }, (err) => {
+      t.ifError(err)
     })
   })
 


### PR DESCRIPTION
## This relates to...

- Hot-path listener overhead in `lib/api/api-stream.js`
- The existing TODO about avoiding `stream.finished()` in `StreamHandler`

## Rationale

`StreamHandler` used `stream.finished(res, { readable: false })` to observe completion of the user-provided writable. That helper is broader than this path needs and registers extra listeners, which adds avoidable overhead on a hot path.

This change narrows lifecycle tracking to the writable side only while preserving the behavior `stream()` depends on for completion, writable errors, and premature close handling.

## Changes

- Replaced `stream.finished()` usage in `StreamHandler` with a small writable lifecycle helper that listens only for `finish`, `error`, and `close`
- Preserved premature close behavior by reporting `ERR_STREAM_PREMATURE_CLOSE` when the writable closes before finishing
- Preserved existing error propagation by aborting the request with the writable error
- Avoided re-destroying the writable with the same error after an `'error'` event, which keeps existing error handling semantics intact
- Added regression coverage for premature writable close without an explicit error
- Added regression coverage for a factory returning an already-finished writable

### Features

N/A

### Bug Fixes

- Reduced listener registration overhead in `stream()` response handling
- Kept `stream()` callback and abort behavior consistent for writable finish, error, and premature close edge cases

### Breaking Changes and Deprecations

- None

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4