### PR TITLE
fix(test): make deduplicate body-streaming test non-flaky

### DIFF
--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -1193,20 +1193,18 @@ describe('Deduplicate Interceptor', () => {
       path: '/'
     }
 
-    const firstResponsePromise = client.request(request)
+    const res1 = await client.request(request)
 
-    // Wait until the first response starts streaming body data.
-    await sleep(20)
+    // Wait for the first chunk of body data to actually arrive on the client side
+    // so that responseDataStarted is guaranteed to be true.
+    await once(res1.body, 'readable')
 
-    const [res1, res2] = await Promise.all([
-      firstResponsePromise,
-      client.request(request)
-    ])
+    // Now send the second request — deduplication must be skipped because
+    // body streaming has already started on the primary handler.
+    const res2 = await client.request(request)
 
-    const [body1, body2] = await Promise.all([
-      res1.body.text(),
-      res2.body.text()
-    ])
+    const body1 = await res1.body.text()
+    const body2 = await res2.body.text()
 
     strictEqual(requestsToOrigin, 2)
     strictEqual(body1, 'chunk-1chunk-2')


### PR DESCRIPTION
Replace `await sleep(20)` with `await once(res1.body, 'readable')` in the "does not deduplicate requests that arrive after body streaming starts" test.

The 20ms sleep was a race — sometimes the first body chunk hadn't arrived yet, so `#responseDataStarted` was still `false` and the second request was deduplicated when it shouldn't have been.

Waiting for the `readable` event on the body stream guarantees the first chunk has actually been received before issuing the second request.

Fixes #5182
