### PR TITLE
fix(test): increase connect-timeout guard timeout and use Promise.race

### DIFF
--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -41,20 +41,24 @@ test('connect-timeout', { skip }, async t => {
   after(() => client.close())
 
   const timeout = setTimeout(() => {
-    t.fail()
-  }, 2e3)
+    t.fail('connect-timeout callback did not fire within budget')
+  }, 5e3)
 
-  client.request({
-    path: '/',
-    method: 'GET'
-  }, (err) => {
-    t.ok(err instanceof errors.ConnectTimeoutError)
-    t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-    t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
-    clearTimeout(timeout)
-  })
-
-  await t.completed
+  await Promise.race([
+    new Promise((resolve) => {
+      client.request({
+        path: '/',
+        method: 'GET'
+      }, (err) => {
+        t.ok(err instanceof errors.ConnectTimeoutError)
+        t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+        t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
+        clearTimeout(timeout)
+        resolve()
+      })
+    }),
+    t.completed
+  ])
 })
 
 test('connect-timeout', { skip }, async t => {
@@ -66,18 +70,22 @@ test('connect-timeout', { skip }, async t => {
   after(() => client.close())
 
   const timeout = setTimeout(() => {
-    t.fail()
-  }, 2e3)
+    t.fail('connect-timeout callback did not fire within budget')
+  }, 5e3)
 
-  client.request({
-    path: '/',
-    method: 'GET'
-  }, (err) => {
-    t.ok(err instanceof errors.ConnectTimeoutError)
-    t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-    t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
-    clearTimeout(timeout)
-  })
-
-  await t.completed
+  await Promise.race([
+    new Promise((resolve) => {
+      client.request({
+        path: '/',
+        method: 'GET'
+      }, (err) => {
+        t.ok(err instanceof errors.ConnectTimeoutError)
+        t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+        t.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
+        clearTimeout(timeout)
+        resolve()
+      })
+    }),
+    t.completed
+  ])
 })


### PR DESCRIPTION
Fixes #5187.

The guard timeout of 2000ms was too tight for the 1000ms connect timeout on
slower CI runners (e.g. Windows), causing the test to flakily fail with
`t.fail()` before the expected callback fired.

Changes:

- Increased guard timeout from 2000ms to 5000ms for headroom
- Replaced bare `t.fail()` with `t.fail('...')` + descriptive message
- Wrapped the request callback in `Promise.race` with `t.completed` so the
  test resolves cleanly when assertions succeed rather than relying solely on
  `t.completed` which can hang after `fail()`
