### PR TITLE
fix: preserve pool capacity after removing stale client

### DIFF
--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -196,7 +196,7 @@ class PoolBase extends DispatcherBase {
 
     client.close(() => {})
 
-    this[kNeedDrain] = this[kClients].some(dispatcher => (
+    this[kNeedDrain] = !this[kClients].some(dispatcher => (
       !dispatcher[kNeedDrain] &&
       dispatcher.closed !== true &&
       dispatcher.destroyed !== true

--- a/test/pool.js
+++ b/test/pool.js
@@ -689,6 +689,64 @@ test('pool replaces stale client when connections limit is reached', async (t) =
   t.strictEqual(statusCode, 200)
 })
 
+test('pool does not report backpressure after removing a stale client when another client is available', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  let created = 0
+  let acceptedBySecondClient = 0
+
+  class FakeClient extends EventEmitter {
+    constructor () {
+      super()
+      this.id = ++created
+      this.closed = false
+      this.destroyed = false
+    }
+
+    dispatch () {
+      if (this.id === 1) {
+        this.emit('connect', new URL('http://notahost'), [this])
+        return false
+      }
+
+      acceptedBySecondClient++
+      return true
+    }
+
+    close (cb) {
+      this.closed = true
+      if (cb) {
+        cb()
+      }
+    }
+
+    destroy () {
+      this.destroyed = true
+    }
+  }
+
+  const pool = new Pool('http://notahost', {
+    connections: 2,
+    clientTtl: 1,
+    factory: () => new FakeClient()
+  })
+  after(() => pool.destroy())
+
+  const handler = {
+    onResponseError (_controller, err) {
+      throw err
+    }
+  }
+
+  t.strictEqual(pool.dispatch({ path: '/', method: 'GET' }, handler), true)
+  t.strictEqual(created, 2)
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  t.strictEqual(pool.dispatch({ path: '/', method: 'GET' }, handler), true)
+  t.strictEqual(acceptedBySecondClient, 1)
+})
+
 test('pool dispatch', async (t) => {
   t = tspl(t, { plan: 2 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5150

## Rationale

`PoolBase[kRemoveClient]` was setting `kNeedDrain` to `true` when any remaining client was available.
That made `Pool.dispatch()` report backpressure even though another client could accept work.

## Changes

Fix `PoolBase[kRemoveClient]` so the pool only needs drain when no remaining client is available.

### Features

N/A

### Bug Fixes

Preserve pool capacity after removing stale client

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5