### PR TITLE
fix(websocket): populate ErrorEvent message on failed connection

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -315,7 +315,11 @@ function failWebsocketConnection (handler, code, reason, cause) {
   handler.controller.abort()
 
   if (isConnecting(handler.readyState)) {
-    // If the connection was not established, we must still emit an 'error' and 'close' events
+    // If the connection was not established, we must still emit an 'error' and 'close' events.
+    // Propagate the reason (and optional cause) so that #onSocketClose can surface a non-empty
+    // ErrorEvent.error.message describing why the connection failed.
+    // Refs https://github.com/nodejs/undici/issues/4735
+    handler.closeInfo = { code, reason, cause }
     handler.onSocketClose()
   } else if (handler.socket?.destroyed === false) {
     handler.socket.destroy()

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -54,6 +54,7 @@ function getSocketAddress (socket) {
  * @property {Set<number>} closeState
  * @property {import('../fetch/index').Fetch} controller
  * @property {boolean} [wasEverConnected=false]
+ * @property {{ code: number|null|undefined, reason: string|undefined, cause: unknown }|null} [closeInfo]
  */
 
 // https://websockets.spec.whatwg.org/#interface-definition
@@ -114,7 +115,8 @@ class WebSocket extends EventTarget {
     socket: null,
     closeState: new Set(),
     controller: null,
-    wasEverConnected: false
+    wasEverConnected: false,
+    closeInfo: null
   }
 
   #url
@@ -580,12 +582,22 @@ class WebSocket extends EventTarget {
 
     let code = 1005
     let reason = ''
+    let cause
 
     const result = this.#parser?.closingInfo
 
     if (result && !result.error) {
       code = result.code ?? 1005
       reason = result.reason
+    } else if (this.#handler.closeInfo) {
+      // The connection was failed before it could be established (e.g. network
+      // error, TLS error, non-101 response). The failure reason/cause were
+      // provided via failWebsocketConnection.
+      // Refs https://github.com/nodejs/undici/issues/4735
+      const info = this.#handler.closeInfo
+      this.#handler.closeInfo = null
+      if (info.reason) reason = info.reason
+      if (info.cause !== undefined) cause = info.cause
     }
 
     // 1. Change the ready state to CLOSED (3).
@@ -604,7 +616,8 @@ class WebSocket extends EventTarget {
       code = 1006
 
       fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new TypeError(reason)
+        error: new TypeError(reason, cause !== undefined ? { cause } : undefined),
+        message: reason
       })
     }
 

--- a/test/websocket/issue-4735.js
+++ b/test/websocket/issue-4735.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const net = require('node:net')
+
+const { WebSocket } = require('../..')
+
+// Regression test for https://github.com/nodejs/undici/issues/4735
+// Prior to 7.16.0 WebSocket's ErrorEvent.error had a descriptive message
+// ("Received network error or non-101 status code.") when the connection
+// could not be opened. After #4521 the message became an empty string,
+// leaving consumers without any information about why the connection failed.
+
+test('error event on failed connection has a non-empty message', async (t) => {
+  t.plan(4)
+
+  // Reserve a port and immediately release it so a connection attempt will be
+  // refused (ECONNREFUSED) — no server ever accepts on this port.
+  const probe = net.createServer()
+  probe.listen(0, '127.0.0.1')
+  await once(probe, 'listening')
+  const { port } = probe.address()
+  await new Promise((resolve) => probe.close(resolve))
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/`)
+
+  ws.addEventListener('error', (ev) => {
+    t.assert.ok(ev.error instanceof TypeError, 'error should be a TypeError')
+    t.assert.ok(
+      typeof ev.error.message === 'string' && ev.error.message.length > 0,
+      `error.message should be non-empty, got ${JSON.stringify(ev.error.message)}`
+    )
+    t.assert.strictEqual(
+      ev.error.message,
+      'Received network error or non-101 status code.'
+    )
+  })
+
+  const [closeEvent] = await once(ws, 'close')
+  t.assert.strictEqual(closeEvent.code, 1006)
+})


### PR DESCRIPTION
## This relates to...

Fixes #4735

## Rationale

Since undici 7.16.0 (PR #4521, commit `909a5845`), the `ErrorEvent` dispatched on a `WebSocket` when the opening handshake fails carries an empty string as its `message`. The old behavior surfaced a descriptive reason (e.g. `"Received network error or non-101 status code."`), which is what consumers — and the WPT / nodejs test fixtures — rely on to diagnose connection failures.

The regression comes from `WebSocket#onSocketClose` unconditionally constructing `new TypeError(reason)` where `reason` defaulted to `""`, discarding the descriptive reason that `failWebsocketConnection` had already produced internally.

This change restores the pre-regression behavior by plumbing the failure reason (and `cause`, when present) from `failWebsocketConnection` through to `#onSocketClose`, so the dispatched `ErrorEvent` once again has a non-empty `message` and its `error` is a `TypeError` with a meaningful `message` (and a `cause` when the underlying failure provides one). The error type remains `TypeError`, consistent with maintainer guidance on the duplicate issue #4625.

## Changes

- `lib/web/websocket/connection.js`: `failWebsocketConnection` now stores `{ code, reason, cause }` on a new `handler.closeInfo` slot before invoking the socket close path, so the reason is not lost by the time `#onSocketClose` runs.
- `lib/web/websocket/websocket.js`: handler typedef and initialization gain a `closeInfo` slot; `#onSocketClose` consumes it to build an `ErrorEvent` whose `message` matches the pre-regression string and whose `error` is a `TypeError` carrying that same `message` (plus `cause` when available).
- `test/websocket/issue-4735.js`: new regression test that opens a `WebSocket` to a closed port and asserts the `error` event's `message` is a non-empty string.

### Features

N/A

### Bug Fixes

- **Bug Fixes**: Populate `ErrorEvent` `message`/`error` with the underlying failure reason on WebSocket connect failures (#4735).

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
