### PR TITLE
Remove unused func and unnecessary shim

### DIFF
--- a/lib/core/constants.js
+++ b/lib/core/constants.js
@@ -107,28 +107,6 @@ const headerNameLowerCasedRecord = {}
 // Note: object prototypes should not be able to be referenced. e.g. `Object#hasOwnProperty`.
 Object.setPrototypeOf(headerNameLowerCasedRecord, null)
 
-/**
- * @type {Record<Lowercase<typeof wellknownHeaderNames[number]>, Buffer>}
- */
-const wellknownHeaderNameBuffers = {}
-
-// Note: object prototypes should not be able to be referenced. e.g. `Object#hasOwnProperty`.
-Object.setPrototypeOf(wellknownHeaderNameBuffers, null)
-
-/**
- * @param {string} header Lowercased header
- * @returns {Buffer}
- */
-function getHeaderNameAsBuffer (header) {
-  let buffer = wellknownHeaderNameBuffers[header]
-
-  if (buffer === undefined) {
-    buffer = Buffer.from(header)
-  }
-
-  return buffer
-}
-
 for (let i = 0; i < wellknownHeaderNames.length; ++i) {
   const key = wellknownHeaderNames[i]
   const lowerCasedKey = key.toLowerCase()
@@ -138,6 +116,5 @@ for (let i = 0; i < wellknownHeaderNames.length; ++i) {
 
 module.exports = {
   wellknownHeaderNames,
-  headerNameLowerCasedRecord,
-  getHeaderNameAsBuffer
+  headerNameLowerCasedRecord
 }

--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -10,13 +10,7 @@ let bufIdx = BUFFER_SIZE
 
 const randomFillSync = runtimeFeatures.has('crypto')
   ? require('node:crypto').randomFillSync
-  // not full compatibility, but minimum.
-  : function randomFillSync (buffer, _offset, _size) {
-    for (let i = 0; i < buffer.length; ++i) {
-      buffer[i] = Math.random() * 255 | 0
-    }
-    return buffer
-  }
+  : null
 
 function generateMask () {
   if (bufIdx === BUFFER_SIZE) {


### PR DESCRIPTION
I have removed unused and unreachable code paths.
The shim for WebSocket `crypto.randomFillSync` is no longer required since SHA-1 (essential for WebSocket functionality) cannot be used in environments without crypto support.