### PR TITLE
test: drain request bodies in request tests

### DIFF
--- a/test/request.js
+++ b/test/request.js
@@ -38,34 +38,40 @@ test('no-slash/one-slash pathname should be included in req.path', async (t) => 
     pathname: `localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPathname.statusCode, 200)
+  await noSlashPathname.body.dump()
   const noSlashPath = await request({
     method: 'GET',
     origin: `http://localhost:${requestedServer.address().port}`,
     path: `localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPath.statusCode, 200)
+  await noSlashPath.body.dump()
   const noSlashPath2Arg = await request(
     `http://localhost:${requestedServer.address().port}`,
     { path: `localhost:${pathServer.address().port}` }
   )
   t.strictEqual(noSlashPath2Arg.statusCode, 200)
+  await noSlashPath2Arg.body.dump()
   const oneSlashPathname = await request({
     method: 'GET',
     origin: `http://localhost:${requestedServer.address().port}`,
     pathname: `/localhost:${pathServer.address().port}`
   })
   t.strictEqual(oneSlashPathname.statusCode, 200)
+  await oneSlashPathname.body.dump()
   const oneSlashPath = await request({
     method: 'GET',
     origin: `http://localhost:${requestedServer.address().port}`,
     path: `/localhost:${pathServer.address().port}`
   })
   t.strictEqual(oneSlashPath.statusCode, 200)
+  await oneSlashPath.body.dump()
   const oneSlashPath2Arg = await request(
     `http://localhost:${requestedServer.address().port}`,
     { path: `/localhost:${pathServer.address().port}` }
   )
   t.strictEqual(oneSlashPath2Arg.statusCode, 200)
+  await oneSlashPath2Arg.body.dump()
   t.end()
 })
 
@@ -102,17 +108,20 @@ test('protocol-relative URL as pathname should be included in req.path', async (
     pathname: `//localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPathname.statusCode, 200)
+  await noSlashPathname.body.dump()
   const noSlashPath = await request({
     method: 'GET',
     origin: `http://localhost:${requestedServer.address().port}`,
     path: `//localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPath.statusCode, 200)
+  await noSlashPath.body.dump()
   const noSlashPath2Arg = await request(
     `http://localhost:${requestedServer.address().port}`,
     { path: `//localhost:${pathServer.address().port}` }
   )
   t.strictEqual(noSlashPath2Arg.statusCode, 200)
+  await noSlashPath2Arg.body.dump()
   t.end()
 })
 
@@ -149,17 +158,20 @@ test('Absolute URL as pathname should be included in req.path', async (t) => {
     pathname: `http://localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPathname.statusCode, 200)
+  await noSlashPathname.body.dump()
   const noSlashPath = await request({
     method: 'GET',
     origin: `http://localhost:${requestedServer.address().port}`,
     path: `http://localhost:${pathServer.address().port}`
   })
   t.strictEqual(noSlashPath.statusCode, 200)
+  await noSlashPath.body.dump()
   const noSlashPath2Arg = await request(
     `http://localhost:${requestedServer.address().port}`,
     { path: `http://localhost:${pathServer.address().port}` }
   )
   t.strictEqual(noSlashPath2Arg.statusCode, 200)
+  await noSlashPath2Arg.body.dump()
   t.end()
 })
 
@@ -256,11 +268,12 @@ describe('DispatchOptions#reset', () => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       reset: true
     })
+    await body.dump()
   })
 
   test('Should include "connection:keep-alive" if reset false', async t => {
@@ -286,11 +299,12 @@ describe('DispatchOptions#reset', () => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       reset: false
     })
+    await body.dump()
   })
 
   test('Should react to manual set of "connection:close" header', async t => {
@@ -316,13 +330,14 @@ describe('DispatchOptions#reset', () => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       headers: {
         connection: 'close'
       }
     })
+    await body.dump()
   })
 })
 
@@ -353,12 +368,13 @@ describe('Should include headers from iterable objects', scope => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       reset: true,
       headers
     })
+    await body.dump()
   })
 
   test('Should include headers built with Map', async t => {
@@ -387,12 +403,13 @@ describe('Should include headers from iterable objects', scope => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       reset: true,
       headers
     })
+    await body.dump()
   })
 
   test('Should include headers built with custom iterable object', async t => {
@@ -424,12 +441,13 @@ describe('Should include headers from iterable objects', scope => {
       })
     })
 
-    await request({
+    const { body } = await request({
       method: 'GET',
       origin: `http://localhost:${server.address().port}`,
       reset: true,
       headers
     })
+    await body.dump()
   })
 
   test('Should include headers from plain objects with polluted Object.prototype[Symbol.iterator]', async t => {
@@ -464,12 +482,13 @@ describe('Should include headers from iterable objects', scope => {
         })
       })
 
-      await request({
+      const { body } = await request({
         method: 'GET',
         origin: `http://localhost:${server.address().port}`,
         reset: true,
         headers
       })
+      await body.dump()
     } finally {
       if (originalIterator === undefined) {
         delete Object.prototype[Symbol.iterator]


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5227

## Rationale

Some tests only awaited `request()` and asserted the status code, leaving response bodies unconsumed. That can keep sockets or async cleanup alive longer than the test body, which may contribute to intermittent file-level failures in CI.

## Changes

Drains successful `request()` response bodies in test/request.js with `body.dump()`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
