### PR TITLE
test: resolve flaky timeout in issue-3356

### DIFF
--- a/test/issue-3356.js
+++ b/test/issue-3356.js
@@ -10,16 +10,17 @@ const { fetch, Agent, RetryAgent } = require('..')
 test('https://github.com/nodejs/undici/issues/3356', { skip: process.env.CITGM }, async (t) => {
   t = tspl(t, { plan: 3 })
 
-  let shouldRetry = true
+  let requestCount = 0
   const server = createServer({ joinDuplicateHeaders: true })
   server.on('request', (req, res) => {
+    requestCount++
     res.writeHead(200, { 'content-type': 'text/plain' })
-    if (shouldRetry) {
-      shouldRetry = false
-
+    if (requestCount === 1) {
+      // First request: send headers and partial body, then delay the rest
+      // long enough for the bodyTimeout to fire via fast timers
       res.flushHeaders()
       res.write('h')
-      setTimeout(() => { res.end('ello world!') }, 100)
+      setTimeout(() => { res.end('ello world!') }, 3000)
     } else {
       res.end('hello world!')
     }
@@ -29,8 +30,10 @@ test('https://github.com/nodejs/undici/issues/3356', { skip: process.env.CITGM }
 
   await once(server, 'listening')
 
-  const agent = new RetryAgent(new Agent({ bodyTimeout: 50 }), {
-    errorCodes: ['UND_ERR_BODY_TIMEOUT']
+  const agent = new RetryAgent(new Agent({ bodyTimeout: 1500 }), {
+    errorCodes: ['UND_ERR_BODY_TIMEOUT'],
+    minTimeout: 10,
+    maxTimeout: 100
   })
 
   after(async () => {
@@ -44,11 +47,14 @@ test('https://github.com/nodejs/undici/issues/3356', { skip: process.env.CITGM }
     dispatcher: agent
   })
 
-  fastTimersTick()
+  // Advance fast timers to trigger the body timeout.
+  // The fast timer resolution is ~1s, so we need to tick past the 1500ms bodyTimeout.
+  fastTimersTick(2000)
 
   try {
     t.equal(response.status, 200)
-    // consume response
+    // consume response - this should throw because the retry mechanism
+    // cannot transparently retry after headers have already been forwarded
     await response.text()
   } catch (err) {
     t.equal(err.name, 'TypeError')


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5179

## Rationale

The `issue-3356.js` test is flaky, intermittently timing out after 180s. The root cause is a mismatch between the `bodyTimeout: 50` (50ms) and undici's fast timer resolution (~1s). The timeout soemtimes doesn't fire before the server completes its 100ms delayed response, leaving the assertion plan unsatisfied and the test hanging.

## Changes

### Features

N/A

### Bug Fixes

- Increased `bodyTimeout` to 1500ms (above the ~1s timer resolution)
- Increased server delay to 3000ms (ensures body timeout fires first)
- Called `fastTimersTick(2000)` to deterministically advance the clock past the timeout threshold
- Added `minTimeout`/`maxTimeout` to RetryAgent to reduce unnecessary retry delay in the test

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: claude:opus-4.6