### PR TITLE
fix(cache): return immutable staleAt in milliseconds

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -479,7 +479,7 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
 
   if (cacheControlDirectives.immutable) {
     // https://www.rfc-editor.org/rfc/rfc8246.html#section-2.2
-    return 31536000
+    return 31536000000
   }
 
   return undefined

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -2132,6 +2132,8 @@ describe('Cache Interceptor', () => {
       const oneYear = 31536000000
       // deleteAt should be approximately 1 year out
       equal(cached.deleteAt >= clock.now + oneYear - 1000, true, `deleteAt (${cached.deleteAt}) should be ~1 year out`)
+      // staleAt should also be approximately 1 year out (not ~8.7 hours)
+      equal(cached.staleAt >= clock.now + oneYear - 1000, true, `staleAt (${cached.staleAt}) should be ~1 year out`)
     })
 
     test('stale-while-revalidate extends deleteAt beyond staleAt', async () => {


### PR DESCRIPTION
determineStaleAt returned 31536000 for immutable responses, but every other branch returns milliseconds. That made immutable cache entries go stale after ~8.76 hours instead of ~1 year. Multiply by 1000 so the unit matches the rest of the function.