### PR TITLE
fix(mock): preserve fetch FormData boundary on net-connect fallback

### DIFF
--- a/lib/mock/mock-symbols.js
+++ b/lib/mock/mock-symbols.js
@@ -28,5 +28,6 @@ module.exports = {
   kMockAgentIsCallHistoryEnabled: Symbol('mock agent is call history enabled'),
   kMockAgentAcceptsNonStandardSearchParameters: Symbol('mock agent accepts non standard search parameters'),
   kMockCallHistoryAddLog: Symbol('mock call history add log'),
-  kTotalDispatchCount: Symbol('total dispatch count')
+  kTotalDispatchCount: Symbol('total dispatch count'),
+  kMockDispatchFallbackBody: Symbol('mock dispatch fallback body')
 }

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -4,12 +4,13 @@ const { MockNotMatchedError } = require('./mock-errors')
 const {
   kDispatches,
   kMockAgent,
+  kMockDispatchFallbackBody,
   kOriginalDispatch,
   kOrigin,
   kGetNetConnect,
   kTotalDispatchCount
 } = require('./mock-symbols')
-const { serializePathWithQuery, parseHeaders } = require('../core/util')
+const { serializePathWithQuery, parseHeaders, isFormDataLike } = require('../core/util')
 const { STATUS_CODES } = require('node:http')
 const {
   types: {
@@ -424,7 +425,14 @@ function buildMockDispatch () {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)${interceptsMessage}`)
           }
           if (checkNetConnect(netConnect, origin)) {
-            originalDispatch.call(this, opts, handler)
+            const dispatchOpts = { ...opts }
+            // Fetch body matchers want the original source, but pass-through
+            // requests must preserve fetch's pre-encoded FormData stream.
+            if (isFormDataLike(dispatchOpts.body) && dispatchOpts[kMockDispatchFallbackBody] != null) {
+              dispatchOpts.body = dispatchOpts[kMockDispatchFallbackBody]
+            }
+            delete dispatchOpts[kMockDispatchFallbackBody]
+            originalDispatch.call(this, dispatchOpts, handler)
           } else {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)${interceptsMessage}`)
           }

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -61,6 +61,7 @@ const { Readable, pipeline, finished, isErrored, isReadable } = require('node:st
 const { addAbortListener, bufferToLowerCasedHeaderName } = require('../../core/util')
 const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = require('./data-url')
 const { getGlobalDispatcher } = require('../../global')
+const { kMockDispatchFallbackBody } = require('../../mock/mock-symbols')
 const { webidl } = require('../webidl')
 const { STATUS_CODES } = require('node:http')
 const { bytesMatch } = require('../subresource-integrity/subresource-integrity')
@@ -2178,25 +2179,16 @@ async function httpNetworkFetch (
     return dispatchWithProtocolPreference(body)
 
     function dispatchWithProtocolPreference (body, allowH2) {
-      // When dispatching to a MockAgent, prefer request.body.source so that
-      // body matchers can compare against the original input. FormData sources
-      // are excluded: the dispatcher would re-encode them with a fresh
-      // multipart boundary, mismatching the content-type header that fetch
-      // already produced (see #5241).
-      let dispatchBody = body
-      if (agent.isMockActive && request.body) {
-        const { source, stream } = request.body
-        dispatchBody = webidl.is.FormData(source) ? body : (source || stream)
-      }
       return new Promise((resolve, reject) => agent.dispatch(
         {
           path: hasTrailingQuestionMark ? `${path}?` : path,
           origin: url.origin,
           method: request.method,
-          body: dispatchBody,
+          body: agent.isMockActive ? request.body && (request.body.source || request.body.stream) : body,
           headers: request.headersList.entries,
           maxRedirections: 0,
           upgrade: request.mode === 'websocket' ? 'websocket' : undefined,
+          ...(agent.isMockActive ? { [kMockDispatchFallbackBody]: body } : null),
           ...(allowH2 === false ? { allowH2 } : null)
         },
         {

--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2178,12 +2178,22 @@ async function httpNetworkFetch (
     return dispatchWithProtocolPreference(body)
 
     function dispatchWithProtocolPreference (body, allowH2) {
+      // When dispatching to a MockAgent, prefer request.body.source so that
+      // body matchers can compare against the original input. FormData sources
+      // are excluded: the dispatcher would re-encode them with a fresh
+      // multipart boundary, mismatching the content-type header that fetch
+      // already produced (see #5241).
+      let dispatchBody = body
+      if (agent.isMockActive && request.body) {
+        const { source, stream } = request.body
+        dispatchBody = webidl.is.FormData(source) ? body : (source || stream)
+      }
       return new Promise((resolve, reject) => agent.dispatch(
         {
           path: hasTrailingQuestionMark ? `${path}?` : path,
           origin: url.origin,
           method: request.method,
-          body: agent.isMockActive ? request.body && (request.body.source || request.body.stream) : body,
+          body: dispatchBody,
           headers: request.headersList.entries,
           maxRedirections: 0,
           upgrade: request.mode === 'websocket' ? 'websocket' : undefined,

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -3,7 +3,7 @@
 const { test, after, describe } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { request, setGlobalDispatcher, MockAgent, Agent } = require('..')
+const { request, setGlobalDispatcher, MockAgent, Agent, FormData } = require('..')
 const { getResponse } = require('../lib/mock/mock-utils')
 const { kClients, kConnected } = require('../lib/core/symbols')
 const { InvalidArgumentError, ClientDestroyedError } = require('../lib/core/errors')
@@ -3005,6 +3005,49 @@ test('MockAgent - Sending ReadableStream body', async (t) => {
   })
 
   t.assert.deepStrictEqual(await response.text(), 'test')
+})
+
+// https://github.com/nodejs/undici/issues/5241
+test('MockAgent - fetch FormData boundary in header matches body when net-connect passes through', async (t) => {
+  t.plan(2)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8')
+      const headerMatch = /boundary=(.+)$/.exec(req.headers['content-type'] || '')
+      const bodyMatch = /^--([^\r\n]+)/.exec(body)
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({
+        headerBoundary: headerMatch && headerMatch[1],
+        bodyBoundary: bodyMatch && bodyMatch[1]
+      }))
+    })
+  })
+  after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const mockAgent = new MockAgent()
+  mockAgent.enableNetConnect(`localhost:${server.address().port}`)
+  setGlobalDispatcher(mockAgent)
+  after(() => mockAgent.close())
+
+  const formData = new FormData()
+  formData.append('file', new Blob([Buffer.from('hello world')], { type: 'txt' }), 'document.txt')
+
+  const response = await fetch(`http://localhost:${server.address().port}/`, {
+    method: 'POST',
+    body: formData
+  })
+  const { headerBoundary, bodyBoundary } = await response.json()
+
+  t.assert.ok(headerBoundary, 'content-type header should carry a boundary')
+  t.assert.strictEqual(bodyBoundary, headerBoundary)
 })
 
 // https://github.com/nodejs/undici/issues/2616


### PR DESCRIPTION
## This relates to...

Fixes #5241

## Rationale

When fetch sends a `FormData` body through a `MockAgent` that falls through to net connect, mock body matching wants the original request source, but the real dispatch path must keep fetch's already-encoded body so the multipart boundary stays aligned with the `content-type` header.

## Changes

- Keep the matcher-friendly `request.body.source || request.body.stream` path for MockAgent requests.
- Carry fetch's pre-encoded request body through an internal mock-only fallback slot.
- Restore that prepared body only when a `FormData` request misses the mock intercept and passes through to the original dispatcher.

### Features

N/A

### Bug Fixes

- fetch + MockAgent + FormData no longer produces a content-type/body boundary mismatch on net-connect pass-through.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
