### PR TITLE
test: include cache-test worker metadata on failure

### DIFF
--- a/test/cache-interceptor/cache-tests.mjs
+++ b/test/cache-interceptor/cache-tests.mjs
@@ -125,7 +125,13 @@ console.log(`PROTOCOL: ${styleText('gray', PROTOCOL)}`)
 console.log('')
 
 /**
- * @type {Array<Promise<[number, Array<Buffer>]>>}
+ * @type {Array<Promise<{
+ *  code: number | null,
+ *  signal: NodeJS.Signals | null,
+ *  stdout: Buffer[],
+ *  environment: TestEnvironment,
+ *  port: number
+ * }>>}
  */
 const results = []
 
@@ -158,8 +164,18 @@ for (let i = 0; i < testEnvironments.length; i++) {
       stdout.push(chunk)
     })
 
-    cacheTestsWorkerProcess.on('close', code => {
-      resolve([code, stdout])
+    cacheTestsWorkerProcess.on('error', err => {
+      stdout.push(Buffer.from(`${err.stack ?? err.message}\n`))
+    })
+
+    cacheTestsWorkerProcess.on('close', (code, signal) => {
+      resolve({
+        code,
+        signal,
+        stdout,
+        environment,
+        port
+      })
     })
   })
 
@@ -170,13 +186,17 @@ for (let i = 0; i < testEnvironments.length; i++) {
 let exitCode = 0
 
 // Print the results of all the results in the order that they exist
-for (const [code, stdout] of await Promise.all(results)) {
-  if (code !== 0) {
-    exitCode = code
+for (const result of await Promise.all(results)) {
+  if (result.code !== 0 || result.signal !== null) {
+    exitCode = result.code ?? 1
   }
 
-  for (const line of stdout) {
+  for (const line of result.stdout) {
     process.stdout.write(line)
+  }
+
+  if (result.code !== 0 || result.signal !== null) {
+    console.error(`cache-tests worker failed: port=${result.port} store=${result.environment.cacheStore ?? 'default'} type=${result.environment.opts.type ?? 'default'} code=${result.code ?? 'null'} signal=${result.signal ?? 'null'}`)
   }
 
   console.log('')


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Refs: https://github.com/nodejs/undici/issues/5199

## Rationale

When a cache-test worker exits before printing its own summary, the parent process currently only reports `Process completed with exit code 1`. This makes it hard to identify which cache environment failed.

## Changes

- Include cache-test worker metadata on failure: port, cache store, cache type, exit code, and signal.
- Capture child process spawn errors in the worker’s buffered output.

### Features

N/A

### Bug Fixes

Include cache-test worker metadata on failure

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
