### PR TITLE
fix(proxy agent): respect connectTimeout

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -104,7 +104,7 @@ class ProxyAgent extends DispatcherBase {
       throw new InvalidArgumentError('Proxy opts.clientFactory must be a function.')
     }
 
-    const { proxyTunnel = true } = opts
+    const { proxyTunnel = true, connectTimeout } = opts
 
     super()
 
@@ -128,9 +128,9 @@ class ProxyAgent extends DispatcherBase {
       this[kProxyHeaders]['proxy-authorization'] = `Basic ${Buffer.from(`${decodeURIComponent(username)}:${decodeURIComponent(password)}`).toString('base64')}`
     }
 
-    const connect = buildConnector({ ...opts.proxyTls })
-    this[kConnectEndpoint] = buildConnector({ ...opts.requestTls })
-    this[kConnectEndpointHTTP1] = buildConnector({ ...opts.requestTls, allowH2: false })
+    const connect = buildConnector({ timeout: connectTimeout, ...opts.proxyTls })
+    this[kConnectEndpoint] = buildConnector({ timeout: connectTimeout, ...opts.requestTls })
+    this[kConnectEndpointHTTP1] = buildConnector({ timeout: connectTimeout, ...opts.requestTls, allowH2: false })
 
     const agentFactory = opts.factory || defaultAgentFactory
     const factory = (origin, options) => {

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -4,11 +4,12 @@ const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const diagnosticsChannel = require('node:diagnostics_channel')
 const { request, fetch, setGlobalDispatcher, getGlobalDispatcher } = require('..')
-const { InvalidArgumentError, SecureProxyConnectionError } = require('../lib/core/errors')
+const { InvalidArgumentError, ConnectTimeoutError, SecureProxyConnectionError } = require('../lib/core/errors')
 const ProxyAgent = require('../lib/dispatcher/proxy-agent')
 const Pool = require('../lib/dispatcher/pool')
 const { createServer } = require('node:http')
 const https = require('node:https')
+const net = require('node:net')
 const { Socket } = require('node:net')
 const { createProxy } = require('proxy')
 
@@ -119,6 +120,58 @@ test('should accept string, URL and object as options', (t) => {
   t.doesNotThrow(() => new ProxyAgent('http://example.com'))
   t.doesNotThrow(() => new ProxyAgent(new URL('http://example.com')))
   t.doesNotThrow(() => new ProxyAgent({ uri: 'http://example.com' }))
+})
+
+test('ProxyAgent forwards connectTimeout to the proxy connector', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  const originalConnect = net.connect
+  let connect
+  const proxyAgent = new ProxyAgent({
+    uri: 'http://localhost:9000',
+    connectTimeout: 1e3,
+    clientFactory (_origin, options) {
+      connect = options.connect
+      return {
+        close () {
+          return Promise.resolve()
+        },
+        destroy () {
+          return Promise.resolve()
+        }
+      }
+    }
+  })
+
+  try {
+    net.connect = function (options) {
+      return new net.Socket(options)
+    }
+
+    t.ok(typeof connect === 'function')
+
+    const timeout = setTimeout(() => {
+      t.fail('connectTimeout was not forwarded to the proxy connector')
+    }, 2e3)
+
+    await new Promise((resolve, reject) => {
+      connect({ hostname: 'localhost', protocol: 'http:', port: 9000 }, (err) => {
+        try {
+          t.ok(err instanceof ConnectTimeoutError)
+          t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+          t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
+          clearTimeout(timeout)
+          resolve()
+        } catch (error) {
+          clearTimeout(timeout)
+          reject(error)
+        }
+      })
+    })
+  } finally {
+    net.connect = originalConnect
+    await proxyAgent.close()
+  }
 })
 
 test('use proxy-agent to connect through proxy (keep alive)', async (t) => {

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -127,6 +127,7 @@ test('ProxyAgent forwards connectTimeout to the proxy connector', async (t) => {
 
   const originalConnect = net.connect
   let connect
+  let socket
   const proxyAgent = new ProxyAgent({
     uri: 'http://localhost:9000',
     connectTimeout: 1e3,
@@ -151,11 +152,14 @@ test('ProxyAgent forwards connectTimeout to the proxy connector', async (t) => {
     t.ok(typeof connect === 'function')
 
     const timeout = setTimeout(() => {
+      if (socket && !socket.destroyed) {
+        socket.destroy()
+      }
       t.fail('connectTimeout was not forwarded to the proxy connector')
     }, 2e3)
 
     await new Promise((resolve, reject) => {
-      connect({ hostname: 'localhost', protocol: 'http:', port: 9000 }, (err) => {
+      socket = connect({ hostname: 'localhost', protocol: 'http:', port: 9000 }, (err) => {
         try {
           t.ok(err instanceof ConnectTimeoutError)
           t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
@@ -170,6 +174,9 @@ test('ProxyAgent forwards connectTimeout to the proxy connector', async (t) => {
     })
   } finally {
     net.connect = originalConnect
+    if (socket && !socket.destroyed) {
+      socket.destroy()
+    }
     await proxyAgent.close()
   }
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

Fixes #4983.

## Rationale
ProxyAgent inherits `connectTimeout`, but it was not forwarding that value to its internal connectors. This meant proxy connections could still use the default 10-second timeout instead of the configured one.

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes
- forward `connectTimeout` to the proxy connector
- forward `connectTimeout` to the request connectors
- add a regression test for the timeout behavior
<!-- Write a summary or list of changes here -->

### Features
n/a
<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes
n/a
<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations
n/a
<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
