### PR TITLE
fix: backport safe main fixes to v7.x

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -21,7 +21,7 @@ class RequestHandler extends AsyncResource {
         throw new InvalidArgumentError('invalid callback')
       }
 
-      if (highWaterMark && (typeof highWaterMark !== 'number' || highWaterMark < 0)) {
+      if (highWaterMark != null && (!Number.isFinite(highWaterMark) || highWaterMark < 0)) {
         throw new InvalidArgumentError('invalid highWaterMark')
       }
 

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -216,7 +216,7 @@ module.exports = class SqliteCacheStore {
           SELECT
             id
           FROM cacheInterceptorV${VERSION}
-          ORDER BY cachedAt DESC
+          ORDER BY cachedAt ASC
           LIMIT ?
         )
       `)

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -409,7 +409,7 @@ module.exports = class SqliteCacheStore {
     const now = Date.now()
     for (const value of values) {
       if (now >= value.deleteAt && !canBeExpired) {
-        return undefined
+        continue
       }
 
       let matches = true

--- a/lib/cache/sqlite-cache-store.js
+++ b/lib/cache/sqlite-cache-store.js
@@ -283,7 +283,6 @@ module.exports = class SqliteCacheStore {
         existingValue.id
       )
     } else {
-      this.#prune()
       // New response, let's insert it
       this.#insertValueQuery.run(
         url,
@@ -299,6 +298,7 @@ module.exports = class SqliteCacheStore {
         value.cachedAt,
         value.staleAt
       )
+      this.#prune()
     }
   }
 

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -38,6 +38,22 @@ const SessionCache = class WeakSessionCache {
       return
     }
 
+    if (this._sessionCache.has(sessionKey)) {
+      this._sessionCache.delete(sessionKey)
+    } else if (this._sessionCache.size >= this._maxCachedSessions) {
+      for (const [key, ref] of this._sessionCache) {
+        if (ref.deref() === undefined) {
+          this._sessionCache.delete(key)
+          return
+        }
+      }
+
+      const oldest = this._sessionCache.keys().next()
+      if (!oldest.done) {
+        this._sessionCache.delete(oldest.value)
+      }
+    }
+
     this._sessionCache.set(sessionKey, new WeakRef(session))
     this._sessionRegistry.register(session, sessionKey)
   }

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -27,6 +27,21 @@ const { headerNameLowerCasedRecord } = require('./constants')
 // Verifies that a given path is valid does not contain control chars \x00 to \x20
 const invalidPathRegex = /[^\u0021-\u00ff]/
 
+function isValidContentLengthHeaderValue (val) {
+  if (typeof val !== 'string' || val.length === 0) {
+    return false
+  }
+
+  for (let i = 0; i < val.length; i++) {
+    const charCode = val.charCodeAt(i)
+    if (charCode < 48 || charCode > 57) {
+      return false
+    }
+  }
+
+  return true
+}
+
 const kHandler = Symbol('handler')
 
 class Request {
@@ -402,10 +417,10 @@ function processHeader (request, key, val) {
     if (request.contentLength !== null) {
       throw new InvalidArgumentError('duplicate content-length header')
     }
-    request.contentLength = parseInt(val, 10)
-    if (!Number.isFinite(request.contentLength)) {
+    if (!isValidContentLengthHeaderValue(val)) {
       throw new InvalidArgumentError('invalid content-length header')
     }
+    request.contentLength = parseInt(val, 10)
   } else if (request.contentType === null && headerName === 'content-type') {
     request.contentType = val
     request.headers.push(key, val)

--- a/lib/core/socks5-client.js
+++ b/lib/core/socks5-client.js
@@ -7,6 +7,7 @@ const { debuglog } = require('node:util')
 const { parseAddress } = require('./socks5-utils')
 
 const debug = debuglog('undici:socks5')
+const EMPTY_BUFFER = Buffer.alloc(0)
 
 // SOCKS5 constants
 const SOCKS_VERSION = 0x05
@@ -72,7 +73,10 @@ class Socks5Client extends EventEmitter {
     this.socket = socket
     this.options = options
     this.state = STATES.INITIAL
-    this.buffer = Buffer.alloc(0)
+    this.buffer = EMPTY_BUFFER
+    this.onSocketData = this.onData.bind(this)
+    this.onSocketError = this.onError.bind(this)
+    this.onSocketClose = this.onClose.bind(this)
 
     // Authentication settings
     this.authMethods = []
@@ -82,9 +86,9 @@ class Socks5Client extends EventEmitter {
     this.authMethods.push(AUTH_METHODS.NO_AUTH)
 
     // Socket event handlers
-    this.socket.on('data', this.onData.bind(this))
-    this.socket.on('error', this.onError.bind(this))
-    this.socket.on('close', this.onClose.bind(this))
+    this.socket.on('data', this.onSocketData)
+    this.socket.on('error', this.onSocketError)
+    this.socket.on('close', this.onSocketClose)
   }
 
   /**
@@ -363,8 +367,9 @@ class Socks5Client extends EventEmitter {
 
     const boundPort = this.buffer.readUInt16BE(offset)
 
-    this.buffer = this.buffer.subarray(responseLength)
+    this.buffer = EMPTY_BUFFER
     this.state = STATES.CONNECTED
+    this.socket.removeListener('data', this.onSocketData)
 
     debug('connected, bound address:', boundAddress, 'port:', boundPort)
     this.emit('connected', { address: boundAddress, port: boundPort })

--- a/lib/core/socks5-utils.js
+++ b/lib/core/socks5-utils.js
@@ -46,34 +46,29 @@ function parseAddress (address) {
  */
 function parseIPv6 (address) {
   const buffer = Buffer.alloc(16)
-  const parts = address.split(':')
-  let partIndex = 0
-  let bufferIndex = 0
 
   // Handle compressed notation (::)
   const doubleColonIndex = address.indexOf('::')
   if (doubleColonIndex !== -1) {
-    // Count non-empty parts
-    const nonEmptyParts = parts.filter(p => p.length > 0).length
-    const skipParts = 8 - nonEmptyParts
+    const before = address.slice(0, doubleColonIndex)
+    const after = address.slice(doubleColonIndex + 2)
+    const beforeParts = before === '' ? [] : before.split(':')
+    const afterParts = after === '' ? [] : after.split(':')
 
-    for (let i = 0; i < parts.length; i++) {
-      if (parts[i] === '' && i === doubleColonIndex / 3) {
-        // Skip empty parts for ::
-        bufferIndex += skipParts * 2
-      } else if (parts[i] !== '') {
-        const value = parseInt(parts[i], 16)
-        buffer.writeUInt16BE(value, bufferIndex)
-        bufferIndex += 2
-      }
+    let bufferIndex = 0
+    for (const part of beforeParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
+    }
+    bufferIndex = 16 - afterParts.length * 2
+    for (const part of afterParts) {
+      buffer.writeUInt16BE(parseInt(part, 16), bufferIndex)
+      bufferIndex += 2
     }
   } else {
-    // No compression, parse normally
-    for (const part of parts) {
-      if (part === '') continue
-      const value = parseInt(part, 16)
-      buffer.writeUInt16BE(value, partIndex * 2)
-      partIndex++
+    const parts = address.split(':')
+    for (let i = 0; i < parts.length; i++) {
+      buffer.writeUInt16BE(parseInt(parts[i], 16), i * 2)
     }
   }
 

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -69,9 +69,9 @@ function lazyllhttp () {
   let useWasmSIMD = process.arch !== 'ppc64'
   // The Env Variable UNDICI_NO_WASM_SIMD allows explicitly overriding the default behavior
   if (process.env.UNDICI_NO_WASM_SIMD === '1') {
-    useWasmSIMD = true
-  } else if (process.env.UNDICI_NO_WASM_SIMD === '0') {
     useWasmSIMD = false
+  } else if (process.env.UNDICI_NO_WASM_SIMD === '0') {
+    useWasmSIMD = true
   }
 
   if (useWasmSIMD) {

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -216,6 +216,7 @@ class Parser {
      */
     this.socket = socket
     this.timeout = null
+    this.timeoutWeakRef = new WeakRef(this)
     this.timeoutValue = null
     this.timeoutType = null
     this.statusCode = 0
@@ -253,9 +254,9 @@ class Parser {
 
       if (delay) {
         if (type & USE_FAST_TIMER) {
-          this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = timers.setFastTimeout(onParserTimeout, delay, this.timeoutWeakRef)
         } else {
-          this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = setTimeout(onParserTimeout, delay, this.timeoutWeakRef)
           this.timeout?.unref()
         }
       }

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -235,9 +235,13 @@ class Client extends DispatcherBase {
         ...(typeof autoSelectFamily === 'boolean' ? { autoSelectFamily, autoSelectFamilyAttemptTimeout } : undefined),
         ...connect
       })
-    } else if (socketPath != null) {
+    } else {
       const customConnect = connect
-      connect = (opts, callback) => customConnect({ ...opts, socketPath }, callback)
+      connect = (opts, callback) => customConnect({
+        ...opts,
+        ...(socketPath != null ? { socketPath } : null),
+        ...(allowH2 != null ? { allowH2 } : null)
+      }, callback)
     }
 
     this[kUrl] = util.parseOrigin(url)

--- a/lib/dispatcher/h2c-client.js
+++ b/lib/dispatcher/h2c-client.js
@@ -15,7 +15,7 @@ class H2CClient extends Client {
       )
     }
 
-    const { connect, maxConcurrentStreams, pipelining, ...opts } =
+    const { maxConcurrentStreams, pipelining, ...opts } =
             clientOpts ?? {}
     let defaultMaxConcurrentStreams = 100
     let defaultPipelining = 100

--- a/lib/mock/mock-call-history.js
+++ b/lib/mock/mock-call-history.js
@@ -3,14 +3,14 @@
 const { kMockCallHistoryAddLog } = require('./mock-symbols')
 const { InvalidArgumentError } = require('../core/errors')
 
-function handleFilterCallsWithOptions (criteria, options, handler, store) {
+function handleFilterCallsWithOptions (criteria, options, handler, store, allLogs) {
   switch (options.operator) {
     case 'OR':
-      store.push(...handler(criteria))
+      store.push(...handler(criteria, allLogs))
 
       return store
     case 'AND':
-      return handler.call({ logs: store }, criteria)
+      return handler(criteria, store)
     default:
       // guard -- should never happens because buildAndValidateFilterCallsOptions is called before
       throw new InvalidArgumentError('options.operator must to be a case insensitive string equal to \'OR\' or \'AND\'')
@@ -35,14 +35,14 @@ function buildAndValidateFilterCallsOptions (options = {}) {
 }
 
 function makeFilterCalls (parameterName) {
-  return (parameterValue) => {
+  return (parameterValue, logs) => {
     if (typeof parameterValue === 'string' || parameterValue == null) {
-      return this.logs.filter((log) => {
+      return logs.filter((log) => {
         return log[parameterName] === parameterValue
       })
     }
     if (parameterValue instanceof RegExp) {
-      return this.logs.filter((log) => {
+      return logs.filter((log) => {
         return parameterValue.test(log[parameterName])
       })
     }
@@ -175,30 +175,30 @@ class MockCallHistory {
 
       const finalOptions = { operator: 'OR', ...buildAndValidateFilterCallsOptions(options) }
 
-      let maybeDuplicatedLogsFiltered = []
+      let maybeDuplicatedLogsFiltered = finalOptions.operator === 'AND' ? this.logs : []
       if ('protocol' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.protocol, finalOptions, this.filterCallsByProtocol, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.protocol, finalOptions, this.filterCallsByProtocol, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('host' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.host, finalOptions, this.filterCallsByHost, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.host, finalOptions, this.filterCallsByHost, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('port' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.port, finalOptions, this.filterCallsByPort, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.port, finalOptions, this.filterCallsByPort, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('origin' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.origin, finalOptions, this.filterCallsByOrigin, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.origin, finalOptions, this.filterCallsByOrigin, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('path' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.path, finalOptions, this.filterCallsByPath, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.path, finalOptions, this.filterCallsByPath, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('hash' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.hash, finalOptions, this.filterCallsByHash, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.hash, finalOptions, this.filterCallsByHash, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('fullUrl' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.fullUrl, finalOptions, this.filterCallsByFullUrl, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.fullUrl, finalOptions, this.filterCallsByFullUrl, maybeDuplicatedLogsFiltered, this.logs)
       }
       if ('method' in criteria) {
-        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.method, finalOptions, this.filterCallsByMethod, maybeDuplicatedLogsFiltered)
+        maybeDuplicatedLogsFiltered = handleFilterCallsWithOptions(criteria.method, finalOptions, this.filterCallsByMethod, maybeDuplicatedLogsFiltered, this.logs)
       }
 
       const uniqLogsFiltered = [...new Set(maybeDuplicatedLogsFiltered)]

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -374,9 +374,11 @@ function assertCacheMethods (methods, name = 'CacheMethods') {
  * @returns {string}
  */
 function makeDeduplicationKey (cacheKey, excludeHeaders) {
-  // Create a deterministic string key from the cache key
-  // Include origin, method, path, and sorted headers
-  let key = `${cacheKey.origin}:${cacheKey.method}:${cacheKey.path}`
+  // Use JSON.stringify to produce a collision-resistant key.
+  // Previous format used `:` and `=` delimiters without escaping, which
+  // allowed different header sets to produce identical keys (e.g.
+  // {a:"x:b=y"} vs {a:"x", b:"y"}). See: https://github.com/nodejs/undici/issues/5012
+  const headers = {}
 
   if (cacheKey.headers) {
     const sortedHeaders = Object.keys(cacheKey.headers).sort()
@@ -385,12 +387,11 @@ function makeDeduplicationKey (cacheKey, excludeHeaders) {
       if (excludeHeaders?.has(header.toLowerCase())) {
         continue
       }
-      const value = cacheKey.headers[header]
-      key += `:${header}=${Array.isArray(value) ? value.join(',') : value}`
+      headers[header] = cacheKey.headers[header]
     }
   }
 
-  return key
+  return JSON.stringify([cacheKey.origin, cacheKey.method, cacheKey.path, headers])
 }
 
 module.exports = {

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -18,7 +18,7 @@ function makeCacheKey (opts) {
 
   let fullPath = opts.path || '/'
 
-  if (opts.query && !pathHasQueryOrFragment(opts.path)) {
+  if (opts.query && !pathHasQueryOrFragment(fullPath)) {
     fullPath = serializePathWithQuery(fullPath, opts.query)
   }
 

--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -204,7 +204,7 @@ function multipartFormDataParser (input, mimeType) {
  * Parses content-disposition attributes (e.g., name="value" or filename*=utf-8''encoded)
  * @param {Buffer} input
  * @param {{ position: number }} position
- * @returns {{ name: string, value: string }}
+ * @returns {{ name: string, value: string, extended: boolean } | null}
  */
 function parseContentDispositionAttribute (input, position) {
   // Skip leading semicolon and whitespace
@@ -304,7 +304,7 @@ function parseContentDispositionAttribute (input, position) {
     value = decoder.decode(tokenValue)
   }
 
-  return { name: attrNameStr, value }
+  return { name: attrNameStr, value, extended: isExtended }
 }
 
 /**
@@ -368,6 +368,9 @@ function parseMultipartFormDataHeaders (input, position) {
     switch (bufferToLowerCasedHeaderName(headerName)) {
       case 'content-disposition': {
         name = filename = null
+        // Track whether filename was set from the extended (RFC 5987) form so
+        // a subsequent legacy `filename` attribute does not override it.
+        let filenameIsExtended = false
 
         // Collect the disposition type (should be "form-data")
         const dispositionType = collectASequenceOfBytes(
@@ -395,7 +398,15 @@ function parseMultipartFormDataHeaders (input, position) {
           if (attribute.name === 'name') {
             name = attribute.value
           } else if (attribute.name === 'filename') {
-            filename = attribute.value
+            // Per RFC 5987 §4.1, when both legacy and extended forms of the
+            // same parameter are present, the extended (filename*) form takes
+            // precedence regardless of the order they appear in.
+            if (attribute.extended) {
+              filename = attribute.value
+              filenameIsExtended = true
+            } else if (!filenameIsExtended) {
+              filename = attribute.value
+            }
           }
         }
 

--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -383,8 +383,8 @@ function parseMultipartFormDataHeaders (input, position) {
         // Parse attributes recursively until CRLF
         while (
           position.position < input.length &&
-          input[position.position] !== 0x0d &&
-          input[position.position + 1] !== 0x0a
+          (input[position.position] !== 0x0d ||
+          input[position.position + 1] !== 0x0a)
         ) {
           const attribute = parseContentDispositionAttribute(input, position)
 
@@ -448,7 +448,7 @@ function parseMultipartFormDataHeaders (input, position) {
 
     // 2.9. If position does not point to a sequence of bytes starting with 0x0D 0x0A
     //      (CR LF), return failure. Otherwise, advance position by 2 (past the newline).
-    if (input[position.position] !== 0x0d && input[position.position + 1] !== 0x0a) {
+    if (input[position.position] !== 0x0d || input[position.position + 1] !== 0x0a) {
       throw parsingError('expected CRLF')
     } else {
       position.position += 2

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1433,7 +1433,10 @@ async function httpNetworkOrCacheFetch (
   //    8. If contentLengthHeaderValue is non-null, then append
   //    `Content-Length`/contentLengthHeaderValue to httpRequest’s header
   //    list.
-  if (contentLengthHeaderValue != null) {
+  if (
+    contentLengthHeaderValue != null &&
+    !httpRequest.headersList.contains('content-length', true)
+  ) {
     httpRequest.headersList.append('content-length', contentLengthHeaderValue, true)
   }
 

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1030,7 +1030,7 @@ function fetchFinale (fetchParams, response) {
       let responseStatus = 0
 
       // 7. If fetchParams’s request’s mode is not "navigate" or response’s has-cross-origin-redirects is false:
-      if (fetchParams.request.mode !== 'navigator' || !response.hasCrossOriginRedirects) {
+      if (fetchParams.request.mode !== 'navigate' || !response.hasCrossOriginRedirects) {
         // 1. Set responseStatus to response’s status.
         responseStatus = response.status
 

--- a/lib/web/webidl/index.js
+++ b/lib/web/webidl/index.js
@@ -190,10 +190,10 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, flags) {
   } else {
     // 3. Otherwise:
 
-    // 1. Let lowerBound be -2^bitLength − 1.
-    lowerBound = Math.pow(-2, bitLength) - 1
+    // 1. Let lowerBound be -2^(bitLength − 1).
+    lowerBound = -Math.pow(2, bitLength - 1)
 
-    // 2. Let upperBound be 2^bitLength − 1 − 1.
+    // 2. Let upperBound be 2^(bitLength − 1) − 1.
     upperBound = Math.pow(2, bitLength - 1) - 1
   }
 
@@ -272,9 +272,9 @@ webidl.util.ConvertToInt = function (V, bitLength, signedness, flags) {
   // 10. Set x to x modulo 2^bitLength.
   x = x % Math.pow(2, bitLength)
 
-  // 11. If signedness is "signed" and x ≥ 2^bitLength − 1,
+  // 11. If signedness is "signed" and x ≥ 2^(bitLength − 1),
   //    then return x − 2^bitLength.
-  if (signedness === 'signed' && x >= Math.pow(2, bitLength) - 1) {
+  if (signedness === 'signed' && x >= Math.pow(2, bitLength - 1)) {
     return x - Math.pow(2, bitLength)
   }
 

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -332,7 +332,7 @@ class WebSocketStream {
       try {
         chunk = utf8Decode(data)
       } catch {
-        failWebsocketConnection(this.#handler, 'Received invalid UTF-8 in text frame.')
+        failWebsocketConnection(this.#handler, 1007, 'Received invalid UTF-8 in text frame.')
         return
       }
     } else if (type === opcodes.BINARY) {

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -284,12 +284,6 @@ class WebSocketStream {
       start: (controller) => {
         this.#readableStreamController = controller
       },
-      pull (controller) {
-        let chunk
-        while (controller.desiredSize > 0 && (chunk = response.socket.read()) !== null) {
-          controller.enqueue(chunk)
-        }
-      },
       cancel: (reason) => this.#cancel(reason)
     })
 

--- a/test/busboy/issue-4661.js
+++ b/test/busboy/issue-4661.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { test } = require('node:test')
+const { Request } = require('../..')
+
+const boundary = '1df6c75e-c5a7-486c-af47-67b632b19522'
+const contentType = `multipart/form-data; boundary=${boundary}`
+
+// https://github.com/nodejs/undici/issues/4661
+test('content-disposition allows both filename and filename* parameters', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename="E 1962 029 1342-0003.JPG"; filename*=utf-8\'\'E%201962%20029%201342-0003.JPG\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'E 1962 029 1342-0003.JPG')
+  t.assert.strictEqual(await file.text(), 'Hello')
+})
+
+test('filename* (RFC 5987) without legacy filename is parsed correctly', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=utf-8\'\'only-extended.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'only-extended.txt')
+})
+
+test('filename* takes precedence over filename when both are present', async (t) => {
+  // Per RFC 5987 §4.1, when both extended and non-extended forms of the
+  // same parameter appear, the extended form is preferred regardless of order.
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=utf-8\'\'extended.txt; filename="legacy.txt"\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'extended.txt')
+})
+
+test('filename* takes precedence when filename appears first', async (t) => {
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename="legacy.txt"; filename*=utf-8\'\'extended.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, 'extended.txt')
+})
+
+test('filename* with percent-encoded UTF-8 bytes is decoded', async (t) => {
+  // %E2%82%AC = U+20AC (€), %20 = space
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="Abc"; filename*=UTF-8\'\'%E2%82%AC%20rates.txt\r\n' +
+      '\r\n' +
+      'Hello\r\n' +
+      `--${boundary}--`
+  })
+
+  const fd = await request.formData()
+  const file = fd.get('Abc')
+  t.assert.ok(file instanceof File)
+  t.assert.strictEqual(file.name, '\u20AC rates.txt')
+})

--- a/test/cache-interceptor/issue-4209.js
+++ b/test/cache-interceptor/issue-4209.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const { equal, notEqual, deepStrictEqual } = require('node:assert')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { request, Agent, interceptors } = require('../../')
+const { makeCacheKey } = require('../../lib/util/cache')
+
+// Regression test for https://github.com/nodejs/undici/issues/4209
+// The cache interceptor must treat requests with different `query` params
+// (or query strings) as distinct cache entries, and must not throw when
+// `opts.path` is absent while `opts.query` is provided.
+
+test('issue #4209 - makeCacheKey includes query in key.path', () => {
+  const k1 = makeCacheKey({
+    origin: 'http://example.com',
+    method: 'GET',
+    path: '/',
+    query: { i: 1 },
+    headers: {}
+  })
+  const k2 = makeCacheKey({
+    origin: 'http://example.com',
+    method: 'GET',
+    path: '/',
+    query: { i: 2 },
+    headers: {}
+  })
+  equal(k1.path, '/?i=1')
+  equal(k2.path, '/?i=2')
+  notEqual(k1.path, k2.path)
+})
+
+test('issue #4209 - makeCacheKey does not throw when opts.path is undefined', () => {
+  // Previously `pathHasQueryOrFragment(opts.path)` threw when opts.path was
+  // undefined, because undefined has no `.includes`. The cache key must be
+  // derivable even when only `query` is supplied.
+  const key = makeCacheKey({
+    origin: 'http://example.com',
+    method: 'GET',
+    query: { i: 42 },
+    headers: {}
+  })
+  deepStrictEqual(key, {
+    origin: 'http://example.com',
+    method: 'GET',
+    path: '/?i=42',
+    headers: {}
+  })
+})
+
+test('issue #4209 - different query strings do not collide in the cache', async () => {
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Cache-Control': 'public, max-age=100'
+    })
+    // Each response embeds the received URL and a per-request counter so
+    // that a cache collision is immediately observable: a cached reply for
+    // a different query would carry the wrong URL/counter.
+    res.end(`req=${requestCount};url=${req.url}`)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const dispatcher = new Agent().compose(interceptors.cache())
+
+  after(async () => {
+    server.close()
+    await dispatcher.close()
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  // First request with ?i=0 – hits origin
+  const r0 = await request(`${origin}/?i=0`, { dispatcher })
+  const b0 = await r0.body.text()
+  equal(requestCount, 1, 'first distinct query hits the origin')
+  equal(b0, 'req=1;url=/?i=0')
+
+  // Same query repeated – must be served from cache
+  const r0b = await request(`${origin}/?i=0`, { dispatcher })
+  const b0b = await r0b.body.text()
+  equal(requestCount, 1, 'repeated query is served from cache')
+  equal(b0b, b0, 'cached body matches original')
+
+  // Different query – must NOT collide with the previous cache entry
+  const r1 = await request(`${origin}/?i=1`, { dispatcher })
+  const b1 = await r1.body.text()
+  equal(requestCount, 2, 'different query goes to origin, not the cache')
+  equal(b1, 'req=2;url=/?i=1')
+  notEqual(b1, b0, 'different query must produce a different response')
+
+  // And the first one still comes from cache.
+  const r0c = await request(`${origin}/?i=0`, { dispatcher })
+  const b0c = await r0c.body.text()
+  equal(requestCount, 2, 'original query still cached after the new one')
+  equal(b0c, b0)
+})
+
+test('issue #4209 - query object form also keyed distinctly', async () => {
+  let requestCount = 0
+  const server = createServer((req, res) => {
+    requestCount++
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Cache-Control': 'public, max-age=100'
+    })
+    res.end(`req=${requestCount};url=${req.url}`)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const dispatcher = new Agent().compose(interceptors.cache())
+
+  after(async () => {
+    server.close()
+    await dispatcher.close()
+  })
+
+  const origin = `http://localhost:${server.address().port}`
+
+  const r0 = await request(origin, { dispatcher, query: { i: 0 } })
+  const b0 = await r0.body.text()
+  equal(requestCount, 1)
+  equal(b0, 'req=1;url=/?i=0')
+
+  const r1 = await request(origin, { dispatcher, query: { i: 1 } })
+  const b1 = await r1.body.text()
+  equal(requestCount, 2, 'different query option must bypass cache')
+  equal(b1, 'req=2;url=/?i=1')
+  notEqual(b0, b1)
+
+  // Re-request first query – served from cache, counter unchanged.
+  const r0b = await request(origin, { dispatcher, query: { i: 0 } })
+  const b0b = await r0b.body.text()
+  equal(requestCount, 2, 'first query still served from cache')
+  equal(b0b, b0)
+})

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -156,6 +156,44 @@ test('SqliteCacheStore two writes', { skip: runtimeFeatures.has('sqlite') === fa
   }
 })
 
+test('SqliteCacheStore prune evicts oldest entries first', { skip: runtimeFeatures.has('sqlite') === false }, async () => {
+  const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
+
+  const maxCount = 10
+  const store = new SqliteCacheStore({ maxCount })
+
+  const baseTime = Date.now()
+
+  for (let i = 0; i < 20; i++) {
+    const key = {
+      origin: 'localhost',
+      path: '/' + i,
+      method: 'GET',
+      headers: {}
+    }
+
+    const value = {
+      statusCode: 200,
+      statusMessage: '',
+      headers: { foo: 'bar' },
+      cachedAt: baseTime + i * 1000,
+      staleAt: baseTime + i * 1000 + 60_000,
+      deleteAt: baseTime + i * 1000 + 120_000,
+      body: Buffer.from('x')
+    }
+
+    store.set(key, value)
+  }
+
+  // The most recently cached entry must still be present;
+  // the oldest entry must have been evicted.
+  const newest = store.get({ origin: 'localhost', path: '/19', method: 'GET', headers: {} })
+  notEqual(newest, undefined)
+
+  const oldest = store.get({ origin: 'localhost', path: '/0', method: 'GET', headers: {} })
+  strictEqual(oldest, undefined)
+})
+
 test('SqliteCacheStore write & read', { skip: runtimeFeatures.has('sqlite') === false }, async () => {
   const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
 

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -231,3 +231,59 @@ test('SqliteCacheStore write & read', { skip: runtimeFeatures.has('sqlite') === 
 
   deepStrictEqual(store.get(key), value)
 })
+
+test('SqliteCacheStore ignores expired Vary variants when a later one is still valid', { skip: runtimeFeatures.has('sqlite') === false }, () => {
+  const store = new SqliteCacheStore()
+  const now = Date.now()
+  const baseKey = {
+    origin: 'localhost',
+    path: '/',
+    method: 'GET'
+  }
+
+  store.set({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'gzip'
+    }
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    vary: {
+      'accept-encoding': 'gzip'
+    },
+    cachedAt: now - 2000,
+    staleAt: now - 1000,
+    deleteAt: now - 1,
+    body: Buffer.from('expired gzip')
+  })
+
+  store.set({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'br'
+    }
+  }, {
+    statusCode: 200,
+    statusMessage: '',
+    headers: {},
+    vary: {
+      'accept-encoding': 'br'
+    },
+    cachedAt: now,
+    staleAt: now + 1000,
+    deleteAt: now + 2000,
+    body: Buffer.from('valid br')
+  })
+
+  const result = store.get({
+    ...baseKey,
+    headers: {
+      'accept-encoding': 'br'
+    }
+  })
+
+  notEqual(result, undefined)
+  strictEqual(result.body.toString(), 'valid br')
+})

--- a/test/cache-interceptor/sqlite-cache-store-tests.js
+++ b/test/cache-interceptor/sqlite-cache-store-tests.js
@@ -75,9 +75,8 @@ test('SqliteCacheStore works nicely with multiple stores', { skip: runtimeFeatur
 test('SqliteCacheStore maxEntries', { skip: runtimeFeatures.has('sqlite') === false }, async () => {
   const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
 
-  const store = new SqliteCacheStore({
-    maxCount: 10
-  })
+  const maxCount = 10
+  const store = new SqliteCacheStore({ maxCount })
 
   for (let i = 0; i < 20; i++) {
     /**
@@ -109,7 +108,43 @@ test('SqliteCacheStore maxEntries', { skip: runtimeFeatures.has('sqlite') === fa
     writeBody(writable, body)
   }
 
-  strictEqual(store.size <= 11, true)
+  strictEqual(store.size <= maxCount, true)
+})
+
+test('SqliteCacheStore enforces maxCount after insert', { skip: runtimeFeatures.has('sqlite') === false }, () => {
+  const SqliteCacheStore = require('../../lib/cache/sqlite-cache-store.js')
+
+  const store = new SqliteCacheStore({ maxCount: 1 })
+
+  store.set(
+    { origin: 'localhost', path: '/a', method: 'GET', headers: {} },
+    {
+      statusCode: 200,
+      statusMessage: '',
+      headers: {},
+      cachedAt: Date.now(),
+      staleAt: Date.now() + 10_000,
+      deleteAt: Date.now() + 20_000,
+      body: Buffer.from('a')
+    }
+  )
+
+  store.set(
+    { origin: 'localhost', path: '/b', method: 'GET', headers: {} },
+    {
+      statusCode: 200,
+      statusMessage: '',
+      headers: {},
+      cachedAt: Date.now() + 1,
+      staleAt: Date.now() + 10_001,
+      deleteAt: Date.now() + 20_001,
+      body: Buffer.from('b')
+    }
+  )
+
+  strictEqual(store.size, 1)
+  strictEqual(store.get({ origin: 'localhost', path: '/a', method: 'GET', headers: {} }), undefined)
+  notEqual(store.get({ origin: 'localhost', path: '/b', method: 'GET', headers: {} }), undefined)
 })
 
 test('SqliteCacheStore two writes', { skip: runtimeFeatures.has('sqlite') === false }, async () => {

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -3,10 +3,67 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
+const EventEmitter = require('node:events')
 const { createServer } = require('node:http')
 const { Readable } = require('node:stream')
 const FakeTimers = require('@sinonjs/fake-timers')
 const timers = require('../lib/util/timers')
+const connectH1 = require('../lib/dispatcher/client-h1')
+const {
+  kMaxHeadersSize,
+  kMaxResponseSize,
+  kParser,
+  kQueue,
+  kRunningIdx
+} = require('../lib/core/symbols')
+
+class DummySocket extends EventEmitter {
+  constructor () {
+    super()
+    this.destroyed = false
+    this.errored = null
+  }
+
+  read () {
+    return null
+  }
+}
+
+test('parser reuses WeakRef when replacing timeout callbacks', async (t) => {
+  const OriginalWeakRef = global.WeakRef
+  t.after(() => {
+    global.WeakRef = OriginalWeakRef
+  })
+
+  t = tspl(t, { plan: 1 })
+
+  let weakRefCount = 0
+
+  global.WeakRef = class CountingWeakRef extends OriginalWeakRef {
+    constructor (target) {
+      weakRefCount++
+      super(target)
+    }
+  }
+
+  const socket = new DummySocket()
+  const client = {
+    [kMaxHeadersSize]: 1024,
+    [kMaxResponseSize]: 1024,
+    [kQueue]: [],
+    [kRunningIdx]: 0
+  }
+
+  await connectH1(client, socket)
+  const parser = socket[kParser]
+
+  parser.setTimeout(200, 0)
+  parser.setTimeout(300, 0)
+  parser.setTimeout(400, 1)
+  parser.destroy()
+
+  t.strictEqual(weakRefCount, 1)
+})
 
 test('refresh timeout on pause', async (t) => {
   t = tspl(t, { plan: 1 })

--- a/test/fetch/content-length.js
+++ b/test/fetch/content-length.js
@@ -27,3 +27,23 @@ test('Content-Length is set when using a FormData body with fetch', async (t) =>
     body: fd
   })
 })
+
+test('Content-Length is not duplicated when provided explicitly', async (t) => {
+  const body = 'a+b+c'
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.assert.strictEqual(req.headers['content-length'], `${Buffer.byteLength(body)}`)
+    res.end()
+  }).listen(0)
+
+  await once(server, 'listening')
+  t.after(closeServerAsPromise(server))
+
+  await fetch(`http://localhost:${server.address().port}`, {
+    method: 'POST',
+    body,
+    headers: {
+      'content-length': Buffer.byteLength(body)
+    }
+  })
+})

--- a/test/fetch/formdata.js
+++ b/test/fetch/formdata.js
@@ -383,3 +383,26 @@ test('.formData() with multipart/form-data body that ends with --\r\n', async (t
 
   await request.formData()
 })
+
+test('.formData() rejects malformed multipart header line ending with bare CR', async (t) => {
+  const boundary = '----formdata-undici-bare-cr-0000000000'
+  const body = Buffer.concat([
+    Buffer.from('--' + boundary + '\r\n'),
+    Buffer.from('Content-Disposition: form-data; name="x"'),
+    Buffer.from([0x0d]), // bare CR (no LF)
+    Buffer.from('Content-Type: text/plain\r\n'),
+    Buffer.from('\r\n'),
+    Buffer.from('hello\r\n'),
+    Buffer.from('--' + boundary + '--\r\n')
+  ])
+
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'multipart/form-data; boundary=' + boundary
+    },
+    body
+  })
+
+  await t.assert.rejects(request.formData(), TypeError)
+})

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -140,6 +140,32 @@ test('Connect to h2c server over a unix domain socket', { skip: process.platform
   })
 })
 
+test('Should pass custom connect function to Client', async t => {
+  const planner = tspl(t, { plan: 3 })
+
+  const connectError = new Error('custom connect error')
+  const socketPath = '/var/run/test.sock'
+  const client = new H2CClient('http://localhost', {
+    socketPath,
+    connect (opts, cb) {
+      planner.strictEqual(opts.socketPath, socketPath)
+      planner.strictEqual(opts.allowH2, true)
+      cb(connectError, null)
+    }
+  })
+
+  t.after(() => client.close())
+
+  client.request({
+    path: '/',
+    method: 'GET'
+  }, (err) => {
+    planner.strictEqual(err, connectError)
+  })
+
+  await planner.completed
+})
+
 test('Should throw if bad useH2c has been passed', async t => {
   t = tspl(t, { plan: 1 })
 

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -3,10 +3,11 @@
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
-const { strictEqual } = require('node:assert')
+const { strictEqual, notStrictEqual } = require('node:assert')
 const { setTimeout: sleep } = require('node:timers/promises')
 const diagnosticsChannel = require('node:diagnostics_channel')
 const { Client, interceptors } = require('../../index')
+const { makeDeduplicationKey } = require('../../lib/util/cache')
 
 describe('Deduplicate Interceptor', () => {
   test('deduplicates concurrent requests for the same resource', async () => {
@@ -1290,5 +1291,63 @@ describe('Deduplicate Interceptor', () => {
       name: 'TypeError',
       message: 'expected opts.excludeHeaderNames to be an array, got string'
     })
+  })
+
+  test('makeDeduplicationKey does not collide when header values contain delimiters', () => {
+    // Regression test for https://github.com/nodejs/undici/issues/5012
+    // Previously, headers {a:"x:b=y"} and {a:"x", b:"y"} produced the same key
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: 'x:b=y' }
+    })
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: 'x', b: 'y' }
+    })
+
+    notStrictEqual(key1, key2)
+  })
+
+  test('makeDeduplicationKey produces same key for identical headers', () => {
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { b: '2', a: '1' }
+    })
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { a: '1', b: '2' }
+    })
+
+    strictEqual(key1, key2)
+  })
+
+  test('makeDeduplicationKey respects excludeHeaders', () => {
+    const excludeHeaders = new Set(['x-request-id'])
+
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { accept: 'text/html', 'x-request-id': '111' }
+    }, excludeHeaders)
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { accept: 'text/html', 'x-request-id': '222' }
+    }, excludeHeaders)
+
+    strictEqual(key1, key2)
   })
 })

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -5,7 +5,7 @@ const { test, after } = require('node:test')
 const { Client, errors } = require('..')
 
 test('invalid headers', (t) => {
-  t = tspl(t, { plan: 10 })
+  t = tspl(t, { plan: 13 })
 
   const client = new Client('http://localhost:3000')
   after(() => client.close())
@@ -14,6 +14,36 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: {
       'content-length': 'asd'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '1.1'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '10abc'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'content-length': '-1'
     }
   }, (err, data) => {
     t.ok(err instanceof errors.InvalidArgumentError)

--- a/test/mock-call-history.js
+++ b/test/mock-call-history.js
@@ -409,7 +409,24 @@ describe('MockCallHistory - filterCalls with options', () => {
 
     const filtered = mockCallHistoryHello.filterCalls({ path: '/', port: '4000' }, { operator: 'AND' })
 
-    t.assert.strictEqual(filtered.length, 2)
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('should use "AND" operator narrowing through every criterion', t => {
+    t.plan(2)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000', method: 'GET' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000', method: 'POST' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:5000', method: 'GET' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/foo', origin: 'http://localhost:4000', method: 'GET' })
+
+    const andFiltered = mockCallHistoryHello.filterCalls({ path: '/', port: '4000', method: 'GET' }, { operator: 'AND' })
+    t.assert.strictEqual(andFiltered.length, 1)
+
+    const orFiltered = mockCallHistoryHello.filterCalls({ path: '/', port: '4000', method: 'GET' }, { operator: 'OR' })
+    t.assert.strictEqual(orFiltered.length, 4)
   })
 
   test('should use "AND" operator with a lot of filters', t => {

--- a/test/node-test/client-errors.js
+++ b/test/node-test/client-errors.js
@@ -1161,7 +1161,7 @@ test('retry idempotent inflight', async (t) => {
 })
 
 test('invalid opts', async (t) => {
-  const p = tspl(t, { plan: 5 })
+  const p = tspl(t, { plan: 7 })
 
   const client = new Client('http://localhost:5000')
   client.request(null, (err) => {
@@ -1182,6 +1182,14 @@ test('invalid opts', async (t) => {
     path: '/',
     method: 'GET',
     highWaterMark: -1
+  }, (err) => {
+    p.ok(err instanceof errors.InvalidArgumentError)
+    p.strictEqual(err.message, 'invalid highWaterMark')
+  })
+  client.request({
+    path: '/',
+    method: 'GET',
+    highWaterMark: Number.NaN
   }, (err) => {
     p.ok(err instanceof errors.InvalidArgumentError)
     p.strictEqual(err.message, 'invalid highWaterMark')

--- a/test/socks5-client.js
+++ b/test/socks5-client.js
@@ -144,7 +144,7 @@ test('Socks5Client - username/password authentication', async (t) => {
 })
 
 test('Socks5Client - connect command', async (t) => {
-  const p = tspl(t, { plan: 8 })
+  const p = tspl(t, { plan: 10 })
 
   const targetHost = 'example.com'
   const targetPort = 80
@@ -206,6 +206,8 @@ test('Socks5Client - connect command', async (t) => {
   client.on('connected', (info) => {
     p.equal(info.address, '127.0.0.1', 'should return bound address')
     p.equal(info.port, 80, 'should return bound port')
+    p.equal(client.buffer.length, 0, 'should clear SOCKS5 protocol buffer after connect')
+    p.equal(socket.listenerCount('data'), 0, 'should stop parsing socket data after connect')
   })
 
   await client.handshake()

--- a/test/socks5-utils.js
+++ b/test/socks5-utils.js
@@ -48,19 +48,31 @@ test('parseAddress - Domain', async (t) => {
 })
 
 test('parseIPv6', async (t) => {
-  const p = tspl(t, { plan: 3 })
+  const p = tspl(t, { plan: 9 })
 
   // Test full IPv6
   const buffer1 = parseIPv6('2001:0db8:0000:0042:0000:8a2e:0370:7334')
   p.equal(buffer1.length, 16, 'should return 16-byte buffer')
+  p.equal(buffer1.toString('hex'), '20010db80000004200008a2e03707334', 'should parse full IPv6 correctly')
 
-  // Test compressed IPv6
+  // Test compressed IPv6 (zero-fill gap must land in the middle, not after `db8`)
   const buffer2 = parseIPv6('2001:db8::1')
   p.equal(buffer2.length, 16, 'should return 16-byte buffer for compressed')
+  p.equal(buffer2.toString('hex'), '20010db8000000000000000000000001', 'should expand :: correctly for 2001:db8::1')
 
   // Test loopback
   const buffer3 = parseIPv6('::1')
   p.equal(buffer3.length, 16, 'should return 16-byte buffer for loopback')
+  p.equal(buffer3.toString('hex'), '00000000000000000000000000000001', 'should expand ::1 correctly')
+
+  // Test :: in the middle with short groups on both sides
+  p.equal(parseIPv6('1::2').toString('hex'), '00010000000000000000000000000002', 'should expand 1::2 correctly')
+
+  // Test link-local with single group after ::
+  p.equal(parseIPv6('fe80::1').toString('hex'), 'fe800000000000000000000000000001', 'should expand fe80::1 correctly')
+
+  // Test trailing ::
+  p.equal(parseIPv6('fe80::').toString('hex'), 'fe800000000000000000000000000000', 'should expand fe80:: correctly')
 
   await p.completed
 })

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -6,7 +6,7 @@ const { readFileSync } = require('node:fs')
 const { join } = require('node:path')
 const https = require('node:https')
 const crypto = require('node:crypto')
-const { Client, Pool } = require('..')
+const { Client, Pool, buildConnector } = require('..')
 const { kSocket } = require('../lib/core/symbols')
 
 const options = {
@@ -176,6 +176,76 @@ describe('A pool should be able to reuse TLS sessions between clients', () => {
       t.ok(true, 'pass')
     })
 
+    await t.completed
+  })
+})
+
+describe('A connector should enforce maxCachedSessions across hostnames', () => {
+  test('Prepare request', async t => {
+    t = tspl(t, { plan: 4 })
+
+    const tlsOptions = {
+      ...options,
+      minVersion: 'TLSv1.2',
+      maxVersion: 'TLSv1.2'
+    }
+
+    const serverA = https.createServer(tlsOptions, (req, res) => {
+      res.end('a')
+    })
+    const serverB = https.createServer(tlsOptions, (req, res) => {
+      res.end('b')
+    })
+
+    await Promise.all([
+      new Promise((resolve) => serverA.listen(0, resolve)),
+      new Promise((resolve) => serverB.listen(0, resolve))
+    ])
+
+    after(() => {
+      serverA.close()
+      serverB.close()
+    })
+
+    const connector = buildConnector({
+      ca,
+      lookup (hostname, options, callback) {
+        if (options?.all) {
+          callback(null, [{ address: '127.0.0.1', family: 4 }])
+        } else {
+          callback(null, '127.0.0.1', 4)
+        }
+      },
+      maxCachedSessions: 1,
+      minVersion: 'TLSv1.2',
+      maxVersion: 'TLSv1.2',
+      rejectUnauthorized: false
+    })
+
+    async function connectOnce ({ hostname, port }) {
+      const { promise, resolve, reject } = Promise.withResolvers()
+
+      connector({ hostname, protocol: 'https:', port }, (err, socket) => {
+        if (err) {
+          reject(err)
+          return
+        }
+
+        const reused = socket.isSessionReused()
+
+        socket.on('error', reject)
+        socket.on('end', () => resolve(reused))
+        socket.resume()
+        socket.write(`GET / HTTP/1.1\r\nHost: ${hostname}\r\nConnection: close\r\n\r\n`)
+      })
+
+      return promise
+    }
+
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), false)
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), true)
+    t.strictEqual(await connectOnce({ hostname: 'b.test', port: serverB.address().port }), false)
+    t.strictEqual(await connectOnce({ hostname: 'a.test', port: serverA.address().port }), false)
     await t.completed
   })
 })

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -8,6 +8,7 @@ const https = require('node:https')
 const crypto = require('node:crypto')
 const { Client, Pool, buildConnector } = require('..')
 const { kSocket } = require('../lib/core/symbols')
+const { createDeferredPromise } = require('../lib/util/promise')
 
 const options = {
   key: readFileSync(join(__dirname, 'fixtures', 'key.pem'), 'utf8'),
@@ -223,7 +224,7 @@ describe('A connector should enforce maxCachedSessions across hostnames', () => 
     })
 
     async function connectOnce ({ hostname, port }) {
-      const { promise, resolve, reject } = Promise.withResolvers()
+      const { promise, resolve, reject } = Promise.withResolvers?.() ?? createDeferredPromise()
 
       connector({ hostname, protocol: 'https:', port }, (err, socket) => {
         if (err) {

--- a/test/webidl/util.js
+++ b/test/webidl/util.js
@@ -125,4 +125,23 @@ test('webidl.util.ConvertToInt(V)', () => {
   }
 
   assert.equal(ConvertToInt(111, 2, 'signed'), -1)
+
+  // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
+  // For N-bit signed integers, lowerBound is -2^(N-1) and the modulo wrap
+  // threshold (step 11) is 2^(N-1).
+  assert.equal(ConvertToInt(128, 8, 'signed'), -128, '8-bit signed wrap at 128')
+  assert.equal(ConvertToInt(200, 8, 'signed'), -56, '8-bit signed wrap at 200')
+  assert.equal(
+    ConvertToInt(-128, 8, 'signed', webidl.attributes.EnforceRange),
+    -128,
+    '8-bit signed EnforceRange lower bound'
+  )
+  assert.throws(() => {
+    ConvertToInt(-129, 8, 'signed', webidl.attributes.EnforceRange)
+  }, TypeError, '8-bit signed EnforceRange below lower bound throws')
+  assert.equal(
+    ConvertToInt(-(2 ** 31), 32, 'signed', webidl.attributes.EnforceRange),
+    -(2 ** 31),
+    '32-bit signed EnforceRange lower bound'
+  )
 })

--- a/test/websocket/stream/invalid-utf8-text-frame.js
+++ b/test/websocket/stream/invalid-utf8-text-frame.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const { WebSocketServer } = require('ws')
+const { WebSocketStream } = require('../../..')
+
+test('WebSocketStream sends close code 1007 when receiving invalid UTF-8 in a text frame', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  t.after(() => server.close())
+
+  const connection = new Promise((resolve) => {
+    server.on('connection', (ws) => {
+      // Send a text frame with invalid UTF-8 payload (unmasked, server->client).
+      // 0x81 = FIN + text opcode, 0x02 = length 2, then 0xFF 0xFE (invalid UTF-8).
+      ws._socket.write(Buffer.from([0x81, 0x02, 0xFF, 0xFE]))
+      resolve(ws)
+    })
+  })
+
+  const wss = new WebSocketStream(`ws://127.0.0.1:${server.address().port}`)
+  // Swallow the expected unclean-close rejection on the client side.
+  wss.closed.catch(() => {})
+
+  await wss.opened
+
+  const ws = await connection
+  const [code] = await once(ws, 'close')
+
+  t.assert.strictEqual(code, 1007)
+})

--- a/test/websocket/stream/issue-4958.js
+++ b/test/websocket/stream/issue-4958.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocketServer } = require('ws')
+
+const { WebSocketStream } = require('../../..')
+
+// Repro for: opened.readable may include raw socket bytes instead of only message payloads.
+test('websocketstream opened.readable should expose text message payloads only', async (t) => {
+  const server = new WebSocketServer({
+    port: 0,
+    path: '/',
+    perMessageDeflate: false
+  })
+
+  t.after(() => {
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  server.on('connection', (socket) => {
+    socket.send(JSON.stringify({ event: 'Initialize', data: 1010 }))
+    socket.send(JSON.stringify({ event: 'Ready', data: { id: 1010 } }))
+  })
+
+  const url = `ws://127.0.0.1:${server.address().port}/`
+
+  for (let run = 1; run <= 100; run++) {
+    const wss = new WebSocketStream(url)
+    const { readable } = await wss.opened
+    const reader = readable.getReader()
+
+    try {
+      for (let index = 1; index <= 2; index++) {
+        const { done, value } = await reader.read()
+
+        if (done) {
+          break
+        }
+
+        t.assert.strictEqual(
+          typeof value,
+          'string',
+          `run ${run}, chunk ${index}: expected string payload but got ${value?.constructor?.name ?? typeof value}`
+        )
+
+        t.assert.doesNotThrow(
+          () => JSON.parse(value),
+          `run ${run}, chunk ${index}: expected valid JSON text payload`
+        )
+      }
+    } finally {
+      reader.releaseLock()
+      wss.close()
+      await wss.closed.catch(() => {})
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Backport a set of low-risk fixes from `main` to `v7.x`.

This includes fixes for:
- cache keying and sqlite cache behavior
- fetch multipart/form-data handling
- malformed request header validation
- WebSocket stream parsing
- SOCKS5 handling
- H2C client connect option preservation
- parser timeout callback reuse
- TLS session cache bounds
- mock call history filtering
- WebIDL signed integer bounds

Also includes one small `v7.x`-specific follow-up commit to preserve `allowH2` when wrapping a custom `connect` function, which was needed to keep the backported `H2CClient` fix working on the `v7.x` branch layout.

## Testing

- `npm run test`
- `./node_modules/.bin/borp --timeout 180000 -p "test/h2c-client.js"`
