### PR TITLE
fix(cache): persist vary when updating sqlite cache entries

### DIFF
--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -173,6 +173,7 @@ module.exports = class SqliteCacheStore {
         headers = ?,
         etag = ?,
         cacheControlDirectives = ?,
+        vary = ?,
         cachedAt = ?,
         staleAt = ?
       WHERE
@@ -278,6 +279,7 @@ module.exports = class SqliteCacheStore {
         value.headers ? JSON.stringify(value.headers) : null,
         value.etag ? value.etag : null,
         value.cacheControlDirectives ? JSON.stringify(value.cacheControlDirectives) : null,
+        value.vary ? JSON.stringify(value.vary) : null,
         value.cachedAt,
         value.staleAt,
         existingValue.id

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -287,3 +287,51 @@ test('SqliteCacheStore ignores expired Vary variants when a later one is still v
   notEqual(result, undefined)
   strictEqual(result.body.toString(), 'valid br')
 })
+
+test('SqliteCacheStore updates vary when overwriting an existing row', { skip: runtimeFeatures.has('sqlite') === false }, () => {
+  const store = new SqliteCacheStore()
+  const now = Date.now()
+  const baseKey = {
+    origin: 'localhost',
+    path: '/',
+    method: 'GET'
+  }
+
+  store.set({
+    ...baseKey,
+    headers: {}
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    cachedAt: now,
+    staleAt: now + 1000,
+    deleteAt: now + 2000,
+    body: Buffer.from('initial')
+  })
+
+  store.set({
+    ...baseKey,
+    headers: {
+      'accept-language': 'en'
+    }
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    vary: {
+      'accept-language': 'en'
+    },
+    cachedAt: now,
+    staleAt: now + 1000,
+    deleteAt: now + 2000,
+    body: Buffer.from('updated')
+  })
+
+  strictEqual(store.get({
+    ...baseKey,
+    headers: {
+      'accept-language': 'fr'
+    }
+  }), undefined)
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5108

## Rationale

`SqliteCacheStore#set()` reuses an existing row for the same URL/method, but the `UPDATE` statement did not include `vary`. That meant an entry could transition from non-varying to varying in memory while the SQLite row still held `NULL`, allowing later lookups to match unrelated request headers.

## Changes

- update `SqliteCacheStore`'s overwrite query to persist `vary`
- pass serialized `value.vary` through the update path in `set()`

### Features

N/A

### Bug Fixes

Fixed `SqliteCacheStore` failing to update `vary` when overwriting an existing cache entry

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4