### PR TITLE
fix: validate H2CClient maxConcurrentStreams option

### DIFF
--- a/lib/dispatcher/h2c-client.js
+++ b/lib/dispatcher/h2c-client.js
@@ -17,15 +17,15 @@ class H2CClient extends Client {
 
     const { maxConcurrentStreams, pipelining, ...opts } =
             clientOpts ?? {}
-    let defaultMaxConcurrentStreams = 100
+    const defaultMaxConcurrentStreams = maxConcurrentStreams ?? 100
     let defaultPipelining = 100
 
     if (
       maxConcurrentStreams != null &&
-            Number.isInteger(maxConcurrentStreams) &&
-            maxConcurrentStreams > 0
+            (!Number.isInteger(maxConcurrentStreams) ||
+            maxConcurrentStreams < 1)
     ) {
-      defaultMaxConcurrentStreams = maxConcurrentStreams
+      throw new InvalidArgumentError('maxConcurrentStreams must be a positive integer, greater than 0')
     }
 
     if (pipelining != null && Number.isInteger(pipelining) && pipelining > 0) {

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -25,6 +25,24 @@ test('Should throw if pipelining greather than concurrent streams', async t => {
   await planner.completed
 })
 
+test('Should throw if bad maxConcurrentStreams has been passed', async t => {
+  const planner = tspl(t, { plan: 3 })
+
+  planner.throws(() => new H2CClient('http://localhost/', { maxConcurrentStreams: {} }), {
+    message: 'maxConcurrentStreams must be a positive integer, greater than 0'
+  })
+
+  planner.throws(() => new H2CClient('http://localhost/', { maxConcurrentStreams: 0 }), {
+    message: 'maxConcurrentStreams must be a positive integer, greater than 0'
+  })
+
+  planner.throws(() => new H2CClient('http://localhost/', { maxConcurrentStreams: 1.5 }), {
+    message: 'maxConcurrentStreams must be a positive integer, greater than 0'
+  })
+
+  await planner.completed
+})
+
 test('Should support h2c connection', async t => {
   const planner = tspl(t, { plan: 6 })
   let authority = ''


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5142

## Rationale

`H2CClient` previously only applied `maxConcurrentStreams` when the value was valid.
Invalid user-provided values were replaced with the default instead of throwing like `Client` does.

## Changes

Validate `H2CClient` `maxConcurrentStreams` values and throw `InvalidArgumentError` for invalid input.

### Features

N/A

### Bug Fixes

Validate H2CClient maxConcurrentStreams option

### Breaking Changes and Deprecations

> Should this be considered as a breaking change?
> Although the types do not call it out, the value is expected to be a positive integer.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5