### PR TITLE
fix: handle incomplete multi-byte UTF-8 sequences in setEncoding()

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -14,6 +14,7 @@ const kContentType = Symbol('kContentType')
 const kContentLength = Symbol('kContentLength')
 const kUsed = Symbol('kUsed')
 const kBytesRead = Symbol('kBytesRead')
+const kPreservedBuffer = Symbol('kPreservedBuffer')
 
 const noop = () => {}
 
@@ -324,7 +325,37 @@ class BodyReadable extends Readable {
    */
   setEncoding (encoding) {
     if (Buffer.isEncoding(encoding)) {
-      this._readableState.encoding = encoding
+      // Preserve raw Buffer chunks for the consume path (body.text(),
+      // body.json(), etc.) before super.setEncoding() replaces them
+      // with decoded strings. Without this, the consume path would
+      // lose access to the original bytes — some of which may be held
+      // by the decoder for incomplete multi-byte sequences, and the
+      // rest converted to strings that can't be safely concatenated
+      // byte-wise.
+      const state = this._readableState
+      const buffer = state.buffer
+      if (buffer && state.length > 0) {
+        const bufferIndex = state.bufferIndex ?? 0
+        const preserved = []
+        const source = typeof buffer.slice === 'function'
+          ? buffer.slice(bufferIndex)
+          : buffer
+        for (const data of source) {
+          if (Buffer.isBuffer(data)) {
+            preserved.push(data)
+          }
+        }
+        if (preserved.length > 0) {
+          this[kPreservedBuffer] = (this[kPreservedBuffer] || []).concat(preserved)
+        }
+      }
+
+      // Delegate to Node.js Readable.setEncoding() which initializes a
+      // StringDecoder and re-encodes already-buffered chunks. This properly
+      // handles multi-byte sequences split at chunk boundaries for the
+      // for-await / on('data') paths. Without this, Node.js uses
+      // buf.toString(encoding) on each chunk, producing U+FFFD for split chars.
+      super.setEncoding(encoding)
     }
     return this
   }
@@ -432,7 +463,17 @@ function consumeStart (consume) {
 
   const { _readableState: state } = consume.stream
 
-  if (state.bufferIndex) {
+  // If setEncoding() was called, state.buffer may contain decoded strings
+  // (which would break Buffer.concat in chunksDecode). Use the preserved
+  // raw Buffers (saved before super.setEncoding() in setEncoding()) for
+  // byte-level accurate consumption. Otherwise read from state.buffer.
+  const preserved = consume.stream[kPreservedBuffer]
+  if (preserved && preserved.length > 0) {
+    for (const chunk of preserved) {
+      consumePush(consume, chunk)
+    }
+    consume.stream[kPreservedBuffer] = null
+  } else if (state.bufferIndex) {
     const start = state.bufferIndex
     const end = state.buffer.length
     for (let n = start; n < end; n++) {

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1525,6 +1525,58 @@ test('request multibyte text with setEncoding', async (t) => {
   await t.completed
 })
 
+test('setEncoding(\'utf8\') handles 3-byte UTF-8 characters split across chunks', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  // CJK character '傳' is 3 bytes: 0xe5, 0x82, 0xb3
+  // Build a payload where this character will be split at the chunk boundary
+  const cjkChar = '傳' // U+50B3, bytes: e5 82 b3
+  const prefix = 'a'.repeat(10) // 10 ASCII bytes
+  const text = prefix + cjkChar + 'end'
+  const buf = Buffer.from(text) // 10 + 3 + 3 = 16 bytes
+
+  // Split at byte 11, which is in the middle of the 3-byte CJK character
+  // prefix (10 bytes) + first byte of '傳' (0xe5) | remaining 2 bytes (0x82 0xb3) + 'end'
+  const chunk1 = buf.subarray(0, 11)
+  const chunk2 = buf.subarray(11)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    // Send raw buffers to ensure the split is exactly where we want it
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+    res.write(chunk1)
+    // Use setTimeout to force separate TCP packets / chunks
+    setTimeout(() => {
+      res.end(chunk2)
+    }, 50)
+  })
+  after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(client.destroy.bind(client))
+
+    const { body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+    body.setEncoding('utf8')
+
+    let result = ''
+    for await (const chunk of body) {
+      result += chunk
+    }
+
+    // Must not contain U+FFFD replacement characters
+    t.strictEqual(result.includes('\ufffd'), false, 'should not contain U+FFFD replacement characters')
+    t.strictEqual(result, text, 'decoded text should match original')
+  })
+
+  await t.completed
+})
+
 test('#3736 - Aborted Response (without consuming body)', async (t) => {
   const plan = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
## This relates to...

Fixes #5002

## Rationale

`setEncoding('utf8')` on undici response body corrupts multi-byte UTF-8 characters (3-byte CJK, 4-byte emoji) at chunk boundaries, replacing them with U+FFFD. Node.js's built-in `https` module handles this correctly.

## Root cause

`BodyReadable.setEncoding()` only set `_readableState.encoding` directly, without initializing a `StringDecoder`:

```js
// Before
setEncoding (encoding) {
  if (Buffer.isEncoding(encoding)) {
    this._readableState.encoding = encoding
  }
  return this
}
```

Node.js `Readable.prototype.setEncoding()` does two things:

1. Creates `_readableState.decoder = new StringDecoder(enc)`, which buffers incomplete multi-byte byte sequences across chunks.
2. **Re-encodes any already-buffered chunks through the decoder** (iterating `_readableState.buffer`), so bytes that arrived before `setEncoding()` was called are also decoded correctly.

Without the decoder, `fromList()` falls back to `buf.toString(encoding)` on each individual chunk, producing `U+FFFD` replacement characters whenever a multi-byte sequence spans a chunk boundary. This silently corrupts data on the streaming path (`for await ... of body`, `body.on('data', ...)`).

## Why not just `super.setEncoding(encoding)`?

Delegating directly to the parent implementation fixes the streaming path, but breaks the `consume` path (`body.text()`, `body.json()`, `body.arrayBuffer()`, etc.) for two reasons:

1. `super.setEncoding()` iterates `_readableState.buffer` and rewrites it from `Buffer` to decoded `string`. `consumeStart` then hands those strings to `chunksDecode`, whose `Buffer.concat(...)` rejects strings.
2. The `StringDecoder` holds any trailing incomplete bytes internally. Those bytes disappear from `_readableState.buffer` entirely, and subsequent `push()` calls into `consumePush` only see the *new* raw `Buffer`s — the held bytes from the pre-`setEncoding()` chunks are permanently lost to the consume path.

Both failure modes are observable against the pre-existing `request multibyte json/text with setEncoding` tests in `test/client-request.js`.

## Fix

Before delegating to `super.setEncoding()`, snapshot any raw `Buffer` chunks already sitting in `_readableState.buffer` into a private `kPreservedBuffer` symbol on the stream. Then teach `consumeStart` to prefer that snapshot over `_readableState.buffer` when present.

- Streaming path (`for await`, `on('data')`) — benefits from the properly initialized `StringDecoder` in the parent class, decoding multi-byte sequences across chunk boundaries correctly.
- Consume path (`body.text()`, `body.json()`, etc.) — reads the preserved raw `Buffer`s, so all original bytes remain available for byte-level `Buffer.concat(...)` + final `toString(encoding)`.

Subsequent `push()` calls continue to feed `consumePush` raw `Buffer`s *before* calling `super.push()`, so no bytes are lost once the consume path is active.

### Bug fixes

- Fixed multi-byte UTF-8 character corruption when using `setEncoding('utf8')` on a response body consumed via `for await ... of` or `on('data', ...)`.

### Breaking changes

None. The fix aligns `BodyReadable.setEncoding()` with Node.js core `Readable` streams, and preserves the existing contract for `body.text()` / `body.json()` / etc.

## Test description

Added a test in `test/client-request.js`:

- **`setEncoding('utf8') handles 3-byte UTF-8 characters split across chunks`** — constructs an HTTP response where a 3-byte CJK character (`傳`, bytes `e5 82 b3`) is deliberately split across two chunks (first chunk ends mid-sequence on `0xe5`), then asserts `for await ... of body` produces the original string with no `U+FFFD`.

All pre-existing tests still pass, including the three `request multibyte json/text with setEncoding` tests that exercise the ordering `body.setEncoding('utf8') → await body.json()/text()` — these are what caught the naive `super.setEncoding()` approach.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin