### PR TITLE
fix: auto-detect HTTP proxy tunneling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,21 +262,24 @@ jobs:
       - name: Run fuzzing tests
         run: npm run test:fuzzing
 
-  test-shared-builtin:
-    name: Test with Node.js ${{ matrix.node-version }} compiled --shared-builtin-undici/undici-path
-    uses: ./.github/workflows/nodejs-shared.yml
-    strategy:
-      fail-fast: false
-      max-parallel: 0
-      matrix:
-        # Node.js 20 and 22 are intentionally excluded here because
-        # --shared-builtin-undici/undici-path still hits upstream Node.js issues there.
-        # Keep validating supported/current majors, and start exercising 26
-        # automatically once a release is available.
-        node-version: ['24', '26']
-        runs-on: ['ubuntu-latest']
-    with:
-      node-version: ${{ matrix.node-version }}
+  # Disabled while the absolute-form proxy forwarding fix from
+  # https://github.com/nodejs/undici/pull/5116 lives only in undici main:
+  # nodejs/node still embeds the previous behavior, so the shared-builtin
+  # build picks up undici from this checkout but runs the bundled Node.js
+  # tests, which expect the old semantics. Re-add Node.js 26 to the matrix
+  # once a Node.js 26 release embeds an undici that includes #5116.
+  # Node.js 24 stays off this job because the change is not being backported.
+  # test-shared-builtin:
+  #   name: Test with Node.js ${{ matrix.node-version }} compiled --shared-builtin-undici/undici-path
+  #   uses: ./.github/workflows/nodejs-shared.yml
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 0
+  #     matrix:
+  #       node-version: ['26']
+  #       runs-on: ['ubuntu-latest']
+  #   with:
+  #     node-version: ${{ matrix.node-version }}
 
   test-types:
     name: Test TypeScript types

--- a/docs/docs/api/ProxyAgent.md
+++ b/docs/docs/api/ProxyAgent.md
@@ -62,12 +62,15 @@ added: v4.8.2
     * `origin` {URL} The proxy origin.
     * `opts` {Object} The resolved options for the dispatcher.
     * Returns: {Dispatcher}
-  * `proxyTunnel` {boolean} Forces tunneling through the proxy. When `false`,
-    requests where both the proxy and the endpoint use the insecure `http:`
-    protocol are sent directly to the proxy with the absolute request URI rather
-    than through a `CONNECT` tunnel, matching `curl` behavior. Secure
-    connections always use a tunnel regardless of this option. **Default:**
-    `true`.
+  * `proxyTunnel` {boolean} Forces tunneling through the proxy. By default,
+    Undici automatically detects when proxy tunneling is required. If either the
+    proxy or the target endpoint uses a secure protocol, Undici establishes a
+    tunnel via `CONNECT`. For plain HTTP proxy to plain HTTP endpoint
+    connections, Undici forwards requests directly to the proxy and prefixes the
+    request path with the target origin. Set `proxyTunnel` to `true` to force
+    tunneling for those unsecured HTTP-to-HTTP connections as well. Currently,
+    there is no way to facilitate HTTP/1.1 IP tunneling as described in
+    [RFC 9484](https://www.rfc-editor.org/rfc/rfc9484.html#name-http-11-request).
 
 Throws an {InvalidArgumentError} when no proxy URI is provided, when
 `clientFactory` is not a function, or when both `auth` and `token` are supplied.

--- a/docs/docs/api/ProxyAgent.md
+++ b/docs/docs/api/ProxyAgent.md
@@ -67,9 +67,10 @@ added: v4.8.2
     endpoint uses HTTPS, Undici establishes a `CONNECT` tunnel through the proxy
     (after the TLS handshake to the proxy itself when the proxy URL is HTTPS).
     If the target endpoint uses plain HTTP, Undici forwards the request to the
-    proxy with the target origin prefixed in the request path (over TLS when the
+    proxy using an HTTP/1.1 absolute-form request target (over TLS when the
     proxy URL is HTTPS), as required by
     [RFC 9112 §3.2.2](https://www.rfc-editor.org/rfc/rfc9112.html#name-absolute-form).
+    This non-tunneled forwarding path does not negotiate HTTP/2 with the proxy.
     Set `proxyTunnel` to `true` to force tunneling for plain HTTP requests as
     well. Currently, there is no way to facilitate HTTP/1.1 IP tunneling as
     described in

--- a/docs/docs/api/ProxyAgent.md
+++ b/docs/docs/api/ProxyAgent.md
@@ -63,13 +63,16 @@ added: v4.8.2
     * `opts` {Object} The resolved options for the dispatcher.
     * Returns: {Dispatcher}
   * `proxyTunnel` {boolean} Forces tunneling through the proxy. By default,
-    Undici automatically detects when proxy tunneling is required. If either the
-    proxy or the target endpoint uses a secure protocol, Undici establishes a
-    tunnel via `CONNECT`. For plain HTTP proxy to plain HTTP endpoint
-    connections, Undici forwards requests directly to the proxy and prefixes the
-    request path with the target origin. Set `proxyTunnel` to `true` to force
-    tunneling for those unsecured HTTP-to-HTTP connections as well. Currently,
-    there is no way to facilitate HTTP/1.1 IP tunneling as described in
+    Undici detects tunneling based on the request protocol. If the target
+    endpoint uses HTTPS, Undici establishes a `CONNECT` tunnel through the proxy
+    (after the TLS handshake to the proxy itself when the proxy URL is HTTPS).
+    If the target endpoint uses plain HTTP, Undici forwards the request to the
+    proxy with the target origin prefixed in the request path (over TLS when the
+    proxy URL is HTTPS), as required by
+    [RFC 9112 §3.2.2](https://www.rfc-editor.org/rfc/rfc9112.html#name-absolute-form).
+    Set `proxyTunnel` to `true` to force tunneling for plain HTTP requests as
+    well. Currently, there is no way to facilitate HTTP/1.1 IP tunneling as
+    described in
     [RFC 9484](https://www.rfc-editor.org/rfc/rfc9484.html#name-http-11-request).
 
 Throws an {InvalidArgumentError} when no proxy URI is provided, when

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -145,6 +145,7 @@ class ProxyAgent extends DispatcherBase {
     }
 
     const connect = buildConnector({ timeout: connectTimeout, ...opts.proxyTls })
+    const connectHTTP1 = buildConnector({ timeout: connectTimeout, ...opts.proxyTls, allowH2: false })
     this[kConnectEndpoint] = buildConnector({ timeout: connectTimeout, ...opts.requestTls })
     this[kConnectEndpointHTTP1] = buildConnector({ timeout: connectTimeout, ...opts.requestTls, allowH2: false })
 
@@ -167,14 +168,14 @@ class ProxyAgent extends DispatcherBase {
 
       if (!shouldProxyTunnel(protocol, this[kTunnelProxy])) {
         const forwardConnect = this[kProxy].protocol === 'https:'
-          ? (opts, cb) => connect(opts, (err, socket) => {
+          ? (opts, cb) => connectHTTP1(opts, (err, socket) => {
               if (err && err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
                 cb(new SecureProxyConnectionError(err))
               } else {
                 cb(err, socket)
               }
             })
-          : connect
+          : connectHTTP1
         return new Http1ProxyWrapper(this[kProxy].uri, {
           headers: this[kProxyHeaders],
           connect: forwardConnect,

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -37,6 +37,10 @@ function defaultAgentFactory (origin, opts) {
   return new Pool(origin, opts)
 }
 
+function shouldProxyTunnel (proxyProtocol, requestProtocol, proxyTunnel) {
+  return proxyTunnel === true || proxyProtocol !== 'http:' || requestProtocol !== 'http:'
+}
+
 class Http1ProxyWrapper extends DispatcherBase {
   #client
 
@@ -105,7 +109,7 @@ class ProxyAgent extends DispatcherBase {
       throw new InvalidArgumentError('Proxy opts.clientFactory must be a function.')
     }
 
-    const { proxyTunnel = true, connectTimeout } = opts
+    const { proxyTunnel, connectTimeout } = opts
 
     super()
 
@@ -152,7 +156,7 @@ class ProxyAgent extends DispatcherBase {
         })
       }
 
-      if (!this[kTunnelProxy] && protocol === 'http:' && this[kProxy].protocol === 'http:') {
+      if (!shouldProxyTunnel(this[kProxy].protocol, protocol, this[kTunnelProxy])) {
         return new Http1ProxyWrapper(this[kProxy].uri, {
           headers: this[kProxyHeaders],
           connect,

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -37,14 +37,15 @@ function defaultAgentFactory (origin, opts) {
   return new Pool(origin, opts)
 }
 
-function shouldProxyTunnel (proxyProtocol, requestProtocol, proxyTunnel) {
-  return proxyTunnel === true || proxyProtocol !== 'http:' || requestProtocol !== 'http:'
+function shouldProxyTunnel (requestProtocol, proxyTunnel) {
+  return proxyTunnel === true || requestProtocol !== 'http:'
 }
 
 class Http1ProxyWrapper extends DispatcherBase {
   #client
+  #proxyServername
 
-  constructor (proxyUrl, { headers = {}, connect, factory }) {
+  constructor (proxyUrl, { headers = {}, connect, factory, proxyServername }) {
     if (!proxyUrl) {
       throw new InvalidArgumentError('Proxy URL is mandatory')
     }
@@ -52,6 +53,7 @@ class Http1ProxyWrapper extends DispatcherBase {
     super()
 
     this[kProxyHeaders] = headers
+    this.#proxyServername = proxyServername
     if (factory) {
       this.#client = factory(proxyUrl, { connect })
     } else {
@@ -85,6 +87,13 @@ class Http1ProxyWrapper extends DispatcherBase {
       headers.host = host
     }
     opts.headers = { ...this[kProxyHeaders], ...headers }
+
+    // Pin the SNI/cert hostname to the proxy. Without this the underlying
+    // Client would derive it from the (rewritten) Host header, which points
+    // at the target — wrong for the TLS handshake to the proxy itself.
+    if (this.#proxyServername != null) {
+      opts.servername = this.#proxyServername
+    }
 
     return this.#client[kDispatch](opts, handler)
   }
@@ -156,11 +165,23 @@ class ProxyAgent extends DispatcherBase {
         })
       }
 
-      if (!shouldProxyTunnel(this[kProxy].protocol, protocol, this[kTunnelProxy])) {
+      if (!shouldProxyTunnel(protocol, this[kTunnelProxy])) {
+        const forwardConnect = this[kProxy].protocol === 'https:'
+          ? (opts, cb) => connect(opts, (err, socket) => {
+              if (err && err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
+                cb(new SecureProxyConnectionError(err))
+              } else {
+                cb(err, socket)
+              }
+            })
+          : connect
         return new Http1ProxyWrapper(this[kProxy].uri, {
           headers: this[kProxyHeaders],
-          connect,
-          factory: agentFactory
+          connect: forwardConnect,
+          factory: agentFactory,
+          proxyServername: this[kProxy].protocol === 'https:'
+            ? (this[kProxyTls]?.servername || proxyHostname)
+            : undefined
         })
       }
       return agentFactory(origin, options)

--- a/test/env-http-proxy-agent-nodejs-bundle.js
+++ b/test/env-http-proxy-agent-nodejs-bundle.js
@@ -20,7 +20,7 @@ describe('EnvHttpProxyAgent and setGlobalDispatcher', () => {
     process.env = { ...env }
   })
 
-  test('should work with undici fetch from index-fetch', async (t) => {
+  test('should work with undici fetch from index-fetch with tunneling enabled', async (t) => {
     const { strictEqual } = tspl(t, { plan: 3 })
 
     // Instead of using mocks, start a real server and a minimal proxy server
@@ -73,7 +73,7 @@ describe('EnvHttpProxyAgent and setGlobalDispatcher', () => {
     const proxyAddress = `http://localhost:${proxy.address().port}`
     const serverAddress = `http://localhost:${server.address().port}`
     process.env.http_proxy = proxyAddress
-    setGlobalDispatcher(new EnvHttpProxyAgent())
+    setGlobalDispatcher(new EnvHttpProxyAgent({ proxyTunnel: true }))
 
     const res = await undiciFetch(serverAddress)
     strictEqual(await res.text(), 'Hello world')

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -4,6 +4,8 @@ const { tspl } = require('@matteo.collina/tspl')
 const { test, describe, after, beforeEach } = require('node:test')
 const { EnvHttpProxyAgent, ProxyAgent, Agent, fetch, MockAgent } = require('..')
 const { kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent, kClosed, kDestroyed, kProxy } = require('../lib/core/symbols')
+const { createServer } = require('node:http')
+const { createProxy } = require('proxy')
 
 const env = { ...process.env }
 
@@ -158,6 +160,54 @@ test('destroys all agents', async (t) => {
   t.ok(dispatcher[kHttpsProxyAgent][kDestroyed])
 })
 
+test('defaults to non-tunneled HTTP proxying for HTTP endpoints - #5093', async (t) => {
+  t = tspl(t, { plan: 3 })
+
+  const server = await buildServer()
+  const proxy = await buildProxy()
+
+  process.env.http_proxy = `http://localhost:${proxy.address().port}`
+
+  const dispatcher = new EnvHttpProxyAgent()
+  const serverUrl = `http://localhost:${server.address().port}`
+
+  try {
+    proxy.on('connect', () => {
+      t.fail('should not tunnel plain HTTP over an HTTP proxy by default')
+    })
+
+    proxy.on('request', (req) => {
+      t.strictEqual(req.url, `${serverUrl}/`)
+    })
+
+    server.on('request', (req, res) => {
+      t.strictEqual(req.url, '/')
+      res.end('ok')
+    })
+
+    const response = await fetch(serverUrl, { dispatcher })
+    t.strictEqual(await response.text(), 'ok')
+  } finally {
+    await new Promise((resolve) => proxy.close(resolve))
+    await new Promise((resolve) => server.close(resolve))
+    await dispatcher.close()
+  }
+})
+
+function buildServer () {
+  return new Promise((resolve) => {
+    const server = createServer({ joinDuplicateHeaders: true })
+    server.listen(0, () => resolve(server))
+  })
+}
+
+function buildProxy () {
+  return new Promise((resolve) => {
+    const server = createProxy(createServer({ joinDuplicateHeaders: true }))
+    server.listen(0, () => resolve(server))
+  })
+}
+
 const createEnvHttpProxyAgentWithMocks = (plan = 1, opts = {}) => {
   const factory = (origin) => {
     const mockAgent = new MockAgent()
@@ -171,7 +221,7 @@ const createEnvHttpProxyAgentWithMocks = (plan = 1, opts = {}) => {
   }
   process.env.http_proxy = 'http://localhost:8080'
   process.env.https_proxy = 'http://localhost:8443'
-  const dispatcher = new EnvHttpProxyAgent({ ...opts, factory })
+  const dispatcher = new EnvHttpProxyAgent({ proxyTunnel: true, ...opts, factory })
   const agentSymbols = [kNoProxyAgent, kHttpProxyAgent, kHttpsProxyAgent]
   agentSymbols.forEach((agentSymbol) => {
     const originalDispatch = dispatcher[agentSymbol].dispatch

--- a/test/issue-3897.js
+++ b/test/issue-3897.js
@@ -33,7 +33,7 @@ test('a proxy that drops the CONNECT tunnel fails the request instead of looping
   await once(proxy, 'listening')
 
   const proxyUrl = `http://127.0.0.1:${proxy.address().port}`
-  const proxyAgent = new ProxyAgent(proxyUrl)
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
 
   after(async () => {
     await proxyAgent.close()

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -901,7 +901,7 @@ test('use proxy-agent with setGlobalDispatcher', async (t) => {
 
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
-  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl })
   const parsedOrigin = new URL(serverUrl)
   setGlobalDispatcher(proxyAgent)
 
@@ -985,7 +985,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623', async
   const serverUrl = `http://localhost:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
-  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl })
   setGlobalDispatcher(proxyAgent)
 
   after(() => setGlobalDispatcher(defaultDispatcher))
@@ -1095,7 +1095,7 @@ test('should throw when proxy does not return 200', async (t) => {
     return false
   }
 
-  const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
+  const proxyAgent = new ProxyAgent({ uri: proxyUrl })
   try {
     await request(serverUrl, { dispatcher: proxyAgent })
     t.fail()

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -9,6 +9,7 @@ const ProxyAgent = require('../lib/dispatcher/proxy-agent')
 const Pool = require('../lib/dispatcher/pool')
 const { createServer } = require('node:http')
 const https = require('node:https')
+const http2 = require('node:http2')
 const net = require('node:net')
 const { Socket } = require('node:net')
 const { createProxy } = require('proxy')
@@ -1328,6 +1329,41 @@ test('Proxy via HTTPS to HTTP endpoint forwards without tunneling by default', a
   proxyAgent.close()
 })
 
+test('Proxy via HTTPS to HTTP endpoint uses HTTP/1.1 when proxy also supports HTTP/2', async (t) => {
+  t = tspl(t, { plan: 4 })
+  const proxy = await buildH2CapableSSLProxy()
+
+  const serverUrl = 'http://example.com/'
+  const proxyUrl = `https://localhost:${proxy.address().port}`
+  const proxyAgent = new ProxyAgent({
+    uri: proxyUrl,
+    proxyTls: {
+      ca: [
+        certs.root.crt
+      ],
+      servername: 'proxy'
+    }
+  })
+
+  proxy.on('stream', (stream) => {
+    t.fail('non-tunneled HTTP forwarding must not negotiate HTTP/2')
+    stream.close()
+  })
+
+  proxy.on('request', function (req, res) {
+    t.strictEqual(req.httpVersion, '1.1')
+    t.strictEqual(req.method, 'GET')
+    t.strictEqual(req.url, serverUrl)
+    res.end('ok')
+  })
+
+  const data = await request(serverUrl, { dispatcher: proxyAgent })
+  t.strictEqual(await data.body.text(), 'ok')
+
+  proxy.close()
+  proxyAgent.close()
+})
+
 test('Proxy via HTTPS to HTTP endpoint with tunneling enabled', async (t) => {
   t = tspl(t, { plan: 3 })
   const server = await buildServer()
@@ -1629,6 +1665,23 @@ function buildSSLProxy () {
 
   return new Promise((resolve) => {
     const server = createProxy(https.createServer(serverOptions))
+    server.listen(0, () => resolve(server))
+  })
+}
+
+function buildH2CapableSSLProxy () {
+  const serverOptions = {
+    ca: [
+      certs.root.crt
+    ],
+    key: certs.proxy.key,
+    cert: certs.proxy.crt,
+    allowHTTP1: true,
+    joinDuplicateHeaders: true
+  }
+
+  return new Promise((resolve) => {
+    const server = http2.createSecureServer(serverOptions)
     server.listen(0, () => resolve(server))
   })
 }

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -1273,6 +1273,61 @@ test('Proxy via HTTPS to HTTPS endpoint', async (t) => {
   proxyAgent.close()
 })
 
+test('Proxy via HTTPS to HTTP endpoint forwards without tunneling by default', async (t) => {
+  t = tspl(t, { plan: 4 })
+  const server = await buildServer()
+  const proxy = await buildSSLProxy()
+
+  const serverUrl = `http://localhost:${server.address().port}`
+  const proxyUrl = `https://localhost:${proxy.address().port}`
+  const proxyAgent = new ProxyAgent({
+    uri: proxyUrl,
+    proxyTls: {
+      ca: [
+        certs.root.crt
+      ],
+      servername: 'proxy'
+    }
+  })
+
+  server.on('request', function (req, res) {
+    t.ok(!req.connection.encrypted)
+    const headers = { host: req.headers.host, connection: req.headers.connection }
+    res.end(JSON.stringify(headers))
+  })
+
+  server.on('secureConnection', () => {
+    t.fail('server is http')
+  })
+
+  proxy.on('secureConnection', () => {
+    t.ok(true, 'TLS handshake to the proxy must still happen')
+  })
+
+  proxy.on('connect', () => {
+    t.fail('should not tunnel plain HTTP through an HTTPS proxy by default')
+  })
+
+  proxy.on('request', function (req) {
+    const bits = { method: req.method, url: req.url }
+    t.deepStrictEqual(bits, {
+      method: 'GET',
+      url: `${serverUrl}/`
+    })
+  })
+
+  const data = await request(serverUrl, { dispatcher: proxyAgent })
+  const json = await data.body.json()
+  t.deepStrictEqual(json, {
+    host: `localhost:${server.address().port}`,
+    connection: 'keep-alive'
+  })
+
+  server.close()
+  proxy.close()
+  proxyAgent.close()
+})
+
 test('Proxy via HTTPS to HTTP endpoint with tunneling enabled', async (t) => {
   t = tspl(t, { plan: 3 })
   const server = await buildServer()

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -26,9 +26,10 @@ declare namespace ProxyAgent {
     clientFactory?(origin: URL, opts: object): Dispatcher;
     /**
      * Undici tunnels via CONNECT when the target endpoint uses HTTPS, and
-     * forwards (absolute-form request-target, per RFC 9112 §3.2.2) otherwise,
-     * regardless of whether the proxy URL is HTTP or HTTPS. Set to true to
-     * force tunneling for plain HTTP requests as well.
+     * forwards (HTTP/1.1 absolute-form request-target, per RFC 9112 §3.2.2)
+     * otherwise, regardless of whether the proxy URL is HTTP or HTTPS. The
+     * non-tunneled forwarding path does not negotiate HTTP/2 with the proxy.
+     * Set to true to force tunneling for plain HTTP requests as well.
      */
     proxyTunnel?: boolean;
   }

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -24,6 +24,11 @@ declare namespace ProxyAgent {
     requestTls?: buildConnector.BuildOptions;
     proxyTls?: buildConnector.BuildOptions;
     clientFactory?(origin: URL, opts: object): Dispatcher;
+    /**
+     * Undici automatically tunnels when either the proxy or the target endpoint
+     * uses a secure protocol. Set to true to force tunneling for plain HTTP
+     * proxy to plain HTTP endpoint connections as well.
+     */
     proxyTunnel?: boolean;
   }
 }

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -25,9 +25,10 @@ declare namespace ProxyAgent {
     proxyTls?: buildConnector.BuildOptions;
     clientFactory?(origin: URL, opts: object): Dispatcher;
     /**
-     * Undici automatically tunnels when either the proxy or the target endpoint
-     * uses a secure protocol. Set to true to force tunneling for plain HTTP
-     * proxy to plain HTTP endpoint connections as well.
+     * Undici tunnels via CONNECT when the target endpoint uses HTTPS, and
+     * forwards (absolute-form request-target, per RFC 9112 §3.2.2) otherwise,
+     * regardless of whether the proxy URL is HTTP or HTTPS. Set to true to
+     * force tunneling for plain HTTP requests as well.
      */
     proxyTunnel?: boolean;
   }


### PR DESCRIPTION
## This relates to...

Fixes #5093

## Rationale

`EnvHttpProxyAgent` currently inherits `ProxyAgent`'s tunneling behavior. For plain HTTP targets reached through an HTTP proxy, defaulting to CONNECT can break proxies that do not implement tunneling and can lead to the looping behavior reported in #5093.

Per [RFC 9112 §3.2.2](https://www.rfc-editor.org/rfc/rfc9112.html#name-absolute-form), the tunnel-vs-forward decision depends only on the **request** protocol, not the proxy protocol. This matches Node's built-in `http.request` / `https.request`.

## Behavior

| Request | Proxy | Action |
|---------|-------|--------|
| HTTP    | HTTP  | Forward, absolute-form URI |
| HTTP    | HTTPS | TLS to proxy, then forward, absolute-form URI |
| HTTPS   | HTTP  | CONNECT tunnel, TLS to target through it |
| HTTPS   | HTTPS | TLS to proxy, CONNECT tunnel, TLS to target |

`proxyTunnel: true` still forces CONNECT for plain HTTP requests.

## Changes

- `shouldProxyTunnel` keys on the request protocol only
- `Http1ProxyWrapper` accepts a `proxyServername` to pin SNI to the proxy (otherwise the inner `Client` derives it from the rewritten Host header, which points at the target)
- Forward path through an HTTPS proxy wraps `ERR_TLS_CERT_ALTNAME_INVALID` as `SecureProxyConnectionError`, matching the tunneling path
- Regression coverage for `EnvHttpProxyAgent` using `http_proxy` (#5093) and for the new HTTPS-proxy-to-HTTP-target forwarding case
- Docs and TypeScript comment updated

### Bug Fixes

- fix default proxy behavior for plain HTTP over HTTP proxy connections
- fix HTTP-over-HTTPS-proxy to forward (absolute-form) instead of tunneling, per RFC 9112 §3.2.2
- fix the `EnvHttpProxyAgent` case behind #5093

### Breaking Changes and Deprecations

HTTP request through an HTTPS proxy now forwards instead of tunneling by default. Matches Node's built-in behavior and the RFC. Pass `proxyTunnel: true` to restore the previous behavior.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin