### PR TITLE
fix: prevent node-fetch test server close from hanging on Windows

### DIFF
--- a/test/node-fetch/utils/server.js
+++ b/test/node-fetch/utils/server.js
@@ -25,6 +25,9 @@ module.exports = class TestServer {
   }
 
   async stop () {
+    // Destroy all active connections before closing
+    // This prevents 'close' from hanging on platforms like Windows
+    this.server.closeAllConnections()
     this.server.close()
     return once(this.server, 'close')
   }


### PR DESCRIPTION
## Description

The `test/node-fetch/main.js` suite was flaking on Windows with:

```
test at test\node-fetch\main.js:1:1
✖ D:\a\undici\undici\test\node-fetch\main.js (696.5575ms)
  'test failed'
Test results (58 passed, 1 failed)
```

This was caused by `TestServer.stop()` calling `server.close()` and awaiting the `'close'` event, but on Windows, lingering socket connections could prevent the `'close'` event from firing. The `after` hook would hang until the test runner's module-level timeout killed it, causing the entire test module to fail.

## Fix

Call `server.closeAllConnections()` before `server.close()` in `TestServer.stop()` to ensure all active connections are destroyed before attempting to close the server. This is a standard pattern for test server teardown and is safe because `closeAllConnections()` was added in Node.js 18.2.0 and the project already requires Node.js 18+.

## Testing

- Full `npm run test:node-fetch` passes (176 pass, 13 skipped, 0 fail)
- Fix addresses the root cause of the Windows CI timeout
