### PR TITLE
test: reduce retry-after invalid date timing flake

### DIFF
--- a/test/retry-handler2.js
+++ b/test/retry-handler2.js
@@ -1722,23 +1722,27 @@ test('Should use retry-after header for retries (date) but date format is wrong 
       throwOnError: false
     }
   }
+  const minRetryDelay = dispatchOptions.retryOptions.minTimeout
 
   server.on('request', (req, res) => {
     switch (counter) {
-      case 0:
-        checkpoint = Date.now()
+      case 0: {
+        checkpoint = process.hrtime.bigint()
         res.writeHead(429, {
           'retry-after': 'this is not a date'
         })
         res.end('rate limit')
         counter++
         return
-      case 1:
+      }
+      case 1: {
         res.writeHead(200)
         res.end('hello world!')
-        t.ok(Date.now() - checkpoint >= 1000)
+        const elapsedMs = Number(process.hrtime.bigint() - checkpoint) / 1e6
+        t.ok(elapsedMs >= minRetryDelay - 100)
         counter++
         return
+      }
       default:
         t.fail('unexpected request')
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

* Fixes: https://github.com/nodejs/undici/issues/5217
* Similar to https://github.com/nodejs/undici/pull/4788

## Rationale

The `throwOnError: false` retry-handler test had the same intermittent timing issue that was previously fixed in `test/retry-handler.js`. The assertion used wall-clock time with an exact lower bound, which can be flaky around timer scheduling boundaries.

## Changes

- Reduce flakiness in the invalid `retry-after` date test in `test/retry-handler2.js`
- Use monotonic time via `process.hrtime.bigint()`
- Allow a small scheduling tolerance around the configured `minTimeout`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
