### PR TITLE
ci: build Node FFI fixtures for shared-builtin tests

### DIFF
--- a/.github/workflows/nodejs-shared.yml
+++ b/.github/workflows/nodejs-shared.yml
@@ -90,6 +90,9 @@ jobs:
           ./configure --shared-builtin-undici/undici-path ${{ github.workspace }}/undici/loader.js --ninja --prefix=./final
           make
           make install
+          if make -qp | grep -q '^build-ffi-tests:'; then
+            make build-ffi-tests
+          fi
           echo "$(pwd)/final/bin" >> $GITHUB_PATH
 
       - name: Print version information
@@ -107,4 +110,3 @@ jobs:
         if: steps.release.outputs.result != ''
         working-directory: ./node-${{ steps.release.outputs.result }}
         run: tools/test.py -p dots --flaky-tests=dontcare
-


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

CI failure in the Node.js 26 `--shared-builtin-undici/undici-path` job:
Example https://github.com/nodejs/undici/actions/runs/25594045521/job/75136796661

## Rationale

Node.js v26 now includes FFI tests that require a native fixture library. The shared-builtin workflow invokes `tools/test.py` directly, bypassing Node's Make targets that would normally build those fixtures first.

## Changes

- Build Node FFI test fixtures before running the upstream Node test suite when the downloaded Node source supports `build-ffi-tests`.
- Keep older Node versions compatible by checking for the target before invoking it.

### Features

N/A

### Bug Fixes

Build Node FFI fixtures for shared-builtin tests

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
