### PR TITLE
test: avoid per-chunk assertions in diagnostics get

### DIFF
--- a/test/node-test/diagnostics-channel/get.js
+++ b/test/node-test/diagnostics-channel/get.js
@@ -7,7 +7,7 @@ const { Client } = require('../../..')
 const { createServer } = require('node:http')
 
 test('Diagnostics channel - get', (t) => {
-  const assert = tspl(t, { plan: 36 })
+  const assert = tspl(t, { plan: 35 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.setHeader('Content-Type', 'text/plain')
     res.setHeader('trailer', 'foo')
@@ -118,8 +118,7 @@ test('Diagnostics channel - get', (t) => {
 
   return new Promise((resolve) => {
     const respChunks = []
-    diagnosticsChannel.channel('undici:request:bodyChunkReceived').subscribe(({ request, chunk }) => {
-      assert.equal(_req, request)
+    diagnosticsChannel.channel('undici:request:bodyChunkReceived').subscribe(({ chunk }) => {
       respChunks.push(chunk)
     })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5190

## Rationale

The diagnostics GET test assumed `undici:request:bodyChunkReceived` would fire exactly once for the response body.

On Windows, the response can sometimes be surfaced as multiple parser chunks, causing extra per-chunk assertions and failing the fixed `tspl` plan even though the response body is correct.

## Changes

- Stop asserting inside the variable-count `bodyChunkReceived` callback.
- Collect response chunks and assert the concatenated response body once when trailers are received.
- Reduce the test plan to match the stable assertion count.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5