### PR TITLE
fix: prevent pipeline body replay on redirect

### DIFF
--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -13,6 +13,7 @@ const {
   RequestAbortedError
 } = require('../core/errors')
 const util = require('../core/util')
+const { kBodyUsed } = require('../core/symbols')
 const { addSignal, removeSignal } = require('./abort-signal')
 
 function noop () {}
@@ -24,6 +25,9 @@ class PipelineRequest extends Readable {
     super({ autoDestroy: true })
 
     this[kResume] = null
+    // Pipeline request bodies come from a live writable side and cannot be
+    // replayed across redirects or retries, even before any bytes are read.
+    this[kBodyUsed] = true
   }
 
   _read () {

--- a/test/redirect-pipeline.js
+++ b/test/redirect-pipeline.js
@@ -2,7 +2,7 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
-const { pipeline: undiciPipeline, Client, interceptors } = require('..')
+const { pipeline: undiciPipeline, Client, Dispatcher, interceptors } = require('..')
 const { pipeline: streamPipelineCb } = require('node:stream')
 const { promisify } = require('node:util')
 const { createReadable, createWritable } = require('./utils/stream')
@@ -10,6 +10,33 @@ const { startRedirectingServer } = require('./utils/redirecting-servers')
 
 const streamPipeline = promisify(streamPipelineCb)
 const redirect = interceptors.redirect
+
+class RedirectingDispatcher extends Dispatcher {
+  dispatch (opts, handler) {
+    const redirectCount = Number(new URL(opts.path, opts.origin).pathname.split('/').pop()) + 1
+    const controller = {
+      resume () {},
+      pause () {},
+      abort () {}
+    }
+
+    handler.onRequestStart?.(controller, opts)
+    handler.onResponseStart?.(controller, 302, {
+      location: `http://localhost/302/${redirectCount}`
+    }, '')
+    handler.onResponseEnd?.(controller, null)
+
+    return true
+  }
+
+  close (callback) {
+    callback?.()
+  }
+
+  destroy (_err, callback) {
+    callback?.()
+  }
+}
 
 test('should not follow redirection by default if not using RedirectAgent', async t => {
   t = tspl(t, { plan: 3 })
@@ -31,6 +58,7 @@ test('should not follow redirection by default if not using RedirectAgent', asyn
   )
 
   t.strictEqual(body.length, 0)
+  await t.completed
 })
 
 test('should not follow redirects when using RedirectAgent within pipeline', async t => {
@@ -51,4 +79,27 @@ test('should not follow redirects when using RedirectAgent within pipeline', asy
   )
 
   t.strictEqual(body.length, 0)
+  await t.completed
+})
+
+test('should not replay pipeline request bodies before they are consumed', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const body = []
+
+  await streamPipeline(
+    createReadable('REQUEST'),
+    undiciPipeline('http://localhost/302/1', {
+      dispatcher: new RedirectingDispatcher().compose(redirect({ maxRedirections: 1 }))
+    }, ({ statusCode, headers, body }) => {
+      t.strictEqual(statusCode, 302)
+      t.strictEqual(headers.location, 'http://localhost/302/2')
+
+      return body
+    }),
+    createWritable(body)
+  )
+
+  t.strictEqual(body.length, 0)
+  await t.completed
 })


### PR DESCRIPTION
## This relates to...

Fixes #5204.

## Rationale

`undici.pipeline()` uses a live writable-side request body that cannot be replayed safely. Redirect handling was only blocking redirects after the body had been consumed, which left a race where a redirect could be followed before any bytes were read.

## Changes

- mark pipeline request bodies as non-replayable from the start
- add a regression test that forces a redirect before the pipeline body is consumed
- wait for `tspl` completion in the redirect pipeline tests

### Features

N/A

### Bug Fixes

- prevent pipeline request bodies from being replayed across redirects
- make `test/redirect-pipeline.js` deterministic

### Breaking Changes and Deprecations

None.

## Status

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
