### PR TITLE
fix(websocket): avoid double-closing canceled stream readers

### DIFF
--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { addAbortListener } = require('node:events')
-const { environmentSettingsObject } = require('../../fetch/util')
+const { environmentSettingsObject, readableStreamClose } = require('../../fetch/util')
 const { states, opcodes, sentCloseFrameState } = require('../constants')
 const { webidl } = require('../../webidl')
 const { getURLRecord, isValidSubprotocol, isEstablished, utf8Decode } = require('../util')
@@ -386,7 +386,7 @@ class WebSocketStream {
     // 6. If the connection was closed cleanly ,
     if (wasClean) {
       // 6.1. Close stream ’s readable stream .
-      this.#readableStreamController.close()
+      readableStreamClose(this.#readableStreamController)
 
       // 6.2. Error stream ’s writable stream with an " InvalidStateError " DOMException indicating that a closed WebSocketStream cannot be written to.
       if (!this.#writableStream.locked) {

--- a/test/websocket/stream/readable-cancel-before-clean-close.js
+++ b/test/websocket/stream/readable-cancel-before-clean-close.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+
+const { WebSocketStream } = require('../../..')
+
+test('WebSocketStream does not throw when readable is canceled before a clean close', async (t) => {
+  let uncaughtException = null
+
+  const uncaughtExceptionHandler = (err) => {
+    uncaughtException = err
+  }
+
+  process.on('uncaughtException', uncaughtExceptionHandler)
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (ws) => {
+    setTimeout(() => {
+      ws.send('hello')
+
+      setTimeout(() => {
+        ws.close(1000, 'bye')
+      }, 20)
+    }, 200)
+  })
+
+  t.after(() => {
+    process.off('uncaughtException', uncaughtExceptionHandler)
+
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  const wss = new WebSocketStream(`ws://127.0.0.1:${server.address().port}`)
+  const { readable } = await wss.opened
+
+  await readable.cancel(new Error('client cancel')).catch(() => {})
+  wss.close()
+
+  await Promise.race([
+    wss.closed.catch(() => {}),
+    new Promise((resolve) => setTimeout(resolve, 1000))
+  ])
+
+  t.assert.strictEqual(uncaughtException, null)
+})


### PR DESCRIPTION
## This relates to...

Closes #5103 
Closes #5104

## Rationale

`WebSocketStream` could throw `ERR_INVALID_STATE` when `readable.cancel()` closed the internal controller before the later clean-close path tried to close it again. This keeps the readable shutdown path idempotent and prevents the uncaught exception.

## Changes

- reuse `readableStreamClose()` in the clean `WebSocketStream` socket close path instead of calling `ReadableStreamDefaultController.close()` directly
- add a regression test that cancels the readable stream before a clean close handshake and asserts no uncaught exception escapes

### Features

N/A

### Bug Fixes

- fix a `WebSocketStream` double-close path that could throw `TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed`
- cover the cancel-then-clean-close sequence with a websocket stream regression test

### Breaking Changes and Deprecations

N/A

## Status

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin