### PR TITLE
test: deflake stream compat coverage

### DIFF
--- a/test/stream-compat.js
+++ b/test/stream-compat.js
@@ -1,90 +1,119 @@
 'use strict'
 
 const { tspl } = require('@matteo.collina/tspl')
-const { test, after } = require('node:test')
+const { test } = require('node:test')
 const { Client } = require('..')
 const { createServer } = require('node:http')
+const { once } = require('node:events')
 const { Readable } = require('node:stream')
 const EE = require('node:events')
 
+function closeServer (server) {
+  return new Promise(resolve => {
+    server.closeAllConnections?.()
+    server.close(resolve)
+  })
+}
+
 test('stream body without destroy', async (t) => {
+  const ctx = t
   t = tspl(t, { plan: 2 })
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end()
   })
-  after(() => server.close())
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    after(() => client.destroy())
 
-    const signal = new EE()
-    const body = new Readable({ read () {} })
-    body.destroy = undefined
-    body.on('error', (err) => {
-      t.ok(err)
-    })
-    client.request({
-      path: '/',
-      method: 'PUT',
-      signal,
-      body
-    }, (err, data) => {
-      t.ok(err)
-    })
-    signal.emit('abort')
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+  ctx.after(async () => {
+    await client.destroy()
+    await closeServer(server)
   })
+
+  const signal = new EE()
+  const body = new Readable({ read () {} })
+  body.destroy = undefined
+  body.on('error', (err) => {
+    t.ok(err)
+  })
+
+  client.request({
+    path: '/',
+    method: 'PUT',
+    signal,
+    body
+  }, (err) => {
+    t.ok(err)
+  })
+  signal.emit('abort')
 
   await t.completed
 })
 
 test('IncomingMessage', async (t) => {
+  const ctx = t
   t = tspl(t, { plan: 2 })
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end()
   })
-  after(() => server.close())
+  server.listen(0)
+  await once(server, 'listening')
 
-  server.listen(0, () => {
-    const proxyClient = new Client(`http://localhost:${server.address().port}`)
-    after(() => proxyClient.destroy())
+  const proxyClient = new Client(`http://localhost:${server.address().port}`)
+  proxyClient.on('disconnect', () => {
+    if (!proxyClient.closed && !proxyClient.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
-    proxyClient.on('disconnect', () => {
-      if (!proxyClient.closed && !proxyClient.destroyed) {
-        t.fail('unexpected disconnect')
+  const proxy = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    proxyClient.request({
+      path: '/',
+      method: 'PUT',
+      body: req
+    }, (err, data) => {
+      t.ifError(err)
+      if (err) {
+        res.destroy(err)
+        return
       }
+
+      data.body.pipe(res)
     })
+  })
+  proxy.listen(0)
+  await once(proxy, 'listening')
 
-    const proxy = createServer({ joinDuplicateHeaders: true }, (req, res) => {
-      proxyClient.request({
-        path: '/',
-        method: 'PUT',
-        body: req
-      }, (err, data) => {
-        t.ifError(err)
-        data.body.pipe(res)
-      })
-    })
-    after(() => proxy.close())
+  const client = new Client(`http://localhost:${proxy.address().port}`)
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
-    proxy.listen(0, () => {
-      const client = new Client(`http://localhost:${proxy.address().port}`)
-      after(() => client.destroy())
+  ctx.after(async () => {
+    await client.destroy()
+    await proxyClient.destroy()
+    await closeServer(proxy)
+    await closeServer(server)
+  })
 
-      client.on('disconnect', () => {
-        if (!client.closed && !client.destroyed) {
-          t.fail('unexpected disconnect')
-        }
-      })
+  await new Promise((resolve, reject) => {
+    client.request({
+      path: '/',
+      method: 'PUT',
+      body: 'hello world'
+    }, (err, data) => {
+      t.ifError(err)
+      if (err) {
+        reject(err)
+        return
+      }
 
-      client.request({
-        path: '/',
-        method: 'PUT',
-        body: 'hello world'
-      }, (err, data) => {
-        t.ifError(err)
-      })
+      data.body.dump().then(resolve, reject)
     })
   })
 


### PR DESCRIPTION
## This relates to...

Fixes: #5207

## Rationale

`test/stream-compat.js` could finish with servers and clients still mid-lifecycle, which makes the `unexpected disconnect` guards race with teardown on CI.

## Changes

- switch the tests to await server startup explicitly with `once(..., 'listening')`
- use per-test teardown via the original test context instead of file-level `after()` hooks
- close active server connections before shutting test servers down
- fully drain the response body in `IncomingMessage` before completing the test

### Features

N/A

### Bug Fixes

- deflake `test/stream-compat.js`

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
