### PR TITLE
fix: register connect listener before initiating requests in close-and-destroy test

### DIFF
--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -166,15 +166,16 @@ test('close should still reconnect', async (t) => {
     const client = new Client(`http://localhost:${server.address().port}`)
     after(() => client.destroy())
 
+    client.once('connect', () => {
+      client[kSocket].destroy()
+    })
+
     t.ok(makeRequest())
     t.ok(!makeRequest())
 
     client.close((err) => {
       t.ifError(err)
       t.strictEqual(client.closed, true)
-    })
-    client.once('connect', () => {
-      client[kSocket].destroy()
     })
 
     function makeRequest () {


### PR DESCRIPTION
Fixes #5265

## Problem

The `test/close-and-destroy.js` test `'close should still reconnect'` was flaky on Windows. It registered the `client.once('connect', ...)` listener *after* calling `makeRequest()`, which initiates the connection. On fast connections (like localhost on Windows), the connection could complete before the listener was registered, causing the `client[kSocket].destroy()` to never execute and making the test outcome non-deterministic.

## Fix

Move the `client.once('connect', ...)` registration to before `makeRequest()` so the listener is always in place when the connection is established.

The test intent is to destroy the socket on connect so the client must reconnect and complete pending requests. This only works if the listener is registered before the connect event fires.
