### PR TITLE
fix: reuse parser WeakRef for timeout callbacks

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -217,6 +217,7 @@ class Parser {
      */
     this.socket = socket
     this.timeout = null
+    this.timeoutWeakRef = new WeakRef(this)
     this.timeoutValue = null
     this.timeoutType = null
     this.statusCode = 0
@@ -254,9 +255,9 @@ class Parser {
 
       if (delay) {
         if (type & USE_FAST_TIMER) {
-          this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = timers.setFastTimeout(onParserTimeout, delay, this.timeoutWeakRef)
         } else {
-          this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = setTimeout(onParserTimeout, delay, this.timeoutWeakRef)
           this.timeout?.unref()
         }
       }

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -30,9 +30,13 @@ class DummySocket extends EventEmitter {
 }
 
 test('parser reuses WeakRef when replacing timeout callbacks', async (t) => {
+  const OriginalWeakRef = global.WeakRef
+  t.after(() => {
+    global.WeakRef = OriginalWeakRef
+  })
+
   t = tspl(t, { plan: 1 })
 
-  const OriginalWeakRef = global.WeakRef
   let weakRefCount = 0
 
   global.WeakRef = class CountingWeakRef extends OriginalWeakRef {
@@ -42,27 +46,23 @@ test('parser reuses WeakRef when replacing timeout callbacks', async (t) => {
     }
   }
 
-  try {
-    const socket = new DummySocket()
-    const client = {
-      [kMaxHeadersSize]: 1024,
-      [kMaxResponseSize]: 1024,
-      [kQueue]: [],
-      [kRunningIdx]: 0
-    }
-
-    await connectH1(client, socket)
-    const parser = socket[kParser]
-
-    parser.setTimeout(200, 0)
-    parser.setTimeout(300, 0)
-    parser.setTimeout(400, 1)
-    parser.destroy()
-
-    t.strictEqual(weakRefCount, 1)
-  } finally {
-    global.WeakRef = OriginalWeakRef
+  const socket = new DummySocket()
+  const client = {
+    [kMaxHeadersSize]: 1024,
+    [kMaxResponseSize]: 1024,
+    [kQueue]: [],
+    [kRunningIdx]: 0
   }
+
+  await connectH1(client, socket)
+  const parser = socket[kParser]
+
+  parser.setTimeout(200, 0)
+  parser.setTimeout(300, 0)
+  parser.setTimeout(400, 1)
+  parser.destroy()
+
+  t.strictEqual(weakRefCount, 1)
 })
 
 test('refresh timeout on pause', async (t) => {

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -3,10 +3,67 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
+const EventEmitter = require('node:events')
 const { createServer } = require('node:http')
 const { Readable } = require('node:stream')
 const FakeTimers = require('@sinonjs/fake-timers')
 const timers = require('../lib/util/timers')
+const connectH1 = require('../lib/dispatcher/client-h1')
+const {
+  kMaxHeadersSize,
+  kMaxResponseSize,
+  kParser,
+  kQueue,
+  kRunningIdx
+} = require('../lib/core/symbols')
+
+class DummySocket extends EventEmitter {
+  constructor () {
+    super()
+    this.destroyed = false
+    this.errored = null
+  }
+
+  read () {
+    return null
+  }
+}
+
+test('parser reuses WeakRef when replacing timeout callbacks', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const OriginalWeakRef = global.WeakRef
+  let weakRefCount = 0
+
+  global.WeakRef = class CountingWeakRef extends OriginalWeakRef {
+    constructor (target) {
+      weakRefCount++
+      super(target)
+    }
+  }
+
+  try {
+    const socket = new DummySocket()
+    const client = {
+      [kMaxHeadersSize]: 1024,
+      [kMaxResponseSize]: 1024,
+      [kQueue]: [],
+      [kRunningIdx]: 0
+    }
+
+    await connectH1(client, socket)
+    const parser = socket[kParser]
+
+    parser.setTimeout(200, 0)
+    parser.setTimeout(300, 0)
+    parser.setTimeout(400, 1)
+    parser.destroy()
+
+    t.strictEqual(weakRefCount, 1)
+  } finally {
+    global.WeakRef = OriginalWeakRef
+  }
+})
 
 test('refresh timeout on pause', async (t) => {
   t = tspl(t, { plan: 1 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

`Parser#setTimeout()` created a new `WeakRef` each time it replaced a timeout callback.
The parser instance is stable for the socket lifetime, so the same `WeakRef` can be reused instead of allocating a new one for every timeout replacement.

## Changes

- Store a single parser `WeakRef` on `Parser` construction.
- Reuse that `WeakRef` for both fast timer and native timer timeout callbacks.

### Features

N/A

### Bug Fixes

Avoid repeated `WeakRef` allocations when replacing parser timeout callbacks.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5