### PR TITLE
types(dispatcher): use OutgoingHttpHeaders for request headers

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -1354,10 +1354,10 @@ Emitted when dispatcher is no longer busy.
 
 ## Parameter: `UndiciHeaders`
 
-* `Record<string, string | string[] | undefined> | string[] | Iterable<[string, string | string[] | undefined]> | null`
+* `Record<string, number | string | string[] | undefined> | string[] | Iterable<[string, string | string[] | undefined]> | null`
 
 Header arguments such as `options.headers` in [`Client.dispatch`](/docs/docs/api/Client.md#clientdispatchoptions-handlers) can be specified in three forms:
-* As an object specified by the `Record<string, string | string[] | undefined>` (`IncomingHttpHeaders`) type.
+* As an object specified by the `Record<string, number | string | string[] | undefined>` (`OutgoingHttpHeaders`) type.
 * As an array of strings. An array representation of a header list must have an even length, or an `InvalidArgumentError` will be thrown.
 * As an iterable that can encompass `Headers`, `Map`, or a custom iterator returning key-value pairs.
 Keys are lowercase and values are not modified.

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders } from 'node:http'
+import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'node:http'
 import { Duplex, Readable, Writable } from 'node:stream'
 import { expectAssignable, expectType } from 'tsd'
 import { Dispatcher, Headers } from '../..'
@@ -14,6 +14,12 @@ expectAssignable<Dispatcher>(new Dispatcher())
     authorization: undefined,
     'content-type': 'application/json'
   } satisfies IncomingHttpHeaders
+
+  const nodeCoreOutgoingHeaders = {
+    'content-length': 42,
+    'content-type': 'application/json',
+    'set-cookie': ['a=1', 'b=2']
+  } satisfies OutgoingHttpHeaders
 
   const headerInstanceHeaders = new Headers({ hello: 'world' })
   const mapHeaders = new Map([['hello', 'world']])
@@ -34,6 +40,8 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: ['hello', 'world'] }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: {} }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: nodeCoreHeaders }, {}))
+  expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: nodeCoreOutgoingHeaders }, {}))
+  expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: { 'content-length': 42 } }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: null, reset: true }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: undefined, reset: true }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: recordHeadersString, reset: true }, {}))
@@ -63,6 +71,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: ['hello', 'world'] }))
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: {} }))
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: nodeCoreHeaders }))
+  expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: nodeCoreOutgoingHeaders }))
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: null }))
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: undefined }))
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '', headers: recordHeadersString }))
@@ -182,6 +191,7 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: ['hello', 'world'] }))
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: {} }))
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: nodeCoreHeaders }))
+  expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: nodeCoreOutgoingHeaders }))
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: null }))
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: undefined }))
   expectAssignable<Promise<Dispatcher.UpgradeData>>(dispatcher.upgrade({ path: '', method: 'GET', headers: recordHeadersString }))

--- a/test/types/header.test-d.ts
+++ b/test/types/header.test-d.ts
@@ -1,6 +1,6 @@
-import { IncomingHttpHeaders as CoreIncomingHttpHeaders } from 'node:http'
+import { IncomingHttpHeaders as CoreIncomingHttpHeaders, OutgoingHttpHeaders as CoreOutgoingHttpHeaders } from 'node:http'
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { IncomingHttpHeaders } from '../../types/header'
+import { IncomingHttpHeaders, OutgoingHttpHeaders } from '../../types/header'
 
 const headers = {
   authorization: undefined,
@@ -14,3 +14,23 @@ expectNotAssignable<CoreIncomingHttpHeaders>({
   authorization: null,
   'content-type': 'application/json'
 })
+
+// `OutgoingHttpHeaders` accepts numeric values (e.g. `content-length`)
+// in addition to strings, string arrays, and undefined values.
+const outgoingHeaders = {
+  'content-length': 42,
+  'content-type': 'application/json',
+  'set-cookie': ['a=1', 'b=2'],
+  authorization: undefined
+} satisfies CoreOutgoingHttpHeaders
+
+expectAssignable<OutgoingHttpHeaders>(outgoingHeaders)
+expectAssignable<OutgoingHttpHeaders>({ 'content-length': 42 })
+
+// `IncomingHttpHeaders` should still be assignable to `OutgoingHttpHeaders`,
+// since every incoming header value (string | string[] | undefined) is also a
+// valid outgoing header value.
+expectAssignable<OutgoingHttpHeaders>(headers)
+
+// Numeric header values are not assignable to `IncomingHttpHeaders`.
+expectNotAssignable<IncomingHttpHeaders>({ 'content-length': 42 })

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -2,7 +2,7 @@ import { URL } from 'node:url'
 import { Duplex, Readable, Writable } from 'node:stream'
 import { EventEmitter } from 'node:events'
 import { Blob } from 'node:buffer'
-import { IncomingHttpHeaders } from './header'
+import { IncomingHttpHeaders, OutgoingHttpHeaders } from './header'
 import BodyReadable from './readable'
 import { FormData } from './formdata'
 import Errors from './errors'
@@ -10,7 +10,7 @@ import { Autocomplete } from './utility'
 
 export default Dispatcher
 
-export type UndiciHeaders = Record<string, string | string[]> | IncomingHttpHeaders | string[] | Iterable<[string, string | string[] | undefined]> | null
+export type UndiciHeaders = OutgoingHttpHeaders | string[] | Iterable<[string, string | string[] | undefined]> | null
 
 /** Dispatcher is the core API used to dispatch requests. */
 declare class Dispatcher extends EventEmitter {

--- a/types/header.d.ts
+++ b/types/header.d.ts
@@ -5,6 +5,11 @@ import { Autocomplete } from './utility'
  */
 export type IncomingHttpHeaders = Record<string, string | string[] | undefined>
 
+/**
+ * The header type declaration of `undici` for outgoing requests.
+ */
+export type OutgoingHttpHeaders = Record<string, number | string | string[] | undefined>
+
 type HeaderNames = Autocomplete<
   | 'Accept'
   | 'Accept-CH'

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -1,7 +1,7 @@
 import Agent from './agent'
 import buildConnector from './connector'
 import Dispatcher from './dispatcher'
-import { IncomingHttpHeaders } from './header'
+import { OutgoingHttpHeaders } from './header'
 
 export default ProxyAgent
 
@@ -20,7 +20,7 @@ declare namespace ProxyAgent {
      */
     auth?: string;
     token?: string;
-    headers?: IncomingHttpHeaders;
+    headers?: OutgoingHttpHeaders;
     requestTls?: buildConnector.BuildOptions;
     proxyTls?: buildConnector.BuildOptions;
     clientFactory?(origin: URL, opts: object): Dispatcher;

--- a/types/socks5-proxy-agent.d.ts
+++ b/types/socks5-proxy-agent.d.ts
@@ -1,6 +1,6 @@
 import Dispatcher from './dispatcher'
 import buildConnector from './connector'
-import { IncomingHttpHeaders } from './header'
+import { OutgoingHttpHeaders } from './header'
 import Pool from './pool'
 
 export default Socks5ProxyAgent
@@ -12,7 +12,7 @@ declare class Socks5ProxyAgent extends Dispatcher {
 declare namespace Socks5ProxyAgent {
   export interface Options extends Pool.Options {
     /** Additional headers to send with the proxy connection */
-    headers?: IncomingHttpHeaders;
+    headers?: OutgoingHttpHeaders;
     /** SOCKS5 proxy username for authentication */
     username?: string;
     /** SOCKS5 proxy password for authentication */


### PR DESCRIPTION
## This relates to...

Closes #3840

## Rationale

`DispatchOptions.headers` (and `ConnectOptions.headers`, `UpgradeOptions.headers`, `ProxyAgent.Options.headers`, `Socks5ProxyAgent.Options.headers`) are used to set headers on **outgoing** requests, but the type union `UndiciHeaders` was built around `IncomingHttpHeaders` (server-side semantics). This prevented users from passing common outgoing values like `{ 'content-length': 42 }` (numeric values), even though the runtime accepts them and coerces them to strings via template-literal interpolation in `lib/core/request.js`.

This change introduces an `OutgoingHttpHeaders` alias in `types/header.d.ts` (mirroring Node core's `http.OutgoingHttpHeaders`: `Record<string, number | string | string[] | undefined>`), and uses it to model `UndiciHeaders` and the `headers` option on the proxy agents. Response/incoming-side fields (`ResponseData.headers`, `ConnectData.headers`, etc.) continue to use `IncomingHttpHeaders` as before.

Because `IncomingHttpHeaders` is a subtype of the new `OutgoingHttpHeaders`, this is a non-breaking widening of the request-header types: any code that previously typechecked still typechecks.

## Changes

### Features

N/A

### Bug Fixes

- Add `OutgoingHttpHeaders` to `types/header.d.ts` and use it for outgoing-request `headers` options:
  - `Dispatcher.UndiciHeaders` (`DispatchOptions`, `ConnectOptions`, `UpgradeOptions`)
  - `ProxyAgent.Options.headers`
  - `Socks5ProxyAgent.Options.headers`
- Update `docs/docs/api/Dispatcher.md` `UndiciHeaders` parameter docs to reflect `OutgoingHttpHeaders` semantics (matches the screenshot in #3840).
- Add `tsd` regression tests in `test/types/header.test-d.ts` and `test/types/dispatcher.test-d.ts` covering numeric header values and Node core `OutgoingHttpHeaders` interop.

### Breaking Changes and Deprecations

None. `OutgoingHttpHeaders` is a strict superset of `IncomingHttpHeaders` for the value union, so existing usages continue to typecheck.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin