### PR TITLE
fix: avoid deduplication key collisions

### DIFF
--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -374,9 +374,8 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
  * @returns {string}
  */
 function makeDeduplicationKey (cacheKey, excludeHeaders) {
-  // Create a deterministic string key from the cache key
-  // Include origin, method, path, and sorted headers
-  let key = `${cacheKey.origin}:${cacheKey.method}:${cacheKey.path}`
+  /** @type {[string, string | string[]][]} */
+  const headers = []
 
   if (cacheKey.headers) {
     const sortedHeaders = Object.keys(cacheKey.headers).sort()
@@ -385,12 +384,17 @@ function makeDeduplicationKey (cacheKey, excludeHeaders) {
       if (excludeHeaders?.has(header.toLowerCase())) {
         continue
       }
-      const value = cacheKey.headers[header]
-      key += `:${header}=${Array.isArray(value) ? value.join(',') : value}`
+
+      headers.push([header, cacheKey.headers[header]])
     }
   }
 
-  return key
+  return JSON.stringify([
+    cacheKey.origin,
+    cacheKey.method,
+    cacheKey.path,
+    headers
+  ])
 }
 
 module.exports = {

--- a/test/cache-interceptor/cache-utils.js
+++ b/test/cache-interceptor/cache-utils.js
@@ -2,7 +2,7 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
-const { normalizeHeaders } = require('../../lib/util/cache')
+const { makeDeduplicationKey, normalizeHeaders } = require('../../lib/util/cache')
 
 test('normalizeHeaders handles plain object headers with polluted Object.prototype[Symbol.iterator]', (t) => {
   const { strictEqual } = tspl(t, { plan: 2 })
@@ -41,4 +41,29 @@ test('normalizeHeaders handles headers from Map', (t) => {
   })
 
   strictEqual(headers['x-test'], 'ok')
+})
+
+test('makeDeduplicationKey does not collide when headers contain delimiters', (t) => {
+  const { strictEqual } = tspl(t, { plan: 1 })
+
+  const keyWithDelimitedValue = makeDeduplicationKey({
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/',
+    headers: {
+      a: 'x:b=y'
+    }
+  })
+
+  const keyWithExtraHeader = makeDeduplicationKey({
+    origin: 'https://example.com',
+    method: 'GET',
+    path: '/',
+    headers: {
+      a: 'x',
+      b: 'y'
+    }
+  })
+
+  strictEqual(keyWithDelimitedValue === keyWithExtraHeader, false)
 })

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -154,6 +154,55 @@ describe('Deduplicate Interceptor', () => {
     strictEqual(body2, 'response for br')
   })
 
+  test('does not deduplicate requests when header delimiters would previously collide', async () => {
+    let requestsToOrigin = 0
+    const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {
+      requestsToOrigin++
+      await sleep(100)
+      res.end(`a=${req.headers.a};b=${req.headers.b ?? ''}`)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.deduplicate())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const [res1, res2] = await Promise.all([
+      client.request({
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          a: 'x:b=y'
+        }
+      }),
+      client.request({
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          a: 'x',
+          b: 'y'
+        }
+      })
+    ])
+
+    strictEqual(requestsToOrigin, 2)
+
+    const [body1, body2] = await Promise.all([
+      res1.body.text(),
+      res2.body.text()
+    ])
+
+    strictEqual(body1, 'a=x:b=y;b=')
+    strictEqual(body2, 'a=x;b=y')
+  })
+
   test('does not deduplicate requests with different paths', async () => {
     let requestsToOrigin = 0
     const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {


### PR DESCRIPTION
## Description
Fix deduplication key collisions in the deduplicate interceptor.

The old key builder concatenated headers with `:` and `=` delimiters without escaping them, so distinct header sets could produce the same in-flight deduplication key.

This change switches `makeDeduplicationKey()` to a structured JSON serialization of:
- origin
- method
- path
- sorted header entries

That preserves deterministic ordering while avoiding delimiter-based collisions.

## Changes
- replace delimiter-based deduplication key construction with structured serialization
- add a unit test covering the reported header collision
- add an interceptor test proving those requests no longer deduplicate incorrectly

## Testing
- `node --test test/cache-interceptor/cache-utils.js`
- `./node_modules/.bin/borp -p "test/interceptors/deduplicate.js"`
- `./node_modules/.bin/eslint lib/util/cache.js test/cache-interceptor/cache-utils.js test/interceptors/deduplicate.js`

Closes: #5012
