### PR TITLE
test: make http2-alpn control requests explicit

### DIFF
--- a/test/http2-alpn.js
+++ b/test/http2-alpn.js
@@ -91,6 +91,7 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for GET', async (t) => 
   const httpsOptions = {
     ca,
     servername: 'agent1',
+    ALPNProtocols: ['http/1.1'],
     headers: {
       'x-custom-request-header': 'want 1.1'
     }
@@ -117,7 +118,7 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for GET', async (t) => 
   t.equal(httpsResponse.headers['x-custom-request-header'], 'want 1.1')
   t.equal(httpsResponse.headers['x-custom-response-header'], 'using 1.1')
   t.equal(Buffer.concat(httpsBody).toString('utf8'), JSON.stringify({
-    alpnProtocol: false,
+    alpnProtocol: 'http/1.1',
     httpVersion: '1.1'
   }))
 
@@ -237,6 +238,7 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for POST', async (t) =>
   const httpsOptions = {
     ca,
     servername: 'agent1',
+    ALPNProtocols: ['http/1.1'],
     method: 'POST',
     headers: {
       'content-type': 'text/plain; charset=utf-8',
@@ -262,7 +264,7 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for POST', async (t) =>
       reject(err)
     })
 
-    httpsRequest.write(Buffer.from(body))
+    httpsRequest.end(Buffer.from(body))
 
     after(() => httpsRequest.destroy())
   })
@@ -270,7 +272,7 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for POST', async (t) =>
   t.equal(httpsResponse.statusCode, 201)
   t.equal(httpsResponse.headers['content-type'], 'text/plain; charset=utf-8')
   t.equal(httpsResponse.headers['x-custom-request-header'], 'want 1.1')
-  t.equal(httpsResponse.headers['x-custom-alpn-protocol'], 'false')
+  t.equal(httpsResponse.headers['x-custom-alpn-protocol'], 'http/1.1')
   t.equal(Buffer.concat(httpsResponseBody).toString('utf-8'), 'hello http/1!')
   t.equal(Buffer.concat(httpsRequestChunks).toString('utf-8'), expectedBody)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5212

## Rationale

The HTTP/1.1 control requests in `test/http2-alpn.js` relied on Node's default `https` ALPN behavior and asserted `alpnProtocol === false`.

That ALPN detail is incidental to the behavior this test is meant to verify. The important distinction is that Undici negotiates `h2` when `allowH2` is enabled, while the same `allowHTTP1: true` server can still handle an HTTP/1.1 request.

Make the control request explicitly HTTP/1.1 so the test documents that intent directly and avoids depending on the default ALPN behavior of `https`.

## Changes

- Make HTTP/1.1 control requests in `test/http2-alpn.js` pass `ALPNProtocols: ['http/1.1']`.
- Update the expected ALPN assertions to `http/1.1`.
- End the POST control request with its body instead of only writing the body.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
