### PR TITLE
perf(client): parse h1 content-length statelessly

### DIFF
--- a/benchmarks/core/parse-content-length.mjs
+++ b/benchmarks/core/parse-content-length.mjs
@@ -1,0 +1,38 @@
+import { bench, group, run } from 'mitata'
+
+const values = [
+  Buffer.from('0'),
+  Buffer.from('9'),
+  Buffer.from('42'),
+  Buffer.from('1234'),
+  Buffer.from('65535'),
+  Buffer.from('1234567890')
+]
+
+function legacyParseContentLength (buf) {
+  return parseInt(buf.toString(), 10)
+}
+
+function statelessParseContentLength (buf) {
+  let contentLength = 0
+  for (let i = 0; i < buf.length; i++) {
+    contentLength = (contentLength * 10) + (buf[i] - 0x30)
+  }
+  return contentLength
+}
+
+group('parse content-length', () => {
+  bench('legacy', () => {
+    for (let i = 0; i < values.length; i++) {
+      legacyParseContentLength(values[i])
+    }
+  })
+
+  bench('stateless', () => {
+    for (let i = 0; i < values.length; i++) {
+      statelessParseContentLength(values[i])
+    }
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -231,7 +231,7 @@ class Parser {
     this.bytesRead = 0
 
     this.keepAlive = ''
-    this.contentLength = ''
+    this.contentLength = -1
     this.connectionKeepAlive = false
     this.maxResponseSize = client[kMaxResponseSize]
   }
@@ -452,7 +452,12 @@ class Parser {
           util.bufferToLowerCasedHeaderName(this.headers[len - 1]) === 'keep-alive'
       }
     } else if (key.length === 14 && util.bufferToLowerCasedHeaderName(key) === 'content-length') {
-      this.contentLength += buf.toString()
+      if (this.contentLength === -1) {
+        this.contentLength = 0
+      }
+      for (let i = 0; i < buf.length; i++) {
+        this.contentLength = (this.contentLength * 10) + (buf[i] - 0x30)
+      }
     }
 
     this.trackHeader(buf.length)
@@ -689,7 +694,7 @@ class Parser {
     this.statusCode = 0
     this.statusText = ''
     this.bytesRead = 0
-    this.contentLength = ''
+    this.contentLength = -1
     this.keepAlive = ''
     this.connectionKeepAlive = false
 
@@ -700,7 +705,7 @@ class Parser {
       return 0
     }
 
-    if (request.method !== 'HEAD' && contentLength && bytesRead !== parseInt(contentLength, 10)) {
+    if (request.method !== 'HEAD' && contentLength !== -1 && bytesRead !== contentLength) {
       util.destroy(socket, new ResponseContentLengthMismatchError())
       return -1
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Avoid allocating and parsing `Content-Length` response headers through strings.
Since llhttp already validates `Content-Length` as `1*DIGIT` and rejects duplicate values, the H1 parser can parse the numeric value directly from the header buffer and use `-1` to represent absence.

## Changes

- Parse H1 response `Content-Length` directly from the header buffer.
- Use `-1` as the parser sentinel for missing `Content-Length`.
- Check response body length against the parsed numeric value on message completion.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.4