### PR TITLE
perf(http2): reduce writeH2 per-request callback allocations

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -44,6 +44,8 @@ const kOpenStreams = Symbol('open streams')
 const kRequestStreamId = Symbol('request stream id')
 const kRequestStream = Symbol('request stream')
 const kRequestStreamCleanup = Symbol('request stream cleanup')
+const kRequestStreamOnData = Symbol('request stream on data')
+const kRequestStreamOnCloseError = Symbol('request stream on close error')
 const kReceivedGoAway = Symbol('received goaway')
 
 let extractBody
@@ -491,6 +493,37 @@ function onSocketClose () {
   this[kClosed] = true
 }
 
+function noop () {}
+
+function closeStreamSession (stream) {
+  const session = stream[kHTTP2Session]
+
+  stream[kHTTP2Session] = null
+  session[kOpenStreams] -= 1
+  if (session[kOpenStreams] === 0) {
+    session.unref()
+  }
+}
+
+function onUpgradeStreamClose () {
+  this.off('error', noop)
+
+  const failUpgradeStream = this[kRequestStreamOnCloseError]
+  this[kRequestStreamOnCloseError] = null
+
+  failUpgradeStream(new InformationalError('HTTP/2: stream closed before response headers'))
+  closeStreamSession(this)
+}
+
+function onRequestStreamClose () {
+  const onData = this[kRequestStreamOnData]
+
+  this[kRequestStreamOnData] = null
+  this.off('data', onData)
+  this.off('error', noop)
+  closeStreamSession(this)
+}
+
 // https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2
 function shouldSendContentLength (method) {
   return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS' && method !== 'TRACE' && method !== 'CONNECT'
@@ -623,14 +656,13 @@ function writeH2 (client, request) {
 
     const setupUpgradeStream = (stream) => {
       let responseReceived = false
-      const onDetachedUpgradeStreamError = () => {}
 
       const removeUpgradeStreamListeners = () => {
         stream.off('response', onUpgradeResponse)
         stream.off('error', onUpgradeStreamError)
         stream.off('end', onUpgradeStreamEnd)
         stream.off('timeout', onUpgradeStreamTimeout)
-        stream.off('error', onDetachedUpgradeStreamError)
+        stream.off('error', noop)
       }
 
       const releaseUpgradeStream = () => {
@@ -641,7 +673,7 @@ function writeH2 (client, request) {
         removeUpgradeStreamListeners()
 
         if (!stream.destroyed && !stream.closed) {
-          stream.once('error', onDetachedUpgradeStreamError)
+          stream.once('error', noop)
         }
       }
 
@@ -691,13 +723,9 @@ function writeH2 (client, request) {
       stream.on('error', onUpgradeStreamError)
       stream.once('end', onUpgradeStreamEnd)
       stream.on('timeout', onUpgradeStreamTimeout)
-      stream.once('close', () => {
-        stream.off('error', onDetachedUpgradeStreamError)
-        failUpgradeStream(new InformationalError('HTTP/2: stream closed before response headers'))
-
-        session[kOpenStreams] -= 1
-        if (session[kOpenStreams] === 0) session.unref()
-      })
+      stream[kHTTP2Session] = session
+      stream[kRequestStreamOnCloseError] = failUpgradeStream
+      stream.once('close', onUpgradeStreamClose)
 
       ++session[kOpenStreams]
       stream.setTimeout(requestTimeout)
@@ -855,7 +883,6 @@ function writeH2 (client, request) {
 
   // Track whether we received a response (headers)
   let responseReceived = false
-  const onDetachedStreamError = () => {}
   const onData = (chunk) => {
     if (request.aborted || request.completed) {
       return
@@ -867,7 +894,7 @@ function writeH2 (client, request) {
   }
 
   const removeRequestStreamListeners = () => {
-    stream.off('error', onDetachedStreamError)
+    stream.off('error', noop)
     stream.off('continue', writeBodyH2)
     stream.off('response', onResponse)
     stream.off('end', onEnd)
@@ -887,7 +914,7 @@ function writeH2 (client, request) {
     removeRequestStreamListeners()
 
     if (!stream.destroyed && !stream.closed) {
-      stream.once('error', onDetachedStreamError)
+      stream.once('error', noop)
     }
   }
 
@@ -933,14 +960,9 @@ function writeH2 (client, request) {
     }
   }
 
-  stream.once('close', () => {
-    stream.off('data', onData)
-    stream.off('error', onDetachedStreamError)
-    session[kOpenStreams] -= 1
-    if (session[kOpenStreams] === 0) {
-      session.unref()
-    }
-  })
+  stream[kHTTP2Session] = session
+  stream[kRequestStreamOnData] = onData
+  stream.once('close', onRequestStreamClose)
 
   const onError = function (err) {
     stream.off('error', onError)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Reduces allocation churn in the HTTP/2 request write path.

## Rationale

`writeH2` created a few request-local cleanup/error callbacks that did not need to capture request-local state.
Under high concurrency, these extra closures add avoidable allocation pressure.

## Changes

Hoists shared HTTP/2 stream cleanup handlers and uses per-stream symbol state only where needed.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5