### PR TITLE
test: wait for cache test server to listen

### DIFF
--- a/test/cache-interceptor/cache-tests-worker.mjs
+++ b/test/cache-interceptor/cache-tests-worker.mjs
@@ -2,6 +2,8 @@
 
 import { styleText } from 'node:util'
 import { exit } from 'node:process'
+import net from 'node:net'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { getResults, runTests as runTestSuite } from '../fixtures/cache-tests/test-engine/client/runner.mjs'
 import { determineTestResult, testLookup } from '../fixtures/cache-tests/test-engine/lib/results.mjs'
 import tests from '../fixtures/cache-tests/tests/index.mjs'
@@ -27,6 +29,9 @@ if (environment.cacheStore) {
 
 // Start the test server
 await import('../fixtures/cache-tests/test-engine/server/server.mjs')
+// TODO: Remove when server.mjs waits for the server to listen.
+// https://github.com/http-tests/cache-tests/issues/161
+await waitForServer(process.env.BASE_URL)
 
 // Output the testing setup
 console.log('TEST ENVIRONMENT')
@@ -84,6 +89,57 @@ async function makeCacheStore (type) {
   }
 
   return new Store()
+}
+
+/**
+ * @param {string} baseUrl
+ * @returns {Promise<void>}
+ */
+async function waitForServer (baseUrl) {
+  const { hostname, port, protocol } = new URL(baseUrl)
+  const deadline = Date.now() + 30_000
+
+  while (Date.now() < deadline) {
+    if (await canConnect(hostname, Number(port), protocol)) {
+      return
+    }
+
+    await sleep(250)
+  }
+
+  throw new Error(`cache test server did not start listening at ${baseUrl}`)
+}
+
+/**
+ * @param {string} host
+ * @param {number} port
+ * @param {string} protocol
+ * @returns {Promise<boolean>}
+ */
+function canConnect (host, port, protocol) {
+  const { promise, resolve } = Promise.withResolvers()
+  const socket = net.connect({ host, port })
+
+  socket.once('connect', () => {
+    socket.end()
+    resolve(true)
+  })
+
+  socket.once('error', () => {
+    resolve(false)
+  })
+
+  socket.setTimeout(1_000, () => {
+    socket.destroy()
+    resolve(false)
+  })
+
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    socket.destroy()
+    resolve(false)
+  }
+
+  return promise
 }
 
 /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5199

## Rationale

The cache test worker imports the upstream cache-tests server fixture, but that fixture can finish module evaluation before the server is actually listening. Until the upstream fixture exposes or awaits server readiness, the worker should wait for the configured `BASE_URL` to accept connections before running the suite.

## Changes

- Wait for the cache test server to listen before starting the cache test suite.
- Add a TODO linking the upstream cache-tests issue so this workaround can be removed once fixed upstream.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5