### PR TITLE
fix(client-h2): stop double-decrementing kOpenStreams on stream timeout

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -757,12 +757,6 @@ function writeH2 (client, request) {
   stream.on('timeout', () => {
     const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
     stream.removeAllListeners('data')
-    session[kOpenStreams] -= 1
-
-    if (session[kOpenStreams] === 0) {
-      session.unref()
-    }
-
     abort(err)
   })
 

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -9,6 +9,7 @@ const { once } = require('node:events')
 const pem = require('@metcoder95/https-pem')
 
 const { Client } = require('..')
+const { kHTTP2Session } = require('../lib/core/symbols')
 
 test('Should handle http2 stream timeout', async t => {
   t = tspl(t, { plan: 1 })
@@ -52,6 +53,69 @@ test('Should handle http2 stream timeout', async t => {
   await t.rejects(res.body.text(), {
     message: 'HTTP/2: "stream timeout after 50"'
   })
+
+  await t.completed
+})
+
+// Regression for the double-decrement of kOpenStreams on stream timeout.
+// Both the 'timeout' handler and the 'close' handler used to decrement the
+// counter, so after a single timeout kOpenStreams became -1. The follow-up
+// request then pre-incremented it to 0 and the client treated the session as
+// idle, which produced "unref called on already-unrefed session" style
+// regressions in downstream code. With the fix only 'close' decrements, so
+// the counter stays accurate and a subsequent request on the same client
+// completes normally.
+test('http2 stream timeout keeps open-stream counter non-negative', async t => {
+  t = tspl(t, { plan: 5 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    // Respond with headers but hold the body long enough for the client
+    // bodyTimeout to fire.
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' })
+    setTimeout(() => {
+      try { stream.end('late') } catch {}
+    }, 500)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    bodyTimeout: 50,
+    pipelining: 1
+  })
+  after(() => client.close())
+
+  // Drive three sequential request timeouts on the same h2 session. Each one
+  // should leave the open-stream counter at 0, not at a negative value.
+  for (let i = 0; i < 3; i++) {
+    const req = await client.request({ path: `/timeout-${i}`, method: 'GET' })
+    await t.rejects(req.body.text(), {
+      message: 'HTTP/2: "stream timeout after 50"'
+    })
+    // Let the stream's 'close' event run before the next iteration so the
+    // close handler has had a chance to update the counter.
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  // Locate the open-stream counter on the session by its Symbol description.
+  // The Symbol itself is module-local to client-h2.js and not exported, so
+  // this is the only stable way to observe the counter value from a test.
+  const session = client[kHTTP2Session]
+  const openStreamsSymbol = Object.getOwnPropertySymbols(session)
+    .find(sym => sym.description === 'open streams')
+
+  t.ok(openStreamsSymbol, 'open-streams symbol must exist on the h2 session')
+  // Before the fix each timed-out stream ran both the 'timeout' and 'close'
+  // decrement paths, so after three cycles the counter drifted to -3. With
+  // only the 'close' handler decrementing, it returns to 0 after each
+  // request completes.
+  t.equal(session[openStreamsSymbol], 0,
+    `open-stream counter should be 0 after all streams close, got ${session[openStreamsSymbol]}`)
 
   await t.completed
 })


### PR DESCRIPTION
Fixes #5073.

The HTTP/2 stream `timeout` handler in `lib/dispatcher/client-h2.js` does:

```js
stream.on('timeout', () => {
  const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
  stream.removeAllListeners('data')
  session[kOpenStreams] -= 1
  if (session[kOpenStreams] === 0) session.unref()
  abort(err)
})
```

`abort(err)` ultimately destroys the http2 stream, which fires `close`, and the `close` listener a few lines above already decrements `kOpenStreams`:

```js
stream.once('close', () => {
  stream.removeAllListeners('data')
  session[kOpenStreams] -= 1
  if (session[kOpenStreams] === 0) session.unref()
})
```

Result: a single timed-out request knocks the counter down twice and it ends at `-1` instead of `0`. Future stream accounting on the session is then permanently skewed — the `=== 0` unref check can never match, and reused-session flows that rely on the counter reaching `0` to release the socket start holding sessions open longer than they should.

Leave the decrement to the `close` handler. The `timeout` handler only needs to stop the data listener and call `abort()`; destruction via `abort()` guarantees `close` fires exactly once. After this change the repro in the issue reports `open streams after timeout: 0` as expected.