### PR TITLE
perf: cache common h2 header name buffers

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -66,20 +66,69 @@ const {
   }
 } = http2
 
+const h2HeaderNameBufferCache = {
+  __proto__: null,
+  age: undefined,
+  'alt-svc': undefined,
+  'cache-control': undefined,
+  connection: undefined,
+  'content-disposition': undefined,
+  'content-encoding': undefined,
+  'content-language': undefined,
+  'content-length': undefined,
+  'content-type': undefined,
+  date: undefined,
+  etag: undefined,
+  expires: undefined,
+  'last-modified': undefined,
+  location: undefined,
+  pragma: undefined,
+  server: undefined,
+  'set-cookie': undefined,
+  trailer: undefined,
+  vary: undefined,
+  via: undefined,
+  warning: undefined,
+  'www-authenticate': undefined,
+  'x-content-type-options': undefined,
+  'x-frame-options': undefined
+}
+
+function getH2HeaderNameBuffer (name) {
+  if (!Object.hasOwn(h2HeaderNameBufferCache, name)) {
+    return Buffer.from(name)
+  }
+
+  let buffer = h2HeaderNameBufferCache[name]
+  if (buffer === undefined) {
+    buffer = Buffer.from(name)
+    h2HeaderNameBufferCache[name] = buffer
+  }
+
+  return buffer
+}
+
 function parseH2Headers (headers) {
   const result = []
 
-  for (const [name, value] of Object.entries(headers)) {
+  for (const name in headers) {
+    if (name[0] === ':') {
+      continue
+    }
+
+    const value = headers[name]
+    const headerName = getH2HeaderNameBuffer(name)
+
     // h2 may concat the header value by array
     // e.g. Set-Cookie
     if (Array.isArray(value)) {
-      for (const subvalue of value) {
+      for (let i = 0; i < value.length; i++) {
         // we need to provide each header value of header name
         // because the headers handler expect name-value pair
-        result.push(Buffer.from(name), Buffer.from(subvalue))
+        result.push(headerName, Buffer.from(`${value[i]}`))
       }
     } else {
-      result.push(Buffer.from(name), Buffer.from(value))
+      result.push(headerName, Buffer.from(`${value}`))
     }
   }
 
@@ -553,9 +602,9 @@ function writeH2 (client, request) {
       stream.once('response', (headers, _flags) => {
         responseReceived = true
 
-        const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
+        const statusCode = headers[HTTP2_HEADER_STATUS]
 
-        request.onRequestUpgrade(statusCode, parseH2Headers(realHeaders), stream)
+        request.onRequestUpgrade(statusCode, parseH2Headers(headers), stream)
 
         if (!request.aborted && !request.completed) {
           stream.off('error', onUpgradeStreamError)
@@ -734,7 +783,7 @@ function writeH2 (client, request) {
   let responseReceived = false
 
   stream.once('response', headers => {
-    const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
+    const statusCode = headers[HTTP2_HEADER_STATUS]
     request.onResponseStarted()
     responseReceived = true
 
@@ -748,7 +797,7 @@ function writeH2 (client, request) {
       return
     }
 
-    if (request.onResponseStart(Number(statusCode), parseH2Headers(realHeaders), stream.resume.bind(stream), '') === false) {
+    if (request.onResponseStart(Number(statusCode), parseH2Headers(headers), stream.resume.bind(stream), '') === false) {
       stream.pause()
     }
 


### PR DESCRIPTION
## Summary

Optimize the HTTP/2 response header path in `client-h2` by:

- avoiding the object rest/spread copy used to strip `:status`
- skipping pseudo-headers inline during H2 header parsing
- caching `Buffer` instances for a bounded set of common response header names

The header-name cache is intentionally bounded to avoid unbounded memory growth from attacker-controlled header names.

## Validation

- `npx eslint lib/dispatcher/client-h2.js`
- `npm run test:h2:core`

## Benchmark notes

I verified this with a controlled A/B `.request()` harness against `main` using the same simple H2 server and interleaved runs.

Average over 5 runs (`80 rounds x 200 parallel requests`):

- this branch: `2401.39ms`
- `main`: `2452.65ms`

That is roughly a **2.1% improvement** on this request-heavy H2 workload.
