### PR TITLE
perf(http2): avoid cloning headers when removing status

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -673,9 +673,10 @@ function writeH2 (client, request) {
       const onUpgradeResponse = (headers, _flags) => {
         responseReceived = true
 
-        const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
+        const statusCode = headers[HTTP2_HEADER_STATUS]
+        delete headers[HTTP2_HEADER_STATUS]
 
-        request.onRequestUpgrade(statusCode, realHeaders, stream)
+        request.onRequestUpgrade(statusCode, headers, stream)
 
         if (request.aborted || request.completed) {
           return
@@ -894,7 +895,8 @@ function writeH2 (client, request) {
   const onResponse = (headers) => {
     stream.off('response', onResponse)
 
-    const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
+    const statusCode = headers[HTTP2_HEADER_STATUS]
+    delete headers[HTTP2_HEADER_STATUS]
     request.onResponseStarted()
     responseReceived = true
 
@@ -908,7 +910,7 @@ function writeH2 (client, request) {
       return
     }
 
-    if (request.onResponseStart(Number(statusCode), realHeaders, stream.resume.bind(stream), '') === false) {
+    if (request.onResponseStart(Number(statusCode), headers, stream.resume.bind(stream), '') === false) {
       stream.pause()
     }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Avoid cloning HTTP/2 response headers just to remove the `:status` pseudo-header before passing headers to request callbacks.

## Changes

The response handling now removes `:status` in place instead of using rest destructuring, avoiding an extra headers object allocation for every H2 response and upgrade response.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5