### PR TITLE
fix: enforce maxCachedSessions in TLS session cache

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -38,6 +38,22 @@ const SessionCache = class WeakSessionCache {
       return
     }
 
+    if (this._sessionCache.has(sessionKey)) {
+      this._sessionCache.delete(sessionKey)
+    } else if (this._sessionCache.size >= this._maxCachedSessions) {
+      for (const [key, ref] of this._sessionCache) {
+        if (ref.deref() === undefined) {
+          this._sessionCache.delete(key)
+          return
+        }
+      }
+
+      const oldest = this._sessionCache.keys().next()
+      if (!oldest.done) {
+        this._sessionCache.delete(oldest.value)
+      }
+    }
+
     this._sessionCache.set(sessionKey, new WeakRef(session))
     this._sessionRegistry.register(session, sessionKey)
   }

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -6,7 +6,7 @@ const { readFileSync } = require('node:fs')
 const { join } = require('node:path')
 const https = require('node:https')
 const crypto = require('node:crypto')
-const { Client, Pool } = require('..')
+const { Client, Pool, buildConnector } = require('..')
 const { kSocket } = require('../lib/core/symbols')
 
 const options = {
@@ -176,6 +176,76 @@ describe('A pool should be able to reuse TLS sessions between clients', () => {
       t.ok(true, 'pass')
     })
 
+    await t.completed
+  })
+})
+
+describe('A connector should enforce maxCachedSessions across hostnames', () => {
+  test('Prepare request', async t => {
+    t = tspl(t, { plan: 4 })
+
+    const tlsOptions = {
+      ...options,
+      minVersion: 'TLSv1.2',
+      maxVersion: 'TLSv1.2'
+    }
+
+    const serverA = https.createServer(tlsOptions, (req, res) => {
+      res.end('a')
+    })
+    const serverB = https.createServer(tlsOptions, (req, res) => {
+      res.end('b')
+    })
+
+    await Promise.all([
+      new Promise((resolve) => serverA.listen(0, resolve)),
+      new Promise((resolve) => serverB.listen(0, resolve))
+    ])
+
+    after(() => {
+      serverA.close()
+      serverB.close()
+    })
+
+    const connector = buildConnector({
+      ca,
+      lookup (hostname, options, callback) {
+        if (options?.all) {
+          callback(null, [{ address: '127.0.0.1', family: 4 }])
+        } else {
+          callback(null, '127.0.0.1', 4)
+        }
+      },
+      maxCachedSessions: 1,
+      minVersion: 'TLSv1.2',
+      maxVersion: 'TLSv1.2',
+      rejectUnauthorized: false
+    })
+
+    async function connectOnce ({ hostname, port }) {
+      const { promise, resolve, reject } = Promise.withResolvers()
+
+      connector({ hostname, protocol: 'https:', port }, (err, socket) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        const reused = socket.isSessionReused()
+
+        socket.on('error', reject)
+        socket.on('end', () => resolve(reused))
+        socket.resume()
+        socket.write(`GET / HTTP/1.1\r\nHost: ${hostname}\r\nConnection: close\r\n\r\n`)
+      })
+
+      return promise
+    }
+
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), false)
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), true)
+    t.strictEqual(await connectOnce({ hostname: 'b.test', port: serverB.address().port }), false)
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), false)
     await t.completed
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5100

## Rationale

`SessionCache` currently relies on `FinalizationRegistry` cleanup to remove dead weak references, but it does not evict live entries when the cache reaches capacity. That allows `_sessionCache` to grow beyond `maxCachedSessions` for long-lived TLS sessions.

## Changes

- Add bounded eviction to `SessionCache.set()`.
- Prefer evicting dead weak-ref entries first when the cache is full.
- Fall back to evicting the oldest live entry when no dead entry is available.
- Refresh insertion order when updating an existing session key.

### Features

N/A

### Bug Fixes

- Enforce `maxCachedSessions` even when cached TLS sessions are still alive.
- Prevent the TLS session cache map from growing past the configured limit.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4