### PR TITLE
fix(socks5): preserve dispatch backpressure return value

### DIFF
--- a/lib/dispatcher/socks5-proxy-agent.js
+++ b/lib/dispatcher/socks5-proxy-agent.js
@@ -173,7 +173,7 @@ class Socks5ProxyAgent extends DispatcherBase {
   /**
    * Dispatch a request through the SOCKS5 proxy
    */
-  async [kDispatch] (opts, handler) {
+  [kDispatch] (opts, handler) {
     const { origin } = opts
 
     debug('dispatching request to', origin, 'via SOCKS5')
@@ -230,8 +230,12 @@ class Socks5ProxyAgent extends DispatcherBase {
       return pool[kDispatch](opts, handler)
     } catch (err) {
       debug('dispatch error:', err)
-      if (typeof handler.onError === 'function') {
+      if (typeof handler.onResponseError === 'function') {
+        handler.onResponseError(null, err)
+        return false
+      } else if (typeof handler.onError === 'function') {
         handler.onError(err)
+        return false
       } else {
         throw err
       }

--- a/test/socks5-proxy-agent.js
+++ b/test/socks5-proxy-agent.js
@@ -84,6 +84,28 @@ test('Socks5ProxyAgent - uses custom connector for proxy connection', async (t) 
   await p.completed
 })
 
+test('Socks5ProxyAgent - dispatch returns boolean backpressure signal', async (t) => {
+  const p = tspl(t, { plan: 1 })
+  const proxyWrapper = new Socks5ProxyAgent('socks5://localhost:9999')
+
+  const ret = proxyWrapper.dispatch({
+    origin: 'http://example.com',
+    path: '/',
+    method: 'GET'
+  }, {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd () {},
+    onResponseError () {}
+  })
+
+  p.equal(typeof ret, 'boolean')
+
+  await proxyWrapper.destroy()
+  await p.completed
+})
+
 test('Socks5ProxyAgent - basic HTTP connection', async (t) => {
   const p = tspl(t, { plan: 2 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5165

## Rationale

`Dispatcher.dispatch()` is documented to return a boolean.

`Socks5ProxyAgent[kDispatch]` was declared `async`, which wrapped the underlying Pool dispatch return value in a `Promise`.

## Changes

- Remove `async` from `Socks5ProxyAgent[kDispatch]` so `dispatch()` returns the underlying Pool boolean.
- Return `false` from the synchronous dispatch error path after reporting the error to the handler.

### Features

N/A

### Bug Fixes

Preserve dispatch backpressure return value in Sock5ProxyAgent

### Breaking Changes and Deprecations

This shouldn't be considered a breaking change, as the return type is defined and expected to be boolean.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assited-by: openai:gpt-5.5