### PR TITLE
fix(interceptor): add throwOnMaxRedirect to types and interceptor opts

### DIFF
--- a/lib/handler/redirect-handler.js
+++ b/lib/handler/redirect-handler.js
@@ -23,6 +23,10 @@ class RedirectHandler {
       throw new InvalidArgumentError('maxRedirections must be a positive number')
     }
 
+    if (opts.throwOnMaxRedirect != null && typeof opts.throwOnMaxRedirect !== 'boolean') {
+      throw new InvalidArgumentError('throwOnMaxRedirect must be a boolean')
+    }
+
     this.dispatch = dispatch
     this.location = null
     const { maxRedirections: _, ...cleanOpts } = opts

--- a/lib/interceptor/redirect.js
+++ b/lib/interceptor/redirect.js
@@ -2,16 +2,16 @@
 
 const RedirectHandler = require('../handler/redirect-handler')
 
-function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections } = {}) {
+function createRedirectInterceptor ({ maxRedirections: defaultMaxRedirections, throwOnMaxRedirect: defaultThrowOnMaxRedirect } = {}) {
   return (dispatch) => {
     return function Intercept (opts, handler) {
-      const { maxRedirections = defaultMaxRedirections, ...rest } = opts
+      const { maxRedirections = defaultMaxRedirections, throwOnMaxRedirect = defaultThrowOnMaxRedirect, ...rest } = opts
 
       if (maxRedirections == null || maxRedirections === 0) {
         return dispatch(opts, handler)
       }
 
-      const dispatchOpts = { ...rest } // Stop sub dispatcher from also redirecting.
+      const dispatchOpts = { ...rest, throwOnMaxRedirect } // Stop sub dispatcher from also redirecting.
       const redirectHandler = new RedirectHandler(dispatch, maxRedirections, dispatchOpts, handler)
       return dispatch(dispatchOpts, redirectHandler)
     }

--- a/test/interceptors/redirect.js
+++ b/test/interceptors/redirect.js
@@ -466,6 +466,43 @@ for (const factory of [
     await t.completed
   })
 
+  test('should throw when max redirections is reached and throwOnMaxRedirect is set as interceptor default', async t => {
+    t = tspl(t, { plan: 1 })
+
+    const server = await startRedirectingServer()
+
+    const dispatcher = new undici.Agent().compose(
+      redirect({ maxRedirections: 2, throwOnMaxRedirect: true })
+    )
+    after(() => dispatcher.close())
+
+    try {
+      await undici.request(`http://${server}/300`, { dispatcher })
+      t.fail('Did not throw')
+    } catch (error) {
+      t.strictEqual(error.message, 'max redirects')
+    }
+
+    await t.completed
+  })
+
+  test('should not allow invalid throwOnMaxRedirect arguments', async t => {
+    t = tspl(t, { plan: 1 })
+
+    try {
+      await request(t, 'localhost', undefined, 'http://localhost', {
+        method: 'GET',
+        maxRedirections: 1,
+        throwOnMaxRedirect: 'INVALID'
+      })
+      t.fail('Did not throw')
+    } catch (err) {
+      t.strictEqual(err.message, 'throwOnMaxRedirect must be a boolean')
+    }
+
+    await t.completed
+  })
+
   test('when a Location response header is NOT present', async t => {
     t = tspl(t, { plan: 6 * 3 })
 

--- a/test/types/redirect-interceptor.test-d.ts
+++ b/test/types/redirect-interceptor.test-d.ts
@@ -1,0 +1,10 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import Interceptors from '../../types/interceptors'
+
+expectAssignable<Interceptors.RedirectInterceptorOpts>({})
+expectAssignable<Interceptors.RedirectInterceptorOpts>({ maxRedirections: 3 })
+expectAssignable<Interceptors.RedirectInterceptorOpts>({ throwOnMaxRedirect: true })
+expectAssignable<Interceptors.RedirectInterceptorOpts>({ maxRedirections: 3, throwOnMaxRedirect: true })
+
+expectNotAssignable<Interceptors.RedirectInterceptorOpts>({ maxRedirections: 'INVALID' })
+expectNotAssignable<Interceptors.RedirectInterceptorOpts>({ throwOnMaxRedirect: 'INVALID' })

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -8,7 +8,7 @@ export default Interceptors
 declare namespace Interceptors {
   export type DumpInterceptorOpts = { maxSize?: number }
   export type RetryInterceptorOpts = RetryHandler.RetryOptions
-  export type RedirectInterceptorOpts = { maxRedirections?: number }
+  export type RedirectInterceptorOpts = { maxRedirections?: number, throwOnMaxRedirect?: boolean }
   export type DecompressInterceptorOpts = {
     skipErrorResponses?: boolean
     skipStatusCodes?: number[]


### PR DESCRIPTION
## This relates to...

Fixes #4376. Continues the work from the now-closed #4377 (author abandoned after #4924 merged the docs in the opposite direction).

## Rationale

Issue #4376 reported that `throwOnMaxRedirect` was missing from the TypeScript declarations, and that the documented usage `redirect({ maxRedirections: 3, throwOnMaxRedirect: true })` did not actually work because the interceptor-level default was never plumbed through to the underlying `RedirectHandler`.

After #4924 settled the canonical name as `throwOnMaxRedirect` (singular, matching existing code), the remaining gaps are:

1. The option is missing from `RedirectInterceptorOpts` in `types/interceptors.d.ts`, so TypeScript users get a compile error when following the docs.
2. `lib/interceptor/redirect.js` only accepts `maxRedirections` as a default; `throwOnMaxRedirect` set on the interceptor itself is silently dropped — only the per-request value works.
3. `RedirectHandler` does not validate the option type.

## Changes

### Bug Fixes

- Plumb `throwOnMaxRedirect` from `createRedirectInterceptor` defaults through `dispatchOpts` so `redirect({ maxRedirections: 3, throwOnMaxRedirect: true })` behaves as documented.
- Add `throwOnMaxRedirect?: boolean` to `RedirectInterceptorOpts` in `types/interceptors.d.ts`.
- Validate `opts.throwOnMaxRedirect` in `RedirectHandler` and throw `InvalidArgumentError('throwOnMaxRedirect must be a boolean')` for non-boolean values.
- Add a JS regression test for the interceptor-level default and validation, plus a new `tsd` type test for `RedirectInterceptorOpts`.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (already documented in `docs/docs/api/Dispatcher.md` after #4924; this PR makes the docs functional)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin