### PR TITLE
fix(dispatcher): remove unreachable assert in writeBlob

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1382,8 +1382,6 @@ function writeBuffer (abort, body, client, request, socket, contentLength, heade
  * @returns {Promise<void>}
  */
 async function writeBlob (abort, body, client, request, socket, contentLength, header, expectsPayload) {
-  assert(contentLength === body.size, 'blob body must have content length')
-
   try {
     if (contentLength != null && contentLength !== body.size) {
       throw new RequestContentLengthMismatchError()

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -1156,8 +1156,6 @@ function writeStream (abort, socket, expectsPayload, h2stream, body, client, req
 }
 
 async function writeBlob (abort, h2stream, body, client, request, socket, contentLength, expectsPayload) {
-  assert(contentLength === body.size, 'blob body must have content length')
-
   try {
     if (contentLength != null && contentLength !== body.size) {
       throw new RequestContentLengthMismatchError()


### PR DESCRIPTION
## This relates to...

Closes #5153

## Rationale

The `assert(contentLength === body.size, ...)` at the top of `writeBlob` (in both `client-h1.js` and `client-h2.js`) can never fire: `writeH1`/`writeH2` always overwrite `contentLength` with `body.size` via `util.bodyLength` before invoking `writeBlob` for blob-like bodies. The follow-up `if (contentLength != null && contentLength !== body.size)` guard is also unreachable today, but is left in place as a defensive net for future refactors of the upstream `contentLength` computation, matching option 2 in the issue.

## Changes

### Features

N/A

### Bug Fixes

- Drop the unreachable `assert(contentLength === body.size, ...)` from `writeBlob` in `lib/dispatcher/client-h1.js` and `lib/dispatcher/client-h2.js`.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin