### PR TITLE
fix(http2): allow GET and HEAD request bodies over h2

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -658,7 +658,7 @@ function writeH2 (client, request) {
   }
 
   // TODO(metcoder95): add support for sending trailers
-  const shouldEndStream = method === 'GET' || method === 'HEAD' || body === null
+  const shouldEndStream = body === null
   if (expectContinue) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
     stream = session.request(headers, { endStream: shouldEndStream, signal })

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -205,6 +206,81 @@ test('Should handle h2 request with body (stream)', async t => {
   t.strictEqual(Buffer.concat(requestChunks).toString('utf-8'), expectedBody)
 
   await t.completed
+})
+
+test('Should handle h2 GET and HEAD requests with body', async () => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const expectedBodies = {
+    GET: 'hello from get',
+    HEAD: 'hello from head'
+  }
+  const requestBodies = new Map()
+
+  server.on('stream', async (stream, headers) => {
+    const method = headers[':method']
+    const chunks = []
+
+    assert.ok(method === 'GET' || method === 'HEAD')
+
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+
+    requestBodies.set(method, Buffer.concat(chunks).toString('utf-8'))
+
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': method,
+      ':status': 200
+    })
+
+    if (method === 'HEAD') {
+      stream.end()
+    } else {
+      stream.end('hello h2!')
+    }
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const getResponse = await client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-type': 'text/plain'
+    },
+    body: expectedBodies.GET
+  })
+
+  assert.strictEqual(getResponse.statusCode, 200)
+  assert.strictEqual(getResponse.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(getResponse.headers['x-custom-h2'], 'GET')
+  assert.strictEqual(await getResponse.body.text(), 'hello h2!')
+
+  const headResponse = await client.request({
+    path: '/',
+    method: 'HEAD',
+    headers: {
+      'content-type': 'text/plain'
+    },
+    body: expectedBodies.HEAD
+  })
+
+  assert.strictEqual(headResponse.statusCode, 200)
+  assert.strictEqual(headResponse.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(headResponse.headers['x-custom-h2'], 'HEAD')
+  assert.strictEqual(await headResponse.body.text(), '')
+  assert.strictEqual(requestBodies.get('GET'), expectedBodies.GET)
+  assert.strictEqual(requestBodies.get('HEAD'), expectedBodies.HEAD)
 })
 
 test('Should handle h2 request with body (iterable)', async t => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5057

## Rationale

HTTP/2 requests with a body on `GET` and `HEAD` currently fail with `ERR_STREAM_WRITE_AFTER_END`.

## Changes

- Change the HTTP/2 `endStream` decision to depend on whether the normalized request body is `null`, instead of special-casing `GET` and `HEAD`.
- Add a regression test in `test/http2-body.js` covering HTTP/2 `GET` and `HEAD` requests with bodies.
- Verify that both request bodies are delivered to the server and that the responses complete successfully.

### Features

N/A

### Bug Fixes

Fix `ERR_STREAM_WRITE_AFTER_END` for HTTP/2 `GET` and `HEAD` requests with a body

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
