### PR TITLE
fix: populate wellknownHeaderNameBuffers cache

### DIFF
--- a/lib/core/constants.js
+++ b/lib/core/constants.js
@@ -134,6 +134,7 @@ for (let i = 0; i < wellknownHeaderNames.length; ++i) {
   const lowerCasedKey = key.toLowerCase()
   headerNameLowerCasedRecord[key] = headerNameLowerCasedRecord[lowerCasedKey] =
     lowerCasedKey
+  wellknownHeaderNameBuffers[lowerCasedKey] = Buffer.from(lowerCasedKey)
 }
 
 module.exports = {

--- a/test/node-test/constants.js
+++ b/test/node-test/constants.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const {
+  wellknownHeaderNames,
+  getHeaderNameAsBuffer
+} = require('../../lib/core/constants')
+
+test('getHeaderNameAsBuffer returns cached buffer for well-known headers', () => {
+  for (let i = 0; i < wellknownHeaderNames.length; ++i) {
+    const lowerCased = wellknownHeaderNames[i].toLowerCase()
+    const first = getHeaderNameAsBuffer(lowerCased)
+    const second = getHeaderNameAsBuffer(lowerCased)
+    assert.ok(Buffer.isBuffer(first))
+    assert.strictEqual(first.toString(), lowerCased)
+    assert.strictEqual(first, second, `expected cached buffer for ${lowerCased}`)
+  }
+})
+
+test('getHeaderNameAsBuffer allocates a new buffer for unknown headers', () => {
+  const buffer = getHeaderNameAsBuffer('x-custom-not-well-known')
+  assert.ok(Buffer.isBuffer(buffer))
+  assert.strictEqual(buffer.toString(), 'x-custom-not-well-known')
+})


### PR DESCRIPTION
The `wellknownHeaderNameBuffers` object was declared but never populated, so `getHeaderNameAsBuffer` always allocated a fresh Buffer on each call, defeating the intended caching optimization. Pre-fill the cache in the same initialization loop used for `headerNameLowerCasedRecord`.