### PR TITLE
perf(client): parse h1 content-length incrementally

### DIFF
--- a/benchmarks/core/parse-content-length.mjs
+++ b/benchmarks/core/parse-content-length.mjs
@@ -1,0 +1,118 @@
+import { bench, group, run } from 'mitata'
+
+const CONTENT_LENGTH_STATE_START = 0
+const CONTENT_LENGTH_STATE_SIGN = 1
+const CONTENT_LENGTH_STATE_DIGITS = 2
+const CONTENT_LENGTH_STATE_NEGATIVE_SIGN = 3
+const CONTENT_LENGTH_STATE_DIGITS_NEGATIVE = 4
+const CONTENT_LENGTH_STATE_DONE = 5
+const CONTENT_LENGTH_STATE_INVALID = 6
+
+const values = [
+  Buffer.from('0'),
+  Buffer.from('9'),
+  Buffer.from('42'),
+  Buffer.from(' 42'),
+  Buffer.from('42 '),
+  Buffer.from('\t123'),
+  Buffer.from('1234'),
+  Buffer.from('65535'),
+  Buffer.from('1234567890'),
+  Buffer.from('abc'),
+  Buffer.from('   ')
+]
+
+function legacyParseContentLength (buf) {
+  return parseInt(buf.toString(), 10)
+}
+
+function incrementalParseContentLength (buf) {
+  let contentLength = 0
+  let contentLengthState = CONTENT_LENGTH_STATE_START
+
+  for (let i = 0; i < buf.length; i++) {
+    const byte = buf[i]
+
+    switch (contentLengthState) {
+      case CONTENT_LENGTH_STATE_START:
+        if (byte === 0x09 || byte === 0x0a || byte === 0x0d || byte === 0x20) {
+          continue
+        }
+
+        if (byte === 0x2b || byte === 0x2d) {
+          contentLengthState = byte === 0x2d
+            ? CONTENT_LENGTH_STATE_NEGATIVE_SIGN
+            : CONTENT_LENGTH_STATE_SIGN
+          continue
+        }
+
+        if (byte >= 0x30 && byte <= 0x39) {
+          contentLength = byte - 0x30
+          contentLengthState = CONTENT_LENGTH_STATE_DIGITS
+          continue
+        }
+
+        contentLength = Number.NaN
+        contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return contentLength
+
+      case CONTENT_LENGTH_STATE_SIGN:
+        if (byte >= 0x30 && byte <= 0x39) {
+          contentLength = byte - 0x30
+          contentLengthState = CONTENT_LENGTH_STATE_DIGITS
+          continue
+        }
+
+        contentLength = Number.NaN
+        contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return contentLength
+
+      case CONTENT_LENGTH_STATE_NEGATIVE_SIGN:
+        if (byte >= 0x30 && byte <= 0x39) {
+          contentLength = 0x30 - byte
+          contentLengthState = CONTENT_LENGTH_STATE_DIGITS_NEGATIVE
+          continue
+        }
+
+        contentLength = Number.NaN
+        contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return contentLength
+
+      case CONTENT_LENGTH_STATE_DIGITS:
+        if (byte >= 0x30 && byte <= 0x39) {
+          contentLength = (contentLength * 10) + (byte - 0x30)
+          continue
+        }
+
+        contentLengthState = CONTENT_LENGTH_STATE_DONE
+        return contentLength
+
+      case CONTENT_LENGTH_STATE_DIGITS_NEGATIVE:
+        if (byte >= 0x30 && byte <= 0x39) {
+          contentLength = (contentLength * 10) - (byte - 0x30)
+          continue
+        }
+
+        contentLengthState = CONTENT_LENGTH_STATE_DONE
+        return contentLength
+    }
+  }
+
+  return contentLength
+}
+
+group('parse content-length', () => {
+  bench('legacy', () => {
+    for (let i = 0; i < values.length; i++) {
+      legacyParseContentLength(values[i])
+    }
+  })
+
+  bench('incremental', () => {
+    for (let i = 0; i < values.length; i++) {
+      incrementalParseContentLength(values[i])
+    }
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -201,6 +201,92 @@ const TIMEOUT_BODY = 4 | USE_FAST_TIMER
 // handling.
 const TIMEOUT_KEEP_ALIVE = 8 | USE_NATIVE_TIMER
 
+const CONTENT_LENGTH_STATE_START = 0
+const CONTENT_LENGTH_STATE_SIGN = 1
+const CONTENT_LENGTH_STATE_DIGITS = 2
+const CONTENT_LENGTH_STATE_NEGATIVE_SIGN = 3
+const CONTENT_LENGTH_STATE_DIGITS_NEGATIVE = 4
+const CONTENT_LENGTH_STATE_DONE = 5
+const CONTENT_LENGTH_STATE_INVALID = 6
+
+function consumeContentLength (parser, buf) {
+  if (parser.contentLength === null) {
+    parser.contentLength = 0
+  }
+
+  if (parser.contentLengthState >= CONTENT_LENGTH_STATE_DONE) {
+    return
+  }
+
+  for (let i = 0; i < buf.length; i++) {
+    const byte = buf[i]
+
+    switch (parser.contentLengthState) {
+      case CONTENT_LENGTH_STATE_START:
+        if (byte === 0x09 || byte === 0x0a || byte === 0x0d || byte === 0x20) {
+          continue
+        }
+
+        if (byte === 0x2b || byte === 0x2d) {
+          parser.contentLengthState = byte === 0x2d
+            ? CONTENT_LENGTH_STATE_NEGATIVE_SIGN
+            : CONTENT_LENGTH_STATE_SIGN
+          continue
+        }
+
+        if (byte >= 0x30 && byte <= 0x39) {
+          parser.contentLength = byte - 0x30
+          parser.contentLengthState = CONTENT_LENGTH_STATE_DIGITS
+          continue
+        }
+
+        parser.contentLength = Number.NaN
+        parser.contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return
+
+      case CONTENT_LENGTH_STATE_SIGN:
+        if (byte >= 0x30 && byte <= 0x39) {
+          parser.contentLength = byte - 0x30
+          parser.contentLengthState = CONTENT_LENGTH_STATE_DIGITS
+          continue
+        }
+
+        parser.contentLength = Number.NaN
+        parser.contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return
+
+      case CONTENT_LENGTH_STATE_NEGATIVE_SIGN:
+        if (byte >= 0x30 && byte <= 0x39) {
+          parser.contentLength = 0x30 - byte
+          parser.contentLengthState = CONTENT_LENGTH_STATE_DIGITS_NEGATIVE
+          continue
+        }
+
+        parser.contentLength = Number.NaN
+        parser.contentLengthState = CONTENT_LENGTH_STATE_INVALID
+        return
+
+      case CONTENT_LENGTH_STATE_DIGITS:
+        if (byte >= 0x30 && byte <= 0x39) {
+          parser.contentLength = (parser.contentLength * 10) + (byte - 0x30)
+          continue
+        }
+
+        parser.contentLengthState = CONTENT_LENGTH_STATE_DONE
+        return
+
+      case CONTENT_LENGTH_STATE_DIGITS_NEGATIVE:
+        if (byte >= 0x30 && byte <= 0x39) {
+          parser.contentLength = (parser.contentLength * 10) - (byte - 0x30)
+          continue
+        }
+
+        parser.contentLengthState = CONTENT_LENGTH_STATE_DONE
+        return
+    }
+  }
+}
+
 class Parser {
   /**
      * @param {import('./client.js')} client
@@ -231,8 +317,9 @@ class Parser {
     this.bytesRead = 0
 
     this.keepAlive = ''
-    this.contentLength = ''
     this.connectionKeepAlive = false
+    this.contentLength = null
+    this.contentLengthState = CONTENT_LENGTH_STATE_START
     this.maxResponseSize = client[kMaxResponseSize]
   }
 
@@ -452,7 +539,7 @@ class Parser {
           util.bufferToLowerCasedHeaderName(this.headers[len - 1]) === 'keep-alive'
       }
     } else if (key.length === 14 && util.bufferToLowerCasedHeaderName(key) === 'content-length') {
-      this.contentLength += buf.toString()
+      consumeContentLength(this, buf)
     }
 
     this.trackHeader(buf.length)
@@ -670,7 +757,17 @@ class Parser {
    * @returns {number}
    */
   onMessageComplete () {
-    const { client, socket, statusCode, upgrade, headers, contentLength, bytesRead, shouldKeepAlive } = this
+    const {
+      client,
+      socket,
+      statusCode,
+      upgrade,
+      headers,
+      contentLength,
+      contentLengthState,
+      bytesRead,
+      shouldKeepAlive
+    } = this
 
     if (socket.destroyed && (!statusCode || shouldKeepAlive)) {
       return -1
@@ -689,7 +786,8 @@ class Parser {
     this.statusCode = 0
     this.statusText = ''
     this.bytesRead = 0
-    this.contentLength = ''
+    this.contentLength = null
+    this.contentLengthState = CONTENT_LENGTH_STATE_START
     this.keepAlive = ''
     this.connectionKeepAlive = false
 
@@ -700,7 +798,14 @@ class Parser {
       return 0
     }
 
-    if (request.method !== 'HEAD' && contentLength && bytesRead !== parseInt(contentLength, 10)) {
+    const expectedContentLength =
+      contentLength === null
+        ? null
+        : contentLengthState < CONTENT_LENGTH_STATE_DIGITS
+          ? Number.NaN
+          : contentLength
+
+    if (request.method !== 'HEAD' && expectedContentLength !== null && bytesRead !== expectedContentLength) {
       util.destroy(socket, new ResponseContentLengthMismatchError())
       return -1
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Avoid allocating and concatenating a `Content-Length` string in the HTTP/1.1 client parser before calling `parseInt()`. Parsing the header value incrementally reduces overhead in the hot response-header path.

## Changes

- Parse `Content-Length` incrementally into a number
- Replace string accumulation with numeric parsing state in the h1 parser

### Features

N/A

### Bug Fixes

Remove the extra string allocation and `parseInt()` call from response `Content-Length` parsing in the h1 client parser while preserving mismatch behavior

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4