### PR TITLE
fix(fetch): correct 'navigator' typo to 'navigate' in fetchFinale

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1025,7 +1025,7 @@ function fetchFinale (fetchParams, response) {
       let responseStatus = 0
 
       // 7. If fetchParams’s request’s mode is not "navigate" or response’s has-cross-origin-redirects is false:
-      if (fetchParams.request.mode !== 'navigator' || !response.hasCrossOriginRedirects) {
+      if (fetchParams.request.mode !== 'navigate' || !response.hasCrossOriginRedirects) {
         // 1. Set responseStatus to response’s status.
         responseStatus = response.status
 


### PR DESCRIPTION
The condition in step 7 of fetchFinale checked `fetchParams.request.mode !== 'navigator'`, but 'navigator' is not a valid request mode — the spec value is 'navigate'. Because the typo never matched, the guarded block always ran, setting responseStatus and extracting the MIME type even for navigate-mode responses with cross-origin redirects, which the spec requires to be skipped.