### PR TITLE
fix(socks5): correctly expand IPv6 '::' compressed notation

### DIFF
--- a/lib/core/socks5-utils.js
+++ b/lib/core/socks5-utils.js
@@ -46,34 +46,29 @@ function parseAddress (address) {
  */
 function parseIPv6 (address) {
   const buffer = Buffer.alloc(16)
-  const parts = address.split(':')
-  let partIndex = 0
-  let bufferIndex = 0
 
   // Handle compressed notation (::)
   const doubleColonIndex = address.indexOf('::')
   if (doubleColonIndex !== -1) {
-    // Count non-empty parts
-    const nonEmptyParts = parts.filter(p => p.length > 0).length
-    const skipParts = 8 - nonEmptyParts
+    const before = address.slice(0, doubleColonIndex)
+    const after = address.slice(doubleColonIndex + 2)
+    const beforeParts = before === '' ? [] : before.split(':')
+    const afterParts = after === '' ? [] : after.split(':')
 
-    for (let i = 0; i < parts.length; i++) {
-      if (parts[i] === '' && i === doubleColonIndex / 3) {
-        // Skip empty parts for ::
-        bufferIndex += skipParts * 2
-      } else if (parts[i] !== '') {
-        const value = parseInt(parts[i], 16)
-        buffer.writeUInt16BE(value, bufferIndex)
-        bufferIndex += 2
-      }
+    let bufferIndex = 0
+    for (const part of beforeParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
+    }
+    bufferIndex = 16 - afterParts.length * 2
+    for (const part of afterParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
     }
   } else {
-    // No compression, parse normally
-    for (const part of parts) {
-      if (part === '') continue
-      const value = parseInt(part, 16)
-      buffer.writeUInt16BE(value, partIndex * 2)
-      partIndex++
+    const parts = address.split(':')
+    for (let i = 0; i < parts.length; i++) {
+      buffer.writeUInt16BE(parseInt(parts[i], 16), i * 2)
     }
   }
 

--- a/test/socks5-utils.js
+++ b/test/socks5-utils.js
@@ -48,19 +48,31 @@ test('parseAddress - Domain', async (t) => {
 })
 
 test('parseIPv6', async (t) => {
-  const p = tspl(t, { plan: 3 })
+  const p = tspl(t, { plan: 9 })
 
   // Test full IPv6
   const buffer1 = parseIPv6('2001:0db8:0000:0042:0000:8a2e:0370:7334')
   p.equal(buffer1.length, 16, 'should return 16-byte buffer')
+  p.equal(buffer1.toString('hex'), '20010db80000004200008a2e03707334', 'should parse full IPv6 correctly')
 
-  // Test compressed IPv6
+  // Test compressed IPv6 (zero-fill gap must land in the middle, not after `db8`)
   const buffer2 = parseIPv6('2001:db8::1')
   p.equal(buffer2.length, 16, 'should return 16-byte buffer for compressed')
+  p.equal(buffer2.toString('hex'), '20010db8000000000000000000000001', 'should expand :: correctly for 2001:db8::1')
 
   // Test loopback
   const buffer3 = parseIPv6('::1')
   p.equal(buffer3.length, 16, 'should return 16-byte buffer for loopback')
+  p.equal(buffer3.toString('hex'), '00000000000000000000000000000001', 'should expand ::1 correctly')
+
+  // Test :: in the middle with short groups on both sides
+  p.equal(parseIPv6('1::2').toString('hex'), '00010000000000000000000000000002', 'should expand 1::2 correctly')
+
+  // Test link-local with single group after ::
+  p.equal(parseIPv6('fe80::1').toString('hex'), 'fe800000000000000000000000000001', 'should expand fe80::1 correctly')
+
+  // Test trailing ::
+  p.equal(parseIPv6('fe80::').toString('hex'), 'fe800000000000000000000000000000', 'should expand fe80:: correctly')
 
   await p.completed
 })


### PR DESCRIPTION
The previous implementation used `doubleColonIndex / 3` to map the character offset of '::' to a parts-array index, which only works when every group before '::' is exactly three characters wide. For typical addresses like `2001:db8::1` or `fe80::1` the zero-fill gap was never applied, producing a wrong 16-byte buffer and, in a SOCKS5 proxy context, connections to unintended destinations.

Rewrite parseIPv6 to split around '::' and write the trailing groups at their correct offsets from the end of the buffer.