### PR TITLE
fix(test): make http2-pseudo-headers test order-independent

### DIFF
--- a/test/http2-pseudo-headers.js
+++ b/test/http2-pseudo-headers.js
@@ -14,15 +14,16 @@ test('Should provide pseudo-headers in proper order', async t => {
 
   const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
   server.on('stream', (stream, _headers, _flags, rawHeaders) => {
-    t.deepStrictEqual(rawHeaders, [
-      ':authority',
-      `localhost:${server.address().port}`,
-      ':method',
-      'GET',
-      ':path',
+    const sortedHeaders = [...rawHeaders].sort()
+    t.deepStrictEqual(sortedHeaders, [
       '/',
+      ':authority',
+      ':method',
+      ':path',
       ':scheme',
-      'https'
+      'GET',
+      'https',
+      `localhost:${server.address().port}`
     ])
 
     stream.respond({


### PR DESCRIPTION
The `rawHeaders` array from Node.js http2 server can arrive in different
order depending on platform and Node.js version. Sort the array before
comparison so the test is deterministic across all environments.

Fixes #5219
