### PR TITLE
perf(http2): avoid response header reserialization

### DIFF
--- a/lib/api/api-connect.js
+++ b/lib/api/api-connect.js
@@ -60,7 +60,7 @@ class ConnectHandler extends AsyncResource {
     // Indicates is an HTTP2Session
     if (responseHeaders != null) {
       responseHeaders = this.responseHeaders === 'raw'
-        ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+        ? util.parseRawHeaders(rawHeaders)
         : headers
     }
 

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -167,7 +167,7 @@ class PipelineHandler extends AsyncResource {
       if (this.onInfo) {
         const rawHeaders = controller?.rawHeaders
         const responseHeaders = this.responseHeaders === 'raw'
-          ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+          ? util.parseRawHeaders(rawHeaders)
           : headers
         this.onInfo({ statusCode, headers: responseHeaders })
       }
@@ -181,7 +181,7 @@ class PipelineHandler extends AsyncResource {
       this.handler = null
       const rawHeaders = controller?.rawHeaders
       const responseHeaders = this.responseHeaders === 'raw'
-        ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+        ? util.parseRawHeaders(rawHeaders)
         : headers
       body = this.runInAsyncScope(handler, null, {
         statusCode,

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -92,7 +92,7 @@ class RequestHandler extends AsyncResource {
 
     const rawHeaders = controller?.rawHeaders
     const responseHeaderData = responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? util.parseRawHeaders(rawHeaders)
       : headers
 
     if (statusCode < 200) {

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -85,7 +85,7 @@ class StreamHandler extends AsyncResource {
 
     const rawHeaders = controller?.rawHeaders
     const responseHeaderData = responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? util.parseRawHeaders(rawHeaders)
       : headers
 
     if (statusCode < 200) {

--- a/lib/api/api-upgrade.js
+++ b/lib/api/api-upgrade.js
@@ -67,7 +67,7 @@ class UpgradeHandler extends AsyncResource {
 
     const rawHeaders = controller?.rawHeaders
     const responseHeaders = this.responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? util.parseRawHeaders(rawHeaders)
       : headers
 
     this.runInAsyncScope(callback, null, null, {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -464,10 +464,30 @@ function parseHeaders (headers, obj) {
 }
 
 /**
- * @param {Buffer[]} headers
+ * @param {Buffer[] | string[] | Record<string, string | string[]> | null | undefined} headers
  * @returns {string[]}
  */
 function parseRawHeaders (headers) {
+  if (headers == null) {
+    return []
+  }
+
+  if (!Array.isArray(headers)) {
+    const rawHeaders = []
+
+    for (const [name, value] of Object.entries(headers)) {
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          rawHeaders.push(name, `${entry}`)
+        }
+      } else {
+        rawHeaders.push(name, `${value}`)
+      }
+    }
+
+    return rawHeaders
+  }
+
   const headersLength = headers.length
   /**
    * @type {string[]}

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -72,26 +72,6 @@ const {
   }
 } = http2
 
-function parseH2Headers (headers) {
-  const result = []
-
-  for (const [name, value] of Object.entries(headers)) {
-    // h2 may concat the header value by array
-    // e.g. Set-Cookie
-    if (Array.isArray(value)) {
-      for (const subvalue of value) {
-        // we need to provide each header value of header name
-        // because the headers handler expect name-value pair
-        result.push(Buffer.from(name), Buffer.from(subvalue))
-      }
-    } else {
-      result.push(Buffer.from(name), Buffer.from(value))
-    }
-  }
-
-  return result
-}
-
 function getGoAwayError (session, errorCode) {
   return session[kError] ||
     (errorCode === NGHTTP2_NO_ERROR
@@ -695,7 +675,7 @@ function writeH2 (client, request) {
 
         const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
 
-        request.onRequestUpgrade(statusCode, parseH2Headers(realHeaders), stream)
+        request.onRequestUpgrade(statusCode, realHeaders, stream)
 
         if (request.aborted || request.completed) {
           return
@@ -928,7 +908,7 @@ function writeH2 (client, request) {
       return
     }
 
-    if (request.onResponseStart(Number(statusCode), parseH2Headers(realHeaders), stream.resume.bind(stream), '') === false) {
+    if (request.onResponseStart(Number(statusCode), realHeaders, stream.resume.bind(stream), '') === false) {
       stream.pause()
     }
 

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -75,6 +75,35 @@ const defaultUserAgent = typeof __UNDICI_IS_NODE__ !== 'undefined' || typeof esb
 /** @type {import('buffer').resolveObjectURL} */
 let resolveObjectURL
 
+function appendHeadersListFromResponseHeaders (headersList, headers, rawHeaders) {
+  if (Array.isArray(rawHeaders)) {
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      const nameStr = bufferToLowerCasedHeaderName(rawHeaders[i])
+      const value = rawHeaders[i + 1]
+
+      if (Array.isArray(value) && !Buffer.isBuffer(value)) {
+        for (const val of value) {
+          headersList.append(nameStr, val.toString('latin1'), true)
+        }
+      } else {
+        headersList.append(nameStr, value.toString('latin1'), true)
+      }
+    }
+
+    return
+  }
+
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        headersList.append(name, `${entry}`, true)
+      }
+    } else {
+      headersList.append(name, `${value}`, true)
+    }
+  }
+}
+
 class Fetch extends EE {
   constructor (dispatcher) {
     super()
@@ -2196,25 +2225,14 @@ async function httpNetworkFetch (
             timingInfo.finalNetworkResponseStartTime = coarsenedSharedCurrentTime(fetchParams.crossOriginIsolatedCapability)
           },
 
-          onResponseStart (controller, status, _headers, statusText) {
+          onResponseStart (controller, status, headers, statusText) {
             if (status < 200) {
               return
             }
 
             const rawHeaders = controller?.rawHeaders ?? []
             const headersList = new HeadersList()
-
-            for (let i = 0; i < rawHeaders.length; i += 2) {
-              const nameStr = bufferToLowerCasedHeaderName(rawHeaders[i])
-              const value = rawHeaders[i + 1]
-              if (Array.isArray(value) && !Buffer.isBuffer(rawHeaders[i + 1])) {
-                for (const val of value) {
-                  headersList.append(nameStr, val.toString('latin1'), true)
-                }
-              } else {
-                headersList.append(nameStr, value.toString('latin1'), true)
-              }
-            }
+            appendHeadersListFromResponseHeaders(headersList, headers, rawHeaders)
             const location = headersList.get('location', true)
 
             this.body = new Readable({ read: () => controller.resume() })
@@ -2349,7 +2367,7 @@ async function httpNetworkFetch (
             reject(error)
           },
 
-          onRequestUpgrade (controller, status, _headers, socket) {
+          onRequestUpgrade (controller, status, headers, socket) {
             // We need to support 200 for websocket over h2 as per RFC-8441
             // Absence of session means H1
             if ((socket.session != null && status !== 200) || (socket.session == null && status !== 101)) {
@@ -2358,18 +2376,7 @@ async function httpNetworkFetch (
 
             const rawHeaders = controller?.rawHeaders ?? []
             const headersList = new HeadersList()
-
-            for (let i = 0; i < rawHeaders.length; i += 2) {
-              const nameStr = bufferToLowerCasedHeaderName(rawHeaders[i])
-              const value = rawHeaders[i + 1]
-              if (Array.isArray(value) && !Buffer.isBuffer(rawHeaders[i + 1])) {
-                for (const val of value) {
-                  headersList.append(nameStr, val.toString('latin1'), true)
-                }
-              } else {
-                headersList.append(nameStr, value.toString('latin1'), true)
-              }
-            }
+            appendHeadersListFromResponseHeaders(headersList, headers, rawHeaders)
 
             resolve({
               status,

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -71,7 +71,7 @@ test('Should handle h2 request without body', async t => {
 })
 
 test('Should handle h2 request with body (string or buffer) - dispatch', async t => {
-  t = tspl(t, { plan: 9 })
+  t = tspl(t, { plan: 7 })
 
   const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
   const expectedBody = 'hello from client!'
@@ -121,13 +121,8 @@ test('Should handle h2 request with body (string or buffer) - dispatch', async t
       onResponseStart (controller, statusCode) {
         const rawHeaders = controller.rawHeaders
         t.strictEqual(statusCode, 200)
-        t.strictEqual(rawHeaders[0].toString('utf-8'), 'content-type')
-        t.strictEqual(
-          rawHeaders[1].toString('utf-8'),
-          'text/plain; charset=utf-8'
-        )
-        t.strictEqual(rawHeaders[2].toString('utf-8'), 'x-custom-h2')
-        t.strictEqual(rawHeaders[3].toString('utf-8'), 'foo')
+        t.strictEqual(rawHeaders['content-type'], 'text/plain; charset=utf-8')
+        t.strictEqual(rawHeaders['x-custom-h2'], 'foo')
       },
       onResponseData (_controller, chunk) {
         response.push(chunk)
@@ -144,6 +139,56 @@ test('Should handle h2 request with body (string or buffer) - dispatch', async t
       }
     }
   )
+
+  await t.completed
+})
+
+test('Should handle h2 request raw response headers', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream, headers) => {
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': headers['x-my-header'],
+      ':status': 200
+    })
+
+    stream.end('hello h2!')
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const { statusCode, headers, body } = await client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-my-header': 'foo'
+    },
+    responseHeaders: 'raw'
+  })
+
+  await body.dump()
+
+  const rawHeaders = Object.create(null)
+  for (let i = 0; i < headers.length; i += 2) {
+    rawHeaders[headers[i]] = headers[i + 1]
+  }
+
+  t.strictEqual(statusCode, 200)
+  t.strictEqual(Array.isArray(headers), true)
+  t.strictEqual(rawHeaders['content-type'], 'text/plain; charset=utf-8')
+  t.strictEqual(rawHeaders['x-custom-h2'], 'foo')
 
   await t.completed
 })

--- a/test/node-test/util.js
+++ b/test/node-test/util.js
@@ -159,8 +159,11 @@ test('parseHeaders decodes array header values as latin1', () => {
 })
 
 test('parseRawHeaders', () => {
+  assert.deepEqual(util.parseRawHeaders(), [])
+  assert.deepEqual(util.parseRawHeaders(null), [])
   assert.deepEqual(util.parseRawHeaders(['key', 'value', Buffer.from('key'), Buffer.from('value')]), ['key', 'value', 'key', 'value'])
   assert.deepEqual(util.parseRawHeaders(['content-length', 'value', 'content-disposition', 'form-data; name="fieldName"']), ['content-length', 'value', 'content-disposition', 'form-data; name="fieldName"'])
+  assert.deepEqual(util.parseRawHeaders({ key: 'value', 'set-cookie': ['a=1', 'b=2'] }), ['key', 'value', 'set-cookie', 'a=1', 'set-cookie', 'b=2'])
 })
 
 test('parseRawHeaders decodes values as latin1, not utf8', () => {

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -210,8 +210,8 @@ declare namespace Dispatcher {
     get aborted(): boolean
     get paused(): boolean
     get reason(): Error | null
-    rawHeaders?: Buffer[] | string[] | null
-    rawTrailers?: Buffer[] | string[] | null
+    rawHeaders?: Buffer[] | string[] | IncomingHttpHeaders | null
+    rawTrailers?: Buffer[] | string[] | IncomingHttpHeaders | null
     abort(reason: Error): void
     pause(): void
     resume(): void


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

HTTP/2 responses currently pass header objects through parts of the dispatcher stack, while the `responseHeaders: 'raw'` path still expects name/value arrays. That mismatch causes unnecessary header reserialization and makes the raw-header path inconsistent across H1 and H2 callers.

## Changes

- Stop reserializing HTTP/2 response and upgrade headers into buffer pairs before handing them to request handlers.
- Extend `parseRawHeaders()` to accept nullish values and plain header objects, and normalize them into the existing flat raw-header array format.
- Reuse that normalization in the request, stream, pipeline, connect, and upgrade APIs when `responseHeaders: 'raw'` is requested.
- Update fetch response header list construction so it works with either raw header arrays or object-form response headers.
- Expand types so `DispatchController.rawHeaders` / `rawTrailers` can be `IncomingHttpHeaders`.

### Features

N/A

### Bug Fixes

- Fix `responseHeaders: 'raw'` for HTTP/2 responses so callers receive normalized raw headers without relying on H1-style buffer pairs.
- Avoid redundant header conversion work on the HTTP/2 response path.
- Preserve fetch/WebSocket header list construction when raw headers arrive in object form.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
