### PR TITLE
fix: handle invalid HTTP/2 connection headers (#4356)

### DIFF
--- a/lib/core/errors.js
+++ b/lib/core/errors.js
@@ -163,8 +163,8 @@ class RequestAbortedError extends AbortError {
 
 const kInformationalError = Symbol.for('undici.error.UND_ERR_INFO')
 class InformationalError extends UndiciError {
-  constructor (message) {
-    super(message)
+  constructor (message, options) {
+    super(message, options)
     this.name = 'InformationalError'
     this.message = message || 'Request information'
     this.code = 'UND_ERR_INFO'

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -491,6 +491,26 @@ function writeH2 (client, request) {
     util.destroy(body, err)
   }
 
+  const requestStream = (headers, options) => {
+    try {
+      return session.request(headers, options)
+    } catch (err) {
+      if (err?.code !== 'ERR_HTTP2_INVALID_CONNECTION_HEADERS') {
+        throw err
+      }
+
+      const wrappedErr = new InformationalError(err.message, { cause: err })
+      session[kError] = wrappedErr
+      session[kSocket][kError] = wrappedErr
+
+      session.destroy(wrappedErr)
+      util.destroy(session[kSocket], wrappedErr)
+      abort(wrappedErr)
+
+      return null
+    }
+  }
+
   try {
     // We are already connected, streams are pending.
     // We can call on connect, and wait for abort
@@ -528,7 +548,11 @@ function writeH2 (client, request) {
         headers[HTTP2_HEADER_SCHEME] = protocol === 'http:' ? 'http' : 'https'
       }
 
-      stream = session.request(headers, { endStream: false, signal })
+      stream = requestStream(headers, { endStream: false, signal })
+      if (stream == null) {
+        session.unref()
+        return false
+      }
       stream[kHTTP2Stream] = true
 
       stream.once('response', (headers, _flags) => {
@@ -563,7 +587,11 @@ function writeH2 (client, request) {
     // will create a new stream. We trigger a request to create the stream and wait until
     // `ready` event is triggered
     // We disabled endStream to allow the user to write to the stream
-    stream = session.request(headers, { endStream: false, signal })
+    stream = requestStream(headers, { endStream: false, signal })
+    if (stream == null) {
+      session.unref()
+      return false
+    }
     stream[kHTTP2Stream] = true
     stream.on('response', headers => {
       const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
@@ -661,15 +689,21 @@ function writeH2 (client, request) {
   const shouldEndStream = method === 'GET' || method === 'HEAD' || body === null
   if (expectContinue) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
-    stream = session.request(headers, { endStream: shouldEndStream, signal })
+    stream = requestStream(headers, { endStream: shouldEndStream, signal })
+    if (stream == null) {
+      return false
+    }
     stream[kHTTP2Stream] = true
 
     stream.once('continue', writeBodyH2)
   } else {
-    stream = session.request(headers, {
+    stream = requestStream(headers, {
       endStream: shouldEndStream,
       signal
     })
+    if (stream == null) {
+      return false
+    }
     stream[kHTTP2Stream] = true
 
     writeBodyH2()

--- a/test/http2-invalid-connection-headers.js
+++ b/test/http2-invalid-connection-headers.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const { once } = require('node:events')
+const { tspl } = require('@matteo.collina/tspl')
+const { createSecureServer } = require('node:http2')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client } = require('..')
+const { InformationalError } = require('../lib/core/errors')
+
+test('should surface invalid HTTP/2 connection headers as a catchable error and resume queued requests', async (t) => {
+  t = tspl(t, { plan: 8 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  let connectCount = 0
+  let streamCount = 0
+  let shouldThrow = true
+
+  http2.connect = function connect (...args) {
+    connectCount++
+
+    const session = originalConnect.apply(this, args)
+    const originalRequest = session.request
+
+    session.request = function request (...requestArgs) {
+      if (shouldThrow) {
+        shouldThrow = false
+
+        const err = new TypeError('HTTP/1 Connection specific headers are forbidden: "http2-settings"')
+        err.code = 'ERR_HTTP2_INVALID_CONNECTION_HEADERS'
+        throw err
+      }
+
+      return originalRequest.apply(this, requestArgs)
+    }
+
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    streamCount++
+    stream.respond({
+      ':status': 200,
+      'content-type': 'text/plain; charset=utf-8'
+    })
+    stream.end('hello world')
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  after(() => client.close())
+
+  const firstRequest = client.request({
+    path: '/',
+    method: 'GET'
+  }).catch(err => err)
+
+  const secondRequest = client.request({
+    path: '/',
+    method: 'GET'
+  })
+
+  const err = await firstRequest
+  t.ok(err instanceof InformationalError)
+  t.strictEqual(err.code, 'UND_ERR_INFO')
+  t.strictEqual(err.message, 'HTTP/1 Connection specific headers are forbidden: "http2-settings"')
+  t.ok(err.cause instanceof TypeError)
+  t.strictEqual(err.cause.code, 'ERR_HTTP2_INVALID_CONNECTION_HEADERS')
+
+  const response = await secondRequest
+  t.strictEqual(connectCount, 2)
+  t.strictEqual(streamCount, 1)
+  t.strictEqual(await response.body.text(), 'hello world')
+
+  await t.completed
+})


### PR DESCRIPTION
## Summary

- catch `ERR_HTTP2_INVALID_CONNECTION_HEADERS` from `session.request()` in the HTTP/2 client
- wrap the Node.js error in `InformationalError` and preserve the original error as `cause`
- tear down the broken HTTP/2 session so queued requests can continue on a fresh connection
- add an HTTP/2 regression test covering both catchable failure and queue recovery

Fixes #4356

## Testing

- `npx eslint lib/core/errors.js lib/dispatcher/client-h2.js test/http2-invalid-connection-headers.js`
- `npx borp -p "test/http2-invalid-connection-headers.js"`
- `npm run test:h2:core`
- `npm run test:h2:fetch`
