### PR TITLE
perf(http2): end zero-length request bodies with headers

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -870,7 +870,7 @@ function writeH2 (client, request) {
   }
 
   // TODO(metcoder95): add support for sending trailers
-  const shouldEndStream = body === null
+  const shouldEndStream = body === null || contentLength === 0
 
   if (expectContinue) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -3,9 +3,10 @@
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
-const { createSecureServer } = require('node:http2')
+const { createSecureServer, constants } = require('node:http2')
 const { createReadStream, readFileSync } = require('node:fs')
 const { once } = require('node:events')
+const { Readable } = require('node:stream')
 
 const pem = require('@metcoder95/https-pem')
 
@@ -112,6 +113,60 @@ test('Should send content-length: 0 for empty h2 requests with payload-expecting
   }
 
   await assert.completed
+})
+
+test('Should end h2 zero-length request bodies with headers', async t => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const requests = new Map()
+
+  server.on('stream', (stream, headers, flags) => {
+    requests.set(headers[':path'], { headers, flags })
+    stream.respond({ ':status': 200 })
+    stream.end()
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false }
+  })
+  after(() => client.close())
+
+  const cases = [
+    {
+      path: '/buffer',
+      body: Buffer.alloc(0),
+      headers: { 'content-length': '0' }
+    },
+    {
+      path: '/blob',
+      body: new Blob([])
+    },
+    {
+      path: '/stream',
+      body: Readable.from([]),
+      headers: { 'content-length': '0' }
+    }
+  ]
+
+  for (const { path, body, headers } of cases) {
+    const response = await client.request({
+      path,
+      method: 'POST',
+      headers,
+      body
+    })
+
+    await response.body.text()
+  }
+
+  for (const { path } of cases) {
+    const request = requests.get(path)
+    assert.ok(request, `received ${path}`)
+    assert.strictEqual(request.headers['content-length'], '0')
+    assert.ok(request.flags & constants.NGHTTP2_FLAG_END_STREAM)
+  }
 })
 
 test('Should handle h2 request with body (string or buffer) - dispatch', async t => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

HTTP/2 request handling for known zero-length bodies.

## Rationale

When an HTTP/2 request body has a known `contentLength === 0`, the request payload is already complete before any DATA frame is written. Previously, only `body === null` caused the request stream to be created with `endStream: true`, so zero-length buffer/blob/stream bodies could still open the stream as if DATA may follow and then go through no-op body write handling.

Ending these requests with the initial HEADERS frame avoids that extra client-side request-body path and lets the peer immediately observe the request side as closed. The performance improvement is expected to be small per request, but useful for workloads that send many HTTP/2 requests with explicit empty bodies such as `Buffer.alloc(0)`, empty `Blob`s, or streams with `content-length: 0`.

## Changes

Treat HTTP/2 requests with `contentLength === 0` as `endStream: true`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5