### PR TITLE
fix: reject malformed content-length request headers

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -27,7 +27,21 @@ const { headerNameLowerCasedRecord } = require('./constants')
 
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
-const contentLengthHeaderValueRegex = /^\d+$/
+
+function isValidContentLengthHeaderValue (val) {
+  if (typeof val !== 'string' || val.length === 0) {
+    return false
+  }
+
+  for (let i = 0; i < val.length; i++) {
+    const charCode = val.charCodeAt(i)
+    if (charCode < 48 || charCode > 57) {
+      return false
+    }
+  }
+
+  return true
+}
 
 const kHandler = Symbol('handler')
 const kController = Symbol('controller')
@@ -485,7 +499,7 @@ function processHeader (request, key, val) {
     if (request.contentLength !== null) {
       throw new InvalidArgumentError('duplicate content-length header')
     }
-    if (typeof val !== 'string' || !contentLengthHeaderValueRegex.test(val)) {
+    if (!isValidContentLengthHeaderValue(val)) {
       throw new InvalidArgumentError('invalid content-length header')
     }
     request.contentLength = parseInt(val, 10)

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -27,6 +27,7 @@ const { headerNameLowerCasedRecord } = require('./constants')
 
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
+const contentLengthHeaderValueRegex = /^\d+$/
 
 const kHandler = Symbol('handler')
 const kController = Symbol('controller')
@@ -484,10 +485,10 @@ function processHeader (request, key, val) {
     if (request.contentLength !== null) {
       throw new InvalidArgumentError('duplicate content-length header')
     }
-    request.contentLength = parseInt(val, 10)
-    if (!Number.isFinite(request.contentLength)) {
+    if (typeof val !== 'string' || !contentLengthHeaderValueRegex.test(val)) {
       throw new InvalidArgumentError('invalid content-length header')
     }
+    request.contentLength = parseInt(val, 10)
   } else if (request.contentType === null && headerName === 'content-type') {
     request.contentType = val
     request.headers.push(key, val)

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1428,7 +1428,10 @@ async function httpNetworkOrCacheFetch (
   //    8. If contentLengthHeaderValue is non-null, then append
   //    `Content-Length`/contentLengthHeaderValue to httpRequest’s header
   //    list.
-  if (contentLengthHeaderValue != null) {
+  if (
+    contentLengthHeaderValue != null &&
+    !httpRequest.headersList.contains('content-length', true)
+  ) {
     httpRequest.headersList.append('content-length', contentLengthHeaderValue, true)
   }
 

--- a/test/fetch/content-length.js
+++ b/test/fetch/content-length.js
@@ -27,3 +27,23 @@ test('Content-Length is set when using a FormData body with fetch', async (t) =>
     body: fd
   })
 })
+
+test('Content-Length is not duplicated when provided explicitly', async (t) => {
+  const body = 'a+b+c'
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers['content-length'], `${Buffer.byteLength(body)}`)
+    res.end()
+  }).listen(0)
+
+  await once(server, 'listening')
+  t.after(closeServerAsPromise(server))
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    method: 'POST',
+    body,
+    headers: {
+      'content-length': Buffer.byteLength(body)
+    }
+  })
+})

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -5,7 +5,7 @@ const { test, after } = require('node:test')
 const { Client, errors } = require('..')
 
 test('invalid headers', (t) => {
-  t = tspl(t, { plan: 10 })
+  t = tspl(t, { plan: 13 })
 
   const client = new Client('http://localhost:3000')
   after(() => client.close())
@@ -14,6 +14,36 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: {
       'content-length': 'asd'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '1.1'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '10abc'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '-1'
     }
   }, (err, data) => {
     t.ok(err instanceof errors.InvalidArgumentError)


### PR DESCRIPTION
## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5059

## Rationale

`content-length` was being validated too loosely because malformed values could be partially normalized before later request-body length checks.

This change makes the header validation stricter so only digit-only values are accepted during request parsing.

## Changes

- Reject non-string, empty, fractional, signed, and partially numeric `content-length` values before parsing them.
- Preserve existing behavior for valid decimal integer `content-length` values.

### Features

N/A

### Bug Fixes

Request `content-length` malformed values are rejected with `InvalidArgumentError('invalid content-length header')` instead of being normalized or deferred into a later mismatch error.

### Breaking Changes and Deprecations

Requests that previously accepted malformed `content-length` values will now fail immediately during header validation.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
