### PR TITLE
fix(websocket): queue close events after CONNECTING close

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -315,11 +315,11 @@ function failWebsocketConnection (handler, code, reason, cause) {
   handler.controller.abort()
 
   if (isConnecting(handler.readyState)) {
-    // If the connection was not established, we must still emit 'error' and
-    // 'close', but they must be queued after close() returns so readyState can
-    // observe the intermediate CLOSING state.
+    // WebSocket.close() while CONNECTING must queue error/close as a task so
+    // close() can return with readyState still at CLOSING. WebSocketStream
+    // keeps the existing synchronous path for its pre-open abort behavior.
     if (handler.queueCloseOnFail === true) {
-      queueMicrotask(() => {
+      setImmediate(() => {
         handler.onSocketClose()
       })
     } else {

--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -315,8 +315,16 @@ function failWebsocketConnection (handler, code, reason, cause) {
   handler.controller.abort()
 
   if (isConnecting(handler.readyState)) {
-    // If the connection was not established, we must still emit an 'error' and 'close' events
-    handler.onSocketClose()
+    // If the connection was not established, we must still emit 'error' and
+    // 'close', but they must be queued after close() returns so readyState can
+    // observe the intermediate CLOSING state.
+    if (handler.queueCloseOnFail === true) {
+      queueMicrotask(() => {
+        handler.onSocketClose()
+      })
+    } else {
+      handler.onSocketClose()
+    }
   } else if (handler.socket?.destroyed === false) {
     handler.socket.destroy()
   }

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -70,6 +70,7 @@ class WebSocketStream {
     socket: null,
     closeState: new Set(),
     controller: null,
+    queueCloseOnFail: false,
     wasEverConnected: false
   }
 

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -53,6 +53,7 @@ function getSocketAddress (socket) {
  * @property {import('stream').Duplex} socket
  * @property {Set<number>} closeState
  * @property {import('../fetch/index').Fetch} controller
+ * @property {boolean} [queueCloseOnFail=false]
  * @property {boolean} [wasEverConnected=false]
  */
 
@@ -114,6 +115,7 @@ class WebSocket extends EventTarget {
     socket: null,
     closeState: new Set(),
     controller: null,
+    queueCloseOnFail: true,
     wasEverConnected: false
   }
 

--- a/test/websocket/issue-4628.js
+++ b/test/websocket/issue-4628.js
@@ -1,16 +1,14 @@
 'use strict'
 
 const assert = require('node:assert')
+const { once } = require('node:events')
 const { test } = require('node:test')
 const { WebSocket } = require('../..')
 
-test('closing before connection is established should only fire error and close events once', (t) => {
-  t.plan(2)
-
-  t.after(() => assert.deepStrictEqual(events, ['error', 'close']))
-
+test('closing before connection is established should only fire error and close events once', async (t) => {
   const events = []
   const ws = new WebSocket('wss://example.com/')
+  const closeEvent = once(ws, 'close')
 
   ws.onopen = t.assert.fail
 
@@ -25,4 +23,8 @@ test('closing before connection is established should only fire error and close 
   })
 
   ws.close()
+
+  await closeEvent
+
+  assert.deepStrictEqual(events, ['error', 'close'])
 })

--- a/test/websocket/issue-4741.js
+++ b/test/websocket/issue-4741.js
@@ -56,6 +56,12 @@ test('close() during CONNECTING fires error and close asynchronously', async (t)
   t.assert.strictEqual(closeSeen, false)
   closeReturned = true
 
+  await Promise.resolve()
+
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSING)
+  t.assert.strictEqual(errorSeen, false)
+  t.assert.strictEqual(closeSeen, false)
+
   await closeEvent
 
   t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)

--- a/test/websocket/issue-4741.js
+++ b/test/websocket/issue-4741.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const net = require('node:net')
+const { WebSocket } = require('../..')
+
+test('close() during CONNECTING fires error and close asynchronously', async (t) => {
+  const sockets = new Set()
+  const server = net.createServer((socket) => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+    socket.on('error', () => {})
+  })
+
+  await new Promise((resolve) => server.listen(0, resolve))
+
+  t.after(async () => {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+
+  let closeReturned = false
+  let errorSeen = false
+  let closeSeen = false
+
+  ws.addEventListener('error', () => {
+    t.assert.ok(closeReturned)
+    t.assert.strictEqual(errorSeen, false)
+    t.assert.strictEqual(closeSeen, false)
+    t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)
+    errorSeen = true
+  })
+
+  ws.addEventListener('close', () => {
+    t.assert.ok(closeReturned)
+    t.assert.strictEqual(errorSeen, true)
+    t.assert.strictEqual(closeSeen, false)
+    t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)
+    closeSeen = true
+  })
+
+  const closeEvent = once(ws, 'close')
+
+  t.assert.strictEqual(ws.readyState, WebSocket.CONNECTING)
+
+  ws.close()
+
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSING)
+  t.assert.strictEqual(errorSeen, false)
+  t.assert.strictEqual(closeSeen, false)
+  closeReturned = true
+
+  await closeEvent
+
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)
+  t.assert.strictEqual(errorSeen, true)
+  t.assert.strictEqual(closeSeen, true)
+})


### PR DESCRIPTION
## Summary
- add a regression test for calling `WebSocket.close()` while the socket is still `CONNECTING`
- queue the CONNECTING failure close-path for `WebSocket` so `error` and `close` fire after `close()` returns
- keep `WebSocketStream` on the old synchronous path so its pre-open abort behavior stays unchanged

Fixes #4741

## Test plan
- `node --test test/websocket/issue-4741.js test/websocket/issue-3546.js test/websocket/issue-4273.js test/websocket/issue-3697-2399493917.js test/websocket/stream/abort-before-open.js`
- `npm run test:websocket` on Node `22.19.0`

## Notes
- `npm run test:websocket` still reports failures in `test/websocket/opening-handshake.js`, `test/websocket/issue-4989.js`, and `test/websocket/diagnostics-channel-handshake-response-h2.js`.
- I reproduced those same three H2 websocket failures on an untouched `main` clone under Node `22.19.0`, so they do not appear to be introduced by this patch.
