### PR TITLE
fix: prevent cache dedup key collision via unescaped delimiters

### DIFF
--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -374,9 +374,11 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
  * @returns {string}
  */
 function makeDeduplicationKey (cacheKey, excludeHeaders) {
-  // Create a deterministic string key from the cache key
-  // Include origin, method, path, and sorted headers
-  let key = `${cacheKey.origin}:${cacheKey.method}:${cacheKey.path}`
+  // Use JSON.stringify to produce a collision-resistant key.
+  // Previous format used `:` and `=` delimiters without escaping, which
+  // allowed different header sets to produce identical keys (e.g.
+  // {a:"x:b=y"} vs {a:"x", b:"y"}). See: https://github.com/nodejs/undici/issues/5012
+  const headers = {}
 
   if (cacheKey.headers) {
     const sortedHeaders = Object.keys(cacheKey.headers).sort()
@@ -385,12 +387,11 @@ function makeDeduplicationKey (cacheKey, excludeHeaders) {
       if (excludeHeaders?.has(header.toLowerCase())) {
         continue
       }
-      const value = cacheKey.headers[header]
-      key += `:${header}=${Array.isArray(value) ? value.join(',') : value}`
+      headers[header] = cacheKey.headers[header]
     }
   }
 
-  return key
+  return JSON.stringify([cacheKey.origin, cacheKey.method, cacheKey.path, headers])
 }
 
 module.exports = {

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -3,10 +3,11 @@
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
-const { strictEqual } = require('node:assert')
+const { strictEqual, notStrictEqual } = require('node:assert')
 const { setTimeout: sleep } = require('node:timers/promises')
 const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client, interceptors } = require('../../index')
+const { makeDeduplicationKey } = require('../../lib/util/cache')
 
 describe('Deduplicate Interceptor', () => {
   test('deduplicates concurrent requests for the same resource', async () => {
@@ -1290,5 +1291,63 @@ describe('Deduplicate Interceptor', () => {
       name: 'TypeError',
       message: 'expected opts.excludeHeaderNames to be an array, got string'
     })
+  })
+
+  test('makeDeduplicationKey does not collide when header values contain delimiters', () => {
+    // Regression test for https://github.com/nodejs/undici/issues/5012
+    // Previously, headers {a:"x:b=y"} and {a:"x", b:"y"} produced the same key
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: 'x:b=y' }
+    })
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: 'x', b: 'y' }
+    })
+
+    notStrictEqual(key1, key2)
+  })
+
+  test('makeDeduplicationKey produces same key for identical headers', () => {
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { b: '2', a: '1' }
+    })
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: '1', b: '2' }
+    })
+
+    strictEqual(key1, key2)
+  })
+
+  test('makeDeduplicationKey respects excludeHeaders', () => {
+    const excludeHeaders = new Set(['x-request-id'])
+
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { accept: 'text/html', 'x-request-id': '111' }
+    }, excludeHeaders)
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { accept: 'text/html', 'x-request-id': '222' }
+    }, excludeHeaders)
+
+    strictEqual(key1, key2)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #5012

`makeDeduplicationKey` in `lib/util/cache.js` constructed deduplication keys using `:` and `=` delimiters without escaping header names or values. This allowed different header sets to produce identical keys, causing potential response confusion when the deduplicate interceptor is enabled.

**Example collision:**
- Headers `{a: "x:b=y"}` → key: `GET:https://example.com:a=x:b=y`
- Headers `{a: "x", b: "y"}` → key: `GET:https://example.com:a=x:b=y`

Both are identical despite representing different request headers.

## Changes

- Replaced string concatenation with `JSON.stringify([origin, method, path, headers])` which is inherently collision-resistant since JSON encoding properly handles all special characters
- Added 3 unit tests for `makeDeduplicationKey`:
  - Verifies that delimiter characters in header values no longer cause key collisions
  - Verifies that identical headers (regardless of insertion order) produce the same key
  - Verifies that `excludeHeaders` parameter is respected

## Test plan

- [x] All 33 existing + new dedup interceptor tests pass (`node --test test/interceptors/deduplicate.js`)
- [x] New test specifically reproduces the collision scenario from #5012 and verifies the fix