### PR TITLE
fix(cache): skip expired sqlite vary entries during lookup

### DIFF
--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -409,7 +409,7 @@ module.exports = class SqliteCacheStore {
     const now = Date.now()
     for (const value of values) {
       if (now >= value.deleteAt && !canBeExpired) {
-        return undefined
+        continue
       }
 
       let matches = true

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -231,3 +231,59 @@ test('SqliteCacheStore write & read', { skip: runtimeFeatures.has('sqlite') === 
 
   deepStrictEqual(store.get(key), value)
 })
+
+test('SqliteCacheStore ignores expired Vary variants when a later one is still valid', { skip: runtimeFeatures.has('sqlite') === false }, () => {
+  const store = new SqliteCacheStore()
+  const now = Date.now()
+  const baseKey = {
+    origin: 'localhost',
+    path: '/',
+    method: 'GET'
+  }
+
+  store.set({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'gzip'
+    }
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    vary: {
+      'accept-encoding': 'gzip'
+    },
+    cachedAt: now - 2000,
+    staleAt: now - 1000,
+    deleteAt: now - 1,
+    body: Buffer.from('expired gzip')
+  })
+
+  store.set({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'br'
+    }
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    vary: {
+      'accept-encoding': 'br'
+    },
+    cachedAt: now,
+    staleAt: now + 1000,
+    deleteAt: now + 2000,
+    body: Buffer.from('valid br')
+  })
+
+  const result = store.get({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'br'
+    }
+  })
+
+  notEqual(result, undefined)
+  strictEqual(result.body.toString(), 'valid br')
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5094

## Rationale

`SqliteCacheStore#findValue()` iterates rows ordered by `deleteAt ASC`. If the first candidate is expired, it returned `undefined` immediately instead of continuing to scan later candidates. That makes lookups incorrect for URLs with multiple `Vary` variants.

## Changes

Change `SqliteCacheStore#findValue()` to skip expired rows during lookup instead of aborting the scan.

### Features

N/A

### Bug Fixes

Fix `SqliteCacheStore#get()` returning a cache miss when an earlier expired `Vary` variant precedes a later valid variant for the same URL/method.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4