### PR TITLE
test: disable timeouts in h2 high concurrency regression

### DIFF
--- a/test/issue-4880.js
+++ b/test/issue-4880.js
@@ -70,8 +70,11 @@ function makeDispatcher (connections, maxConcurrentStreams) {
   return new Agent({
     keepAliveTimeout: 20_000,
     keepAliveMaxTimeout: 60_000,
-    bodyTimeout: 20_000,
-    headersTimeout: 20_000,
+    // This test stresses stream abort/cleanup ordering. Timeouts make the
+    // high-concurrency run dependent on CI host scheduling and can reject
+    // otherwise healthy requests before the regression condition is reached.
+    bodyTimeout: 0,
+    headersTimeout: 0,
     allowH2: true,
     connections,
     pipelining: maxConcurrentStreams,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/undici/issues/5183

Disables per-request `bodyTimeout` and `headersTimeout` in `test/issue-4880.js`.

This regression test is intended to verify that H2 stream cleanup does not crash or reject requests when data arrives around stream abort/cleanup under high concurrency. On slower CI runs, the previous 20s timeouts could reject otherwise valid requests with `HTTP/2: "stream timeout after 20000"`, making the test fail for an unrelated reason.

Assisted-by: openai:gpt-5.5