### PR TITLE
test: only fail max-listener checks on max-listener warnings

### DIFF
--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -27,7 +27,7 @@ test('20 times GET with pipelining 10', async (t) => {
 
   // needed to check for a warning on the maxListeners on the socket
   function onWarning (warning) {
-    if (!/ExperimentalWarning/.test(warning)) {
+    if (warning.name === 'MaxListenersExceededWarning') {
       t.fail()
     }
   }

--- a/test/client-write-max-listeners.js
+++ b/test/client-write-max-listeners.js
@@ -33,7 +33,7 @@ test('socket close listener does not leak', async (t) => {
   }
 
   function onWarning (warning) {
-    if (!/ExperimentalWarning/.test(warning)) {
+    if (warning.name === 'MaxListenersExceededWarning') {
       t.fail()
     }
   }

--- a/test/promises.js
+++ b/test/promises.js
@@ -242,7 +242,7 @@ test('20 times GET with pipelining 10, async await support', async (t) => {
 
   // needed to check for a warning on the maxListeners on the socket
   function onWarning (warning) {
-    if (!/ExperimentalWarning/.test(warning)) {
+    if (warning.name === 'MaxListenersExceededWarning') {
       t.fail()
     }
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5211

## Rationale

The max-listener tests are intended to fail when a `MaxListenersExceededWarning` is emitted. They were also failing on unrelated process warnings that did not contain `ExperimentalWarning`, which made the tests brittle when run alongside other test files.

## Changes

Narrow warning checks in max-listener-focused tests to only fail on `MaxListenersExceededWarning`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
