### PR TITLE
fix(fetch): prefer filename* over filename in multipart form-data

### DIFF
--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -204,7 +204,7 @@ function multipartFormDataParser (input, mimeType) {
  * Parses content-disposition attributes (e.g., name="value" or filename*=utf-8''encoded)
  * @param {Buffer} input
  * @param {{ position: number }} position
- * @returns {{ name: string, value: string }}
+ * @returns {{ name: string, value: string, extended: boolean } | null}
  */
 function parseContentDispositionAttribute (input, position) {
   // Skip leading semicolon and whitespace
@@ -304,7 +304,7 @@ function parseContentDispositionAttribute (input, position) {
     value = decoder.decode(tokenValue)
   }
 
-  return { name: attrNameStr, value }
+  return { name: attrNameStr, value, extended: isExtended }
 }
 
 /**
@@ -368,6 +368,9 @@ function parseMultipartFormDataHeaders (input, position) {
     switch (bufferToLowerCasedHeaderName(headerName)) {
       case 'content-disposition': {
         name = filename = null
+        // Track whether filename was set from the extended (RFC 5987) form so
+        // a subsequent legacy `filename` attribute does not override it.
+        let filenameIsExtended = false
 
         // Collect the disposition type (should be "form-data")
         const dispositionType = collectASequenceOfBytes(
@@ -395,7 +398,15 @@ function parseMultipartFormDataHeaders (input, position) {
           if (attribute.name === 'name') {
             name = attribute.value
           } else if (attribute.name === 'filename') {
-            filename = attribute.value
+            // Per RFC 5987 §4.1, when both legacy and extended forms of the
+            // same parameter are present, the extended (filename*) form takes
+            // precedence regardless of the order they appear in.
+            if (attribute.extended) {
+              filename = attribute.value
+              filenameIsExtended = true
+            } else if (!filenameIsExtended) {
+              filename = attribute.value
+            }
           }
         }
 

--- a/test/busboy/issue-4661.js
+++ b/test/busboy/issue-4661.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { test } = require('node:test')
+const { Request } = require('../..')
+
+const boundary = '1df6c75e-c5a7-486c-af47-67b632b19522'
+const contentType = `multipart/form-data; boundary=${boundary}`
+
+// https://github.com/nodejs/undici/issues/4661
+test('content-disposition allows both filename and filename* parameters', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename="E 1962 029 1342-0003.JPG"; filename*=utf-8\'\'E%201962%20029%201342-0003.JPG\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'E 1962 029 1342-0003.JPG')
+  t.assert.strictEqual(await file.text(), 'Hello')
+})
+
+test('filename* (RFC 5987) without legacy filename is parsed correctly', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=utf-8\'\'only-extended.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'only-extended.txt')
+})
+
+test('filename* takes precedence over filename when both are present', async (t) => {
+  // Per RFC 5987 §4.1, when both extended and non-extended forms of the
+  // same parameter appear, the extended form is preferred regardless of order.
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=utf-8\'\'extended.txt; filename="legacy.txt"\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'extended.txt')
+})
+
+test('filename* takes precedence when filename appears first', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename="legacy.txt"; filename*=utf-8\'\'extended.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'extended.txt')
+})
+
+test('filename* with percent-encoded UTF-8 bytes is decoded', async (t) => {
+  // %E2%82%AC = U+20AC (€), %20 = space
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=UTF-8\'\'%E2%82%AC%20rates.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, '\u20AC rates.txt')
+})


### PR DESCRIPTION
## This relates to...

Closes #4661

## Rationale

When a `multipart/form-data` `Content-Disposition` header carries both the legacy `filename` parameter and the RFC 5987 extended `filename*` parameter, [RFC 5987 §4.1](https://www.rfc-editor.org/rfc/rfc5987#section-4.1) requires the extended form to take precedence regardless of the order the two parameters appear in:

> When the same parameter name is defined both in non-extended and extended notation, the latter is preferred.

The previous parser simply assigned `filename` to whichever attribute was seen last, so a legacy `filename` appearing after `filename*` would clobber the percent-decoded extended value. The original bug report (#4661) used a payload generated by the C# HTTP client which emits both attributes in that order — pre PR #4662 the parser threw `expected CRLF`; after PR #4662 it parses successfully but ignores the `filename*` value.

This change tracks whether `filename` was sourced from the extended form and refuses to overwrite it with a subsequent legacy `filename`, so the extended value is always used when both are present.

The maintainer follow-up on the issue specifically requested:

> - A test that explicitly ensures filename* is parsed correctly
> - A test that ensures that without filename, parsing still succeeds
> - A test that ensures filename* takes priority over filename when both are present

All three are added in `test/busboy/issue-4661.js`, plus tests for both attribute orderings and a percent-encoded UTF-8 value (`%E2%82%AC` → `€`).

## Changes

### Features

N/A

### Bug Fixes

- `lib/web/fetch/formdata-parser.js` — `parseContentDispositionAttribute` now reports whether the attribute used the extended (`*`) notation, and the `content-disposition` header handler keeps the extended `filename*` value even when a legacy `filename` follows it.
- `test/busboy/issue-4661.js` — regression coverage for the original payload, filename-only, filename*-only, both orderings, and percent-encoded UTF-8.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin