### PR TITLE
fix(socks5): enforce authenticated state before CONNECT

### DIFF
--- a/lib/core/socks5-client.js
+++ b/lib/core/socks5-client.js
@@ -51,6 +51,7 @@ const STATES = {
   INITIAL: 'initial',
   HANDSHAKING: 'handshaking',
   AUTHENTICATING: 'authenticating',
+  AUTHENTICATED: 'authenticated',
   CONNECTING: 'connecting',
   CONNECTED: 'connected',
   ERROR: 'error',
@@ -139,6 +140,11 @@ class Socks5Client extends EventEmitter {
     }
   }
 
+  markAuthenticated () {
+    this.state = STATES.AUTHENTICATED
+    this.emit('authenticated')
+  }
+
   /**
    * Start the SOCKS5 handshake
    */
@@ -189,7 +195,7 @@ class Socks5Client extends EventEmitter {
     debug('server selected auth method', method)
 
     if (method === AUTH_METHODS.NO_AUTH) {
-      this.emit('authenticated')
+      this.markAuthenticated()
     } else if (method === AUTH_METHODS.USERNAME_PASSWORD) {
       this.state = STATES.AUTHENTICATING
       this.sendAuthRequest()
@@ -254,7 +260,7 @@ class Socks5Client extends EventEmitter {
 
     this.buffer = this.buffer.subarray(2)
     debug('authentication successful')
-    this.emit('authenticated')
+    this.markAuthenticated()
   }
 
   /**
@@ -263,8 +269,12 @@ class Socks5Client extends EventEmitter {
    * @param {number} port - Target port
    */
   connect (address, port) {
-    if (this.state === STATES.CONNECTED) {
-      throw new InvalidArgumentError('Already connected')
+    if (this.state === STATES.CONNECTING || this.state === STATES.CONNECTED) {
+      throw new InvalidArgumentError('Connection already in progress')
+    }
+
+    if (this.state !== STATES.AUTHENTICATED) {
+      throw new InvalidArgumentError('Client must be authenticated before CONNECT')
     }
 
     debug('connecting to', address, port)

--- a/lib/dispatcher/socks5-proxy-agent.js
+++ b/lib/dispatcher/socks5-proxy-agent.js
@@ -6,7 +6,7 @@ const { URL } = require('node:url')
 let tls // include tls conditionally since it is not always available
 const DispatcherBase = require('./dispatcher-base')
 const { InvalidArgumentError } = require('../core/errors')
-const { Socks5Client } = require('../core/socks5-client')
+const { Socks5Client, STATES } = require('../core/socks5-client')
 const { kDispatch, kClose, kDestroy } = require('../core/symbols')
 const Pool = require('./pool')
 const buildConnector = require('../core/connect')
@@ -133,7 +133,7 @@ class Socks5ProxyAgent extends DispatcherBase {
     }
 
     // Check if already authenticated (for NO_AUTH method)
-    if (socks5Client.state === 'authenticated') {
+    if (socks5Client.state === STATES.AUTHENTICATED) {
       clearTimeout(authenticationTimeout)
       authenticationReady.resolve()
     } else {

--- a/test/socks5-client.js
+++ b/test/socks5-client.js
@@ -51,7 +51,7 @@ test('Socks5Client - handshake flow', async (t) => {
   p.equal(client.state, STATES.INITIAL, 'should start in INITIAL state')
 
   client.on('authenticated', () => {
-    p.equal(client.state, STATES.HANDSHAKING, 'should be in HANDSHAKING state after auth')
+    p.equal(client.state, STATES.AUTHENTICATED, 'should be in AUTHENTICATED state after auth')
     p.ok(true, 'should emit authenticated event')
   })
 
@@ -59,7 +59,7 @@ test('Socks5Client - handshake flow', async (t) => {
 
   // Wait for the authenticated event
   await new Promise((resolve) => {
-    if (client.state !== STATES.HANDSHAKING) {
+    if (client.state === STATES.AUTHENTICATED) {
       resolve()
     } else {
       client.once('authenticated', resolve)
@@ -68,6 +68,37 @@ test('Socks5Client - handshake flow', async (t) => {
 
   socket.destroy()
   server.close()
+
+  await p.completed
+})
+
+test('Socks5Client - connect requires authenticated state', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  class MockSocket {
+    constructor () {
+      this.destroyed = false
+      this.writes = []
+    }
+
+    on () {}
+
+    write (chunk) {
+      this.writes.push(chunk)
+    }
+
+    destroy () {
+      this.destroyed = true
+    }
+  }
+
+  const socket = new MockSocket()
+  const client = new Socks5Client(socket)
+
+  p.throws(() => {
+    client.connect('example.com', 80)
+  }, InvalidArgumentError, 'should reject connect before authentication')
+  p.equal(socket.writes.length, 0, 'should not write CONNECT before authentication')
 
   await p.completed
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5096

## Rationale

`Socks5Client` emitted `'authenticated'` on successful handshake/authentication but never transitioned into an authenticated state. As a result, `connect()` only rejected the already-connected state and could write a SOCKS `CONNECT` frame from invalid states such as `initial`, `handshaking`, `authenticating`, `closed`, or `error`.

This also affected `Socks5ProxyAgent`, which checks `socks5Client.state === 'authenticated'` in the `NO_AUTH` flow. Since that state was never set, the agent could miss the already-emitted `'authenticated'` event and wait until the authentication timeout.

## Changes

- add an explicit `AUTHENTICATED` state to `Socks5Client`
- transition to `AUTHENTICATED` before emitting `'authenticated'` in both auth-success paths
- reject `Socks5Client.connect()` unless the client is authenticated
- update `Socks5ProxyAgent` to check `STATES.AUTHENTICATED`

### Features

N/A

### Bug Fixes

- prevent `Socks5Client.connect()` from sending `CONNECT` before authentication completes
- prevent `Socks5Client.connect()` from sending `CONNECT` after invalid lifecycle states
- fix `Socks5ProxyAgent`’s `NO_AUTH` authentication readiness check to use the actual authenticated state

### Breaking Changes and Deprecations

This changes the internal `Socks5Client.state` value after successful authentication from the previous implicit/incorrect behavior to an explicit `authenticated` state. `Socks5Client` is not part of the public top-level `undici` API, so there is no intended public API break.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4