### PR TITLE
docs: mention install() also installs WebSocket globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ await fetch('https://example.com', {
 ```
 
 `install()` replaces the global `fetch`, `Headers`, `Response`, `Request`, and
-`FormData` implementations with undici's versions, so they all match.
+`FormData` implementations with undici's versions, so they all match. It also
+installs undici's `WebSocket`, `CloseEvent`, `ErrorEvent`, `MessageEvent`, and
+`EventSource` globals.
 
 Avoid mixing a global `FormData` with `undici.fetch()`, or `undici.FormData`
 with the built-in global `fetch()`.
@@ -283,12 +285,12 @@ const data2 = await getData();
 
 ## Global Installation
 
-Undici provides an `install()` function to add all WHATWG fetch classes to `globalThis`, making them available globally:
+Undici provides an `install()` function to add fetch-related and other web API classes to `globalThis`, making them available globally:
 
 ```js
 import { install } from 'undici'
 
-// Install all WHATWG fetch classes globally
+// Install undici's global web APIs
 install()
 
 // Now you can use fetch classes globally without importing
@@ -316,8 +318,9 @@ The `install()` function adds the following classes to `globalThis`:
 
 When you call `install()`, these globals come from the same undici
 implementation. For example, global `fetch` and global `FormData` will both be
-undici's versions, which is the recommended setup if you want to use undici
-through globals.
+undici's versions, and `WebSocket` and `EventSource` will also come from
+undici, which is the recommended setup if you want to use undici through
+globals.
 
 This is useful for:
 - Polyfilling environments that don't have fetch

--- a/docs/docs/api/GlobalInstallation.md
+++ b/docs/docs/api/GlobalInstallation.md
@@ -1,17 +1,17 @@
 # Global Installation
 
-Undici provides an `install()` function to add all WHATWG fetch classes to `globalThis`, making them available globally without requiring imports.
+Undici provides an `install()` function to add fetch-related and other web API classes to `globalThis`, making them available globally without requiring imports.
 
 ## `install()`
 
-Install all WHATWG fetch classes globally on `globalThis`.
+Install undici's global web APIs on `globalThis`.
 
 **Example:**
 
 ```js
 import { install } from 'undici'
 
-// Install all WHATWG fetch classes globally  
+// Install undici's global web APIs
 install()
 
 // Now you can use fetch classes globally without importing
@@ -74,6 +74,8 @@ await fetch('https://example.com', {
 
 After `install()`, `fetch`, `Headers`, `Response`, `Request`, and `FormData`
 all come from the installed `undici` package, so they work as a matching set.
+`WebSocket`, `CloseEvent`, `ErrorEvent`, `MessageEvent`, and `EventSource`
+also come from the installed `undici` package.
 
 If you do not want to install globals, import both from `undici` instead:
 
@@ -135,5 +137,5 @@ test('fetch API test', async () => {
 
 - The `install()` function overwrites any existing global implementations
 - Classes installed are undici's implementations, not Node.js built-ins
-- This provides access to undici's latest features and performance improvements
+- This provides access to undici's latest fetch, WebSocket, and EventSource features and performance improvements
 - The global installation persists for the lifetime of the process


### PR DESCRIPTION
## Summary
- document that `install()` also installs `WebSocket` and related event globals
- clarify that `install()` installs more than just fetch-related classes
- update the README and global installation API docs to match the implementation

## Testing
- docs only
