### PR TITLE
fix(http2): respect peer max concurrent streams

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -233,6 +233,14 @@ function connectH2 (client, socket) {
      * @returns {boolean}
     */
     busy (request) {
+      if (session[kRemoteSettings] === false && client[kRunning] > 0) {
+        return true
+      }
+
+      if (client[kRunning] >= client[kMaxConcurrentStreams]) {
+        return true
+      }
+
       if (request != null) {
         if (client[kRunning] > 0) {
           // We are already processing requests

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -83,6 +83,56 @@ test('Should support h2c connection with body', async t => {
   planner.equal(Buffer.concat(bodyChunks).toString(), 'Hello, world!')
 })
 
+test('Should queue h2c requests above the remote max concurrent streams setting', async t => {
+  const planner = tspl(t, { plan: 3 })
+  let activeStreams = 0
+  let maxActiveStreams = 0
+  const paths = []
+
+  const server = createServer({
+    settings: {
+      maxConcurrentStreams: 1
+    }
+  })
+
+  server.on('stream', (stream, headers) => {
+    activeStreams++
+    maxActiveStreams = Math.max(maxActiveStreams, activeStreams)
+    paths.push(headers[':path'])
+
+    stream.respond({ ':status': 200 })
+    setTimeout(() => {
+      activeStreams--
+      stream.end('Hello, world!')
+    }, 50)
+  })
+
+  server.listen()
+  await once(server, 'listening')
+  const client = new H2CClient(`http://localhost:${server.address().port}/`, {
+    maxConcurrentStreams: 10,
+    pipelining: 10
+  })
+
+  t.after(() => client.close())
+  t.after(() => server.close())
+
+  const responses = await Promise.all(Array.from({ length: 5 }, async (_, i) => {
+    const response = await client.request({ path: `/${i}`, method: 'GET' })
+    return {
+      statusCode: response.statusCode,
+      body: await response.body.text()
+    }
+  }))
+
+  planner.strictEqual(maxActiveStreams, 1)
+  planner.deepStrictEqual(paths, ['/0', '/1', '/2', '/3', '/4'])
+  planner.deepStrictEqual(responses, Array.from({ length: 5 }, () => ({
+    statusCode: 200,
+    body: 'Hello, world!'
+  })))
+})
+
 test('Should reject request if not h2c supported', async t => {
   const planner = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5134

## Rationale

HTTP/2 remote settings update `client[kMaxConcurrentStreams]`, but dispatch was only throttled by `pipelining`.

When `pipelining` was higher than the server's advertised stream limit, Undici could open too many concurrent streams and receive `NGHTTP2_REFUSED_STREAM`.

## Changes

- Queue HTTP/2 requests while remote SETTINGS have not arrived and one stream is already running.
- Queue HTTP/2 requests when the number of running streams reaches `client[kMaxConcurrentStreams]`.

### Features

N/A

### Bug Fixes

Respect http/2 peer max concurrent streams

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5