### PR TITLE
test: capture cache test worker stderr and preserve failures

### DIFF
--- a/test/cache-interceptor/cache-tests.mjs
+++ b/test/cache-interceptor/cache-tests.mjs
@@ -154,7 +154,7 @@ for (let i = 0; i < testEnvironments.length; i++) {
       stdout.push(chunk)
     })
 
-    cacheTestsWorkerProcess.stderr.on('error', chunk => {
+    cacheTestsWorkerProcess.stderr.on('data', chunk => {
       stdout.push(chunk)
     })
 
@@ -171,7 +171,9 @@ let exitCode = 0
 
 // Print the results of all the results in the order that they exist
 for (const [code, stdout] of await Promise.all(results)) {
-  exitCode = code
+  if (code !== 0) {
+    exitCode = code
+  }
 
   for (const line of stdout) {
     process.stdout.write(line)


### PR DESCRIPTION
Refs: https://github.com/nodejs/undici/issues/5199

Fixes the Undici cache test wrapper so worker failures are reported reliably.

- Capture cache test worker stderr with `stderr.on('data')` instead of listening for stream errors.
- Preserve any nonzero worker exit code across the environment matrix instead of overwriting it with later worker results.