### PR TITLE
fix(websocket): queue close/error events asynchronously when closing during CONNECTING

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -243,8 +243,23 @@ function closeWebSocketConnection (object, code, reason, validate = false) {
     // Do nothing.
   } else if (!isEstablished(object.readyState)) {
     // Fail the WebSocket connection and set object’s ready state to CLOSING (2). [WSP]
-    failWebsocketConnection(object)
+    //
+    // Per https://websockets.spec.whatwg.org/#feedback-from-the-protocol, the
+    // error and close events that result from failing the WebSocket connection
+    // must be fired by queuing a task rather than synchronously from inside
+    // close(). Abort the underlying fetch now, but defer firing the events to
+    // a microtask so that `close()` returns before any event is dispatched.
+    // See https://github.com/nodejs/undici/issues/4741
+    object.controller.abort()
     object.readyState = states.CLOSING
+    queueMicrotask(() => {
+      // The connection may already be closed (e.g. close() was called again,
+      // or the socket finished closing) by the time the microtask runs. Only
+      // dispatch the close events when they have not yet been fired.
+      if (!isClosed(object.readyState)) {
+        object.onSocketClose()
+      }
+    })
   } else if (!object.closeState.has(sentCloseFrameState.SENT) && !object.closeState.has(sentCloseFrameState.RECEIVED)) {
     // Upon either sending or receiving a Close control frame, it is said
     // that _The WebSocket Closing Handshake is Started_ and that the

--- a/test/websocket/issue-4741.js
+++ b/test/websocket/issue-4741.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocket } = require('../..')
+
+// https://github.com/nodejs/undici/issues/4741
+//
+// When close() is invoked on a WebSocket that is still in the CONNECTING state,
+// the error and close events must be fired asynchronously (by queuing a task),
+// not synchronously from inside the close() call.
+//
+// See:
+//   - https://websockets.spec.whatwg.org/#feedback-from-the-protocol
+//   - https://github.com/web-platform-tests/wpt/blob/master/websockets/interfaces/WebSocket/close/close-connecting-async.any.js
+
+test('close() while CONNECTING fires error and close events asynchronously', (t, done) => {
+  t.plan(5)
+
+  // An unreachable wss address so the connection cannot complete before close().
+  const ws = new WebSocket('wss://example.invalid/')
+
+  let closeReturned = false
+  const order = []
+
+  ws.addEventListener('error', () => {
+    order.push('error')
+    t.assert.strictEqual(
+      closeReturned,
+      true,
+      'error must fire after close() has already returned'
+    )
+  })
+
+  ws.addEventListener('close', () => {
+    order.push('close')
+    t.assert.strictEqual(
+      closeReturned,
+      true,
+      'close must fire after close() has already returned'
+    )
+    t.assert.deepStrictEqual(order, ['error', 'close'], 'event order is error then close')
+    done()
+  })
+
+  ws.close()
+  closeReturned = true
+
+  // Synchronously after close() returns, no events should have been dispatched.
+  t.assert.deepStrictEqual(order, [], 'no events dispatched synchronously from close()')
+  t.assert.strictEqual(
+    ws.readyState,
+    WebSocket.CLOSING,
+    'readyState should be CLOSING synchronously after close()'
+  )
+})


### PR DESCRIPTION
## This relates to...

Fixes #4741

## Rationale

Per the [WHATWG WebSocket spec](https://websockets.spec.whatwg.org/#dom-websocket-close), when `close()` is invoked on a `WebSocket` whose `readyState` is `CONNECTING`, the implementation must "fail the WebSocket connection", and all resulting event dispatches (`error`, `close`) must be delivered via a *queued task* — not synchronously from the `close()` call itself.

Prior to this PR, undici dispatched those events synchronously from inside `close()` via `failWebsocketConnection` → `handler.onSocketClose()`. User code observed `error` and `close` events *before* the `close()` method returned, which is observably different from browser behavior and breaks consumers that set listeners after calling `close()`.

The fix is intentionally scoped to the `CONNECTING` branch of `closeWebSocketConnection`. Other callers of `failWebsocketConnection` (receiver errors, handshake failures, `WebSocketStream`'s abort listener) keep their current synchronous behavior, preserving existing tests such as `test/websocket/stream/abort-before-open.js`.

## Changes

- `lib/web/websocket/connection.js`: In `closeWebSocketConnection`, when the socket is still `CONNECTING`, continue to abort the underlying fetch synchronously and set `readyState = CLOSING` (so that `close()` returns with the correct observable state), but defer the `onSocketClose()` dispatch — which fires `error` and `close` — to a `queueMicrotask`. The microtask guards against re-entry (e.g. a racing socket close or a second `close()` call) by bailing when `readyState` is already `CLOSED`.
- `test/websocket/issue-4741.js`: New regression test asserting that no `error` or `close` event is dispatched synchronously from `close()` when the socket is in `CONNECTING`.

### Features

N/A

### Bug Fixes

- Queue `close`/`error` events asynchronously in `closeWebSocketConnection` when the socket is still `CONNECTING` (#4741).

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented (no public API surface changed)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
