### PR TITLE
test: deflake connect-timeout watchdog

### DIFF
--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -51,11 +51,11 @@ async function assertConnectTimeout (dispatcher, t) {
         tt.ok(err instanceof errors.ConnectTimeoutError)
         tt.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
         tt.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
-        clearTimeout(timeout)
         resolve()
       } catch (error) {
-        clearTimeout(timeout)
         reject(error)
+      } finally {
+        clearTimeout(timeout)
       }
     })
   })

--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { tspl } = require('@matteo.collina/tspl')
-const { test, after, describe } = require('node:test')
+const { test, describe } = require('node:test')
 const { Client, Pool, errors } = require('..')
 const net = require('node:net')
 const assert = require('node:assert')
@@ -32,54 +32,53 @@ net.connect = function (options) {
   return new net.Socket(options)
 }
 
-test('connect-timeout', { skip }, async t => {
-  t = tspl(t, { plan: 3 })
+async function assertConnectTimeout (dispatcher, t) {
+  const tt = tspl(t, { plan: 3 })
 
+  await new Promise((resolve, reject) => {
+    // Connection timeouts use FastTimers, which have a deliberately low
+    // resolution, and Windows adds an extra setImmediate before timing out.
+    const timeout = setTimeout(() => {
+      dispatcher.destroy()
+      reject(new Error('connect-timeout callback did not fire'))
+    }, 5e3)
+
+    dispatcher.request({
+      path: '/',
+      method: 'GET'
+    }, (err) => {
+      try {
+        tt.ok(err instanceof errors.ConnectTimeoutError)
+        tt.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+        tt.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
+        clearTimeout(timeout)
+        resolve()
+      } catch (error) {
+        clearTimeout(timeout)
+        reject(error)
+      }
+    })
+  })
+
+  await tt.completed
+}
+
+test('connect-timeout (Client)', { skip }, async t => {
   const client = new Client('http://localhost:9000', {
     connectTimeout: 1e3
   })
-  after(() => client.close())
+  t.after(() => client.close().catch(() => {}))
 
-  const timeout = setTimeout(() => {
-    t.fail()
-  }, 5e3)
-
-  client.request({
-    path: '/',
-    method: 'GET'
-  }, (err) => {
-    t.ok(err instanceof errors.ConnectTimeoutError)
-    t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-    t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
-    clearTimeout(timeout)
-  })
-
-  await t.completed
+  await assertConnectTimeout(client, t)
 })
 
-test('connect-timeout', { skip }, async t => {
-  t = tspl(t, { plan: 3 })
-
+test('connect-timeout (Pool)', { skip }, async t => {
   const client = new Pool('http://localhost:9000', {
     connectTimeout: 1e3
   })
-  after(() => client.close())
+  t.after(() => client.close().catch(() => {}))
 
-  const timeout = setTimeout(() => {
-    t.fail()
-  }, 5e3)
-
-  client.request({
-    path: '/',
-    method: 'GET'
-  }, (err) => {
-    t.ok(err instanceof errors.ConnectTimeoutError)
-    t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-    t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
-    clearTimeout(timeout)
-  })
-
-  await t.completed
+  await assertConnectTimeout(client, t)
 })
 
 test('autoSelectFamily AggregateError with ETIMEDOUT is normalized to ConnectTimeoutError', { skip }, async t => {

--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -82,6 +82,7 @@ test('connect-timeout (Pool)', { skip }, async t => {
 })
 
 test('autoSelectFamily AggregateError with ETIMEDOUT is normalized to ConnectTimeoutError', { skip }, async t => {
+  const _t = t
   t = tspl(t, { plan: 5 })
 
   const aggregate = new AggregateError([
@@ -102,7 +103,7 @@ test('autoSelectFamily AggregateError with ETIMEDOUT is normalized to ConnectTim
   const client = new Client('http://localhost:9000', {
     connectTimeout: 1e3
   })
-  after(() => client.close())
+  _t.after(() => client.close().catch(() => {}))
 
   client.request({
     path: '/',


### PR DESCRIPTION
## Summary
- deflake the connect-timeout tests by using a shared helper for Client and Pool
- replace the aggressive 2s watchdog with a longer guard that matches FastTimer behavior and the extra Windows setImmediate hop
- use test-scoped cleanup that tolerates an already-closed dispatcher

## Testing
- npx borp -p "test/connect-timeout.js"
- npx eslint test/connect-timeout.js

Closes #5187
