### PR TITLE
test: avoid global dispatcher state in mock client tests

### DIFF
--- a/test/mock-client.js
+++ b/test/mock-client.js
@@ -3,7 +3,7 @@
 const { test, after, describe } = require('node:test')
 const { createServer } = require('node:http')
 const { promisify } = require('node:util')
-const { MockAgent, MockClient, setGlobalDispatcher, request } = require('..')
+const { MockAgent, MockClient, getGlobalDispatcher, setGlobalDispatcher, request } = require('..')
 const { kUrl } = require('../lib/core/symbols')
 const { kDispatches } = require('../lib/mock/mock-symbols')
 const { InvalidArgumentError } = require('../lib/core/errors')
@@ -220,7 +220,10 @@ test('MockClient - should be able to set as globalDispatcher', async (t) => {
 
   const mockClient = mockAgent.get(baseUrl)
   t.assert.ok(mockClient instanceof MockClient)
+
+  const originalDispatcher = getGlobalDispatcher()
   setGlobalDispatcher(mockClient)
+  t.after(() => setGlobalDispatcher(originalDispatcher))
 
   mockClient.intercept({
     path: '/foo',
@@ -258,7 +261,6 @@ test('MockClient - should support query params', async (t) => {
 
   const mockClient = mockAgent.get(baseUrl)
   t.assert.ok(mockClient instanceof MockClient)
-  setGlobalDispatcher(mockClient)
 
   const query = {
     pageNum: 1
@@ -271,6 +273,7 @@ test('MockClient - should support query params', async (t) => {
 
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET',
+    dispatcher: mockClient,
     query
   })
   t.assert.strictEqual(statusCode, 200)
@@ -301,7 +304,6 @@ test('MockClient - should intercept query params with hardcoded path', async (t)
 
   const mockClient = mockAgent.get(baseUrl)
   t.assert.ok(mockClient instanceof MockClient)
-  setGlobalDispatcher(mockClient)
 
   const query = {
     pageNum: 1
@@ -313,6 +315,7 @@ test('MockClient - should intercept query params with hardcoded path', async (t)
 
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET',
+    dispatcher: mockClient,
     query
   })
   t.assert.strictEqual(statusCode, 200)
@@ -343,7 +346,6 @@ test('MockClient - should intercept query params regardless of key ordering', as
 
   const mockClient = mockAgent.get(baseUrl)
   t.assert.ok(mockClient instanceof MockClient)
-  setGlobalDispatcher(mockClient)
 
   const query = {
     pageNum: 1,
@@ -363,6 +365,7 @@ test('MockClient - should intercept query params regardless of key ordering', as
 
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
     method: 'GET',
+    dispatcher: mockClient,
     query
   })
   t.assert.strictEqual(statusCode, 200)
@@ -477,7 +480,6 @@ test('MockClient - cleans mocks', async (t) => {
 
   const mockClient = mockAgent.get(baseUrl)
   t.assert.ok(mockClient instanceof MockClient)
-  setGlobalDispatcher(mockClient)
 
   mockClient.intercept({
     path: '/foo',
@@ -491,7 +493,8 @@ test('MockClient - cleans mocks', async (t) => {
   t.assert.strictEqual(mockClient[kDispatches].length, 0)
 
   const { statusCode, body } = await request(`${baseUrl}/foo`, {
-    method: 'GET'
+    method: 'GET',
+    dispatcher: mockClient
   })
   t.assert.strictEqual(statusCode, 200)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5202

## Rationale

Some `test/mock-client.js` cases replaced the global dispatcher even though they only needed a mock dispatcher for a single request. This left process-wide state mutated across tests and could contribute to flaky file-level failures.

## Changes

- Use `dispatcher: mockClient` in mock client tests that do not explicitly test global dispatcher behavior.
- Restore the original global dispatcher in the one test that verifies `setGlobalDispatcher()`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
