### PR TITLE
fix(fetch): use headersList for Range check on opaque 206 response

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -705,7 +705,7 @@ async function mainFetch (fetchParams, recursive) {
       response.type === 'opaque' &&
       internalResponse.status === 206 &&
       internalResponse.rangeRequested &&
-      !request.headers.contains('range', true)
+      !request.headersList.contains('range', true)
     ) {
       response = internalResponse = makeNetworkError()
     }


### PR DESCRIPTION
The internal request state has a `headersList` property, not `headers`. Accessing `request.headers.contains('range', true)` would throw a TypeError when processing an opaque response with status 206 and the range-requested flag set.