### PR TITLE
fix: preserve timeout errors for HTTP/2 requests

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -8,7 +8,9 @@ const {
   RequestAbortedError,
   SocketError,
   InformationalError,
-  InvalidArgumentError
+  InvalidArgumentError,
+  HeadersTimeoutError,
+  BodyTimeoutError
 } = require('../core/errors.js')
 const {
   kUrl,
@@ -33,6 +35,7 @@ const {
   kSize,
   kHTTPContext,
   kClosed,
+  kHeadersTimeout,
   kBodyTimeout,
   kEnableConnectProtocol,
   kRemoteSettings,
@@ -629,7 +632,7 @@ function onUpgradeStreamEnd () {
 
 function onUpgradeStreamTimeout () {
   const state = this[kRequestStreamState]
-  failUpgradeStream(state, new InformationalError(`HTTP/2: "stream timeout after ${state.requestTimeout}"`))
+  failUpgradeStream(state, new InformationalError(`HTTP/2: "stream timeout after ${state.headersTimeout}"`))
 }
 
 function onUpgradeResponse (headers, _flags) {
@@ -654,7 +657,7 @@ function onUpgradeResponse (headers, _flags) {
 }
 
 function setupUpgradeStream (stream, state) {
-  const { request, requestTimeout, session } = state
+  const { request, headersTimeout, session } = state
 
   stream[kHTTP2Stream] = true
   stream[kHTTP2Session] = session
@@ -669,11 +672,12 @@ function setupUpgradeStream (stream, state) {
   stream.once('close', onUpgradeStreamClose)
 
   ++session[kOpenStreams]
-  stream.setTimeout(requestTimeout)
+  stream.setTimeout(headersTimeout)
 }
 
 function writeH2 (client, request) {
-  const requestTimeout = request.bodyTimeout ?? client[kBodyTimeout]
+  const headersTimeout = request.headersTimeout ?? client[kHeadersTimeout]
+  const bodyTimeout = request.bodyTimeout ?? client[kBodyTimeout]
   const session = client[kHTTP2Session]
   const { method, path, host, upgrade, expectContinue, signal, protocol, headers: reqHeaders } = request
   let { body } = request
@@ -771,7 +775,8 @@ function writeH2 (client, request) {
       abort,
       finalizeRequest,
       request,
-      requestTimeout,
+      headersTimeout,
+      bodyTimeout,
       responseReceived: false,
       session,
       stream: null
@@ -912,7 +917,8 @@ function writeH2 (client, request) {
     expectsPayload,
     finalizeRequest,
     request,
-    requestTimeout,
+    headersTimeout,
+    bodyTimeout,
     responseReceived: false,
     session,
     stream: null
@@ -932,7 +938,7 @@ function writeH2 (client, request) {
 
   // Increment counter as we have new streams open
   ++session[kOpenStreams]
-  stream.setTimeout(requestTimeout)
+  stream.setTimeout(headersTimeout)
 
   stream[kHTTP2Session] = session
   stream.once('close', onRequestStreamClose)
@@ -1016,6 +1022,7 @@ function onResponse (headers) {
   delete headers[HTTP2_HEADER_STATUS]
   request.onResponseStarted()
   state.responseReceived = true
+  stream.setTimeout(state.bodyTimeout)
 
   // Due to the stream nature, it is possible we face a race condition
   // where the stream has been assigned, but the request has been aborted
@@ -1086,7 +1093,9 @@ function onTimeout () {
 
   releaseRequestStream(stream)
 
-  const err = new InformationalError(`HTTP/2: "stream timeout after ${state.requestTimeout}"`)
+  const err = state.responseReceived
+    ? new BodyTimeoutError(`HTTP/2: "stream timeout after ${state.bodyTimeout}"`)
+    : new HeadersTimeoutError(`HTTP/2: "headers timeout after ${state.headersTimeout}"`)
   state.abort(err)
 }
 

--- a/test/issue-5087.js
+++ b/test/issue-5087.js
@@ -2,17 +2,15 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
-const { createSecureServer } = require('node:http2')
+const { createServer } = require('node:http2')
 const { once } = require('node:events')
-
-const pem = require('@metcoder95/https-pem')
 
 const { Client, Agent, RetryAgent, errors, request } = require('..')
 
 test('https://github.com/nodejs/undici/issues/5087 bodyTimeout over h2 rejects with BodyTimeoutError', async (t) => {
   t = tspl(t, { plan: 3 })
 
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createServer()
   server.on('stream', (stream) => {
     stream.respond({ ':status': 200, 'content-type': 'text/plain' })
     setTimeout(() => {
@@ -25,9 +23,9 @@ test('https://github.com/nodejs/undici/issues/5087 bodyTimeout over h2 rejects w
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
-    connect: { rejectUnauthorized: false },
+  const client = new Client(`http://localhost:${server.address().port}`, {
     allowH2: true,
+    useH2c: true,
     bodyTimeout: 50,
     headersTimeout: 50
   })
@@ -52,7 +50,7 @@ test('https://github.com/nodejs/undici/issues/5087 bodyTimeout over h2 rejects w
 test('https://github.com/nodejs/undici/issues/5087 headersTimeout over h2 rejects with HeadersTimeoutError', async (t) => {
   t = tspl(t, { plan: 3 })
 
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createServer()
   server.on('stream', (stream) => {
     setTimeout(() => {
       try {
@@ -64,9 +62,9 @@ test('https://github.com/nodejs/undici/issues/5087 headersTimeout over h2 reject
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
-    connect: { rejectUnauthorized: false },
+  const client = new Client(`http://localhost:${server.address().port}`, {
     allowH2: true,
+    useH2c: true,
     bodyTimeout: 60_000,
     headersTimeout: 50
   })
@@ -90,7 +88,7 @@ test('https://github.com/nodejs/undici/issues/5087 RetryAgent retries h2 body ti
   t = tspl(t, { plan: 2 })
 
   let hits = 0
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createServer()
   server.on('stream', (stream) => {
     hits += 1
 
@@ -113,7 +111,7 @@ test('https://github.com/nodejs/undici/issues/5087 RetryAgent retries h2 body ti
 
   const dispatcher = new RetryAgent(new Agent({
     allowH2: true,
-    connect: { rejectUnauthorized: false },
+    useH2c: true,
     bodyTimeout: 50,
     headersTimeout: 50
   }), {
@@ -123,7 +121,7 @@ test('https://github.com/nodejs/undici/issues/5087 RetryAgent retries h2 body ti
   })
   after(() => dispatcher.close())
 
-  const res = await request(`https://localhost:${server.address().port}/`, {
+  const res = await request(`http://localhost:${server.address().port}/`, {
     dispatcher,
     method: 'GET'
   })

--- a/test/issue-5087.js
+++ b/test/issue-5087.js
@@ -1,0 +1,135 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client, Agent, RetryAgent, errors, request } = require('..')
+
+test('https://github.com/nodejs/undici/issues/5087 bodyTimeout over h2 rejects with BodyTimeoutError', async (t) => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' })
+    setTimeout(() => {
+      try {
+        stream.end('late')
+      } catch {}
+    }, 500)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    bodyTimeout: 50,
+    headersTimeout: 50
+  })
+  after(() => client.close())
+
+  const res = await client.request({ path: '/', method: 'GET' })
+
+  let err = null
+  try {
+    await res.body.text()
+  } catch (error) {
+    err = error
+  }
+
+  t.ok(err instanceof errors.BodyTimeoutError)
+  t.strictEqual(err.code, 'UND_ERR_BODY_TIMEOUT')
+  t.strictEqual(err.message, 'HTTP/2: "stream timeout after 50"')
+
+  await t.completed
+})
+
+test('https://github.com/nodejs/undici/issues/5087 headersTimeout over h2 rejects with HeadersTimeoutError', async (t) => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    setTimeout(() => {
+      try {
+        stream.close()
+      } catch {}
+    }, 500)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    bodyTimeout: 60_000,
+    headersTimeout: 50
+  })
+  after(() => client.close())
+
+  let err = null
+  try {
+    await client.request({ path: '/', method: 'GET' })
+  } catch (error) {
+    err = error
+  }
+
+  t.ok(err instanceof errors.HeadersTimeoutError)
+  t.strictEqual(err.code, 'UND_ERR_HEADERS_TIMEOUT')
+  t.strictEqual(err.message, 'HTTP/2: "headers timeout after 50"')
+
+  await t.completed
+})
+
+test('https://github.com/nodejs/undici/issues/5087 RetryAgent retries h2 body timeouts by default error code matching', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  let hits = 0
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    hits += 1
+
+    stream.respond({ ':status': 200, 'content-type': 'text/plain' })
+
+    if (hits === 1) {
+      setTimeout(() => {
+        try {
+          stream.end('late')
+        } catch {}
+      }, 500)
+      return
+    }
+
+    stream.end(`ok after ${hits} attempt(s)`)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const dispatcher = new RetryAgent(new Agent({
+    allowH2: true,
+    connect: { rejectUnauthorized: false },
+    bodyTimeout: 50,
+    headersTimeout: 50
+  }), {
+    maxRetries: 3,
+    minTimeout: 10,
+    errorCodes: ['UND_ERR_BODY_TIMEOUT']
+  })
+  after(() => dispatcher.close())
+
+  const res = await request(`https://localhost:${server.address().port}/`, {
+    dispatcher,
+    method: 'GET'
+  })
+
+  t.strictEqual(await res.body.text(), 'ok after 2 attempt(s)')
+  t.strictEqual(hits, 2)
+
+  await t.completed
+})

--- a/test/issue-5137.js
+++ b/test/issue-5137.js
@@ -2,10 +2,8 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
-const { createSecureServer } = require('node:http2')
+const { createServer } = require('node:http2')
 const { once } = require('node:events')
-
-const pem = require('@metcoder95/https-pem')
 
 const { RetryAgent, Client } = require('..')
 
@@ -19,7 +17,7 @@ const { RetryAgent, Client } = require('..')
 test('RetryAgent rejects after exhausting retries on HTTP/2 stream timeout', async t => {
   t = tspl(t, { plan: 2 })
 
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createServer()
 
   let streamCount = 0
   let resolveStreamCount
@@ -39,10 +37,11 @@ test('RetryAgent rejects after exhausting retries on HTTP/2 stream timeout', asy
   await once(server.listen(0), 'listening')
 
   const client = new RetryAgent(
-    new Client(`https://localhost:${server.address().port}`, {
-      connect: { rejectUnauthorized: false },
+    new Client(`http://localhost:${server.address().port}`, {
       allowH2: true,
-      bodyTimeout: 50
+      useH2c: true,
+      bodyTimeout: 50,
+      headersTimeout: 50
     }),
     {
       maxRetries: 3,
@@ -61,8 +60,8 @@ test('RetryAgent rejects after exhausting retries on HTTP/2 stream timeout', asy
 
   // The request itself should reject after exhausting retries
   await t.rejects(client.request({ path: '/', method: 'GET' }), {
-    code: 'UND_ERR_INFO',
-    message: /stream timeout/
+    code: 'UND_ERR_HEADERS_TIMEOUT',
+    message: /headers timeout/
   })
 
   await streamCountReached


### PR DESCRIPTION
Fixes #5087

## Description

Preserve documented timeout error semantics for HTTP/2 requests by:

- using `headersTimeout` until response headers arrive
- switching to `bodyTimeout` once the response starts
- rejecting with `HeadersTimeoutError` / `UND_ERR_HEADERS_TIMEOUT` when headers time out over h2
- rejecting with `BodyTimeoutError` / `UND_ERR_BODY_TIMEOUT` when the response body stalls over h2

This also restores `RetryAgent({ errorCodes: ['UND_ERR_BODY_TIMEOUT'] })` behavior for HTTP/2 requests.

## Tests

- `./node_modules/.bin/borp --timeout 180000 -p "test/issue-5087.js"`
- `./node_modules/.bin/borp --timeout 180000 -p "test/http2-timeout.js"`
- `npm run test:h2:core`
- `./node_modules/.bin/eslint lib/dispatcher/client-h2.js test/issue-5087.js`
