### PR TITLE
test(http2): ensure websocket upgrade resumes queued requests

### DIFF
--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -295,6 +295,73 @@ test('Dispatcher#Upgrade', async t => {
   await new Promise((resolve) => server.close(resolve))
 })
 
+test('Dispatcher#Upgrade resumes queued requests after successful WebSocket upgrade', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let postReachedServer = false
+
+  const server = createSecureServer({
+    ...(await pem.generate({ opts: { keySize: 2048 } })),
+    settings: { enableConnectProtocol: true }
+  })
+
+  server.on('stream', (stream, headers) => {
+    stream.on('error', err => {
+      t.fail(err)
+    })
+
+    if (headers[':method'] === 'CONNECT' && headers[':protocol'] === 'websocket') {
+      stream.respond({ ':status': 200 })
+      return
+    }
+
+    if (headers[':method'] === 'POST') {
+      postReachedServer = true
+      stream.resume()
+      stream.respond({ ':status': 200 })
+      stream.end('ok')
+      return
+    }
+
+    stream.close()
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  let upgradeSocket
+
+  try {
+    const upgrade = client.upgrade({ path: '/', protocol: 'websocket' })
+    const post = client.request({ method: 'POST', path: '/', body: 'hello' })
+
+    const { socket } = await upgrade
+    upgradeSocket = socket
+    t.strictEqual(socket.closed, false)
+
+    const response = await Promise.race([
+      post,
+      sleep(1_000).then(() => null)
+    ])
+
+    t.ok(postReachedServer)
+    t.strictEqual(response?.statusCode, 200)
+  } finally {
+    upgradeSocket?.on('error', () => {})
+    upgradeSocket?.end()
+    await client.close()
+    await new Promise((resolve) => server.close(resolve))
+  }
+
+  await t.completed
+})
+
 test('Dispatcher#Upgrade rejects if stream closes before response headers', async t => {
   t = tspl(t, { plan: 2 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Refs: https://github.com/nodejs/undici/issues/5131

## Rationale

This was fixed in https://github.com/nodejs/undici/pull/5090, but I'd used an older state of main for generating bug report

## Changes

Adds regression coverage for HTTP/2 WebSocket upgrades resuming queued requests.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5