### PR TITLE
perf: avoid redundant scans in BalancedPool dispatcher selection

### DIFF
--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -164,32 +164,25 @@ class BalancedPool extends PoolBase {
       throw new BalancedPoolMissingUpstreamError()
     }
 
-    const dispatcher = this[kClients].find(dispatcher => (
-      !dispatcher[kNeedDrain] &&
-      dispatcher.closed !== true &&
-      dispatcher.destroyed !== true
-    ))
-
-    if (!dispatcher) {
-      return
-    }
-
-    const allClientsBusy = this[kClients].map(pool => pool[kNeedDrain]).reduce((a, b) => a && b, true)
-
-    if (allClientsBusy) {
-      return
-    }
-
     let counter = 0
 
-    let maxWeightIndex = this[kClients].findIndex(pool => !pool[kNeedDrain])
+    let maxWeightIndex = -1
 
     while (counter++ < this[kClients].length) {
       this[kIndex] = (this[kIndex] + 1) % this[kClients].length
       const pool = this[kClients][this[kIndex]]
+      const available = (
+        !pool[kNeedDrain] &&
+        pool.closed !== true &&
+        pool.destroyed !== true
+      )
 
       // find pool index with the largest weight
-      if (pool[kWeight] > this[kClients][maxWeightIndex][kWeight] && !pool[kNeedDrain]) {
+      if (available && (
+        maxWeightIndex === -1 ||
+        pool[kWeight] > this[kClients][maxWeightIndex][kWeight] ||
+        (pool[kWeight] === this[kClients][maxWeightIndex][kWeight] && this[kIndex] < maxWeightIndex)
+      )) {
         maxWeightIndex = this[kIndex]
       }
 
@@ -202,9 +195,13 @@ class BalancedPool extends PoolBase {
           this[kCurrentWeight] = this[kMaxWeightPerServer]
         }
       }
-      if (pool[kWeight] >= this[kCurrentWeight] && (!pool[kNeedDrain])) {
+      if (available && pool[kWeight] >= this[kCurrentWeight]) {
         return pool
       }
+    }
+
+    if (maxWeightIndex === -1) {
+      return
     }
 
     this[kCurrentWeight] = this[kClients][maxWeightIndex][kWeight]

--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -171,19 +171,6 @@ class BalancedPool extends PoolBase {
     while (counter++ < this[kClients].length) {
       this[kIndex] = (this[kIndex] + 1) % this[kClients].length
       const pool = this[kClients][this[kIndex]]
-      const available = (
-        !pool[kNeedDrain] &&
-        pool.closed !== true &&
-        pool.destroyed !== true
-      )
-
-      // find pool index with the largest weight
-      if (available && (
-        maxWeightIndex === -1 ||
-        pool[kWeight] > this[kClients][maxWeightIndex][kWeight]
-      )) {
-        maxWeightIndex = this[kIndex]
-      }
 
       // decrease the current weight every `this[kClients].length`.
       if (this[kIndex] === 0) {
@@ -194,7 +181,22 @@ class BalancedPool extends PoolBase {
           this[kCurrentWeight] = this[kMaxWeightPerServer]
         }
       }
-      if (available && pool[kWeight] >= this[kCurrentWeight]) {
+
+      // Skip unavailable pools after updating the current weight for this cycle.
+      if (
+        pool[kNeedDrain] ||
+        pool.closed === true ||
+        pool.destroyed === true
+      ) {
+        continue
+      }
+
+      // Track the best fallback if no pool matches the current weight.
+      if (maxWeightIndex === -1 || pool[kWeight] > this[kClients][maxWeightIndex][kWeight]) {
+        maxWeightIndex = this[kIndex]
+      }
+
+      if (pool[kWeight] >= this[kCurrentWeight]) {
         return pool
       }
     }

--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -180,8 +180,7 @@ class BalancedPool extends PoolBase {
       // find pool index with the largest weight
       if (available && (
         maxWeightIndex === -1 ||
-        pool[kWeight] > this[kClients][maxWeightIndex][kWeight] ||
-        (pool[kWeight] === this[kClients][maxWeightIndex][kWeight] && this[kIndex] < maxWeightIndex)
+        pool[kWeight] > this[kClients][maxWeightIndex][kWeight]
       )) {
         maxWeightIndex = this[kIndex]
       }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Performance cleanup in `BalancedPool` dispatcher selection.

## Rationale

`BalancedPool[kGetDispatcher]` previously scanned the client list multiple times per dispatch: once to find an available dispatcher, again to check whether all clients were busy, then again to find a non-draining fallback index before entering the weighted selection loop.

The busy check was redundant after an available dispatcher had already been found, and the fallback selection can be tracked during the weighted loop.

## Changes

Collapse dispatcher availability checks and fallback max-weight tracking into the existing weighted round-robin loop.

> This keeps per-dispatch complexity at `O(n)` but removes up to three extra client-array scans. The improvement should be measurable with a targeted `kGetDispatcher()` microbenchmark, especially as upstream count grows; it may be hard to see in network-heavy benchmarks.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5