### PR TITLE
fix(websocket): correct argument order in WebSocketStream UTF-8 failure

### DIFF
--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -332,7 +332,7 @@ class WebSocketStream {
       try {
         chunk = utf8Decode(data)
       } catch {
-        failWebsocketConnection(this.#handler, 'Received invalid UTF-8 in text frame.')
+        failWebsocketConnection(this.#handler, 1007, 'Received invalid UTF-8 in text frame.')
         return
       }
     } else if (type === opcodes.BINARY) {

--- a/test/websocket/stream/invalid-utf8-text-frame.js
+++ b/test/websocket/stream/invalid-utf8-text-frame.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const { WebSocketServer } = require('ws')
+const { WebSocketStream } = require('../../..')
+
+test('WebSocketStream sends close code 1007 when receiving invalid UTF-8 in a text frame', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  t.after(() => server.close())
+
+  const connection = new Promise((resolve) => {
+    server.on('connection', (ws) => {
+      // Send a text frame with invalid UTF-8 payload (unmasked, server->client).
+      // 0x81 = FIN + text opcode, 0x02 = length 2, then 0xFF 0xFE (invalid UTF-8).
+      ws._socket.write(Buffer.from([0x81, 0x02, 0xFF, 0xFE]))
+      resolve(ws)
+    })
+  })
+
+  const wss = new WebSocketStream(`ws://127.0.0.1:${server.address().port}`)
+  // Swallow the expected unclean-close rejection on the client side.
+  wss.closed.catch(() => {})
+
+  await wss.opened
+
+  const ws = await connection
+  const [code] = await once(ws, 'close')
+
+  t.assert.strictEqual(code, 1007)
+})


### PR DESCRIPTION
When a text frame with invalid UTF-8 was received, failWebsocketConnection was called with the reason string in the code position, causing the close frame to be sent with code 0 (NaN coerced from string) instead of 1007.