### PR TITLE
refactor(h1): track HEAD keep-alive override as boolean

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -232,7 +232,7 @@ class Parser {
 
     this.keepAlive = ''
     this.contentLength = ''
-    this.connection = ''
+    this.connectionKeepAlive = false
     this.maxResponseSize = client[kMaxResponseSize]
   }
 
@@ -447,7 +447,9 @@ class Parser {
       if (headerName === 'keep-alive') {
         this.keepAlive += buf.toString()
       } else if (headerName === 'connection') {
-        this.connection += buf.toString()
+        this.connectionKeepAlive =
+          this.headers[len - 1].length === 10 &&
+          util.bufferToLowerCasedHeaderName(this.headers[len - 1]) === 'keep-alive'
       }
     } else if (key.length === 14 && util.bufferToLowerCasedHeaderName(key) === 'content-length') {
       this.contentLength += buf.toString()
@@ -554,7 +556,7 @@ class Parser {
     this.shouldKeepAlive = (
       shouldKeepAlive ||
       // Override llhttp value which does not allow keepAlive for HEAD.
-      (request.method === 'HEAD' && !socket[kReset] && this.connection.toLowerCase() === 'keep-alive')
+      (request.method === 'HEAD' && !socket[kReset] && this.connectionKeepAlive)
     )
 
     if (this.statusCode >= 200) {
@@ -689,7 +691,7 @@ class Parser {
     this.bytesRead = 0
     this.contentLength = ''
     this.keepAlive = ''
-    this.connection = ''
+    this.connectionKeepAlive = false
 
     this.headers = []
     this.headersSize = 0

--- a/test/client-keep-alive.js
+++ b/test/client-keep-alive.js
@@ -113,6 +113,67 @@ test('keep-alive header 1', async (t) => {
   await t.completed
 })
 
+test('HEAD keep-alive header reuses socket when connection header is fragmented', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  let connections = 0
+  let requests = 0
+
+  const server = createServer((socket) => {
+    connections++
+
+    let request = ''
+    socket.on('data', (chunk) => {
+      request += chunk.toString()
+
+      while (request.includes('\r\n\r\n')) {
+        const endOfHeaders = request.indexOf('\r\n\r\n') + 4
+        request = request.slice(endOfHeaders)
+        requests++
+
+        socket.write('HTTP/1.1 200 OK\r\n')
+        socket.write('Content-Length: 0\r\n')
+        socket.write('Connection: keep-')
+        socket.write('alive\r\n')
+        socket.write('\r\n')
+
+        if (requests === 2) {
+          socket.end()
+        }
+      }
+    })
+  })
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+  after(() => client.destroy())
+
+  const disconnect = once(client, 'disconnect')
+
+  const first = await client.request({
+    path: '/',
+    method: 'HEAD',
+    reset: false
+  })
+  t.strictEqual(first.statusCode, 200)
+  await first.body.text()
+
+  const second = await client.request({
+    path: '/',
+    method: 'HEAD',
+    reset: false
+  })
+  t.strictEqual(second.statusCode, 200)
+  await second.body.text()
+
+  await disconnect
+  t.strictEqual(connections, 1)
+  t.strictEqual(requests, 2)
+
+  await t.completed
+})
+
 test('keep-alive header no postfix', async (t) => {
   t = tspl(t, { plan: 2 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

HEAD response keep-alive handling in `client-h1`

## Rationale

The HEAD-specific keep-alive override was depending on 1this.connection.toLowerCase()` at headers-complete time. This change replaces that with an explicit tracked boolean so the parser carries only the state needed for the override and avoids string-based re-checks.

## Changes

- Track `Connection: keep-alive` as a boolean on the H1 parser
- Use that boolean in the HEAD keep-alive override path
- Reset the tracked state between responses

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4