### PR TITLE
fix: align h2 empty body content-length methods with h1

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -804,7 +804,10 @@ function writeH2 (client, request) {
   const expectsPayload = (
     method === 'PUT' ||
     method === 'POST' ||
-    method === 'PATCH'
+    method === 'PATCH' ||
+    method === 'QUERY' ||
+    method === 'PROPFIND' ||
+    method === 'PROPPATCH'
   )
 
   if (body && typeof body.read === 'function') {

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -70,6 +70,50 @@ test('Should handle h2 request without body', async t => {
   await t.completed
 })
 
+test('Should send content-length: 0 for empty h2 requests with payload-expecting methods', async t => {
+  const assert = tspl(t, { plan: 18 })
+  const methods = ['PUT', 'POST', 'PATCH', 'QUERY', 'PROPFIND', 'PROPPATCH']
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream, headers) => {
+    assert.strictEqual(headers['content-length'], '0')
+    assert.ok(methods.includes(headers[':method']))
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(async () => {
+    server.close()
+    await client.close()
+  })
+
+  for (const method of methods) {
+    const response = await client.request({
+      path: '/',
+      method,
+      body: ''
+    })
+
+    assert.strictEqual(response.statusCode, 200)
+
+    response.body.resume()
+    await once(response.body, 'end')
+  }
+
+  await assert.completed
+})
+
 test('Should handle h2 request with body (string or buffer) - dispatch', async t => {
   t = tspl(t, { plan: 7 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5171

## Rationale

H1 treats `QUERY`, `PROPFIND`, and `PROPPATCH` as methods that can expect a payload, so empty requests for those methods send `content-length: 0`.

H2 only included `PUT`, `POST`, and `PATCH` in its payload-expecting method list, causing the same empty requests to omit `content-length` when HTTP/2 was used.

## Changes

- Align H2 payload-expecting method handling with H1 by including `QUERY`, `PROPFIND`, and `PROPPATCH`.

### Features

N/A

### Bug Fixes

Align h2 empty body content-length methods with h1

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5