### PR TITLE
fix(http2): avoid double-decrementing open streams on timeout

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -757,12 +757,6 @@ function writeH2 (client, request) {
   stream.on('timeout', () => {
     const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
     stream.removeAllListeners('data')
-    session[kOpenStreams] -= 1
-
-    if (session[kOpenStreams] === 0) {
-      session.unref()
-    }
-
     abort(err)
   })
 

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -9,9 +9,10 @@ const { once } = require('node:events')
 const pem = require('@metcoder95/https-pem')
 
 const { Client } = require('..')
+const { kHTTP2Session } = require('../lib/core/symbols')
 
 test('Should handle http2 stream timeout', async t => {
-  t = tspl(t, { plan: 1 })
+  t = tspl(t, { plan: 2 })
 
   const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
   const stream = createReadStream(__filename)
@@ -52,6 +53,12 @@ test('Should handle http2 stream timeout', async t => {
   await t.rejects(res.body.text(), {
     message: 'HTTP/2: "stream timeout after 50"'
   })
+
+  const session = client[kHTTP2Session]
+  const kOpenStreams = Object.getOwnPropertySymbols(session)
+    .find((symbol) => symbol.description === 'open streams')
+
+  t.strictEqual(session[kOpenStreams], 0)
 
   await t.completed
 })


### PR DESCRIPTION
## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5073

## Rationale

`client-h2.js` was decrementing `session[kOpenStreams]` in both the `timeout` handler and the stream `close` handler.

Since the timeout path aborts and closes the stream, a single timed-out request could underflow the counter and skew H2 session ref/unref bookkeeping.

## Changes

- Remove the extra `session[kOpenStreams]` decrement from the HTTP/2 stream timeout handler.
- Keep stream accounting single-sourced in the stream `close` handler.

### Features

N/A

### Bug Fixes

Prevent `kOpenStreams` from being decremented twice for a single timed-out HTTP/2 request.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
