### PR TITLE
fix(http2): send body for non-expectsPayload methods with content

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -622,7 +622,7 @@ function writeH2 (client, request) {
     contentLength = request.contentLength
   }
 
-  if (!expectsPayload) {
+  if (contentLength === 0 && !expectsPayload) {
     // https://tools.ietf.org/html/rfc7230#section-3.3.2
     // A user agent SHOULD NOT send a Content-Length header field when
     // the request message does not contain a payload body and the method

--- a/test/http2-body-delete.js
+++ b/test/http2-body-delete.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+const assert = require('node:assert')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client } = require('..')
+
+test('Should handle h2 DELETE request with body', async t => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const expectedBody = '{"ids":[1,2,3]}'
+  const requestBody = []
+  let contentLengthHeader = null
+
+  server.on('stream', async (stream, headers) => {
+    assert.strictEqual(headers[':method'], 'DELETE')
+    assert.strictEqual(headers[':path'], '/')
+    assert.strictEqual(headers[':scheme'], 'https')
+
+    contentLengthHeader = headers['content-length']
+
+    stream.respond({
+      'content-type': 'application/json',
+      ':status': 200
+    })
+
+    for await (const chunk of stream) {
+      requestBody.push(chunk)
+    }
+
+    stream.end(JSON.stringify({ deleted: true }))
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const response = await client.request({
+    path: '/',
+    method: 'DELETE',
+    body: expectedBody,
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  // Content-Length header should be sent for DELETE with body
+  assert.strictEqual(contentLengthHeader, String(expectedBody.length))
+  assert.strictEqual(Buffer.concat(requestBody).toString('utf-8'), expectedBody)
+
+  await response.body.dump()
+})
+
+test('Should not send Content-Length for h2 DELETE without body', async t => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  let contentLengthHeader = null
+
+  server.on('stream', async (stream, headers) => {
+    assert.strictEqual(headers[':method'], 'DELETE')
+
+    contentLengthHeader = headers['content-length']
+
+    stream.respond({
+      'content-type': 'application/json',
+      ':status': 200
+    })
+
+    stream.end(JSON.stringify({ deleted: true }))
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const response = await client.request({
+    path: '/',
+    method: 'DELETE'
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  // Content-Length header should NOT be sent for DELETE without body
+  assert.strictEqual(contentLengthHeader, undefined)
+
+  await response.body.dump()
+})


### PR DESCRIPTION
Fixes #5027

## Summary

HTTP/2 crashes with `AssertionError: buffer body must have content length` when sending DELETE (or other non-expectsPayload methods) with a body.

## Root Cause

In `lib/dispatcher/client-h2.js`, the `writeH2` function unconditionally set `contentLength = null` for all methods that don't expect a payload (DELETE, GET, HEAD, etc.). However, when a body was provided, it still got passed to `writeBodyH2`, which then called `writeBuffer` with `body` and `null` contentLength. The `writeBuffer` function asserts `contentLength === body.byteLength`, which fails when `contentLength` is `null`.

## Fix

Changed line 625 from:
```js
if (!expectsPayload) {
```
to:
```js
if (contentLength === 0 && !expectsPayload) {
```

This matches the H1 behavior and only omits the Content-Length header when the body is empty for methods that don't expect a payload. When a body is present, the Content-Length header is included and the body is sent correctly.

## Testing

- All existing HTTP/2 tests pass (42 tests)
- All client and content-length tests pass (342 tests)
- Verified the fix resolves the reported issue with DELETE + body over HTTP/2
