### PR TITLE
fix(websocket): use 1002 close code on parser errors

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -76,7 +76,7 @@ class WebSocket extends EventTarget {
   #handler = {
     onConnectionEstablished: (response, extensions) => this.#onConnectionEstablished(response, extensions),
     onMessage: (opcode, data) => this.#onMessage(opcode, data),
-    onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message),
+    onParserError: (err) => failWebsocketConnection(this.#handler, 1002, err.message),
     onParserDrain: () => this.#onParserDrain(),
     onSocketData: (chunk) => {
       if (!this.#parser.write(chunk)) {

--- a/test/websocket/parser-error-close-code.js
+++ b/test/websocket/parser-error-close-code.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+const { ByteParser } = require('../../lib/web/websocket/receiver')
+
+test('Parser errors close the connection with 1002 (Protocol Error)', async (t) => {
+  const originalWrite = ByteParser.prototype._write
+  ByteParser.prototype._write = function (chunk, enc, cb) {
+    this.emit('error', new Error('simulated parser error'))
+    cb()
+  }
+  t.after(() => {
+    ByteParser.prototype._write = originalWrite
+  })
+
+  const server = new WebSocketServer({ port: 0, host: '127.0.0.1' })
+  await new Promise((resolve) => server.on('listening', resolve))
+  t.after(() => server.close())
+
+  const receivedCode = new Promise((resolve) => {
+    server.on('connection', (serverWs) => {
+      serverWs.on('close', (code) => resolve(code))
+      // Trigger the patched parser with any valid frame (a PING).
+      serverWs._socket.write(Buffer.from([0x89, 0x00]))
+    })
+  })
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => ws.close())
+
+  t.assert.strictEqual(await receivedCode, 1002)
+})


### PR DESCRIPTION
onParserError passed null as the close code to failWebsocketConnection, causing closeWebSocketConnection to default the code to 1000 ("Normal Closure") whenever the reason string was non-empty. Protocol errors (invalid frames, RSV bit violations, etc.) surfaced through the parser were thus reported to the peer as normal closures instead of 1002 ("Protocol Error"), violating RFC 6455 section 7.4.1.