### PR TITLE
fix(pool): propagate useH2c to connector when connections > 1

### DIFF
--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -36,6 +36,7 @@ class Pool extends PoolBase {
     autoSelectFamily,
     autoSelectFamilyAttemptTimeout,
     allowH2,
+    useH2c,
     clientTtl,
     ...options
   } = {}) {
@@ -56,6 +57,7 @@ class Pool extends PoolBase {
         ...tls,
         maxCachedSessions,
         allowH2,
+        useH2c,
         socketPath,
         timeout: connectTimeout,
         ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
@@ -67,7 +69,7 @@ class Pool extends PoolBase {
 
     this[kConnections] = connections || null
     this[kUrl] = util.parseOrigin(origin)
-    this[kOptions] = { ...util.deepClone(options), connect, allowH2, clientTtl, socketPath }
+    this[kOptions] = { ...util.deepClone(options), connect, allowH2, useH2c, clientTtl, socketPath }
     this[kFactory] = factory
 
     this.on('connect', (origin, targets) => {

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -7,7 +7,7 @@ const { test } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
-const { H2CClient, Client } = require('..')
+const { H2CClient, Client, Agent, Pool, request } = require('..')
 
 test('Should throw if no h2c origin', async t => {
   const planner = tspl(t, { plan: 1 })
@@ -179,4 +179,64 @@ test('Should throw if bad useH2c has been passed', async t => {
   })
 
   await t.completed
+})
+
+test('Pool with useH2c and connections > 1 should not raise HTTPParserError', async t => {
+  const planner = tspl(t, { plan: 6 })
+
+  const server = createServer((req, res) => {
+    res.writeHead(200)
+    res.end('Hello, world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+  const url = `http://localhost:${server.address().port}`
+  const pool = new Pool(url, { useH2c: true, connections: 2 })
+
+  t.after(() => pool.close())
+  t.after(() => server.close())
+
+  const responses = await Promise.all([
+    pool.request({ path: '/test1', method: 'GET' }),
+    pool.request({ path: '/test2', method: 'GET' }),
+    pool.request({ path: '/test3', method: 'GET' })
+  ])
+
+  for (const response of responses) {
+    planner.equal(response.statusCode, 200)
+    planner.equal(await response.body.text(), 'Hello, world!')
+  }
+
+  await planner.completed
+})
+
+test('Agent with useH2c and connections > 1 should not raise HTTPParserError', async t => {
+  const planner = tspl(t, { plan: 6 })
+
+  const server = createServer((req, res) => {
+    res.writeHead(200)
+    res.end('Hello, world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+  const port = server.address().port
+  const agent = new Agent({ useH2c: true, connections: 2 })
+
+  t.after(() => agent.close())
+  t.after(() => server.close())
+
+  const responses = await Promise.all([
+    request(`http://localhost:${port}/test1`, { dispatcher: agent }),
+    request(`http://localhost:${port}/test2`, { dispatcher: agent }),
+    request(`http://localhost:${port}/test3`, { dispatcher: agent })
+  ])
+
+  for (const response of responses) {
+    planner.equal(response.statusCode, 200)
+    planner.equal(await response.body.text(), 'Hello, world!')
+  }
+
+  await planner.completed
 })


### PR DESCRIPTION
Fixes #4737.

When constructing a `Pool` directly (or indirectly via `Agent` with `connections > 1`), the `useH2c` option was not in the constructor's destructured parameter list. It ended up in `...options` and was therefore not forwarded to `buildConnector`. The resulting connector did not set `socket.alpnProtocol = 'h2'` for plaintext h2c, so child Clients picked the HTTP/1 context for the new socket. The first response carrying an HTTP/2 `SETTINGS` frame then failed parsing with:

```
HTTPParserError: Response does not match the HTTP/1.1 protocol (Expected HTTP/, RTSP/ or ICE/)
```

`connections === 1` was unaffected because `Agent`'s default factory short-circuits to `new Client(origin, opts)`, and `Client` already destructures and forwards `useH2c` to `buildConnector`.

The fix adds `useH2c` to `Pool`'s destructured options, passes it to `buildConnector`, and stores it on `kOptions` for symmetry with `allowH2`.

I added two regression tests in `test/h2c-client.js` covering both `Pool` and `Agent` with `useH2c: true, connections: 2` against an `http2.createServer()` (h2c) backend. Both tests fail on `main` with the parser error and pass with the fix.

Test results:
- `test/h2c-client.js`: 10/10 pass (8 existing + 2 new)
- `test/pool.js`: 35/35 pass
- `test/http2-dispatcher.js`: 11/11 pass
- `test/http2-agent.js`, `test/http2-alpn.js`: pass
- `eslint lib/dispatcher/pool.js test/h2c-client.js`: clean

Manually verified the original repro from the issue (Promise.all of 3 requests through `new Agent({ useH2c: true, connections: 2 })`) now succeeds.