### PR TITLE
fix: clean up benchmark resources before worker exit

### DIFF
--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -102,13 +102,30 @@ const dispatcher = new Class(httpBaseOptions.url, {
   ...dest
 })
 
-setGlobalDispatcher(new Agent({
+const globalDispatcher = new Agent({
   pipelining,
   connections,
   connect: {
     rejectUnauthorized: false
   }
-}))
+})
+
+setGlobalDispatcher(globalDispatcher)
+
+async function cleanup () {
+  httpNoKeepAliveOptions.agent.destroy()
+  httpKeepAliveOptions.agent.destroy()
+  axiosAgent.destroy()
+  fetchAgent.destroy()
+  gotAgent.destroy()
+  requestAgent.destroy()
+  superagentAgent.destroy()
+
+  await Promise.allSettled([
+    dispatcher.destroy(),
+    globalDispatcher.destroy()
+  ])
+}
 
 class SimpleRequest {
   constructor (resolve) {
@@ -317,8 +334,16 @@ async function main () {
   // https://github.com/ladjs/superagent/issues/1540#issue-561464561
   superagent = _superagent.agent().use((req) => req.agent(superagentAgent))
 
+  // cronometro runs each benchmark in a worker, so attach cleanup to every
+  // test before the worker exits.
+  const tests = Object.fromEntries(
+    Object.entries(experiments).map(([name, test]) => {
+      return [name, { test, after: cleanup }]
+    })
+  )
+
   cronometro(
-    experiments,
+    tests,
     {
       iterations,
       errorThreshold,
@@ -330,7 +355,7 @@ async function main () {
       }
 
       printResults(results)
-      dispatcher.destroy()
+      cleanup()
     }
   )
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5213

## Rationale

`cronometro` runs each benchmark case in a worker. Since `benchmark.js` creates HTTP agents and Undici dispatchers at module scope, each worker can exit with live keep-alive resources. Explicitly cleaning those resources up before worker exit should avoid intermittent native teardown crashes during benchmark runs.

## Changes

- Destroy benchmark HTTP agents and Undici dispatchers during cleanup.
- Attach cleanup as a `cronometro` `after` hook for each benchmark worker.
- Keep final cleanup after benchmark results are printed.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5