### PR TITLE
perf: use byteLength property for binary body chunks

### DIFF
--- a/benchmarks/core/body-chunk-byte-length.mjs
+++ b/benchmarks/core/body-chunk-byte-length.mjs
@@ -1,0 +1,63 @@
+import { bench, do_not_optimize as doNotOptimize, group, run } from 'mitata'
+
+const buffer = Buffer.alloc(16 * 1024)
+const uint8Array = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+const string = 'a'.repeat(buffer.byteLength)
+
+function previousChunkLength (chunk) {
+  return Buffer.byteLength(chunk)
+}
+
+function currentChunkLength (chunk) {
+  return chunk instanceof Uint8Array ? chunk.byteLength : Buffer.byteLength(chunk)
+}
+
+group('body writer chunk length', () => {
+  bench('Buffer.byteLength(buffer)', () => {
+    doNotOptimize(Buffer.byteLength(buffer))
+  })
+
+  bench('buffer.byteLength', () => {
+    doNotOptimize(buffer.byteLength)
+  })
+
+  bench('Buffer.byteLength(uint8Array)', () => {
+    doNotOptimize(Buffer.byteLength(uint8Array))
+  })
+
+  bench('uint8Array.byteLength', () => {
+    doNotOptimize(uint8Array.byteLength)
+  })
+
+  bench('Buffer.byteLength(string)', () => {
+    doNotOptimize(Buffer.byteLength(string))
+  })
+})
+
+group('body writer chunk length helper', () => {
+  bench('previousChunkLength(buffer)', () => {
+    doNotOptimize(previousChunkLength(buffer))
+  })
+
+  bench('currentChunkLength(buffer)', () => {
+    doNotOptimize(currentChunkLength(buffer))
+  })
+
+  bench('previousChunkLength(uint8Array)', () => {
+    doNotOptimize(previousChunkLength(uint8Array))
+  })
+
+  bench('currentChunkLength(uint8Array)', () => {
+    doNotOptimize(currentChunkLength(uint8Array))
+  })
+
+  bench('previousChunkLength(string)', () => {
+    doNotOptimize(previousChunkLength(string))
+  })
+
+  bench('currentChunkLength(string)', () => {
+    doNotOptimize(currentChunkLength(string))
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1490,7 +1490,7 @@ class AsyncWriter {
   }
 
   /**
-   * @param {Buffer} chunk
+   * @param {string|Uint8Array} chunk
    * @returns
    */
   write (chunk) {
@@ -1504,7 +1504,7 @@ class AsyncWriter {
       return false
     }
 
-    const len = Buffer.byteLength(chunk)
+    const len = chunk instanceof Uint8Array ? chunk.byteLength : Buffer.byteLength(chunk)
     if (!len) {
       return true
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Improves HTTP/1 body writer chunk-size handling for binary chunks

## Rationale

`AsyncWriter.write()` used `Buffer.byteLength(chunk)` for every body chunk.

For `Buffer` and `Uint8Array` chunks, `chunk.byteLength` is cheaper and avoids the string-oriented logic in `Buffer.byteLength()`. String chunks still need `Buffer.byteLength()` to preserve byte-accurate content-length and chunked framing behavior.

## Changes

- Use `chunk.byteLength` when body writer chunks are `Uint8Array` instances, including `Buffer`.
- Keep `Buffer.byteLength(chunk)` for string chunks and invalid non-binary values.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5