### PR TITLE
test: make websocket diagnostics ping-pong ordering deterministic

### DIFF
--- a/test/websocket/diagnostics-channel-ping-pong.js
+++ b/test/websocket/diagnostics-channel-ping-pong.js
@@ -11,31 +11,48 @@ test('diagnostics channel - undici:websocket:[ping/pong]', async (t) => {
 
   const server = new WebSocketServer({ port: 0 })
   const { port } = server.address()
-  const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
-
-  server.on('connection', (ws) => {
-    ws.ping('Ping')
-    ws.pong('Pong')
-    ws.close()
-  })
+  const pingChannel = dc.channel('undici:websocket:ping')
+  const pongChannel = dc.channel('undici:websocket:pong')
 
   const pingListener = ({ websocket, payload }) => {
+    // Diagnostics channels are process-global, so ignore events from other
+    // WebSocket instances.
+    if (websocket !== ws) {
+      return
+    }
+
     t.assert.strictEqual(websocket, ws)
     t.assert.deepStrictEqual(payload, Buffer.from('Ping'))
   }
 
   const pongListener = ({ websocket, payload }) => {
+    // Diagnostics channels are process-global, so ignore events from other
+    // WebSocket instances.
+    if (websocket !== ws) {
+      return
+    }
+
     t.assert.strictEqual(websocket, ws)
     t.assert.deepStrictEqual(payload, Buffer.from('Pong'))
   }
 
-  dc.channel('undici:websocket:ping').subscribe(pingListener)
-  dc.channel('undici:websocket:pong').subscribe(pongListener)
+  pingChannel.subscribe(pingListener)
+  pongChannel.subscribe(pongListener)
+
+  // The listeners and server handler must be in place before creating the
+  // WebSocket, because the constructor starts the connection immediately.
+  server.on('connection', (websocket) => {
+    websocket.ping('Ping')
+    websocket.pong('Pong')
+    websocket.close()
+  })
+
+  const ws = new WebSocket(`ws://localhost:${port}`, 'chat')
 
   t.after(() => {
     server.close()
-    dc.channel('undici:websocket:ping').unsubscribe(pingListener)
-    dc.channel('undici:websocket:pong').unsubscribe(pongListener)
+    pingChannel.unsubscribe(pingListener)
+    pongChannel.unsubscribe(pongListener)
   })
 
   await once(ws, 'close')


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5200

## Rationale

The test created the client `WebSocket` before subscribing to the diagnostics channels and before registering the server `connection` handler. Since the constructor starts the connection immediately, the server could send `ping`, `pong`, and `close` before the test was fully set up.

Diagnostics channels are also process-global, so the test should ignore ping/pong events from other websocket instances.

## Changes

- Subscribe to `undici:websocket:ping` and `undici:websocket:pong` before creating the client `WebSocket`.
- Register the server `connection` handler before creating the client `WebSocket`.
- Filter diagnostics events so the test only asserts events for its own `WebSocket` instance.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5