### PR TITLE
perf: lazily materialize raw h2 headers

### DIFF
--- a/lib/api/api-connect.js
+++ b/lib/api/api-connect.js
@@ -56,12 +56,10 @@ class ConnectHandler extends AsyncResource {
     this.callback = null
 
     let responseHeaders = headers
-    const rawHeaders = controller?.rawHeaders
     // Indicates is an HTTP2Session
-    if (responseHeaders != null) {
-      responseHeaders = this.responseHeaders === 'raw'
-        ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
-        : headers
+    if (responseHeaders != null && this.responseHeaders === 'raw') {
+      const rawHeaders = controller?.rawHeaders
+      responseHeaders = Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
     }
 
     this.runInAsyncScope(callback, null, null, {

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -165,9 +165,11 @@ class PipelineHandler extends AsyncResource {
 
     if (statusCode < 200) {
       if (this.onInfo) {
-        const rawHeaders = controller?.rawHeaders
         const responseHeaders = this.responseHeaders === 'raw'
-          ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+          ? (() => {
+              const rawHeaders = controller?.rawHeaders
+              return Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
+            })()
           : headers
         this.onInfo({ statusCode, headers: responseHeaders })
       }
@@ -179,9 +181,11 @@ class PipelineHandler extends AsyncResource {
     let body
     try {
       this.handler = null
-      const rawHeaders = controller?.rawHeaders
       const responseHeaders = this.responseHeaders === 'raw'
-        ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+        ? (() => {
+            const rawHeaders = controller?.rawHeaders
+            return Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
+          })()
         : headers
       body = this.runInAsyncScope(handler, null, {
         statusCode,

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -90,9 +90,11 @@ class RequestHandler extends AsyncResource {
   onResponseStart (controller, statusCode, headers, statusText) {
     const { callback, opaque, context, responseHeaders, highWaterMark } = this
 
-    const rawHeaders = controller?.rawHeaders
     const responseHeaderData = responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? (() => {
+          const rawHeaders = controller?.rawHeaders
+          return Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
+        })()
       : headers
 
     if (statusCode < 200) {

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -83,9 +83,11 @@ class StreamHandler extends AsyncResource {
   onResponseStart (controller, statusCode, headers, _statusMessage) {
     const { factory, opaque, context, responseHeaders } = this
 
-    const rawHeaders = controller?.rawHeaders
     const responseHeaderData = responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? (() => {
+          const rawHeaders = controller?.rawHeaders
+          return Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
+        })()
       : headers
 
     if (statusCode < 200) {

--- a/lib/api/api-upgrade.js
+++ b/lib/api/api-upgrade.js
@@ -65,9 +65,11 @@ class UpgradeHandler extends AsyncResource {
 
     this.callback = null
 
-    const rawHeaders = controller?.rawHeaders
     const responseHeaders = this.responseHeaders === 'raw'
-      ? (Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : [])
+      ? (() => {
+          const rawHeaders = controller?.rawHeaders
+          return Array.isArray(rawHeaders) ? util.parseRawHeaders(rawHeaders) : []
+        })()
       : headers
 
     this.runInAsyncScope(callback, null, null, {

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -46,6 +46,7 @@ function isValidContentLengthHeaderValue (val) {
 const kHandler = Symbol('handler')
 const kController = Symbol('controller')
 const kResume = Symbol('resume')
+const kRawHeaders = Symbol('raw headers')
 
 class RequestController {
   #paused = false
@@ -53,13 +54,27 @@ class RequestController {
   #aborted = false
   #abort
 
-  [kResume] = null
+  [kResume] = null;
+  [kRawHeaders] = null
 
-  rawHeaders = null
   rawTrailers = null
 
   constructor (abort) {
     this.#abort = abort
+  }
+
+  get rawHeaders () {
+    let rawHeaders = this[kRawHeaders]
+    if (typeof rawHeaders === 'function') {
+      rawHeaders = rawHeaders()
+      this[kRawHeaders] = rawHeaders
+    }
+
+    return rawHeaders
+  }
+
+  set rawHeaders (rawHeaders) {
+    this[kRawHeaders] = rawHeaders
   }
 
   pause () {
@@ -325,7 +340,7 @@ class Request {
     return this[kHandler].onResponseStarted?.()
   }
 
-  onResponseStart (statusCode, headers, resume, statusText) {
+  onResponseStart (statusCode, headers, resume, statusText, rawHeaders = headers) {
     assert(!this.aborted)
     assert(!this.completed)
 
@@ -336,7 +351,7 @@ class Request {
     const controller = this[kController]
     if (controller) {
       controller[kResume] = resume
-      controller.rawHeaders = headers
+      controller.rawHeaders = rawHeaders
     }
 
     const parsedHeaders = Array.isArray(headers) ? parseHeaders(headers) : headers
@@ -368,13 +383,13 @@ class Request {
     }
   }
 
-  onRequestUpgrade (statusCode, headers, socket) {
+  onRequestUpgrade (statusCode, headers, socket, rawHeaders = headers) {
     assert(!this.aborted)
     assert(!this.completed)
 
     const controller = this[kController]
     if (controller) {
-      controller.rawHeaders = headers
+      controller.rawHeaders = rawHeaders
     }
 
     const parsedHeaders = Array.isArray(headers) ? parseHeaders(headers) : headers

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -108,6 +108,18 @@ function getH2HeaderNameBuffer (name) {
   return buffer
 }
 
+function parseH2HeadersObject (headers) {
+  const result = Object.create(null)
+
+  for (const name in headers) {
+    if (name[0] !== ':') {
+      result[name] = headers[name]
+    }
+  }
+
+  return result
+}
+
 function parseH2Headers (headers) {
   const result = []
 
@@ -604,7 +616,7 @@ function writeH2 (client, request) {
 
         const statusCode = headers[HTTP2_HEADER_STATUS]
 
-        request.onRequestUpgrade(statusCode, parseH2Headers(headers), stream)
+        request.onRequestUpgrade(statusCode, parseH2HeadersObject(headers), stream, () => parseH2Headers(headers))
 
         if (!request.aborted && !request.completed) {
           stream.off('error', onUpgradeStreamError)
@@ -797,7 +809,7 @@ function writeH2 (client, request) {
       return
     }
 
-    if (request.onResponseStart(Number(statusCode), parseH2Headers(headers), stream.resume.bind(stream), '') === false) {
+    if (request.onResponseStart(Number(statusCode), parseH2HeadersObject(headers), stream.resume.bind(stream), '', () => parseH2Headers(headers)) === false) {
       stream.pause()
     }
 


### PR DESCRIPTION
## Summary

This stacks on top of #5122.

It keeps the bounded common-header buffer cache, and adds a follow-up optimization for the HTTP/2 response path:

- pass parsed response headers as an object to the H2 request handlers
- defer raw header materialization until `controller.rawHeaders` is actually accessed
- update the API handlers to only read `controller.rawHeaders` when `responseHeaders === 'raw'`

The goal is to avoid paying the `parseH2Headers()` allocation cost on the hot path when callers only need the normal parsed header object.

## Validation

- `npx eslint lib/core/request.js lib/dispatcher/client-h2.js lib/api/api-request.js lib/api/api-stream.js lib/api/api-connect.js lib/api/api-upgrade.js lib/api/api-pipeline.js`
- `npm run test:h2:core`
- `npm run test:h2:fetch`

## Benchmark notes

I verified this against commit `63a1b0ff` from #5122 using the same controlled H2 `.request()` harness and interleaved runs.

Average over 5 runs (`80 rounds x 200 parallel requests`):

- `63a1b0ff`: `2409.08ms`
- this branch: `2396.64ms`

That is roughly a **0.5% improvement** on top of the previous optimization.
