### PR TITLE
perf: avoid duplicate pool dispatcher selection on backpressure

### DIFF
--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -14,6 +14,7 @@ const kOnConnect = Symbol('onConnect')
 const kOnDisconnect = Symbol('onDisconnect')
 const kOnConnectionError = Symbol('onConnectionError')
 const kGetDispatcher = Symbol('get dispatcher')
+const kHasDispatcher = Symbol('has dispatcher')
 const kAddClient = Symbol('add client')
 const kRemoveClient = Symbol('remove client')
 
@@ -162,10 +163,26 @@ class PoolBase extends DispatcherBase {
       this[kQueued]++
     } else if (!dispatcher.dispatch(opts, handler)) {
       dispatcher[kNeedDrain] = true
-      this[kNeedDrain] = !this[kGetDispatcher]()
+      this[kNeedDrain] = !this[kHasDispatcher]()
     }
 
     return !this[kNeedDrain]
+  }
+
+  [kHasDispatcher] () {
+    for (let i = 0; i < this[kClients].length; i++) {
+      const dispatcher = this[kClients][i]
+
+      if (
+        !dispatcher[kNeedDrain] &&
+        dispatcher.closed !== true &&
+        dispatcher.destroyed !== true
+      ) {
+        return true
+      }
+    }
+
+    return false
   }
 
   [kAddClient] (client) {
@@ -210,5 +227,6 @@ module.exports = {
   kNeedDrain,
   kAddClient,
   kRemoveClient,
-  kGetDispatcher
+  kGetDispatcher,
+  kHasDispatcher
 }

--- a/lib/dispatcher/pool.js
+++ b/lib/dispatcher/pool.js
@@ -6,6 +6,7 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher,
+  kHasDispatcher,
   kRemoveClient
 } = require('./pool-base')
 const Client = require('./client')
@@ -114,6 +115,28 @@ class Pool extends PoolBase {
       this[kAddClient](dispatcher)
       return dispatcher
     }
+  }
+
+  [kHasDispatcher] () {
+    const clientTtlOption = this[kOptions].clientTtl
+    for (let i = 0; i < this[kClients].length; i++) {
+      const client = this[kClients][i]
+
+      if (clientTtlOption != null && clientTtlOption > 0 && client.ttl && ((Date.now() - client.ttl) > clientTtlOption)) {
+        this[kRemoveClient](client)
+        i--
+      } else if (!client[kNeedDrain]) {
+        return true
+      }
+    }
+
+    if (!this[kConnections] || this[kClients].length < this[kConnections]) {
+      const dispatcher = this[kFactory](this[kUrl], this[kOptions])
+      this[kAddClient](dispatcher)
+      return true
+    }
+
+    return false
   }
 }
 

--- a/lib/dispatcher/round-robin-pool.js
+++ b/lib/dispatcher/round-robin-pool.js
@@ -6,6 +6,7 @@ const {
   kNeedDrain,
   kAddClient,
   kGetDispatcher,
+  kHasDispatcher,
   kRemoveClient
 } = require('./pool-base')
 const Client = require('./client')
@@ -127,6 +128,31 @@ class RoundRobinPool extends PoolBase {
       this[kAddClient](dispatcher)
       return dispatcher
     }
+  }
+
+  [kHasDispatcher] () {
+    const clientTtlOption = this[kOptions].clientTtl
+    for (let i = 0; i < this[kClients].length; i++) {
+      const client = this[kClients][i]
+
+      if (clientTtlOption != null && clientTtlOption > 0 && client.ttl && ((Date.now() - client.ttl) > clientTtlOption)) {
+        this[kRemoveClient](client)
+        if (i <= this[kIndex]) {
+          this[kIndex]--
+        }
+        i--
+      } else if (!client[kNeedDrain]) {
+        return true
+      }
+    }
+
+    if (!this[kConnections] || this[kClients].length < this[kConnections]) {
+      const dispatcher = this[kFactory](this[kUrl], this[kOptions])
+      this[kAddClient](dispatcher)
+      return true
+    }
+
+    return false
   }
 }
 

--- a/test/node-test/balanced-pool.js
+++ b/test/node-test/balanced-pool.js
@@ -3,9 +3,12 @@
 const { describe, test } = require('node:test')
 const assert = require('node:assert/strict')
 const { BalancedPool, Pool, Client, errors } = require('../..')
+const { EventEmitter } = require('node:events')
 const { createServer } = require('node:http')
 const { promisify } = require('node:util')
 const { tspl } = require('@matteo.collina/tspl')
+const { kUrl } = require('../../lib/core/symbols')
+const { kGetDispatcher } = require('../../lib/dispatcher/pool-base')
 
 test('throws when factory is not a function', (t) => {
   const p = tspl(t, { plan: 2 })
@@ -46,6 +49,56 @@ test('add/remove upstreams', (t) => {
 
   pool.removeUpstream(upstream01)
   p.deepStrictEqual(pool.upstreams, [])
+})
+
+test('does not select dispatcher twice when selected dispatcher backpressures', (t) => {
+  class FakeDispatcher extends EventEmitter {
+    constructor (origin) {
+      super()
+      this[kUrl] = new URL(origin)
+    }
+
+    dispatch () {
+      return false
+    }
+
+    close () {
+      this.closed = true
+      return Promise.resolve()
+    }
+
+    destroy () {
+      this.destroyed = true
+      return Promise.resolve()
+    }
+  }
+
+  class CountingBalancedPool extends BalancedPool {
+    constructor (...args) {
+      super(...args)
+      this.calls = 0
+    }
+
+    [kGetDispatcher] () {
+      this.calls++
+      return super[kGetDispatcher]()
+    }
+  }
+
+  const pool = new CountingBalancedPool([
+    'http://localhost:1',
+    'http://localhost:2'
+  ], {
+    factory: (origin) => new FakeDispatcher(origin)
+  })
+  t.after(() => pool.close())
+
+  const ret = pool.dispatch({}, {
+    onResponseError () {}
+  })
+
+  assert.strictEqual(ret, true)
+  assert.strictEqual(pool.calls, 1)
 })
 
 test('basic get', async (t) => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Performance improvement for `PoolBase` dispatch backpressure handling.

## Rationale

`PoolBase[kDispatch]` previously called `kGetDispatcher()` again when the selected dispatcher returned `false`.
For `BalancedPool`, that repeated the weighted dispatcher selection path just to determine whether another dispatcher was available.

This PR replaces that second selection with an internal availability check, avoiding duplicate weighted selection work on backpressured dispatches.

## Changes

- Avoid calling `kGetDispatcher()` twice in `PoolBase[kDispatch]` when the selected dispatcher backpressures.
- Add an internal `kHasDispatcher` hook for availability checks.
- Preserve existing `Pool` and `RoundRobinPool` behavior where availability checks can create a new dispatcher when capacity allows.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5