### PR TITLE
fix: avoid premature cleanup of dispatcher in Agent

### DIFF
--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { InvalidArgumentError, MaxOriginsReachedError } = require('../core/errors')
-const { kBusy, kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
+const { kBusy, kClients, kConnected, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
 const DispatcherBase = require('./dispatcher-base')
 const Pool = require('./pool')
 const Client = require('./client')
@@ -65,7 +65,7 @@ class Agent extends DispatcherBase {
 
   get [kRunning] () {
     let ret = 0
-    for (const { dispatcher } of this[kClients].values()) {
+    for (const dispatcher of this[kClients].values()) {
       ret += dispatcher[kRunning]
     }
     return ret
@@ -86,54 +86,52 @@ class Agent extends DispatcherBase {
       throw new MaxOriginsReachedError()
     }
 
-    const result = this[kClients].get(key)
-    let dispatcher = result && result.dispatcher
+    let dispatcher = this[kClients].get(key)
     if (!dispatcher) {
-      const closeClientIfUnused = (connected) => {
-        const result = this[kClients].get(key)
-        if (result) {
-          if (connected) result.count -= 1
-          if (result.count <= 0 && !result.dispatcher[kBusy]) {
-            this[kClients].delete(key)
-            if (!result.dispatcher.destroyed) {
-              result.dispatcher.close()
-            }
-
-            let hasOrigin = false
-            for (const entry of this[kClients].values()) {
-              if (entry.origin === origin) {
-                hasOrigin = true
-                break
-              }
-            }
-
-            if (!hasOrigin) {
-              this[kOrigins].delete(origin)
-            }
-          }
-        }
-      }
       dispatcher = this[kFactory](opts.origin, allowH2 === false
         ? { ...this[kOptions], allowH2: false }
         : this[kOptions])
-        .on('drain', this[kOnDrain])
-        .on('connect', (origin, targets) => {
-          const result = this[kClients].get(key)
-          if (result) {
-            result.count += 1
+
+      const closeClientIfUnused = () => {
+        if (this[kClients].get(key) !== dispatcher) {
+          return
+        }
+
+        if (dispatcher[kConnected] > 0 || dispatcher[kBusy]) {
+          return
+        }
+
+        this[kClients].delete(key)
+        if (!dispatcher.destroyed) {
+          dispatcher.close()
+        }
+
+        let hasOrigin = false
+        for (const client of this[kClients].values()) {
+          if (client[kUrl].origin === dispatcher[kUrl].origin) {
+            hasOrigin = true
+            break
           }
-          this[kOnConnect](origin, targets)
-        })
+        }
+
+        if (!hasOrigin) {
+          this[kOrigins].delete(dispatcher[kUrl].origin)
+        }
+      }
+
+      dispatcher
+        .on('drain', this[kOnDrain])
+        .on('connect', this[kOnConnect])
         .on('disconnect', (origin, targets, err) => {
-          closeClientIfUnused(true)
+          closeClientIfUnused()
           this[kOnDisconnect](origin, targets, err)
         })
         .on('connectionError', (origin, targets, err) => {
-          closeClientIfUnused(false)
+          closeClientIfUnused()
           this[kOnConnectionError](origin, targets, err)
         })
 
-      this[kClients].set(key, { count: 0, dispatcher, origin })
+      this[kClients].set(key, dispatcher)
       this[kOrigins].add(origin)
     }
 
@@ -142,7 +140,7 @@ class Agent extends DispatcherBase {
 
   [kClose] () {
     const closePromises = []
-    for (const { dispatcher } of this[kClients].values()) {
+    for (const dispatcher of this[kClients].values()) {
       closePromises.push(dispatcher.close())
     }
     this[kClients].clear()
@@ -152,7 +150,7 @@ class Agent extends DispatcherBase {
 
   [kDestroy] (err) {
     const destroyPromises = []
-    for (const { dispatcher } of this[kClients].values()) {
+    for (const dispatcher of this[kClients].values()) {
       destroyPromises.push(dispatcher.destroy(err))
     }
     this[kClients].clear()
@@ -162,7 +160,7 @@ class Agent extends DispatcherBase {
 
   get stats () {
     const allClientStats = {}
-    for (const { dispatcher } of this[kClients].values()) {
+    for (const dispatcher of this[kClients].values()) {
       if (dispatcher.stats) {
         allClientStats[dispatcher[kUrl].origin] = dispatcher.stats
       }

--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { InvalidArgumentError, MaxOriginsReachedError } = require('../core/errors')
-const { kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
+const { kBusy, kClients, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
 const DispatcherBase = require('./dispatcher-base')
 const Pool = require('./pool')
 const Client = require('./client')
@@ -93,23 +93,23 @@ class Agent extends DispatcherBase {
         const result = this[kClients].get(key)
         if (result) {
           if (connected) result.count -= 1
-          if (result.count <= 0) {
+          if (result.count <= 0 && !result.dispatcher[kBusy]) {
             this[kClients].delete(key)
             if (!result.dispatcher.destroyed) {
               result.dispatcher.close()
             }
-          }
 
-          let hasOrigin = false
-          for (const entry of this[kClients].values()) {
-            if (entry.origin === origin) {
-              hasOrigin = true
-              break
+            let hasOrigin = false
+            for (const entry of this[kClients].values()) {
+              if (entry.origin === origin) {
+                hasOrigin = true
+                break
+              }
             }
-          }
 
-          if (!hasOrigin) {
-            this[kOrigins].delete(origin)
+            if (!hasOrigin) {
+              this[kOrigins].delete(origin)
+            }
           }
         }
       }

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1106,7 +1106,7 @@ function writeH1 (client, request) {
     socket[kReset] = reset
   }
 
-  if (client[kMaxRequests] && socket[kCounter]++ >= client[kMaxRequests]) {
+  if (client[kMaxRequests] && ++socket[kCounter] >= client[kMaxRequests]) {
     socket[kReset] = true
   }
 

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -167,7 +167,7 @@ class MockAgent extends Dispatcher {
   }
 
   [kMockAgentSet] (origin, dispatcher) {
-    this[kClients].set(origin, { count: 0, dispatcher })
+    this[kClients].set(origin, dispatcher)
   }
 
   [kFactory] (origin) {
@@ -179,9 +179,9 @@ class MockAgent extends Dispatcher {
 
   [kMockAgentGet] (origin) {
     // First check if we can immediately find it
-    const result = this[kClients].get(origin)
-    if (result?.dispatcher) {
-      return result.dispatcher
+    const dispatcher = this[kClients].get(origin)
+    if (dispatcher) {
+      return dispatcher
     }
 
     // If the origin is not a string create a dummy parent pool and return to user
@@ -192,11 +192,11 @@ class MockAgent extends Dispatcher {
     }
 
     // If we match, create a pool and assign the same dispatches
-    for (const [keyMatcher, result] of Array.from(this[kClients])) {
-      if (result && typeof keyMatcher !== 'string' && matchValue(keyMatcher, origin)) {
+    for (const [keyMatcher, nonExplicitDispatcher] of Array.from(this[kClients])) {
+      if (nonExplicitDispatcher && typeof keyMatcher !== 'string' && matchValue(keyMatcher, origin)) {
         const dispatcher = this[kFactory](origin)
         this[kMockAgentSet](origin, dispatcher)
-        dispatcher[kDispatches] = result.dispatcher[kDispatches]
+        dispatcher[kDispatches] = nonExplicitDispatcher[kDispatches]
         return dispatcher
       }
     }
@@ -210,7 +210,7 @@ class MockAgent extends Dispatcher {
     const mockAgentClients = this[kClients]
 
     return Array.from(mockAgentClients.entries())
-      .flatMap(([origin, result]) => result.dispatcher[kDispatches].map(dispatch => ({ ...dispatch, origin })))
+      .flatMap(([origin, dispatcher]) => dispatcher[kDispatches].map(dispatch => ({ ...dispatch, origin })))
       .filter(({ pending }) => pending)
   }
 

--- a/test/agent-connection-management.js
+++ b/test/agent-connection-management.js
@@ -62,7 +62,10 @@ describe('Agent should close inactive clients', () => {
 
     await p
   })
+})
 
+// https://github.com/nodejs/undici/issues/5022
+describe('Agent should not close active clients', () => {
   test('should reuse replacement keep-alive connection after server closes the previous one', async (t) => {
     let nextSocketId = 0
     const socketIds = new Map()

--- a/test/agent-connection-management.js
+++ b/test/agent-connection-management.js
@@ -17,17 +17,15 @@ describe('Agent should close inactive clients', () => {
       server.close()
     })
 
+    /** @type {Promise<void>} */
     let p
     const agent = new Agent({
       factory: (origin, opts) => {
         const pool = new Pool(origin, opts)
-        let _resolve, _reject
-        p = new Promise((resolve, reject) => {
-          _resolve = resolve
-          _reject = reject
-        })
+        const { promise, resolve, reject } = Promise.withResolvers()
+        p = promise
         pool.on('disconnect', () => {
-          setImmediate(() => pool.destroyed ? _resolve() : _reject(new Error('client not destroyed')))
+          setImmediate(() => pool.destroyed ? resolve() : reject(new Error('client not destroyed')))
         })
         return pool
       }
@@ -39,17 +37,15 @@ describe('Agent should close inactive clients', () => {
   })
 
   test('in case of connection error', async (t) => {
+    /** @type {Promise<void>} */
     let p
     const agent = new Agent({
       factory: (origin, opts) => {
         const pool = new Pool(origin, opts)
-        let _resolve, _reject
-        p = new Promise((resolve, reject) => {
-          _resolve = resolve
-          _reject = reject
-        })
+        const { promise, resolve, reject } = Promise.withResolvers()
+        p = promise
         pool.on('connectionError', () => {
-          setImmediate(() => pool.destroyed ? _resolve() : _reject(new Error('client not destroyed')))
+          setImmediate(() => pool.destroyed ? resolve() : reject(new Error('client not destroyed')))
         })
         return pool
       }

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -265,17 +265,20 @@ test('close after and destroy should error', async (t) => {
 
 test('close socket and reconnect after maxRequestsPerClient reached', async (t) => {
   t = tspl(t, { plan: 1 })
+  let nextConnectionId = 0
+  const socketToIdMap = new Map()
+  const connectionUsedForRequest = []
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    connectionUsedForRequest.push(socketToIdMap.get(req.socket))
     res.end(req.url)
   })
 
   after(() => server.close())
 
   server.listen(0, async () => {
-    let connections = 0
-    server.on('connection', () => {
-      connections++
+    server.on('connection', (sock) => {
+      socketToIdMap.set(sock, nextConnectionId++)
     })
     const client = new Client(
       `http://localhost:${server.address().port}`,
@@ -287,7 +290,7 @@ test('close socket and reconnect after maxRequestsPerClient reached', async (t) 
     await makeRequest()
     await makeRequest()
     await makeRequest()
-    t.strictEqual(connections, 2)
+    t.deepEqual(connectionUsedForRequest, [0, 0, 1, 1])
 
     function makeRequest () {
       return client.request({ path: '/', method: 'GET' })
@@ -299,17 +302,20 @@ test('close socket and reconnect after maxRequestsPerClient reached', async (t) 
 
 test('close socket and reconnect after maxRequestsPerClient reached (async)', async (t) => {
   t = tspl(t, { plan: 1 })
+  let nextConnectionId = 0
+  const socketToIdMap = new Map()
+  const connectionUsedForRequest = []
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    connectionUsedForRequest.push(socketToIdMap.get(req.socket))
     res.end(req.url)
   })
 
   after(() => server.close())
 
   server.listen(0, async () => {
-    let connections = 0
-    server.on('connection', () => {
-      connections++
+    server.on('connection', (sock) => {
+      socketToIdMap.set(sock, nextConnectionId++)
     })
     const client = new Client(
       `http://localhost:${server.address().port}`,
@@ -323,7 +329,7 @@ test('close socket and reconnect after maxRequestsPerClient reached (async)', as
       makeRequest(),
       makeRequest()
     ])
-    t.strictEqual(connections, 2)
+    t.deepEqual(connectionUsedForRequest, [0, 0, 1, 1])
 
     function makeRequest () {
       return client.request({ path: '/', method: 'GET' })

--- a/test/issue-4244.js
+++ b/test/issue-4244.js
@@ -62,4 +62,96 @@ describe('Agent should close inactive clients', () => {
 
     await p
   })
+
+  test('should reuse replacement keep-alive connection after server closes the previous one', async (t) => {
+    let nextSocketId = 0
+    const socketIds = new Map()
+    const requestsPerSocket = new Map()
+
+    const server = createServer((req, res) => {
+      const socket = req.socket
+      if (!socketIds.has(socket)) {
+        socketIds.set(socket, ++nextSocketId)
+      }
+
+      const count = (requestsPerSocket.get(socket) || 0) + 1
+      requestsPerSocket.set(socket, count)
+
+      const remaining = 3 - count
+      res.setHeader('x-socket-id', String(socketIds.get(socket)))
+
+      if (remaining > 0) {
+        res.setHeader('connection', 'Keep-Alive')
+        res.setHeader('keep-alive', `timeout=30, max=${remaining}`)
+      } else {
+        res.setHeader('connection', 'close')
+      }
+
+      res.writeHead(200)
+      res.end('ok')
+    }).listen(0)
+
+    t.after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    const agent = new Agent({ connections: 1 })
+    t.after(() => agent.close())
+
+    const socketSequence = []
+    for (let i = 0; i < 5; i++) {
+      const { statusCode, headers, body } = await request(`http://localhost:${server.address().port}`, {
+        dispatcher: agent
+      })
+
+      assert.equal(statusCode, 200)
+      await body.dump()
+      socketSequence.push(headers['x-socket-id'])
+    }
+
+    assert.deepEqual(socketSequence.slice(0, 3), ['1', '1', '1'])
+    assert.deepEqual(socketSequence.slice(3), ['2', '2'])
+  })
+
+  test('should reuse replacement connection after keep-alive max closes the previous one', async (t) => {
+    let nextSocketId = 0
+    const socketIds = new Map()
+
+    const server = createServer((req, res) => {
+      const socket = req.socket
+      if (!socketIds.has(socket)) {
+        socketIds.set(socket, ++nextSocketId)
+      }
+
+      res.setHeader('x-socket-id', String(socketIds.get(socket)))
+      res.setHeader('connection', 'Keep-Alive')
+      res.setHeader('keep-alive', 'timeout=30')
+
+      res.writeHead(200)
+      res.end('ok')
+    }).listen(0)
+
+    t.after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    const agent = new Agent({ connections: 1, maxRequestsPerClient: 3 })
+    t.after(() => agent.close())
+
+    const socketSequence = []
+    for (let i = 0; i < 5; i++) {
+      const { statusCode, headers, body } = await request(`http://localhost:${server.address().port}`, {
+        dispatcher: agent
+      })
+
+      assert.equal(statusCode, 200)
+      await body.dump()
+      socketSequence.push(headers['x-socket-id'])
+    }
+
+    assert.deepEqual(socketSequence.slice(0, 3), ['1', '1', '1'])
+    assert.deepEqual(socketSequence.slice(3), ['2', '2'])
+  })
 })


### PR DESCRIPTION
## This relates to...

#5022 

## Changes

The fixes in #4223 and #4425 introduce a bug where keep-alive connections are sometimes not correctly reused after the first disconnection for a dispatcher.

The issue is a race between disconnect and new dispatches. After a response with `Connection: close` or after the connection reaches its request limit, the socket disconnects. If a new request has already been dispatched to the same dispatcher but has not yet been processed into a new connection, the `disconnect` handler can incorrectly treat the dispatcher as unused and call `close()` on it.

As far as I can tell, this is still a graceful failure (new request doesn't fail), but it does result in a new connection being used. If new requests are continually dispatched like this, then connections are never reused after the first one disconnects. Delaying the next dispatched request to the next event loop iteration (e.g. via `setTimeout(cb, 0)`) or longer results in the connection being reused correctly.

### Features

N/A

### Bug Fixes

#5022 

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
