### PR TITLE
fix(http2): record ping failures on the socket

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -273,7 +273,7 @@ function onHttp2SendPing (session) {
 
   function onPing (err, duration) {
     const client = this[kClient]
-    const socket = this[kClient]
+    const socket = this[kSocket]
 
     if (err != null) {
       const error = new InformationalError(`HTTP/2: "PING" errored - type ${err.message}`)

--- a/test/http2-ping-errors.js
+++ b/test/http2-ping-errors.js
@@ -1,0 +1,101 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const { EventEmitter } = require('node:events')
+const { setTimeout: sleep } = require('node:timers/promises')
+const { tspl } = require('@matteo.collina/tspl')
+
+const connectH2 = require('../lib/dispatcher/client-h2')
+const {
+  kError,
+  kHTTP2ConnectionWindowSize,
+  kHTTP2InitialWindowSize,
+  kMaxConcurrentStreams,
+  kOnError,
+  kPingInterval,
+  kSocket,
+  kUrl
+} = require('../lib/core/symbols')
+
+test('Should record http2 ping failures on the socket', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  class FakeSocket extends EventEmitter {
+    constructor () {
+      super()
+      this.destroyed = false
+      this[kError] = null
+    }
+
+    destroy () {
+      this.destroyed = true
+      return this
+    }
+
+    ref () {}
+    unref () {}
+  }
+
+  class FakeSession extends EventEmitter {
+    constructor () {
+      super()
+      this.closed = false
+      this.destroyed = false
+    }
+
+    close () {
+      this.closed = true
+    }
+
+    destroy () {
+      this.destroyed = true
+    }
+
+    ref () {}
+    unref () {}
+
+    ping (cb) {
+      cb(new Error('boom'))
+      this.closed = true
+    }
+  }
+
+  const socket = new FakeSocket()
+  const session = new FakeSession()
+  let pingError = null
+
+  const client = {
+    [kHTTP2ConnectionWindowSize]: null,
+    [kHTTP2InitialWindowSize]: null,
+    [kMaxConcurrentStreams]: 100,
+    [kOnError] (err) {
+      pingError = err
+    },
+    [kPingInterval]: 1,
+    [kSocket]: null,
+    [kUrl]: new URL('https://localhost'),
+    emit () {}
+  }
+
+  http2.connect = function connectStub () {
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  connectH2(client, socket)
+
+  await sleep(20)
+
+  t.ok(pingError)
+  t.strictEqual(pingError.code, 'UND_ERR_INFO')
+  t.strictEqual(pingError.message, 'HTTP/2: "PING" errored - type boom')
+  t.strictEqual(socket[kError], pingError)
+
+  await t.completed
+})


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

HTTP/2 ping failures were being recorded on the `Client` object instead of the underlying socket.

That meant the connection state did not retain the ping error in the place later session/socket shutdown paths expect to read it from.

## Changes

Fix the HTTP/2 ping callback to store ping errors on `session[kSocket]`

### Features

N/A

### Bug Fixes

- Fix incorrect error recording for HTTP/2 ping failures
- Preserve ping failure state for later close/disconnect handling

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
