### PR TITLE
client: cache llhttp wasm buffer view

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -323,7 +323,12 @@ class Parser {
       currentBufferPtr = llhttp.malloc(currentBufferSize)
     }
 
-    if (currentBuffer === null || currentBuffer.buffer !== llhttp.memory.buffer) {
+    if (
+      currentBuffer === null ||
+      currentBuffer.buffer !== llhttp.memory.buffer ||
+      currentBuffer.byteOffset !== currentBufferPtr ||
+      currentBuffer.byteLength !== currentBufferSize
+    ) {
       currentBuffer = new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize)
     }
 

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -188,6 +188,7 @@ let currentBufferRef = null
  */
 let currentBufferSize = 0
 let currentBufferPtr = null
+let currentBuffer = null
 
 const USE_NATIVE_TIMER = 0
 const USE_FAST_TIMER = 1
@@ -322,7 +323,11 @@ class Parser {
       currentBufferPtr = llhttp.malloc(currentBufferSize)
     }
 
-    new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize).set(chunk)
+    if (currentBuffer === null || currentBuffer.buffer !== llhttp.memory.buffer) {
+      currentBuffer = new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize)
+    }
+
+    currentBuffer.set(chunk)
 
     // Call `execute` on the wasm parser.
     // We pass the `llhttp_parser` pointer address, the pointer address of buffer view data,

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -129,3 +129,69 @@ test('split header value', async (t) => {
 
   await t.completed
 })
+
+test('refreshes wasm input view after reallocating parser buffer', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  const smallBody = Buffer.from('ok')
+  const largeBody = Buffer.alloc(8192, 'a')
+  const responses = [
+    Buffer.concat([
+      Buffer.from(`HTTP/1.1 200 OK\r\nContent-Length: ${smallBody.length}\r\n\r\n`),
+      smallBody
+    ]),
+    Buffer.concat([
+      Buffer.from(`HTTP/1.1 200 OK\r\nContent-Length: ${largeBody.length}\r\n\r\n`),
+      largeBody
+    ])
+  ]
+
+  const server = net.createServer(socket => {
+    let responsesSent = 0
+
+    socket.on('data', () => {
+      socket.write(responses[responsesSent++])
+    })
+  })
+  after(() => server.close())
+
+  await new Promise(resolve => server.listen(0, resolve))
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+  after(() => client.destroy())
+
+  function request () {
+    return new Promise((resolve, reject) => {
+      client.request({
+        method: 'GET',
+        path: '/'
+      }, (err, { statusCode, body } = {}) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        const bufs = []
+
+        body.on('data', buf => {
+          bufs.push(buf)
+        })
+        body.on('end', () => {
+          resolve({
+            statusCode,
+            body: Buffer.concat(bufs)
+          })
+        })
+        body.on('error', reject)
+      })
+    })
+  }
+
+  const smallResponse = await request()
+  t.strictEqual(smallResponse.statusCode, 200)
+  t.strictEqual(smallResponse.body.toString(), smallBody.toString())
+
+  const largeResponse = await request()
+  t.strictEqual(largeResponse.statusCode, 200)
+  t.strictEqual(largeResponse.body.toString(), largeBody.toString())
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

`Parser#execute()` copied every socket chunk into wasm memory through a newly created `Uint8Array` view.
The wasm buffer allocation is already reused until a larger chunk arrives, so the memory view can be cached too.

## Changes

Cache the llhttp wasm memory view alongside `currentBufferPtr` and `currentBufferSize`, refreshing it only when needed.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5