### PR TITLE
chore: gitignore benchmarks/package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ AGENTS.md
 
 # Ignore .githuman
 .githuman
+
+benchmarks/package-lock.json


### PR DESCRIPTION
## This relates to...

* Follow-up to https://github.com/nodejs/undici/pull/5139 which removed `package-lock.json` from `.gitignore`
* I attempted to add `benchmarks/package-lock.json` in https://github.com/nodejs/undici/pull/5226, but it's breaking CI because of vulnerable packages in deprecated dependencies.

## Rationale

Since `package-lock.json` is removed from `.gitignore`, it gets populated in benchmarks folder on running npm install.

## Changes

Add `benchmarks/package-lock.json` to `.gitignore`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
