### PR TITLE
fix(request): reject NaN highWaterMark during option validation

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -21,7 +21,7 @@ class RequestHandler extends AsyncResource {
         throw new InvalidArgumentError('invalid callback')
       }
 
-      if (highWaterMark && (typeof highWaterMark !== 'number' || highWaterMark < 0)) {
+      if (highWaterMark != null && (!Number.isFinite(highWaterMark) || highWaterMark < 0)) {
         throw new InvalidArgumentError('invalid highWaterMark')
       }
 

--- a/test/node-test/client-errors.js
+++ b/test/node-test/client-errors.js
@@ -1161,7 +1161,7 @@ test('retry idempotent inflight', async (t) => {
 })
 
 test('invalid opts', async (t) => {
-  const p = tspl(t, { plan: 5 })
+  const p = tspl(t, { plan: 7 })
 
   const client = new Client('http://localhost:5000')
   client.request(null, (err) => {
@@ -1182,6 +1182,14 @@ test('invalid opts', async (t) => {
     path: '/',
     method: 'GET',
     highWaterMark: -1
+  }, (err) => {
+    p.ok(err instanceof errors.InvalidArgumentError)
+    p.strictEqual(err.message, 'invalid highWaterMark')
+  })
+  client.request({
+    path: '/',
+    method: 'GET',
+    highWaterMark: Number.NaN
   }, (err) => {
     p.ok(err instanceof errors.InvalidArgumentError)
     p.strictEqual(err.message, 'invalid highWaterMark')


### PR DESCRIPTION
## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5061

## Rationale

`NaN` was bypassing request option validation because the current guard used a truthiness check. That allowed the request to progress until the response body stream was created, where Node then threw `ERR_INVALID_ARG_VALUE` from the `Readable` constructor.

## Changes

Update `RequestHandler` option validation to reject non-finite `highWaterMark` values when provided

### Features

N/A

### Bug Fixes

`highWaterMark: NaN` is rejected during option validation instead of surfacing later as Node's `ERR_INVALID_ARG_VALUE`

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
