### PR TITLE
types: stop interfering with @types/node

### DIFF
--- a/test/types/fetch.test-d.ts
+++ b/test/types/fetch.test-d.ts
@@ -178,8 +178,6 @@ expectType<Promise<Uint8Array>>(response.bytes())
 expectType<Promise<unknown>>(response.json())
 expectType<Promise<string>>(response.text())
 expectType<Response>(response.clone())
-expectAssignable<globalThis.Response>(response)
-expectAssignable<Promise<globalThis.Response>>(fetch(request))
 
 expectType<Request>(new Request('https://example.com', { body: 'Hello, world', duplex: 'half' }))
 expectAssignable<RequestInit>({ duplex: 'half' })

--- a/types/formdata.d.ts
+++ b/types/formdata.d.ts
@@ -4,12 +4,6 @@
 import { File } from 'node:buffer'
 import { SpecIterableIterator } from './fetch'
 
-declare module 'node:buffer' {
-  interface File {
-    readonly [Symbol.toStringTag]: string
-  }
-}
-
 /**
  * A `string` or `File` that represents a single value from a set of `FormData` key-value pairs.
  */


### PR DESCRIPTION
This was driven by some quirky nonsense whereby

- undici's type definitions use the File interface defined by @types/node (which, like TypeScript's own web libraries, doesn't declare a toStringTag property)
- within the repo itself, the project's devDependencies use @types/node 22.x, which depends on the outdated undici-types 6.21.0 from 2024
- this version of undici-types is old enough to have had [its own File implementation](https://github.com/nodejs/undici/blob/71121e5b67fc3dba79888269957198f639de8df4/types/file.d.ts) (which declared a toStringTag property)
- in the tsd test environment, it's possible to accidentally unearth the File interface from the outdated undici-types, if it's resolved via a _global_ fetch type rather than an imported one (since TS resolves the globals to the undici-types dependency in node\_modules, not the local project)
- it was noticed in the test environment that if one manages to observe this old undici-types File interface by deliberately targeting `globalThis`, then it's not assignable from the one used in the undici project itself (the @types/node one), due to the missing toStringTag property – even though this is a meaningless observation
- the solution for this non-issue was to (breakingly) externally monkeypatch @types/node from undici, in order to make its File interface assignable to the one that no longer exists

Let's not do this again.

Refs: https://github.com/nodejs/undici/pull/4867#issuecomment-4364917030