### PR TITLE
fix(cache): allow streamed entries at maxEntrySize limit

### DIFF
--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -138,7 +138,7 @@ class MemoryCacheStore extends EventEmitter {
 
         entry.size += chunk.byteLength
 
-        if (entry.size >= store.#maxEntrySize) {
+        if (entry.size > store.#maxEntrySize) {
           this.destroy()
         } else {
           entry.body.push(chunk)

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -325,7 +325,7 @@ module.exports = class SqliteCacheStore {
       write (chunk, encoding, callback) {
         size += chunk.byteLength
 
-        if (size < store.#maxEntrySize) {
+        if (size <= store.#maxEntrySize) {
           body.push(chunk)
         } else {
           this.destroy()

--- a/test/cache-interceptor/cache-store-test-utils.js
+++ b/test/cache-interceptor/cache-store-test-utils.js
@@ -108,6 +108,45 @@ function cacheStoreTests (CacheStore, options) {
       }
     })
 
+    test('caches streamed body at maxEntrySize boundary', options, async () => {
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheKey}
+       */
+      const key = {
+        origin: 'localhost',
+        path: '/',
+        method: 'GET',
+        headers: {}
+      }
+
+      /**
+       * @type {import('../../types/cache-interceptor.d.ts').default.CacheValue}
+       */
+      const value = {
+        statusCode: 200,
+        statusMessage: '',
+        headers: { foo: 'bar' },
+        cacheControlDirectives: {},
+        cachedAt: Date.now(),
+        staleAt: Date.now() + 10000,
+        deleteAt: Date.now() + 20000
+      }
+
+      const body = [Buffer.from('asd'), Buffer.from('123')]
+      const store = new CacheStore({ maxEntrySize: 6 })
+      const writable = store.createWriteStream(key, value)
+
+      notEqual(writable, undefined)
+
+      const finished = once(writable, 'finish')
+      writeBody(writable, body)
+      await finished
+
+      const result = await store.get(structuredClone(key))
+      notEqual(result, undefined)
+      await compareGetResults(result, value, body)
+    })
+
     test('returns stale response before deleteAt', options, async () => {
       const clock = FakeTimers.install({
         shouldClearNativeTimers: true


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5128

## Rationale

`maxEntrySize` should allow entries whose body size is exactly equal to the configured limit

`SqliteCacheStore#set()` already rejects only entries larger than `maxEntrySize`, but `createWriteStream()` rejected exact-limit entries.

## Changes

- Allow `SqliteCacheStore#createWriteStream()` to cache streamed entries where `size === maxEntrySize`.
- Allow `MemoryCacheStore#createWriteStream()` to cache streamed entries where `entry.size === maxEntrySize`.

### Features

N/A

### Bug Fixes

Update streamed cache writes to reject entries only when they exceed `maxEntrySize`

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5