### PR TITLE
fix(socks5): encode embedded IPv4 tails in IPv6 literals correctly

### DIFF
--- a/lib/core/socks5-utils.js
+++ b/lib/core/socks5-utils.js
@@ -46,12 +46,26 @@ function parseAddress (address) {
  */
 function parseIPv6 (address) {
   const buffer = Buffer.alloc(16)
+  let normalizedAddress = address
+
+  // Expand an embedded IPv4 tail into the last two IPv6 groups.
+  if (address.includes('.')) {
+    const lastColonIndex = address.lastIndexOf(':')
+    const ipv4Part = address.slice(lastColonIndex + 1)
+
+    if (net.isIPv4(ipv4Part)) {
+      const octets = ipv4Part.split('.').map(Number)
+      const high = ((octets[0] << 8) | octets[1]).toString(16)
+      const low = ((octets[2] << 8) | octets[3]).toString(16)
+      normalizedAddress = `${address.slice(0, lastColonIndex)}:${high}:${low}`
+    }
+  }
 
   // Handle compressed notation (::)
-  const doubleColonIndex = address.indexOf('::')
+  const doubleColonIndex = normalizedAddress.indexOf('::')
   if (doubleColonIndex !== -1) {
-    const before = address.slice(0, doubleColonIndex)
-    const after = address.slice(doubleColonIndex + 2)
+    const before = normalizedAddress.slice(0, doubleColonIndex)
+    const after = normalizedAddress.slice(doubleColonIndex + 2)
     const beforeParts = before === '' ? [] : before.split(':')
     const afterParts = after === '' ? [] : after.split(':')
 
@@ -66,7 +80,7 @@ function parseIPv6 (address) {
       bufferIndex += 2
     }
   } else {
-    const parts = address.split(':')
+    const parts = normalizedAddress.split(':')
     for (let i = 0; i < parts.length; i++) {
       buffer.writeUInt16BE(parseInt(parts[i], 16), i * 2)
     }

--- a/test/socks5-utils.js
+++ b/test/socks5-utils.js
@@ -48,7 +48,7 @@ test('parseAddress - Domain', async (t) => {
 })
 
 test('parseIPv6', async (t) => {
-  const p = tspl(t, { plan: 9 })
+  const p = tspl(t, { plan: 10 })
 
   // Test full IPv6
   const buffer1 = parseIPv6('2001:0db8:0000:0042:0000:8a2e:0370:7334')
@@ -73,6 +73,9 @@ test('parseIPv6', async (t) => {
 
   // Test trailing ::
   p.equal(parseIPv6('fe80::').toString('hex'), 'fe800000000000000000000000000000', 'should expand fe80:: correctly')
+
+  // Test IPv4-mapped IPv6
+  p.equal(parseIPv6('::ffff:192.0.2.128').toString('hex'), '00000000000000000000ffffc0000280', 'should encode embedded IPv4 tail correctly')
 
   await p.completed
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5098

## Rationale

`parseIPv6()` in the SOCKS5 utilities treated each post-`::` segment as a hexadecimal hextet. That breaks valid IPv6 literals with an embedded IPv4 tail, causing Undici to write the wrong 16-byte destination address into SOCKS5 connect requests.

## Changes

Normalize embedded IPv4 tails in `parseIPv6()` before expanding compressed IPv6 notation.

### Features

N/A

### Bug Fixes

Correct SOCKS5 IPv6 address encoding for IPv4-mapped IPv6 literals.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4