### PR TITLE
docs: Change the default value of allowH2 in JSDoc

### DIFF
--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -79,7 +79,7 @@ export declare namespace Client {
     autoSelectFamilyAttemptTimeout?: number;
     /**
      * @description Enables support for H2 if the server has assigned bigger priority to it through ALPN negotiation.
-     * @default false
+     * @default true
      */
     allowH2?: boolean;
     /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Docs

## Rationale

release: https://github.com/nodejs/undici/releases/tag/v8.0.0
Recently, the default value of allowH2 was changed from false to true.

docs: https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md
And the above document specifies that the default value of allowH2 is true.

However, this was missing from the JSDoc in the code.

## Changes

chore docs update

update JSDoc in client.d.ts

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
