### PR TITLE
test(wpt): increase server readiness timeout on Windows to 60s

### DIFF
--- a/test/web-platform-tests/wpt-runner.mjs
+++ b/test/web-platform-tests/wpt-runner.mjs
@@ -179,7 +179,7 @@ async function runWithTestUtil (testFunction) {
         .join(', ')
       rejectReady(new Error(`Timed out waiting for WPT server readiness. Missing: ${missing}`))
     }
-  }, 30_000)
+  }, process.platform === 'win32' ? 60_000 : 30_000)
 
   try {
     while (!serverResponding && !proc.killed && proc.exitCode == null) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Refs: https://github.com/nodejs/undici/issues/5184

## Rationale

The WPT runner waits for all sub-servers (HTTP, HTTPS, WSS, H2) to report readiness before running tests. On Windows CI runners, the TLS-dependent servers (https-8443, https-8444, https-local, https-public, wss, h2) occasionally take longer than 30 seconds to initialize due to resource pressure, causing a timeout and failing the entire test run.

## Changes

Increase the server readiness timeout from 30s to 60s on Windows. Other platforms keep the 30s timeout.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
