### PR TITLE
test: wait for inflight-and-close body cleanup

### DIFF
--- a/test/inflight-and-close.js
+++ b/test/inflight-and-close.js
@@ -1,9 +1,10 @@
 'use strict'
 
 const { tspl } = require('@matteo.collina/tspl')
-const { test } = require('node:test')
+const { test, after } = require('node:test')
 const { request } = require('..')
 const http = require('node:http')
+const { once } = require('node:events')
 
 test('inflight and close', async (t) => {
   t = tspl(t, { plan: 3 })
@@ -12,26 +13,33 @@ test('inflight and close', async (t) => {
     res.writeHead(200)
     res.end('Response body')
     res.socket.end() // Close the connection immediately with every response
-  }).listen(0, '127.0.0.1', function () {
-    const url = `http://127.0.0.1:${this.address().port}`
-    request(url)
-      .then(({ statusCode, headers, body }) => {
-        t.ok(true, 'first response')
-        body.resume()
-        body.on('close', function () {
-          t.ok(true, 'first body closed')
-        })
-        return request(url)
-          .then(({ statusCode, headers, body }) => {
-            t.ok(true, 'second response')
-            body.resume()
-            body.on('close', function () {
-              server.close()
-            })
-          })
-      }).catch((err) => {
-        t.ifError(err)
-      })
   })
+
+  after(() => server.close())
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const url = `http://127.0.0.1:${server.address().port}`
+
+  const first = await request(url)
+  t.ok(true, 'first response')
+
+  const firstBodyClosed = once(first.body, 'close').then(() => {
+    t.ok(true, 'first body closed')
+  })
+  first.body.resume()
+
+  const second = await request(url)
+  t.ok(true, 'second response')
+
+  const secondBodyClosed = once(second.body, 'close')
+  second.body.resume()
+
+  await Promise.all([
+    firstBodyClosed,
+    secondBodyClosed
+  ])
+
   await t.completed
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes: https://github.com/nodejs/undici/issues/5260

## Rationale

`test/inflight-and-close.js` could complete its assertion plan before all async cleanup had settled. In particular, the test asserted the second response, then relied on the second body’s `close` handler to close the server without waiting for that body close or server shutdown.

On slower or differently scheduled platforms like Windows, this can leave stream/socket/server cleanup racing the test runner and surface as an intermittent file-level `'test failed'`.

## Changes

- Rewrite `test/inflight-and-close.js` to use `async`/`await` instead of nested promise callbacks.
- Wait for both response body `close` events before completing the test.
- Move server shutdown into `node:test` cleanup via `test.after()`.
- Preserve the original behavior under test: the second request still starts before awaiting the first body close.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
