### PR TITLE
test: use shared IPv4 loopback host instead of localhost

### DIFF
--- a/test/agent-connection-management.js
+++ b/test/agent-connection-management.js
@@ -1,4 +1,5 @@
 const { test, describe } = require('node:test')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const assert = require('node:assert')
 const { createServer } = require('node:http')
 const { request, Agent, Pool } = require('..')
@@ -30,7 +31,7 @@ describe('Agent should close inactive clients', () => {
         return pool
       }
     })
-    const { statusCode } = await request(`http://localhost:${server.address().port}`, { dispatcher: agent })
+    const { statusCode } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
     assert.equal(statusCode, 200)
 
     await p
@@ -100,7 +101,7 @@ describe('Agent should not close active clients', () => {
 
     const socketSequence = []
     for (let i = 0; i < 5; i++) {
-      const { statusCode, headers, body } = await request(`http://localhost:${server.address().port}`, {
+      const { statusCode, headers, body } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         dispatcher: agent
       })
 
@@ -141,7 +142,7 @@ describe('Agent should not close active clients', () => {
 
     const socketSequence = []
     for (let i = 0; i < 5; i++) {
-      const { statusCode, headers, body } = await request(`http://localhost:${server.address().port}`, {
+      const { statusCode, headers, body } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         dispatcher: agent
       })
 

--- a/test/cache-interceptor/issue-4209.js
+++ b/test/cache-interceptor/issue-4209.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { equal, notEqual, deepStrictEqual } = require('node:assert')
 const { createServer } = require('node:http')
@@ -74,7 +75,7 @@ test('issue #4209 - different query strings do not collide in the cache', async 
     await dispatcher.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // First request with ?i=0 – hits origin
   const r0 = await request(`${origin}/?i=0`, { dispatcher })
@@ -123,7 +124,7 @@ test('issue #4209 - query object form also keyed distinctly', async () => {
     await dispatcher.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const r0 = await request(origin, { dispatcher, query: { i: 0 } })
   const b0 = await r0.body.text()

--- a/test/client-connect.js
+++ b/test/client-connect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -25,7 +26,7 @@ test('connect aborted after connect', async (t) => {
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     pipelining: 3
   })
   after(() => client.close())

--- a/test/client-head-reset-override.js
+++ b/test/client-head-reset-override.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -20,7 +21,7 @@ test('override HEAD reset', async (t) => {
   after(() => server.close())
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   let done

--- a/test/client-idempotent-body.js
+++ b/test/client-idempotent-body.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -21,7 +22,7 @@ test('idempotent retry', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())

--- a/test/client-keep-alive.js
+++ b/test/client-keep-alive.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -22,7 +23,7 @@ test('keep-alive header', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.request({
@@ -59,7 +60,7 @@ test('keep-alive header 0', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     keepAliveTimeoutThreshold: 500
   })
   after(() => client.close())
@@ -92,7 +93,7 @@ test('keep-alive header 1', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.request({
@@ -146,7 +147,7 @@ test('HEAD keep-alive header reuses socket when connection header is fragmented'
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
 
   const disconnect = once(client, 'disconnect')
@@ -187,7 +188,7 @@ test('keep-alive header no postfix', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.request({
@@ -227,7 +228,7 @@ test('keep-alive not timeout', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     keepAliveTimeout: 1e3
   })
   after(() => client.close())
@@ -268,7 +269,7 @@ test('keep-alive threshold', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     keepAliveTimeout: 30e3,
     keepAliveTimeoutThreshold: 29e3
   })
@@ -311,7 +312,7 @@ test('keep-alive max keepalive', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     keepAliveTimeout: 30e3,
     keepAliveMaxTimeout: 1e3
   })
@@ -353,7 +354,7 @@ test('connection close', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     pipelining: 2
   })
   after(() => client.close())
@@ -409,7 +410,7 @@ test('Disable keep alive', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, { pipelining: 0 })
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { pipelining: 0 })
   after(() => client.close())
 
   client.request({

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -19,7 +20,7 @@ test('pipeline get', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     t.strictEqual(undefined, req.headers['content-length'])
     res.setHeader('Content-Type', 'text/plain')
     res.end('hello')
@@ -27,7 +28,7 @@ test('pipeline get', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     {
@@ -81,7 +82,7 @@ test('pipeline echo', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let res = ''
@@ -132,7 +133,7 @@ test('pipeline ignore request body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let res = ''
@@ -191,7 +192,7 @@ test('pipeline invalid handler return after destroy should not error', async (t)
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     after(() => client.destroy())
@@ -227,7 +228,7 @@ test('pipeline error body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const buf = Buffer.alloc(1e6).toString()
@@ -269,7 +270,7 @@ test('pipeline destroy body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const buf = Buffer.alloc(1e6).toString()
@@ -311,7 +312,7 @@ test('pipeline backpressure', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const buf = Buffer.alloc(1e6).toString()
@@ -346,7 +347,7 @@ test('pipeline invalid handler return', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -387,7 +388,7 @@ test('pipeline throw handler', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -416,7 +417,7 @@ test('pipeline destroy and throw handler', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const dup = client.pipeline({
@@ -451,7 +452,7 @@ test('pipeline abort res', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -489,7 +490,7 @@ test('pipeline abort server res', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -516,7 +517,7 @@ test('pipeline abort duplex', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -549,7 +550,7 @@ test('pipeline abort piped res', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -580,7 +581,7 @@ test('pipeline abort piped res 2', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -615,7 +616,7 @@ test('pipeline abort piped res 3', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -652,7 +653,7 @@ test('pipeline abort server res after headers', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -682,7 +683,7 @@ test('pipeline w/ write abort server res after headers', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -713,7 +714,7 @@ test('destroy in push', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.pipeline({ path: '/', method: 'GET' }, ({ body }) => {
@@ -769,7 +770,7 @@ test('pipeline factory throw not unhandled', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -796,7 +797,7 @@ test('pipeline destroy before dispatch', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client
@@ -825,7 +826,7 @@ test('pipeline legacy stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client
@@ -853,7 +854,7 @@ test('pipeline objectMode', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client
@@ -883,7 +884,7 @@ test('pipeline invalid opts', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.close((err) => {
@@ -910,7 +911,7 @@ test('pipeline CONNECT throw', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -938,7 +939,7 @@ test('pipeline body without destroy', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.pipeline({
@@ -969,7 +970,7 @@ test('pipeline ignore 1xx', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let buf = ''
@@ -1000,7 +1001,7 @@ test('pipeline ignore 1xx and use onInfo', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let buf = ''
@@ -1037,7 +1038,7 @@ test('pipeline backpressure', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let buf = ''
@@ -1078,7 +1079,7 @@ test('pipeline abort after headers', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const signal = new EE()

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -37,7 +38,7 @@ test('20 times GET with pipelining 10', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 10
     })
     after(() => client.close())
@@ -99,7 +100,7 @@ test('A client should enqueue as much as twice its pipelining factor', async (t)
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())
@@ -154,7 +155,7 @@ test('pipeline 1 is 1 active request', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1
     })
     after(() => client.destroy())
@@ -212,7 +213,7 @@ test('pipelined chunked POST stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())
@@ -286,7 +287,7 @@ test('pipelined chunked POST iterator', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())
@@ -355,7 +356,7 @@ function errordInflightPost (bodyType) {
     after(() => server.close())
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 2
       })
       after(() => client.destroy())
@@ -414,7 +415,7 @@ test('pipelining non-idempotent', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())
@@ -465,7 +466,7 @@ function pipeliningNonIdempotentWithBody (bodyType) {
     after(() => server.close())
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 2
       })
       after(() => client.close())
@@ -531,7 +532,7 @@ function pipeliningHeadBusy (bodyType) {
     after(() => server.close())
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 10
       })
       after(() => client.close())
@@ -609,7 +610,7 @@ test('pipelining empty pipeline before reset', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 10
     })
     after(() => client.close())
@@ -666,7 +667,7 @@ function pipeliningIdempotentBusy (bodyType) {
     after(() => server.close())
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 10
       })
       after(() => client.close())
@@ -778,7 +779,7 @@ test('pipelining blocked', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 10
     })
     after(() => client.close())

--- a/test/client-post.js
+++ b/test/client-post.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -24,7 +25,7 @@ test('request post blob', async (t) => {
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(client.destroy.bind(client))
   client.on('disconnect', () => {
     if (!client.closed && !client.destroyed) {
@@ -65,7 +66,7 @@ test('request post arrayBuffer', async (t) => {
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
   client.on('disconnect', () => {
     if (!client.closed && !client.destroyed) {

--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -28,7 +29,7 @@ test('multiple reconnect', async (t) => {
 
   server.listen(0)
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(client.destroy.bind(client))
 
   client.request({ path: '/', method: 'GET' }, (err, data) => {

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after, describe, before } = require('node:test')
 const { Client, errors } = require('..')
@@ -28,7 +29,7 @@ test('request dump head', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     let dumped = false
@@ -65,7 +66,7 @@ test('request dump big', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     let dumped = false
@@ -102,7 +103,7 @@ test('request dump', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     let dumped = false
@@ -135,7 +136,7 @@ test('request dump with abort signal', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -175,7 +176,7 @@ test('request dump with POJO as invalid signal', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -212,7 +213,7 @@ test('request dump with aborted signal', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -252,7 +253,7 @@ test('request hwm', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -283,7 +284,7 @@ test('request abort before headers', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client[kConnect](() => {
@@ -323,7 +324,7 @@ test('request body destroyed on invalid callback', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const body = new Readable({
@@ -357,7 +358,7 @@ test('trailers', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const { body, trailers } = await client.request({
@@ -398,7 +399,7 @@ test('destroy socket abruptly', async (t) => {
   })
 
   await promisify(server.listen.bind(server))(0)
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const { statusCode, body } = await client.request({
@@ -443,7 +444,7 @@ test('destroy socket abruptly with keep-alive', async (t) => {
   })
 
   await promisify(server.listen.bind(server))(0)
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const { statusCode, body } = await client.request({
@@ -480,7 +481,7 @@ test('request json', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -506,7 +507,7 @@ test('request long multibyte json', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -532,7 +533,7 @@ test('request text', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -616,7 +617,7 @@ describe('headers', () => {
     before(async () => {
       server.listen(0)
       await EE.once(server, 'listening')
-      serverAddress = `localhost:${server.address().port}`
+      serverAddress = `${LOOPBACK_HOST}:${server.address().port}`
     })
 
     after(() => {
@@ -659,7 +660,7 @@ describe('headers', () => {
     before(async () => {
       server.listen(0)
       await EE.once(server, 'listening')
-      serverAddress = `localhost:${server.address().port}`
+      serverAddress = `${LOOPBACK_HOST}:${server.address().port}`
     })
 
     after(() => {
@@ -723,7 +724,7 @@ test('request long multibyte text', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -750,7 +751,7 @@ test('request blob', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -779,7 +780,7 @@ test('request arrayBuffer', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -808,7 +809,7 @@ test('request bytes', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -837,7 +838,7 @@ test('request body', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -872,7 +873,7 @@ test('request post body no missing data', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -909,7 +910,7 @@ test('request post body no extra data handler', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const reqBody = new Readable({
@@ -947,7 +948,7 @@ test('request with onInfo callback', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     await client.request({
@@ -977,7 +978,7 @@ test('request with onInfo callback but socket is destroyed before end of respons
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
     try {
       await client.request({
@@ -1025,7 +1026,7 @@ test('request onInfo callback headers parsing', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const { body } = await client.request({
@@ -1064,7 +1065,7 @@ test('request raw responseHeaders', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const { body, headers } = await client.request({
@@ -1093,7 +1094,7 @@ test('request formData', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1125,7 +1126,7 @@ test('request text2', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1185,7 +1186,7 @@ test('request with FormData body', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     await client.request({
@@ -1218,7 +1219,7 @@ test('request post body Buffer from string', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1252,7 +1253,7 @@ test('request post body Buffer from buffer', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1286,7 +1287,7 @@ test('request post body Uint8Array', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1320,7 +1321,7 @@ test('request post body Uint32Array', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1354,7 +1355,7 @@ test('request post body Float64Array', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1388,7 +1389,7 @@ test('request post body BigUint64Array', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1422,7 +1423,7 @@ test('request post body DataView', async (t) => {
   })
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const { body } = await client.request({
@@ -1452,7 +1453,7 @@ test('request multibyte json with setEncoding', async (t) => {
   after(server.close.bind(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const { body } = await client.request({
@@ -1480,7 +1481,7 @@ test('request multibyte text with setEncoding', async (t) => {
   after(server.close.bind(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const { body } = await client.request({
@@ -1508,7 +1509,7 @@ test('request multibyte text with setEncoding', async (t) => {
   after(server.close.bind(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const { body } = await client.request({
@@ -1539,7 +1540,7 @@ test('#3736 - Aborted Response (without consuming body)', async (t) => {
   server.listen(0)
 
   await EE.once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   after(server.close.bind(server))
   after(client.destroy.bind(client))

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -13,14 +14,14 @@ test('stream get', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -61,14 +62,14 @@ test('stream promise get', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -103,14 +104,14 @@ test('stream GET destroy res', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.stream({
@@ -169,7 +170,7 @@ test('stream GET remote destroy', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.stream({
@@ -215,7 +216,7 @@ test('stream response resume back pressure and non standard error', async (t) =>
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const pt = new PassThrough()
@@ -262,7 +263,7 @@ test('stream waits only for writable side', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -334,7 +335,7 @@ test('stream destroy if not readable', async (t) => {
   const pt = new PassThrough()
   pt.readable = false
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -365,7 +366,7 @@ test('stream server side destroy', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     client.stream({
@@ -390,7 +391,7 @@ test('stream invalid return', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     client.stream({
@@ -415,7 +416,7 @@ test('stream body without destroy', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -448,7 +449,7 @@ test('stream factory abort', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const signal = new EE()
@@ -478,7 +479,7 @@ test('stream factory throw', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     client.stream({
@@ -519,7 +520,7 @@ test('stream CONNECT throw', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     client.stream({
@@ -543,7 +544,7 @@ test('stream abort after complete', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -577,7 +578,7 @@ test('stream abort before dispatch', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const pt = new PassThrough()
@@ -608,7 +609,7 @@ test('trailers', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -638,7 +639,7 @@ test('stream ignore 1xx', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -675,7 +676,7 @@ test('stream ignore 1xx and use onInfo', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -718,7 +719,7 @@ test('stream backpressure', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
     client.on('disconnect', () => {
       if (!client.closed && !client.destroyed) {
@@ -753,7 +754,7 @@ test('stream body destroyed on invalid callback', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(client.destroy.bind(client))
 
     const body = new Readable({
@@ -782,7 +783,7 @@ test('stream needDrain', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => {
       client.destroy()
     })
@@ -843,7 +844,7 @@ test('stream legacy needDrain', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => {
       client.destroy()
     })

--- a/test/client-timeout.js
+++ b/test/client-timeout.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -74,7 +75,7 @@ test('refresh timeout on pause', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 500
     })
     after(() => client.destroy())
@@ -123,7 +124,7 @@ test('start headers timeout after request body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0,
       headersTimeout: 100
     })
@@ -181,7 +182,7 @@ test('start headers timeout after async iterator request body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0,
       headersTimeout: 100
     })
@@ -232,7 +233,7 @@ test('parser resume with no body timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.destroy())

--- a/test/client-unref.js
+++ b/test/client-unref.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { Worker, isMainThread, workerData } = require('node:worker_threads')
 
 if (isMainThread) {
@@ -20,7 +21,7 @@ if (isMainThread) {
     server.listen(0)
 
     await once(server, 'listening')
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
     const worker = new Worker(__filename, { workerData: { url } })
     worker.on('exit', code => {
       t.strictEqual(code, 0)

--- a/test/client-upgrade.js
+++ b/test/client-upgrade.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -29,7 +30,7 @@ test('basic upgrade', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const signal = new EE()
@@ -87,7 +88,7 @@ test('basic upgrade promise', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const { headers, socket } = await client.upgrade({
@@ -135,7 +136,7 @@ test('upgrade error', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -195,7 +196,7 @@ test('basic upgrade2', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.upgrade({
@@ -249,7 +250,7 @@ test('upgrade wait for empty pipeline', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     after(() => client.close())
@@ -308,7 +309,7 @@ test('upgrade aborted', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     after(() => client.destroy())
@@ -356,7 +357,7 @@ test('basic aborted after res', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.upgrade({
@@ -391,7 +392,7 @@ test('basic upgrade error', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const _err = new Error()
@@ -421,7 +422,7 @@ test('upgrade disconnect', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', (origin, [self], error) => {
@@ -451,7 +452,7 @@ test('upgrade invalid signal', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.on('disconnect', () => {

--- a/test/client-write-max-listeners.js
+++ b/test/client-write-max-listeners.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -45,7 +46,7 @@ test('socket close listener does not leak', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
 
   client.on('disconnect', () => {

--- a/test/client.js
+++ b/test/client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { readFileSync, createReadStream } = require('node:fs')
 const { createServer } = require('node:http')
@@ -25,7 +26,7 @@ test('basic get', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     t.strictEqual(undefined, req.headers.foo)
     t.strictEqual('bar', req.headers.bar)
     t.strictEqual(undefined, req.headers['content-length'])
@@ -40,12 +41,12 @@ test('basic get', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
 
-    t.strictEqual(client[kUrl].origin, `http://localhost:${server.address().port}`)
+    t.strictEqual(client[kUrl].origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
 
     const signal = new EE()
     client.request({
@@ -121,7 +122,7 @@ test('basic get with custom request.reset=true', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     t.strictEqual(req.headers.connection, 'close')
     t.strictEqual(undefined, req.headers.foo)
     t.strictEqual('bar', req.headers.bar)
@@ -137,10 +138,10 @@ test('basic get with custom request.reset=true', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {})
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {})
     after(() => client.close())
 
-    t.strictEqual(client[kUrl].origin, `http://localhost:${server.address().port}`)
+    t.strictEqual(client[kUrl].origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
 
     const signal = new EE()
     client.request({
@@ -219,7 +220,7 @@ test('basic get with query params', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -256,7 +257,7 @@ test('basic get with query params fails if url includes hashmark', async (t) => 
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -290,7 +291,7 @@ test('basic get with empty query params', async (t) => {
   const query = {}
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -325,7 +326,7 @@ test('basic get with query params partially in path', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -354,7 +355,7 @@ test('using throwOnError should throw (request)', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -384,7 +385,7 @@ test('using throwOnError should throw (stream)', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeout: 300e3
     })
     after(() => client.close())
@@ -414,14 +415,14 @@ test('basic head', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/123', req.url)
     t.strictEqual('HEAD', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('content-type', 'text/plain')
     res.end('hello')
   })
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/123', method: 'HEAD' }, (err, { statusCode, headers, body }) => {
@@ -505,7 +506,7 @@ test('get with host header', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'GET', headers: { host: 'example.com' } }, (err, { statusCode, headers, body }) => {
@@ -571,7 +572,7 @@ test('head with host header', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'HEAD', headers: { host: 'example.com' } }, (err, { statusCode, headers, body }) => {
@@ -616,7 +617,7 @@ test('basic POST with string', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'POST', body: expected }, (err, data) => {
@@ -643,7 +644,7 @@ test('basic POST with empty string', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'POST', body: '' }, (err, { statusCode, headers, body }) => {
@@ -671,7 +672,7 @@ test('basic POST with string and content-length', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -706,7 +707,7 @@ test('basic POST with Buffer', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'POST', body: expected }, (err, { statusCode, headers, body }) => {
@@ -734,7 +735,7 @@ test('basic POST with stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -770,7 +771,7 @@ test('basic POST with paused stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const stream = createReadStream(__filename)
@@ -810,7 +811,7 @@ test('basic POST with custom stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const body = new EE()
@@ -876,7 +877,7 @@ test('basic POST with iterator', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -913,7 +914,7 @@ test('basic POST with iterator with invalid data', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -938,7 +939,7 @@ test('basic POST with async iterator', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -990,7 +991,7 @@ test('basic POST with transfer encoding: chunked', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     body = new Readable({
@@ -1028,7 +1029,7 @@ test('basic POST with empty stream', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const body = new Readable({
@@ -1073,7 +1074,7 @@ test('10 times GET', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     for (let i = 0; i < num; i++) {
@@ -1108,7 +1109,7 @@ test('10 times HEAD', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     for (let i = 0; i < num; i++) {
@@ -1142,7 +1143,7 @@ test('Set-Cookie', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
@@ -1172,7 +1173,7 @@ test('ignore request header mutations', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const headers = { test: 'test' }
@@ -1287,7 +1288,7 @@ test('only one streaming req at a time', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 4
     })
     after(() => client.destroy())
@@ -1345,7 +1346,7 @@ test('only one async iterating req at a time', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 4
     })
     after(() => client.destroy())
@@ -1401,7 +1402,7 @@ test('300 requests succeed', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     for (let n = 0; n < 300; ++n) {
@@ -1461,7 +1462,7 @@ test('increase pipelining', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -1509,7 +1510,7 @@ test('destroy in push', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'GET' }, (err, { body }) => {
@@ -1549,7 +1550,7 @@ test('non recoverable socket error fails pending request', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'GET' }, (err, data) => {
@@ -1575,7 +1576,7 @@ test('POST empty with error', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const body = new Readable({
@@ -1606,7 +1607,7 @@ test('busy', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1
     })
     after(() => client.close())
@@ -1636,7 +1637,7 @@ test('connected', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const url = new URL(`http://localhost:${server.address().port}`)
+    const url = new URL(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const client = new Client(url, {
       pipelining: 1
     })
@@ -1675,7 +1676,7 @@ test('emit disconnect after destroy', async t => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const url = new URL(`http://localhost:${server.address().port}`)
+    const url = new URL(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const client = new Client(url)
 
     t.strictEqual(client[kConnected], false)
@@ -1704,7 +1705,7 @@ test('end response before request', async t => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const readable = new Readable({
       read () {
         this.push('asd')
@@ -1749,7 +1750,7 @@ test('parser pause with no body timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1773,7 +1774,7 @@ test('TypedArray and DataView body', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1807,7 +1808,7 @@ test('async iterator empty chunk continues', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1837,7 +1838,7 @@ test('async iterator error from server destroys early', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1877,7 +1878,7 @@ test('regular iterator error from server closes early', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1917,7 +1918,7 @@ test('async iterator early return closes early', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1957,7 +1958,7 @@ test('async iterator yield unsupported TypedArray', {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -1989,7 +1990,7 @@ test('async iterator yield object error', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0
     })
     after(() => client.close())
@@ -2029,7 +2030,7 @@ test('Successfully get a Response when neither a Transfer-Encoding or Content-Le
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({ path: '/', method: 'GET' }, (err, { body, headers }) => {
@@ -2197,14 +2198,14 @@ test('stats', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
-    t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end('hello')
   })
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -18,7 +19,7 @@ test('close waits for queued requests to finish', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({ path: '/', method: 'GET' }, function (err, data) {
@@ -62,7 +63,7 @@ test('destroy invoked all pending callbacks', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.destroy())
@@ -96,7 +97,7 @@ test('destroy invoked all pending callbacks ticked', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.destroy())
@@ -126,7 +127,7 @@ test('close waits until socket is destroyed', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     makeRequest()
@@ -163,7 +164,7 @@ test('close should still reconnect', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     t.ok(makeRequest())
@@ -200,7 +201,7 @@ test('close should call callback once finished', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     t.ok(makeRequest())
@@ -281,7 +282,7 @@ test('close socket and reconnect after maxRequestsPerClient reached', async (t) 
       socketToIdMap.set(sock, nextConnectionId++)
     })
     const client = new Client(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       { maxRequestsPerClient: 2 }
     )
     after(() => client.destroy())
@@ -318,7 +319,7 @@ test('close socket and reconnect after maxRequestsPerClient reached (async)', as
       socketToIdMap.set(sock, nextConnectionId++)
     })
     const client = new Client(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       { maxRequestsPerClient: 2 }
     )
     after(() => client.destroy())
@@ -353,7 +354,7 @@ test('should not close socket when no maxRequestsPerClient is provided', async (
     server.on('connection', () => {
       connections++
     })
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     await makeRequest()

--- a/test/connect-pre-shared-session.js
+++ b/test/connect-pre-shared-session.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after, mock } = require('node:test')
 const { Client } = require('..')
@@ -23,7 +24,7 @@ test('custom session passed to client will be used in tls connect call', async (
   server.listen(0, async () => {
     const session = Buffer.from('test-session')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false,
         session

--- a/test/content-length.js
+++ b/test/content-length.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -15,7 +16,7 @@ test('request invalid content-length', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -108,7 +109,7 @@ function invalidContentLength (bodyType) {
     })
     after(() => server.close())
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       after(() => client.close())
 
       client.once('disconnect', () => {
@@ -170,7 +171,7 @@ function zeroContentLength (bodyType) {
     })
     after(() => server.close())
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       after(() => client.close())
 
       client.request({
@@ -206,7 +207,7 @@ test('request streaming no body data when content-length=0', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -247,7 +248,7 @@ test('response invalid content length with close', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 0
     })
     after(() => client.close())
@@ -281,7 +282,7 @@ test('request streaming with Readable.from(buf)', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -323,7 +324,7 @@ test('request DELETE, content-length=0, with body', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -382,7 +383,7 @@ test('content-length shouldSendContentLength=false', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({

--- a/test/env-http-proxy-agent-nodejs-bundle.js
+++ b/test/env-http-proxy-agent-nodejs-bundle.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test, after, before } = require('node:test')
 const { EnvHttpProxyAgent, setGlobalDispatcher, fetch: undiciFetch } = require('../index-fetch')
@@ -39,7 +40,7 @@ describe('EnvHttpProxyAgent and setGlobalDispatcher', () => {
     proxy.on('connect', (req, clientSocket, head) => {
       // Check that the proxy is actually used to tunnel the request sent below.
       const [hostname, port] = req.url.split(':')
-      strictEqual(hostname, 'localhost')
+      strictEqual(hostname, LOOPBACK_HOST)
       strictEqual(port, server.address().port.toString())
 
       const serverSocket = net.connect(port, hostname, () => {
@@ -70,8 +71,8 @@ describe('EnvHttpProxyAgent and setGlobalDispatcher', () => {
 
     // Use setGlobalDispatcher and EnvHttpProxyAgent from Node.js
     // and make sure that they work together.
-    const proxyAddress = `http://localhost:${proxy.address().port}`
-    const serverAddress = `http://localhost:${server.address().port}`
+    const proxyAddress = `http://${LOOPBACK_HOST}:${proxy.address().port}`
+    const serverAddress = `http://${LOOPBACK_HOST}:${server.address().port}`
     process.env.http_proxy = proxyAddress
     setGlobalDispatcher(new EnvHttpProxyAgent())
 

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, describe, after, beforeEach } = require('node:test')
 const { EnvHttpProxyAgent, ProxyAgent, Agent, fetch, MockAgent } = require('..')
@@ -395,18 +396,18 @@ describe('no_proxy', () => {
 
   test('CIDR is NOT supported', async (t) => {
     t = tspl(t, { plan: 2 })
-    process.env.no_proxy = '127.0.0.1/32'
+    process.env.no_proxy = `${LOOPBACK_HOST}/32`
     const { dispatcher, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(2)
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://127.0.0.1'))
-    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://127.0.0.1/32'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, `http://${LOOPBACK_HOST}`))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, `http://${LOOPBACK_HOST}/32`))
     return dispatcher.close()
   })
 
-  test('127.0.0.1 does NOT match localhost', async (t) => {
+  test(`${LOOPBACK_HOST} does NOT match localhost`, async (t) => {
     t = tspl(t, { plan: 2 })
-    process.env.no_proxy = '127.0.0.1'
+    process.env.no_proxy = LOOPBACK_HOST
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(2)
-    t.ok(await doesNotProxy('http://127.0.0.1'))
+    t.ok(await doesNotProxy(`http://${LOOPBACK_HOST}`))
     t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://localhost'))
     return dispatcher.close()
   })

--- a/test/eventsource/eventsource-custom-dispatcher.js
+++ b/test/eventsource/eventsource-custom-dispatcher.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { Agent, EventSource } = require('../..')
 const { test } = require('node:test')
@@ -27,7 +28,7 @@ test('EventSource allows setting custom dispatcher.', (t, done) => {
       }
     }
 
-    const eventSourceInstance = new EventSource(`http://localhost:${server.address().port}`, {
+    const eventSourceInstance = new EventSource(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       dispatcher: new CustomHeaderAgent()
     })
     t.after(() => {
@@ -60,7 +61,7 @@ test('EventSource allows setting custom dispatcher in EventSourceDict.', (t, don
       }
     }
 
-    const eventSourceInstance = new EventSource(`http://localhost:${server.address().port}`, {
+    const eventSourceInstance = new EventSource(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       node: {
         dispatcher: new CustomHeaderAgent()
       }

--- a/test/eventsource/eventsource-redirecting.js
+++ b/test/eventsource/eventsource-redirecting.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { once } = require('node:events')
 const http = require('node:http')
 const { test, describe } = require('node:test')
@@ -93,16 +94,16 @@ describe('EventSource - redirecting', () => {
     const targetPort = targetServer.address().port
 
     const sourceServer = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
-      res.writeHead(301, undefined, { Location: `http://127.0.0.1:${targetPort}/target` })
+      res.writeHead(301, undefined, { Location: `http://${LOOPBACK_HOST}:${targetPort}/target` })
       res.end()
     })
 
     await once(sourceServer.listen(0), 'listening')
     const sourcePort = sourceServer.address().port
 
-    const eventSourceInstance = new EventSource(`http://127.0.0.1:${sourcePort}/redirect`)
+    const eventSourceInstance = new EventSource(`http://${LOOPBACK_HOST}:${sourcePort}/redirect`)
     eventSourceInstance.onmessage = (event) => {
-      t.assert.strictEqual(event.origin, `http://127.0.0.1:${targetPort}`)
+      t.assert.strictEqual(event.origin, `http://${LOOPBACK_HOST}:${targetPort}`)
       eventSourceInstance.close()
       targetServer.close()
       sourceServer.close()

--- a/test/fetch/401-statuscode-no-infinite-loop.js
+++ b/test/fetch/401-statuscode-no-infinite-loop.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -17,7 +18,7 @@ test('Receiving a 401 status code should not cause infinite retry loop', async (
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const response = await fetch(`http://localhost:${server.address().port}`)
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
   assert.strictEqual(response.status, 401)
 })
 
@@ -30,7 +31,7 @@ test('Receiving a 401 status code should not fail for stream-backed request bodi
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'PUT',
     duplex: 'half',
     body: new ReadableStream({
@@ -54,7 +55,7 @@ test('Receiving a 401 status code should work for POST with JSON body', async (t
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ data: 'test' })

--- a/test/fetch/407-statuscode-window-null.js
+++ b/test/fetch/407-statuscode-window-null.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -18,5 +19,5 @@ test('Receiving a 407 status code w/ a window option present should reject', asy
 
   // if init.window exists, the spec tells us to set request.window to 'no-window',
   // which later causes the request to be rejected if the status code is 407
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, { window: null }))
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { window: null }))
 })

--- a/test/fetch/abort.js
+++ b/test/fetch/abort.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -15,7 +16,7 @@ test('allows aborting with custom errors', async (t) => {
   await t.test('Using AbortSignal.timeout with cause', async (t) => {
     t.plan(2)
     try {
-      await fetch(`http://localhost:${server.address().port}`, {
+      await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         signal: AbortSignal.timeout(50)
       })
       t.assert.fail('should throw')
@@ -38,7 +39,7 @@ test('allows aborting with custom errors', async (t) => {
     ac.abort() // no reason
 
     await t.assert.rejects(
-      fetch(`http://localhost:${server.address().port}`, {
+      fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         signal: ac.signal
       }),
       {

--- a/test/fetch/abort2.js
+++ b/test/fetch/abort2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -25,7 +26,7 @@ test('parallel fetch with the same AbortController works as expected', async (t)
   const abortController = new AbortController()
 
   async function makeRequest () {
-    const result = await fetch(`http://localhost:${server.address().port}`, {
+    const result = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       signal: abortController.signal
     }).then(response => response.json())
 

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { fetch, Response, Request, FormData } = require('../..')
@@ -48,7 +49,7 @@ test('request json', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.deepStrictEqual(obj, await body.json())
     done()
   })
@@ -64,7 +65,7 @@ test('request text', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.strictEqual(JSON.stringify(obj), await body.text())
     done()
   })
@@ -80,7 +81,7 @@ test('request arrayBuffer', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.deepStrictEqual(Buffer.from(JSON.stringify(obj)), Buffer.from(await body.arrayBuffer()))
     done()
   })
@@ -97,7 +98,7 @@ test('should set type of blob object to the value of the `Content-Type` header f
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const response = await fetch(`http://localhost:${server.address().port}`)
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.strictEqual('application/json', (await response.blob()).type)
     done()
   })
@@ -113,7 +114,7 @@ test('pre aborted with readable request body', (t, done) => {
   server.listen(0, async () => {
     const ac = new AbortController()
     ac.abort()
-    await fetch(`http://localhost:${server.address().port}`, {
+    await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       signal: ac.signal,
       method: 'POST',
       body: new ReadableStream({
@@ -148,7 +149,7 @@ test('pre aborted with closed readable request body', (t, done) => {
       }
     })
     queueMicrotask(() => {
-      fetch(`http://localhost:${server.address().port}`, {
+      fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         signal: ac.signal,
         method: 'POST',
         body,
@@ -170,7 +171,7 @@ test('unsupported formData 1', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`)
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(res => res.formData())
       .catch(err => {
         t.assert.strictEqual(err.name, 'TypeError')
@@ -202,7 +203,7 @@ test('multipart formdata not base64', async (t) => {
   const listen = promisify(server.listen.bind(server))
   await listen(0)
 
-  const res = await fetch(`http://localhost:${server.address().port}`)
+  const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
   const form = await res.formData()
   t.assert.strictEqual(form.get('field1'), 'value1')
 
@@ -237,7 +238,7 @@ test('multipart formdata base64', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`)
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(res => res.formData())
       .then(form => form.get('file').arrayBuffer())
       .then(buffer => createHash('sha256').update(Buffer.from(buffer)).digest('base64'))
@@ -286,7 +287,7 @@ test('busboy emit error', async (t) => {
   const listen = promisify(server.listen.bind(server))
   await listen(0)
 
-  const res = await fetch(`http://localhost:${server.address().port}`)
+  const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
   await t.assert.rejects(res.formData(), 'Unexpected end of multipart data')
 })
 
@@ -312,7 +313,7 @@ test('urlencoded formData', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`)
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(res => res.formData())
       .then(formData => {
         t.assert.strictEqual(formData.get('field1'), 'value1')
@@ -332,7 +333,7 @@ test('text with BOM', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`)
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(res => res.text())
       .then(text => {
         t.assert.strictEqual(text, 'test=\uFEFF')
@@ -351,7 +352,7 @@ test('formData with BOM', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`)
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(res => res.formData())
       .then(formData => {
         t.assert.strictEqual(formData.get('\uFEFFtest'), '\uFEFF')
@@ -369,7 +370,7 @@ test('locked blob body', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`)
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const reader = res.body.getReader()
     res.blob().catch(err => {
       t.assert.strictEqual(err.message, 'Body is unusable: Body has already been read')
@@ -387,7 +388,7 @@ test('disturbed blob body', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`)
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     await res.blob().then(() => {
       t.assert.ok(true)
     })
@@ -419,7 +420,7 @@ test('redirect with body', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`, {
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'PUT',
       body: 'asd'
     })
@@ -447,7 +448,7 @@ test('redirect with stream', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`, {
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       redirect: 'manual'
     })
     t.assert.strictEqual(res.status, 302)
@@ -501,7 +502,7 @@ test('post FormData with Blob', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`, {
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'PUT',
       body
     })
@@ -522,7 +523,7 @@ test('post FormData with File', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const res = await fetch(`http://localhost:${server.address().port}`, {
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'PUT',
       body
     })
@@ -562,7 +563,7 @@ test('custom agent', (t, done) => {
       t.assert.ok(true)
       return oldDispatch.call(this, options, handler)
     }
-    const body = await fetch(`http://localhost:${server.address().port}`, {
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       dispatcher
     })
     t.assert.deepStrictEqual(obj, await body.json())
@@ -589,7 +590,7 @@ test('custom agent node fetch', (t, done) => {
       t.assert.ok(true)
       return oldDispatch.call(this, options, handler)
     }
-    const body = await nodeFetch.fetch(`http://localhost:${server.address().port}`, {
+    const body = await nodeFetch.fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       dispatcher
     })
     t.assert.deepStrictEqual(obj, await body.json())
@@ -605,7 +606,7 @@ test('error on redirect', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const errorCause = await fetch(`http://localhost:${server.address().port}`, {
+    const errorCause = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       redirect: 'error'
     }).catch((e) => e.cause)
 
@@ -625,7 +626,7 @@ test('fetching with Request object - issue #1527', async (t) => {
   await once(server, 'listening')
 
   const body = JSON.stringify({ foo: 'bar' })
-  const request = new Request(`http://localhost:${server.address().port}`, {
+  const request = new Request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST',
     body
   })
@@ -655,7 +656,7 @@ test('do not decode redirect body', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}/resource`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/resource`)
     t.assert.strictEqual(JSON.stringify(obj), await body.text())
     done()
   })
@@ -675,7 +676,7 @@ test('decode non-redirect body with location header', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}/resource`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/resource`)
     t.assert.strictEqual(JSON.stringify(obj), await body.text())
     done()
   })
@@ -701,7 +702,7 @@ test('Receiving non-Latin1 headers', async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   const response = await fetch(url, { method: 'HEAD' })
   const cdHeaders = [...response.headers]
     .filter(([k]) => k.startsWith('content-disposition'))

--- a/test/fetch/content-length.js
+++ b/test/fetch/content-length.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -22,7 +23,7 @@ test('Content-Length is set when using a FormData body with fetch', async (t) =>
   fd.set('file', new Blob(['hello world 👋'], { type: 'text/plain' }), 'readme.md')
   fd.set('string', 'some string value')
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST',
     body: fd
   })
@@ -39,7 +40,7 @@ test('Content-Length is not duplicated when provided explicitly', async (t) => {
   await once(server, 'listening')
   t.after(closeServerAsPromise(server))
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST',
     body,
     headers: {

--- a/test/fetch/cookies.js
+++ b/test/fetch/cookies.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test, describe, before, after } = require('node:test')
@@ -32,12 +33,12 @@ describe('cookies', () => {
     const query = qsStringify({
       'set-cookie': 'name=value; Domain=example.com'
     })
-    const response = await fetch(`http://localhost:${server.address().port}?${query}`)
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}?${query}`)
 
     t.assert.strictEqual(response.headers.get('set-cookie'), 'name=value; Domain=example.com')
     t.assert.strictEqual(await response.text(), '')
 
-    const response2 = await fetch(`http://localhost:${server.address().port}?${query}`, {
+    const response2 = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}?${query}`, {
       credentials: 'include'
     })
 
@@ -53,14 +54,14 @@ describe('cookies', () => {
     ]
 
     for (const headers of headersInit) {
-      const response = await fetch(`http://localhost:${server.address().port}`, { headers })
+      const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { headers })
       const text = await response.text()
       t.assert.strictEqual(text, 'value')
     }
   })
 
   test('Cookie header is delimited with a semicolon rather than a comma - issue #1905', async (t) => {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headers: [
         ['cookie', 'FOO=lorem-ipsum-dolor-sit-amet'],
         ['cookie', 'BAR=the-quick-brown-fox']
@@ -85,7 +86,7 @@ describe('cookies', () => {
 
     await once(server.listen(0), 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -93,7 +94,7 @@ describe('cookies', () => {
     })
 
     const response = await fetch(
-      `https://localhost:${server.address().port}/`,
+      `https://${LOOPBACK_HOST}:${server.address().port}/`,
       // Needs to be passed to disable the reject unauthorized
       {
         method: 'GET',

--- a/test/fetch/encoding.js
+++ b/test/fetch/encoding.js
@@ -4,6 +4,7 @@ const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test, before, after, describe } = require('node:test')
 const { fetch, Client } = require('../..')
+const { LOOPBACK_HOST } = require('../utils/node-http')
 
 describe('content-encoding handling', () => {
   const gzipDeflateText = Buffer.from('H4sIAAAAAAAAA6uY89nj7MmT1wM5zuuf8gxkYZCfx5IFACQ8u/wVAAAA', 'base64')
@@ -55,7 +56,7 @@ describe('content-encoding handling', () => {
   })
 
   test('content-encoding header', async (t) => {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepalive: false,
       headers: { 'accept-encoding': 'deflate, gzip' }
     })
@@ -66,7 +67,7 @@ describe('content-encoding handling', () => {
   })
 
   test('content-encoding header is case-iNsENsITIve', async (t) => {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepalive: false,
       headers: { 'accept-encoding': 'DeFlAtE, GzIp' }
     })
@@ -77,7 +78,7 @@ describe('content-encoding handling', () => {
   })
 
   test('should decompress zstandard response', async (t) => {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepalive: false,
       headers: { 'accept-encoding': 'zstd' }
     })
@@ -109,7 +110,7 @@ describe('content-encoding chain limit', () => {
       res.flushHeaders()
       res.end('test')
     })
-    await once(server.listen(0, '127.0.0.1'), 'listening')
+    await once(server.listen(0, LOOPBACK_HOST), 'listening')
   })
 
   after(() => {
@@ -118,10 +119,10 @@ describe('content-encoding chain limit', () => {
   })
 
   test(`should allow exactly ${MAX_CONTENT_ENCODINGS} content-encodings`, async (t) => {
-    const client = new Client(`http://127.0.0.1:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => client.close())
 
-    const response = await fetch(`http://127.0.0.1:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       dispatcher: client,
       keepalive: false,
       headers: { 'x-encoding-count': String(MAX_CONTENT_ENCODINGS) }
@@ -133,11 +134,11 @@ describe('content-encoding chain limit', () => {
   })
 
   test(`should reject more than ${MAX_CONTENT_ENCODINGS} content-encodings`, async (t) => {
-    const client = new Client(`http://127.0.0.1:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => client.close())
 
     await t.assert.rejects(
-      fetch(`http://127.0.0.1:${server.address().port}`, {
+      fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         dispatcher: client,
         keepalive: false,
         headers: { 'x-encoding-count': String(MAX_CONTENT_ENCODINGS + 1) }
@@ -150,11 +151,11 @@ describe('content-encoding chain limit', () => {
   })
 
   test('should reject excessive content-encoding chains', async (t) => {
-    const client = new Client(`http://127.0.0.1:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => client.close())
 
     await t.assert.rejects(
-      fetch(`http://127.0.0.1:${server.address().port}`, {
+      fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         dispatcher: client,
         keepalive: false,
         headers: { 'x-encoding-count': '100' }

--- a/test/fetch/exiting.js
+++ b/test/fetch/exiting.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -23,7 +24,7 @@ test('abort the request on the other side if the stream is canceled', async (t) 
 
   await once(server.listen(0), 'listening')
 
-  const url = new URL(`http://127.0.0.1:${server.address().port}`)
+  const url = new URL(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   const response = await fetch(url)
 

--- a/test/fetch/fetch-leak.js
+++ b/test/fetch/fetch-leak.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -23,7 +24,7 @@ test('do not leak', (t, done) => {
     if (isDone) {
       return
     }
-    url ??= new URL(`http://127.0.0.1:${server.address().port}`)
+    url ??= new URL(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const controller = new AbortController()
     fetch(url, { signal: controller.signal })
       .then(res => res.arrayBuffer())

--- a/test/fetch/fetch-timeouts.js
+++ b/test/fetch/fetch-timeouts.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 
 const { fetch, Agent } = require('../..')
@@ -32,7 +33,7 @@ test('Fetch very long request, timeout overridden so no error', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    fetch(`http://localhost:${server.address().port}`, {
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       path: '/',
       method: 'GET',
       dispatcher: new Agent({

--- a/test/fetch/fetch-url-after-redirect.js
+++ b/test/fetch/fetch-url-after-redirect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { fetch } = require('../..')
@@ -33,9 +34,9 @@ test('after redirecting the url of the response is set to the target url', async
   const listenAsync = promisify(server.listen.bind(server))
   await listenAsync(0)
   const { port } = server.address()
-  const response = await fetch(`http://127.0.0.1:${port}/redirect-1`)
+  const response = await fetch(`http://${LOOPBACK_HOST}:${port}/redirect-1`)
 
-  t.assert.strictEqual(response.url, `http://127.0.0.1:${port}/target`)
+  t.assert.strictEqual(response.url, `http://${LOOPBACK_HOST}:${port}/target`)
 })
 
 test('location header with non-ASCII character redirects to a properly encoded url', async (t) => {
@@ -54,7 +55,7 @@ test('location header with non-ASCII character redirects to a properly encoded u
   const listenAsync = promisify(server.listen.bind(server))
   await listenAsync(0)
   const { port } = server.address()
-  const response = await fetch(`http://127.0.0.1:${port}/redirect`)
+  const response = await fetch(`http://${LOOPBACK_HOST}:${port}/redirect`)
 
-  t.assert.strictEqual(response.url, `http://127.0.0.1:${port}/${encodeURIComponent('안녕')}`)
+  t.assert.strictEqual(response.url, `http://${LOOPBACK_HOST}:${port}/${encodeURIComponent('안녕')}`)
 })

--- a/test/fetch/fire-and-forget.js
+++ b/test/fetch/fire-and-forget.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { randomFillSync } = require('node:crypto')
 const { setTimeout: sleep, setImmediate: nextTick } = require('node:timers/promises')
 const { test } = require('node:test')
@@ -105,7 +106,7 @@ test('does not need the body to be consumed to continue', { timeout: 180_000 }, 
     server.listen(0, resolve)
   })
 
-  const url = new URL(`http://127.0.0.1:${server.address().port}`)
+  const url = new URL(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   const batch = 50
   const delay = 0

--- a/test/fetch/headers-case.js
+++ b/test/fetch/headers-case.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { fetch, Headers, Request } = require('../..')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -18,7 +19,7 @@ test('Headers retain keys case-sensitive', async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   for (const headers of [
     new Headers([['Content-Type', 'text/plain']]),
     { 'Content-Type': 'text/plain' },

--- a/test/fetch/headers.js
+++ b/test/fetch/headers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { Headers, fill, setHeadersGuard } = require('../../lib/web/fetch/headers')
 const { once } = require('node:events')
@@ -700,7 +701,7 @@ test('Headers.prototype.getSetCookie', async (t) => {
     await once(server, 'listening')
     t.after(closeServerAsPromise(server))
 
-    const res = await fetch(`http://localhost:${server.address().port}`)
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const entries = Object.fromEntries(res.headers.entries())
 
     t.assert.deepStrictEqual(res.headers.getSetCookie(), ['test=onetwo'])
@@ -716,7 +717,7 @@ test('Headers.prototype.getSetCookie', async (t) => {
     await once(server, 'listening')
     t.after(closeServerAsPromise(server))
 
-    const res = await fetch(`http://localhost:${server.address().port}`)
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const entries = Object.fromEntries(res.headers.entries())
 
     t.assert.deepStrictEqual(res.headers.getSetCookie(), ['test=onetwo', 'test=onetwothree'])

--- a/test/fetch/http2.js
+++ b/test/fetch/http2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createSecureServer } = require('node:http2')
 const { createServer } = require('node:http')
 const { createReadStream, readFileSync } = require('node:fs')
@@ -38,7 +39,7 @@ test('[Fetch] Issue#2311', async (t) => {
   server.listen()
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -46,7 +47,7 @@ test('[Fetch] Issue#2311', async (t) => {
   })
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'POST',
@@ -87,7 +88,7 @@ test('[Fetch] Simple GET with h2', async (t) => {
   server.listen()
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -95,7 +96,7 @@ test('[Fetch] Simple GET with h2', async (t) => {
   })
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'GET',
@@ -146,7 +147,7 @@ test('[Fetch] Should handle h2 request with body (string or buffer)', async (t) 
   server.listen()
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -154,7 +155,7 @@ test('[Fetch] Should handle h2 request with body (string or buffer)', async (t) 
   })
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'POST',
@@ -207,7 +208,7 @@ test(
     server.listen(0)
     await once(server, 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -217,7 +218,7 @@ test(
     t.after(closeClientAndServerAsPromise(client, server))
 
     const response = await fetch(
-      `https://localhost:${server.address().port}/`,
+      `https://${LOOPBACK_HOST}:${server.address().port}/`,
       // Needs to be passed to disable the reject unauthorized
       {
         method: 'PUT',
@@ -269,7 +270,7 @@ test('Should handle h2 request with body (Blob)', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -279,7 +280,7 @@ test('Should handle h2 request with body (Blob)', async (t) => {
   t.after(closeClientAndServerAsPromise(client, server))
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       body,
@@ -334,7 +335,7 @@ test(
     server.listen(0)
     await once(server, 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -344,7 +345,7 @@ test(
     t.after(closeClientAndServerAsPromise(client, server))
 
     const response = await fetch(
-      `https://localhost:${server.address().port}/`,
+      `https://${LOOPBACK_HOST}:${server.address().port}/`,
       // Needs to be passed to disable the reject unauthorized
       {
         body,
@@ -381,7 +382,7 @@ test('Issue#2415', async (t) => {
   server.listen()
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -389,7 +390,7 @@ test('Issue#2415', async (t) => {
   })
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'GET',
@@ -433,7 +434,7 @@ test('Issue #2386', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -443,7 +444,7 @@ test('Issue #2386', async (t) => {
   t.after(closeClientAndServerAsPromise(client, server))
 
   await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       body,
@@ -483,7 +484,7 @@ test('Issue #3046', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -493,7 +494,7 @@ test('Issue #3046', async (t) => {
   t.after(closeClientAndServerAsPromise(client, server))
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'GET',
@@ -516,7 +517,7 @@ test('[Fetch] Empty POST without h2 has Content-Length', async (t) => {
     res.end(`content-length:${req.headers['content-length']}`)
   }).listen(0)
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   t.after(async () => {
     server.close()
@@ -528,7 +529,7 @@ test('[Fetch] Empty POST without h2 has Content-Length', async (t) => {
   await once(server, 'listening')
 
   const response = await fetch(
-    `http://localhost:${server.address().port}/`, {
+    `http://${LOOPBACK_HOST}:${server.address().port}/`, {
       method: 'POST',
       dispatcher: client
     }
@@ -555,7 +556,7 @@ test('[Fetch] Empty POST with h2 has Content-Length', async (t) => {
   server.listen()
   await once(server, 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -565,7 +566,7 @@ test('[Fetch] Empty POST with h2 has Content-Length', async (t) => {
   t.after(closeClientAndServerAsPromise(client, server))
 
   const response = await fetch(
-    `https://localhost:${server.address().port}/`,
+    `https://${LOOPBACK_HOST}:${server.address().port}/`,
     // Needs to be passed to disable the reject unauthorized
     {
       method: 'POST',

--- a/test/fetch/integrity.js
+++ b/test/fetch/integrity.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { gzipSync } = require('node:zlib')
@@ -32,7 +33,7 @@ test('request with correct integrity checksum', { skip }, async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${hash}`
   })
   t.assert.strictEqual(body, await response.text())
@@ -53,7 +54,7 @@ test('request with wrong integrity checksum', { skip }, async (t) => {
     cause: new Error('integrity mismatch')
   })
 
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${hash}`
   }), expectedError)
 })
@@ -70,7 +71,7 @@ test('request with integrity checksum on encoded body', { skip }, async (t) => {
   t.after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${hash}`
   })
   t.assert.strictEqual(body, await response.text())
@@ -84,7 +85,7 @@ test('request with a totally incorrect integrity', { skip }, async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  await t.assert.doesNotReject(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.doesNotReject(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: 'what-integrityisthis'
   }))
 })
@@ -100,7 +101,7 @@ test('request with mixed in/valid integrities', { skip }, async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  await t.assert.doesNotReject(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.doesNotReject(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `invalid-integrity sha256-${hash}`
   }))
 })
@@ -117,12 +118,12 @@ test('request with sha384 hash', { skip }, async (t) => {
   await once(server, 'listening')
 
   // request should succeed
-  await t.assert.doesNotReject(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.doesNotReject(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${hash}`
   }))
 
   // request should fail
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: 'sha384-ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs='
   }))
 })
@@ -139,12 +140,12 @@ test('request with sha512 hash', { skip }, async (t) => {
   await once(server, 'listening')
 
   // request should succeed
-  await t.assert.doesNotReject(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.doesNotReject(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha512-${hash}`
   }))
 
   // request should fail
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: 'sha512-ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs='
   }))
 })
@@ -161,7 +162,7 @@ test('request with sha512 hash', { skip }, async (t) => {
   await once(server, 'listening')
 
   // request should fail
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha512-${hash384} sha384-${hash384}`
   }))
 })
@@ -178,7 +179,7 @@ test('request with correct integrity checksum (base64url)', { skip }, async (t) 
   after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${hash}`
   })
   t.assert.strictEqual(body, await response.text())
@@ -198,7 +199,7 @@ test('request with incorrect integrity checksum (base64url)', { skip }, async (t
   after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${hash}`
   }))
 })
@@ -215,7 +216,7 @@ test('request with incorrect integrity checksum (only dash)', { skip }, async (t
   after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  await t.assert.rejects(fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: 'sha256--'
   }))
 })
@@ -232,7 +233,7 @@ test('request with incorrect integrity checksum (non-ascii character)', { skip }
   after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  await t.assert.rejects(() => fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(() => fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: 'sha256-ä'
   }))
 })
@@ -251,10 +252,10 @@ test('request with incorrect stronger integrity checksum (non-ascii character)',
   after(closeServerAsPromise(server))
 
   await once(server.listen(0), 'listening')
-  await t.assert.rejects(() => fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(() => fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${sha256} sha384-${sha384}`
   }))
-  await t.assert.rejects(() => fetch(`http://localhost:${server.address().port}`, {
+  await t.assert.rejects(() => fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha256-${sha256}`
   }))
 })
@@ -274,29 +275,29 @@ test('request with correct integrity checksum (base64). mixed', { skip }, async 
 
   await once(server.listen(0), 'listening')
   let response
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${sha256} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha512-${sha512} sha256-${sha256}`
   })
 
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
 
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${sha256} sha384-${sha384}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha256-${sha256}`
   })
   t.assert.strictEqual(body, await response.text())
@@ -317,29 +318,29 @@ test('request with correct integrity checksum (base64url). mixed', { skip }, asy
 
   await once(server.listen(0), 'listening')
   let response
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${sha256} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha512-${sha512} sha256-${sha256}`
   })
 
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha512-${sha512}`
   })
   t.assert.strictEqual(body, await response.text())
 
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha256-${sha256} sha384-${sha384}`
   })
   t.assert.strictEqual(body, await response.text())
-  response = await fetch(`http://localhost:${server.address().port}`, {
+  response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     integrity: `sha384-${sha384} sha256-${sha256}`
   })
   t.assert.strictEqual(body, await response.text())

--- a/test/fetch/issue-1711.js
+++ b/test/fetch/issue-1711.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -25,7 +26,7 @@ test('Redirecting a bunch does not cause a MaxListenersExceededWarning', async (
 
   process.emitWarning = t.assert.fail.bind(t)
 
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   const response = await fetch(url, { redirect: 'follow' })
 
   t.assert.deepStrictEqual(response.url, `${url}/${redirects - 1}`)

--- a/test/fetch/issue-2009.js
+++ b/test/fetch/issue-2009.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -21,7 +22,7 @@ test('issue 2009', async (t) => {
 
   for (let i = 0; i < 10; i++) {
     await t.assert.doesNotReject(
-      fetch(`http://localhost:${server.address().port}`).then(
+      fetch(`http://${LOOPBACK_HOST}:${server.address().port}`).then(
         async (resp) => {
           await resp.body.cancel('Some message')
         }

--- a/test/fetch/issue-2021.js
+++ b/test/fetch/issue-2021.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -23,7 +24,7 @@ test('content-length header is removed on redirect', async (t) => {
 
   const body = 'a+b+c'
 
-  await t.assert.doesNotReject(fetch(`http://localhost:${server.address().port}/redirect`, {
+  await t.assert.doesNotReject(fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`, {
     method: 'POST',
     body,
     headers: {

--- a/test/fetch/issue-2171.js
+++ b/test/fetch/issue-2171.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { fetch } = require('../..')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -14,7 +15,7 @@ test('error reason is forwarded - issue #2171', async (t) => {
 
   const timeout = AbortSignal.timeout(100)
   await t.assert.rejects(
-    fetch(`http://localhost:${server.address().port}`, {
+    fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       signal: timeout
     }),
     {

--- a/test/fetch/issue-2318.js
+++ b/test/fetch/issue-2318.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -10,7 +11,7 @@ test('Undici overrides user-provided `Host` header', async (t) => {
   t.plan(1)
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
-    t.assert.strictEqual(req.headers.host, `localhost:${server.address().port}`)
+    t.assert.strictEqual(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
 
     res.end()
   }).listen(0)
@@ -18,7 +19,7 @@ test('Undici overrides user-provided `Host` header', async (t) => {
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     headers: {
       host: 'www.idk.org'
     }

--- a/test/fetch/issue-2828.js
+++ b/test/fetch/issue-2828.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -23,7 +24,7 @@ test('issue #2828, dispatcher is allowed in RequestInit options', async (t) => {
   t.after(server.close.bind(server))
   await once(server, 'listening')
 
-  const request = new Request(`http://localhost:${server.address().port}`, {
+  const request = new Request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher: new CustomAgent()
   })
 

--- a/test/fetch/issue-2898-comment.js
+++ b/test/fetch/issue-2898-comment.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -33,7 +34,7 @@ test('issue #2828, RequestInit dispatcher options overrides Request input dispat
     })
   })
 
-  const request = new Request(`http://localhost:${server.address().port}`, {
+  const request = new Request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher: new CustomAgentA()
   })
 

--- a/test/fetch/issue-2898.js
+++ b/test/fetch/issue-2898.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -21,7 +22,7 @@ test('421 requests with a body work as expected', async (t) => {
     'hello',
     new Uint8Array(Buffer.from('helloworld', 'utf-8'))
   ]) {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'POST',
       body
     })

--- a/test/fetch/issue-3334.js
+++ b/test/fetch/issue-3334.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -17,7 +18,7 @@ test('a non-empty origin is not appended (issue #3334)', async (t) => {
   t.after(server.close.bind(server))
   await once(server, 'listening')
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     headers: { origin },
     body: '',
     method: 'POST',

--- a/test/fetch/issue-3616.js
+++ b/test/fetch/issue-3616.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { fetch } = require('../..')
@@ -32,7 +33,7 @@ describe('https://github.com/nodejs/undici/issues/3616', () => {
       server.listen(0)
 
       await once(server, 'listening')
-      const result = await fetch(`http://localhost:${server.address().port}/`)
+      const result = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/`)
 
       t.assert.ok(result.body.getReader())
 

--- a/test/fetch/issue-3624.js
+++ b/test/fetch/issue-3624.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -18,7 +19,7 @@ test('crlf is appended to formdata body (issue #3624)', async (t) => {
   fd.set('a', 'b')
   fd.set('c', new File(['d'], 'd.txt.exe'), 'd.txt.exe')
 
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     body: fd,
     method: 'POST'
   })

--- a/test/fetch/issue-3767.js
+++ b/test/fetch/issue-3767.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -20,7 +21,7 @@ test('referrerPolicy unsafe-url is respected', async (t) => {
   t.after(server.close.bind(server))
   await once(server, 'listening')
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     referrer,
     referrerPolicy: 'unsafe-url'
   })

--- a/test/fetch/issue-4105.js
+++ b/test/fetch/issue-4105.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -27,7 +28,7 @@ test('markResourceTiming responseStatus is set', async (t) => {
     })
   }).observe({ type: 'resource', buffered: true })
 
-  const response = await fetch(`http://localhost:${server.address().port}`)
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
   await response.text()
 
   await promise.promise

--- a/test/fetch/issue-4789.js
+++ b/test/fetch/issue-4789.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
 const { once } = require('node:events')
@@ -23,7 +24,7 @@ test('transferred buffers and extractBody works', { skip: !ArrayBuffer.prototype
   await once(server, 'listening')
 
   {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'POST',
       body: new TextEncoder().encode('test')
     })
@@ -32,7 +33,7 @@ test('transferred buffers and extractBody works', { skip: !ArrayBuffer.prototype
   }
 
   {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'POST',
       body: Buffer.from('test')
     })
@@ -44,7 +45,7 @@ test('transferred buffers and extractBody works', { skip: !ArrayBuffer.prototype
     const buffer = new TextEncoder().encode('test')
     buffer.buffer.transfer()
 
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'POST',
       body: buffer
     })

--- a/test/fetch/issue-4799.js
+++ b/test/fetch/issue-4799.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -18,7 +19,7 @@ test('response clone + abort should return AbortError, not TypeError', async (t)
   await once(server, 'listening')
 
   const controller = new AbortController()
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     signal: controller.signal
   })
 
@@ -62,7 +63,7 @@ test('response without clone + abort should still return AbortError', async (t) 
   await once(server, 'listening')
 
   const controller = new AbortController()
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     signal: controller.signal
   })
 
@@ -90,7 +91,7 @@ test('response bodyUsed after clone and abort', async (t) => {
   await once(server, 'listening')
 
   const controller = new AbortController()
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     signal: controller.signal
   })
 

--- a/test/fetch/issue-4836.js
+++ b/test/fetch/issue-4836.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -15,7 +16,7 @@ test('fetch preserves trailing ? in request URL', async (t) => {
   await once(server, 'listening')
   t.after(closeServerAsPromise(server))
 
-  const base = `http://localhost:${server.address().port}`
+  const base = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const cases = [
     ['/echo', '/echo'],

--- a/test/fetch/issue-5241.js
+++ b/test/fetch/issue-5241.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
 const { test } = require('node:test')
@@ -43,9 +44,9 @@ test('MockAgent net connect keeps multipart boundaries in sync with fetch header
 
   const previousDispatcher = getGlobalDispatcher()
   const mockAgent = new MockAgent()
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
-  mockAgent.enableNetConnect(`localhost:${server.address().port}`)
+  mockAgent.enableNetConnect(`${LOOPBACK_HOST}:${server.address().port}`)
   setGlobalDispatcher(mockAgent)
 
   t.after(async () => {

--- a/test/fetch/issue-node-46525.js
+++ b/test/fetch/issue-node-46525.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -23,6 +24,6 @@ test('No warning when reusing AbortController', async (t) => {
 
   const controller = new AbortController()
   for (let i = 0; i < 15; i++) {
-    await fetch(`http://localhost:${server.address().port}`, { signal: controller.signal })
+    await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { signal: controller.signal })
   }
 })

--- a/test/fetch/issue-rsshub-15532.js
+++ b/test/fetch/issue-rsshub-15532.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { test } = require('node:test')
@@ -18,7 +19,7 @@ test('An invalid Origin header is not set', async (t) => {
   await once(server, 'listening')
   t.after(server.close.bind(server))
 
-  await fetch(`http://localhost:${server.address().port}`, {
+  await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST'
   })
 })

--- a/test/fetch/long-lived-abort-controller.js
+++ b/test/fetch/long-lived-abort-controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const http = require('node:http')
 const { fetch } = require('../../')
 const { once, setMaxListeners } = require('node:events')
@@ -33,7 +34,7 @@ test('long-lived-abort-controller', async (t) => {
   // Unfortunately we are relying on GC and implementation details here.
   for (let i = 0; i < 2000; i++) {
     // make request
-    const res = await fetch(`http://localhost:${server.address().port}`, {
+    const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       signal: controller.signal
     })
 

--- a/test/fetch/pull-dont-push.js
+++ b/test/fetch/pull-dont-push.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { createServer } = require('node:http')
@@ -35,7 +36,7 @@ test('pull dont\'t push', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const res = await fetch(`http://localhost:${server.address().port}`)
+  const res = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   // Some time is needed to fill the buffer
   await sleep(1000)

--- a/test/fetch/redirect.js
+++ b/test/fetch/redirect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -24,7 +25,7 @@ test('Redirecting with a body does not cancel the current request - #1776', asyn
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const resp = await fetch(`http://localhost:${server.address().port}/redirect`)
+  const resp = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`)
   t.assert.strictEqual(await resp.text(), '/redirect/')
   t.assert.ok(resp.redirected)
 })
@@ -45,7 +46,7 @@ test('Redirecting with an empty body does not throw an error - #2027', async (t)
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const resp = await fetch(`http://localhost:${server.address().port}/redirect`, { method: 'PUT', body: '' })
+  const resp = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`, { method: 'PUT', body: '' })
   t.assert.strictEqual(await resp.text(), '/redirect/')
   t.assert.ok(resp.redirected)
 })
@@ -68,7 +69,7 @@ test('Redirecting with a body does not fail to write body - #2543', async (t) =>
   t.after(closeServerAsPromise(server))
   await once(server, 'listening')
 
-  const resp = await fetch(`http://localhost:${server.address().port}/redirect`, {
+  const resp = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`, {
     method: 'POST',
     body: 'body'
   })

--- a/test/fetch/referrrer-policy.js
+++ b/test/fetch/referrrer-policy.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { describe, test } = require('node:test')
@@ -87,13 +88,13 @@ describe('referrer-policy', () => {
                 t.assert.strictEqual(req.headers['referer'], undefined)
                 break
               case 'origin':
-                t.assert.strictEqual(req.headers['referer'], `http://127.0.0.1:${port}/`)
+                t.assert.strictEqual(req.headers['referer'], `http://${LOOPBACK_HOST}:${port}/`)
                 break
               case 'strict-origin-when-cross-origin':
-                t.assert.strictEqual(req.headers['referer'], `http://127.0.0.1:${port}/index.html?test=1`)
+                t.assert.strictEqual(req.headers['referer'], `http://${LOOPBACK_HOST}:${port}/index.html?test=1`)
                 break
               case 'unsafe-url':
-                t.assert.strictEqual(req.headers['referer'], `http://127.0.0.1:${port}/index.html?test=1`)
+                t.assert.strictEqual(req.headers['referer'], `http://${LOOPBACK_HOST}:${port}/index.html?test=1`)
                 break
             }
             res.writeHead(200, 'dummy', { 'Content-Type': 'text/plain' })
@@ -106,8 +107,8 @@ describe('referrer-policy', () => {
       await once(server, 'listening')
 
       const { port } = server.address()
-      await fetch(`http://127.0.0.1:${port}/redirect`, {
-        referrer: referrer || `http://127.0.0.1:${port}/index.html?test=1`
+      await fetch(`http://${LOOPBACK_HOST}:${port}/redirect`, {
+        referrer: referrer || `http://${LOOPBACK_HOST}:${port}/index.html?test=1`
       })
 
       server.closeAllConnections()

--- a/test/fetch/relative-url.js
+++ b/test/fetch/relative-url.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, afterEach } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -79,7 +80,7 @@ test('fetch', async (t) => {
       res.end()
     }).listen(0)
 
-    setGlobalOrigin(`http://localhost:${server.address().port}`)
+    setGlobalOrigin(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(closeServerAsPromise(server))
     await once(server, 'listening')
 
@@ -92,12 +93,12 @@ test('fetch', async (t) => {
       res.end()
     }).listen(0)
 
-    setGlobalOrigin(`http://localhost:${server.address().port}`)
+    setGlobalOrigin(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(closeServerAsPromise(server))
     await once(server, 'listening')
 
     const response = await fetch('/relative/path')
 
-    t.assert.strictEqual(response.url, `http://localhost:${server.address().port}/relative/path`)
+    t.assert.strictEqual(response.url, `http://${LOOPBACK_HOST}:${server.address().port}/relative/path`)
   })
 })

--- a/test/fetch/resource-timing.js
+++ b/test/fetch/resource-timing.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { fetch, Agent } = require('../..')
@@ -14,7 +15,7 @@ test('should create a PerformanceResourceTiming after each fetch request', (t, d
   t.plan(8)
 
   const obs = new PerformanceObserver(list => {
-    const expectedResourceEntryName = `http://localhost:${server.address().port}/`
+    const expectedResourceEntryName = `http://${LOOPBACK_HOST}:${server.address().port}/`
 
     const entries = list.getEntries()
     t.assert.strictEqual(entries.length, 1)
@@ -39,7 +40,7 @@ test('should create a PerformanceResourceTiming after each fetch request', (t, d
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end('ok')
   }).listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.strictEqual('ok', await body.text())
   })
 
@@ -64,7 +65,7 @@ test('should include encodedBodySize in performance entry', (t, done) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end('ok')
   }).listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.assert.strictEqual('ok', await body.text())
   })
 
@@ -100,7 +101,7 @@ test('timing entries should be in order', (t, done) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end('ok')
   }).listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}/redirect`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`)
     t.assert.strictEqual('ok', await body.text())
   })
 
@@ -132,7 +133,7 @@ test('redirect timing entries should be included when redirecting', (t, done) =>
     }
     res.end('ok')
   }).listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}/redirect`)
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`)
     t.assert.strictEqual('ok', await body.text())
   })
 
@@ -160,7 +161,7 @@ test('responseStart should be greater than 0 with composed interceptor', (t, don
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end('ok')
   }).listen(0, async () => {
-    const body = await fetch(`http://localhost:${server.address().port}`, { dispatcher })
+    const body = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
     t.assert.strictEqual('ok', await body.text())
   })
 

--- a/test/fetch/user-agent.js
+++ b/test/fetch/user-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const events = require('node:events')
 const http = require('node:http')
@@ -16,7 +17,7 @@ test('user-agent defaults correctly', async (t) => {
 
   server.listen(0)
   await events.once(server, 'listening')
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   const [nodeBuildJSON, undiciJSON] = await Promise.all([
     nodeBuild.fetch(url).then((body) => body.json()),
     undici.fetch(url).then((body) => body.json())
@@ -34,7 +35,7 @@ test('set user-agent for fetch', async (t) => {
 
   server.listen(0)
   await events.once(server, 'listening')
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   const [nodeBuildJSON, undiciJSON] = await Promise.all([
     nodeBuild.fetch(url, { headers: { 'user-agent': 'AcmeCo Crawler - acme.co - node@acme.co' } }).then((body) => body.json()),
     undici.fetch(url, {

--- a/test/fetch/util.js
+++ b/test/fetch/util.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { describe, test } = require('node:test')
 const util = require('../../lib/web/fetch/util')
 const { HeadersList } = require('../../lib/web/fetch/headers')
@@ -120,7 +121,7 @@ test('isURLPotentiallyTrustworthy', (t) => {
   const valid = [
     'http://localhost',
     'http://localhost.',
-    'http://127.0.0.1',
+    `http://${LOOPBACK_HOST}`,
     'http://[::1]',
     'https://something.com',
     'wss://hello.com',
@@ -301,7 +302,7 @@ describe('isOriginIPPotentiallyTrustworthy()', () => {
     ['::', false],
     ['126.0.0.0', false],
     ['127.0.0.0', true],
-    ['127.0.0.1', true],
+    [LOOPBACK_HOST, true],
     ['127.255.255.255', true],
     ['128.255.255.255', false]
   ].forEach(([ip, expected]) => {

--- a/test/fixtures/interceptors/retry-event-loop.js
+++ b/test/fixtures/interceptors/retry-event-loop.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
 const {
@@ -17,7 +18,7 @@ server.on('request', (req, res) => {
 server.listen(0)
 once(server, 'listening').then(() => {
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(
     retry({
       maxTimeout: 1000,

--- a/test/gc.js
+++ b/test/gc.js
@@ -1,4 +1,5 @@
 'use strict'
+const { LOOPBACK_HOST } = require('./utils/node-http')
 /* global WeakRef, FinalizationRegistry */
 
 const { tspl } = require('@matteo.collina/tspl')
@@ -39,7 +40,7 @@ test('gc should collect the client if, and only if, there are no active sockets'
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       keepAliveTimeoutThreshold: 100
     })
     client.once('disconnect', () => {
@@ -86,7 +87,7 @@ test('gc should collect the pool if, and only if, there are no active sockets', 
   })
 
   server.listen(0, () => {
-    const pool = new Pool(`http://localhost:${server.address().port}`, {
+    const pool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       keepAliveTimeoutThreshold: 500
     })

--- a/test/get-head-body.js
+++ b/test/get-head-body.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -18,7 +19,7 @@ test('GET and HEAD with body should reset connection', async (t) => {
 
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.on('disconnect', () => {
@@ -146,7 +147,7 @@ test('HEAD should reset connection', async (t) => {
 
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.once('disconnect', () => {

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { createServer, createSecureServer } = require('node:http2')
 const { once } = require('node:events')
 const { test } = require('node:test')
@@ -58,7 +59,7 @@ test('Should support h2c connection', async t => {
 
   server.listen()
   await once(server, 'listening')
-  authority = `localhost:${server.address().port}`
+  authority = `${LOOPBACK_HOST}:${server.address().port}`
   const client = new H2CClient(`http://${authority}/`)
 
   t.after(() => client.close())
@@ -86,7 +87,7 @@ test('Should support h2c connection with body', async t => {
 
   server.listen()
   await once(server, 'listening')
-  const client = new H2CClient(`http://localhost:${server.address().port}/`)
+  const client = new H2CClient(`http://${LOOPBACK_HOST}:${server.address().port}/`)
 
   t.after(() => client.close())
   t.after(() => server.close())
@@ -127,7 +128,7 @@ test('Should queue h2c requests above the remote max concurrent streams setting'
 
   server.listen()
   await once(server, 'listening')
-  const client = new H2CClient(`http://localhost:${server.address().port}/`, {
+  const client = new H2CClient(`http://${LOOPBACK_HOST}:${server.address().port}/`, {
     maxConcurrentStreams: 10,
     pipelining: 10
   })
@@ -161,7 +162,7 @@ test('Should reject request if not h2c supported', async t => {
 
   server.listen()
   await once(server, 'listening')
-  const client = new H2CClient(`http://localhost:${server.address().port}/`)
+  const client = new H2CClient(`http://${LOOPBACK_HOST}:${server.address().port}/`)
 
   t.after(() => client.destroy())
   t.after(() => server.close())
@@ -275,7 +276,7 @@ test('Pool with useH2c and connections > 1 should not raise HTTPParserError', as
 
   server.listen(0)
   await once(server, 'listening')
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
   const pool = new Pool(url, { useH2c: true, connections: 2 })
 
   t.after(() => pool.close())

--- a/test/headers-as-array.js
+++ b/test/headers-as-array.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -17,7 +18,7 @@ test('handle headers as array', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -49,7 +50,7 @@ test('handle multi-valued headers as array', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -81,7 +82,7 @@ test('handle headers with array', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -113,7 +114,7 @@ test('handle multi-valued headers', async (t) => {
   })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -139,7 +140,7 @@ test('fail if headers array is odd', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -168,7 +169,7 @@ test('fail if headers is not an object or an array', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -197,7 +198,7 @@ test('fail if duplicate content-length headers (different case)', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -221,7 +222,7 @@ test('fail if duplicate content-length headers (same case)', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -245,7 +246,7 @@ test('fail if duplicate host headers (different case)', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -268,7 +269,7 @@ test('fail if duplicate host headers (same case)', async (t) => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => { res.end() })
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({

--- a/test/headers-crlf.js
+++ b/test/headers-crlf.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -18,7 +19,7 @@ test('CRLF Injection in Nodejs ‘undici’ via host', async (t) => {
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.on('disconnect', () => {

--- a/test/http-100.js
+++ b/test/http-100.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -18,7 +19,7 @@ test('ignore informational response', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.on('disconnect', () => {
@@ -57,7 +58,7 @@ test('error 103 body', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   after(() => server.close())
   after(() => client.close())
@@ -85,7 +86,7 @@ test('error 100 body', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.request({
@@ -111,7 +112,7 @@ test('error 101 upgrade', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.request({
@@ -137,7 +138,7 @@ test('1xx response without timeouts', async t => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     bodyTimeout: 0,
     headersTimeout: 0
   })

--- a/test/http2-abort.js
+++ b/test/http2-abort.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -28,7 +29,7 @@ test('#2364 - Concurrent aborts', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -146,7 +147,7 @@ test('#2364 - Concurrent aborts (2nd variant)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-agent.js
+++ b/test/http2-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -38,7 +39,7 @@ test('Agent should support H2 connection', async t => {
   after(() => client.close())
 
   const response = await client.request({
-    origin: `https://localhost:${server.address().port}`,
+    origin: `https://${LOOPBACK_HOST}:${server.address().port}`,
     path: '/',
     method: 'GET',
     headers: {

--- a/test/http2-body-delete.js
+++ b/test/http2-body-delete.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
 const { once } = require('node:events')
@@ -37,7 +38,7 @@ test('Should handle h2 DELETE request with body', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -82,7 +83,7 @@ test('Should not send Content-Length for h2 DELETE without body', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
@@ -41,7 +42,7 @@ test('Should handle h2 request without body', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -87,7 +88,7 @@ test('Should send content-length: 0 for empty h2 requests with payload-expecting
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -128,7 +129,7 @@ test('Should end h2 zero-length request bodies with headers', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: { rejectUnauthorized: false }
   })
   after(() => client.close())
@@ -192,7 +193,7 @@ test('Should handle h2 request with body (string or buffer) - dispatch', async t
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -260,7 +261,7 @@ test('Should handle h2 request raw response headers', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -322,7 +323,7 @@ test('Should handle h2 request with body (stream)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -388,7 +389,7 @@ test('Should handle h2 GET and HEAD requests with body', async () => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -464,7 +465,7 @@ test('Should handle h2 request with body (iterable)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -526,7 +527,7 @@ test('Should handle h2 request with body (Blob)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -590,7 +591,7 @@ test('Should handle h2 request with body (Blob:ArrayBuffer)',
     after(() => server.close())
     await once(server.listen(0), 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -649,7 +650,7 @@ test('#3803 - sending FormData bodies works', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-connection.js
+++ b/test/http2-connection.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -35,7 +36,7 @@ test('Should support H2 connection', async t => {
 
   await once(server.listen(0), 'listening')
 
-  authority = `localhost:${server.address().port}`
+  authority = `${LOOPBACK_HOST}:${server.address().port}`
   const client = new Client(`https://${authority}`, {
     connect: {
       rejectUnauthorized: false
@@ -90,7 +91,7 @@ test('Should support H2 connection(multiple requests)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -148,7 +149,7 @@ test('Should support H2 connection (headers as array)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -207,7 +208,7 @@ test('Should support multiple header values with semicolon separator', async t =
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -290,7 +291,7 @@ test('Should support H2 connection(POST Buffer)', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-continue.js
+++ b/test/http2-continue.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -34,7 +35,7 @@ test('Should handle h2 continue', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -12,6 +12,7 @@ const pem = require('@metcoder95/https-pem')
 
 const { Client, errors } = require('..')
 const { kQueue, kRunningIdx } = require('../lib/core/symbols')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 test('Dispatcher#Stream', async t => {
   t = tspl(t, { plan: 4 })
@@ -37,7 +38,7 @@ test('Dispatcher#Stream', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -91,7 +92,7 @@ test('Dispatcher#Pipeline', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -151,7 +152,7 @@ test('Dispatcher#Connect', async t => {
       t.fail(err)
     })
 
-    const forward = new Client(`https://localhost:${server.address().port}`, {
+    const forward = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -232,7 +233,7 @@ test('Dispatcher#Upgrade - Should throw on non-websocket upgrade', async t => {
   t = tspl(t, { plan: 1 })
 
   server.listen(0, async () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -273,7 +274,7 @@ test('Dispatcher#Upgrade', async t => {
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -328,7 +329,7 @@ test('Dispatcher#Upgrade resumes queued requests after successful WebSocket upgr
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -373,7 +374,7 @@ test('Dispatcher#Upgrade rejects if stream closes before response headers', asyn
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -406,7 +407,7 @@ test('Dispatcher#Connect rejects if stream closes before response headers', asyn
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -451,7 +452,7 @@ test('Dispatcher#Upgrade rejects websocket upgrade on non-200 HTTP/2 response', 
 
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -488,7 +489,7 @@ test('Dispatcher#destroy', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -581,7 +582,7 @@ test('Should handle h2 request without body', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -627,7 +628,7 @@ test('Should clear h2 request stream references before completing a response', a
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -736,7 +737,7 @@ test('Should send http2 PING frames', async t => {
 
   t = tspl(t, { plan: 2 })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
   await once(server, 'listening')
 
   const client = new Client(`https://${server.address().address}:${server.address().port}`, {
@@ -807,7 +808,7 @@ test('Should not send http2 PING frames if interval === 0', async t => {
 
   t = tspl(t, { plan: 2 })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
   await once(server, 'listening')
 
   const client = new Client(`https://${server.address().address}:${server.address().port}`, {
@@ -878,7 +879,7 @@ test('Should not send http2 PING frames after connection is closed', async t => 
 
   t = tspl(t, { plan: 2 })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
   await once(server, 'listening')
 
   const client = new Client(`https://${server.address().address}:${server.address().port}`, {

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -36,7 +37,7 @@ test('#3046 - GOAWAY Frame', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -106,7 +107,7 @@ test('#3753 - Handle GOAWAY Gracefully', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -191,7 +192,7 @@ test('#5089 - Handle GOAWAY Gracefully', async (t) => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-instantiation.js
+++ b/test/http2-instantiation.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -69,7 +70,7 @@ test(
     after(() => server.close())
     await once(server.listen(0), 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       allowH2: false,
       connect: {
         rejectUnauthorized: false

--- a/test/http2-invalid-connection-headers.js
+++ b/test/http2-invalid-connection-headers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
 const { tspl } = require('@matteo.collina/tspl')
@@ -58,7 +59,7 @@ test('should surface invalid HTTP/2 connection headers as a catchable error and 
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-pseudo-headers.js
+++ b/test/http2-pseudo-headers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -17,13 +18,13 @@ test('Should provide pseudo-headers in proper order', async t => {
     const sortedHeaders = [...rawHeaders].sort()
     t.deepStrictEqual(sortedHeaders, [
       '/',
+      `${LOOPBACK_HOST}:${server.address().port}`,
       ':authority',
       ':method',
       ':path',
       ':scheme',
       'GET',
-      'https',
-      `localhost:${server.address().port}`
+      'https'
     ])
 
     stream.respond({
@@ -36,7 +37,7 @@ test('Should provide pseudo-headers in proper order', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -71,7 +72,7 @@ test('The h2 pseudo-headers is not included in the headers', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-stream.js
+++ b/test/http2-stream.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -21,7 +22,7 @@ test('Should throw informational error on half-closed streams (remote)', async t
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -32,7 +33,7 @@ test('Should handle http2 stream timeout', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
@@ -82,7 +83,7 @@ test('http2 stream timeout keeps open-stream counter non-negative', async t => {
   after(() => server.close())
   await once(server.listen(0), 'listening')
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: { rejectUnauthorized: false },
     allowH2: true,
     bodyTimeout: 50,

--- a/test/http2-trailers.js
+++ b/test/http2-trailers.js
@@ -8,6 +8,7 @@ const { once } = require('node:events')
 const pem = require('@metcoder95/https-pem')
 
 const { Client } = require('..')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 test('Should handle http2 trailers', async t => {
   t = tspl(t, { plan: 1 })
@@ -34,7 +35,7 @@ test('Should handle http2 trailers', async t => {
   })
 
   after(() => server.close())
-  await once(server.listen(0, '127.0.0.1'), 'listening')
+  await once(server.listen(0, LOOPBACK_HOST), 'listening')
 
   const client = new Client(`https://${server.address().address}:${server.address().port}`, {
     connect: {

--- a/test/https.js
+++ b/test/https.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -18,7 +19,7 @@ test('https get with tls opts', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       tls: {
         rejectUnauthorized: false
       }
@@ -60,7 +61,7 @@ test('https get with tls opts ip', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`https://127.0.0.1:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       tls: {
         rejectUnauthorized: false
       }

--- a/test/inflight-and-close.js
+++ b/test/inflight-and-close.js
@@ -5,6 +5,7 @@ const { test, after } = require('node:test')
 const { request } = require('..')
 const http = require('node:http')
 const { once } = require('node:events')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 test('inflight and close', async (t) => {
   t = tspl(t, { plan: 3 })
@@ -17,10 +18,10 @@ test('inflight and close', async (t) => {
 
   after(() => server.close())
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
   await once(server, 'listening')
 
-  const url = `http://127.0.0.1:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const first = await request(url)
   t.ok(true, 'first response')

--- a/test/interceptors/cache-async-store.js
+++ b/test/interceptors/cache-async-store.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after, describe } = require('node:test')
 const { strictEqual, notStrictEqual } = require('node:assert')
 const { createServer } = require('node:http')
@@ -74,7 +75,7 @@ describe('cache interceptor with async store', () => {
     await once(server, 'listening')
 
     const store = new AsyncCacheStore()
-    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    const dispatcher = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({ store }))
 
     after(async () => {
@@ -82,7 +83,7 @@ describe('cache interceptor with async store', () => {
       await dispatcher.close()
     })
 
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     // First request, populates cache
     {
@@ -135,7 +136,7 @@ describe('cache interceptor with async store', () => {
     await once(server, 'listening')
 
     const store = new AsyncCacheStore()
-    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    const dispatcher = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({ store }))
 
     after(async () => {
@@ -143,7 +144,7 @@ describe('cache interceptor with async store', () => {
       await dispatcher.close()
     })
 
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     // First request
     {
@@ -197,7 +198,7 @@ describe('cache interceptor with async store', () => {
     await once(server, 'listening')
 
     const store = new AsyncCacheStore()
-    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    const dispatcher = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({ store }))
 
     after(async () => {
@@ -205,7 +206,7 @@ describe('cache interceptor with async store', () => {
       await dispatcher.close()
     })
 
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     // First request without X-Custom-Header or X-Another-Header
     // These will be stored as null in the vary record

--- a/test/interceptors/cache-query-params.js
+++ b/test/interceptors/cache-query-params.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { equal, notEqual } = require('node:assert')
 const { createServer } = require('node:http')
@@ -26,7 +27,7 @@ test('query parameters create separate cache entries', async () => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     .compose(interceptors.cache())
 
   after(async () => {
@@ -34,7 +35,7 @@ test('query parameters create separate cache entries', async () => {
     await client.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // First request with param=value1
   const response1 = await request(origin, {
@@ -81,7 +82,7 @@ test('complex query parameters are handled correctly', async () => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     .compose(interceptors.cache())
 
   after(async () => {
@@ -89,7 +90,7 @@ test('complex query parameters are handled correctly', async () => {
     await client.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // Complex query with arrays and multiple parameters
   const complexQuery = {
@@ -149,7 +150,7 @@ test('query parameters vs path equivalence', async () => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     .compose(interceptors.cache())
 
   after(async () => {
@@ -157,7 +158,7 @@ test('query parameters vs path equivalence', async () => {
     await client.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // Request using query object
   const response1 = await request(origin, {
@@ -194,7 +195,7 @@ test('empty and undefined query parameters', async () => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     .compose(interceptors.cache())
 
   after(async () => {
@@ -202,7 +203,7 @@ test('empty and undefined query parameters', async () => {
     await client.close()
   })
 
-  const origin = `http://localhost:${server.address().port}`
+  const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // Request with no query
   const response1 = await request(origin, { dispatcher: client })

--- a/test/interceptors/cache-revalidate-stale.js
+++ b/test/interceptors/cache-revalidate-stale.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after, describe } = require('node:test')
 const { strictEqual } = require('node:assert')
 const { createServer } = require('node:http')
@@ -25,7 +26,7 @@ test('revalidates the request when the response is stale', async () => {
   server.listen(0)
   await once(server, 'listening')
 
-  const dispatcher = new Client(`http://localhost:${server.address().port}`)
+  const dispatcher = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     .compose(interceptors.cache())
 
   after(async () => {
@@ -33,7 +34,7 @@ test('revalidates the request when the response is stale', async () => {
     await dispatcher.close()
   })
 
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   {
     const res = await request(url, { dispatcher })
@@ -104,7 +105,7 @@ describe('revalidates the request, handles 304s during stale-while-revalidate', 
     server.listen(0)
     await once(server, 'listening')
 
-    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    const dispatcher = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -112,7 +113,7 @@ describe('revalidates the request, handles 304s during stale-while-revalidate', 
       await dispatcher.close()
     })
 
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     // initial request, cache the response
     {

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
@@ -19,7 +20,7 @@ describe('Cache Interceptor', () => {
       res.end('asd')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -68,7 +69,7 @@ describe('Cache Interceptor', () => {
       }
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -148,7 +149,7 @@ describe('Cache Interceptor', () => {
 
     await once(server, 'listening')
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({
         cacheByDefault: 1000
       }))
@@ -186,7 +187,7 @@ describe('Cache Interceptor', () => {
       res.end('asd')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -264,7 +265,7 @@ describe('Cache Interceptor', () => {
       res.end('asd')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -339,7 +340,7 @@ describe('Cache Interceptor', () => {
       res.end('asd')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -423,7 +424,7 @@ describe('Cache Interceptor', () => {
       }
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -497,7 +498,7 @@ describe('Cache Interceptor', () => {
       originalDelete(key)
     }
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({
         store,
         methods: ['GET'] // explicitly only cache GET methods
@@ -539,7 +540,7 @@ describe('Cache Interceptor', () => {
 
     after(() => server.close())
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({
         store: {
           get () {
@@ -588,7 +589,7 @@ describe('Cache Interceptor', () => {
       res.end()
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -638,7 +639,7 @@ describe('Cache Interceptor', () => {
 
     after(() => server.close())
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache({
         cacheByDefault: 3600
       }))
@@ -688,7 +689,7 @@ describe('Cache Interceptor', () => {
       }
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -763,7 +764,7 @@ describe('Cache Interceptor', () => {
         res.end()
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -832,7 +833,7 @@ describe('Cache Interceptor', () => {
         }
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -897,7 +898,7 @@ describe('Cache Interceptor', () => {
         res.end()
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -961,7 +962,7 @@ describe('Cache Interceptor', () => {
         }
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -1018,7 +1019,7 @@ describe('Cache Interceptor', () => {
         fail('shouln\'t have reached this')
       }
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({ store }))
 
       after(async () => {
@@ -1046,7 +1047,7 @@ describe('Cache Interceptor', () => {
         requestsToOrigin++
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -1122,7 +1123,7 @@ describe('Cache Interceptor', () => {
         }
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -1235,7 +1236,7 @@ describe('Cache Interceptor', () => {
         res.end(body)
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(async () => {
@@ -1291,7 +1292,7 @@ describe('Cache Interceptor', () => {
         res.end(body)
       }).listen(0)
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({ cacheByDefault: 60 }))
 
       after(async () => {
@@ -1338,7 +1339,7 @@ describe('Cache Interceptor', () => {
       res.end(body)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -1388,7 +1389,7 @@ describe('Cache Interceptor', () => {
       res.end(body)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -1438,7 +1439,7 @@ describe('Cache Interceptor', () => {
       res.end(body)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -1498,7 +1499,7 @@ describe('Cache Interceptor', () => {
       }
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -1567,7 +1568,7 @@ describe('Cache Interceptor', () => {
       }
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.cache())
 
     after(async () => {
@@ -1624,7 +1625,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: ['localhost']
         }))
@@ -1663,7 +1664,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: ['http://example.com']
         }))
@@ -1702,7 +1703,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: [/localhost/]
         }))
@@ -1741,7 +1742,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: [/example\.com/]
         }))
@@ -1780,7 +1781,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: ['http://other.com', /localhost/]
         }))
@@ -1819,7 +1820,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())
@@ -1856,7 +1857,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: []
         }))
@@ -1919,7 +1920,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: ['LOCALHOST']
         }))
@@ -1958,7 +1959,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache({
           origins: ['example.com']
         }))
@@ -2007,7 +2008,7 @@ describe('Cache Interceptor', () => {
 
       await once(server, 'listening')
 
-      const origin = `http://localhost:${server.address().port}`
+      const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
       const client = new Client(origin)
         .compose(interceptors.cache({ store }))
 
@@ -2064,7 +2065,7 @@ describe('Cache Interceptor', () => {
 
       await once(server, 'listening')
 
-      const origin = `http://localhost:${server.address().port}`
+      const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
       const client = new Client(origin)
         .compose(interceptors.cache({ store, type: 'private' }))
 
@@ -2119,7 +2120,7 @@ describe('Cache Interceptor', () => {
 
       await once(server, 'listening')
 
-      const origin = `http://localhost:${server.address().port}`
+      const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
       const client = new Client(origin)
         .compose(interceptors.cache({ store }))
 
@@ -2155,7 +2156,7 @@ describe('Cache Interceptor', () => {
 
       await once(server, 'listening')
 
-      const origin = `http://localhost:${server.address().port}`
+      const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
       const client = new Client(origin)
         .compose(interceptors.cache({ store }))
 
@@ -2184,7 +2185,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())
@@ -2222,7 +2223,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())
@@ -2260,7 +2261,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())
@@ -2298,7 +2299,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())
@@ -2335,7 +2336,7 @@ describe('Cache Interceptor', () => {
       after(() => server.close())
       await once(server, 'listening')
 
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         .compose(interceptors.cache())
 
       after(() => client.close())

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -28,7 +29,7 @@ test('should decompress gzip response', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -70,7 +71,7 @@ test('should decompress deflate response', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -112,7 +113,7 @@ test('should decompress brotli response', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -154,7 +155,7 @@ test('should decompress zstd response', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -191,7 +192,7 @@ test('should pass through uncompressed response', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -229,7 +230,7 @@ test('should pass through unsupported encoding', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -271,7 +272,7 @@ test('should pass through error responses (4xx, 5xx)', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -308,7 +309,7 @@ test('should pass through 204 No Content responses', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -342,7 +343,7 @@ test('should pass through 304 Not Modified responses', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -381,7 +382,7 @@ test('should handle large compressed responses', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -423,7 +424,7 @@ test('should handle case-insensitive content-encoding', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -465,7 +466,7 @@ test('should remove content-length header when decompressing', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -507,7 +508,7 @@ test('should allow decompressing 5xx responses when skipErrorResponses is false'
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor({ skipErrorResponses: false }))
 
   after(async () => {
@@ -550,7 +551,7 @@ test('should allow custom skipStatusCodes', async t => {
 
   // Skip decompression for 201 status codes
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor({ skipStatusCodes: [201, 204, 304] }))
 
   after(async () => {
@@ -598,7 +599,7 @@ test('should decompress multiple encodings in correct order', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -640,7 +641,7 @@ test('should handle legacy encoding names (x-gzip)', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -678,7 +679,7 @@ test('should pass through responses with unsupported encoding in chain', async t
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -720,7 +721,7 @@ test('should handle empty encoding values', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -762,7 +763,7 @@ test('should handle multiple pause/resume cycles during decompression', async t 
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -834,7 +835,7 @@ test('should handle controller pause with chained decompression', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -904,7 +905,7 @@ test('should behave like fetch() for compressed responses', async t => {
   server.listen(0)
   await once(server, 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const { fetch } = require('../..')
   const fetchResponse = await fetch(baseUrl)
@@ -964,7 +965,7 @@ test(`should allow exactly ${MAX_CONTENT_ENCODINGS} content-encodings`, async t 
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -1002,7 +1003,7 @@ test(`should reject more than ${MAX_CONTENT_ENCODINGS} content-encodings`, async
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -1041,7 +1042,7 @@ test('should reject excessive content-encoding chains', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(createDecompressInterceptor())
 
   after(async () => {
@@ -1090,7 +1091,7 @@ test('should work with global dispatcher for both fetch() and request()', async 
   server.listen(0)
   await once(server, 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const originalDispatcher = getGlobalDispatcher()
 

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
@@ -19,7 +20,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response-body')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -65,7 +66,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers['accept-encoding']}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -109,7 +110,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers['accept-encoding']}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -163,7 +164,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.url}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -200,7 +201,7 @@ describe('Deduplicate Interceptor', () => {
       res.destroy()
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -241,7 +242,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('cached-response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
       .compose(interceptors.cache())
 
@@ -280,7 +281,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('non-cached-response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
       .compose(interceptors.cache())
 
@@ -327,7 +328,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -373,7 +374,7 @@ describe('Deduplicate Interceptor', () => {
       res.end()
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -417,7 +418,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -469,7 +470,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -514,7 +515,7 @@ describe('Deduplicate Interceptor', () => {
       res.destroy() // Simulate error
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -562,7 +563,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.url}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -606,7 +607,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers.authorization}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -652,7 +653,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers.cookie}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -698,7 +699,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers.authorization}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -744,7 +745,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response ${requestsToOrigin}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ skipHeaderNames: ['x-no-dedupe'] }))
 
     after(async () => {
@@ -790,7 +791,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response ${requestsToOrigin}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ skipHeaderNames: ['X-No-Dedupe'] }))
 
     after(async () => {
@@ -836,7 +837,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ skipHeaderNames: ['x-no-dedupe'] }))
 
     after(async () => {
@@ -880,7 +881,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response ${requestsToOrigin}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ skipHeaderNames: ['x-skip-1', 'x-skip-2'] }))
 
     after(async () => {
@@ -946,7 +947,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ excludeHeaderNames: ['x-request-id'] }))
 
     after(async () => {
@@ -992,7 +993,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ excludeHeaderNames: ['X-Request-ID'] }))
 
     after(async () => {
@@ -1038,7 +1039,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response for ${req.headers['accept-encoding']}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ excludeHeaderNames: ['x-request-id'] }))
 
     after(async () => {
@@ -1084,7 +1085,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('response')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ excludeHeaderNames: ['x-request-id', 'x-correlation-id'] }))
 
     after(async () => {
@@ -1130,7 +1131,7 @@ describe('Deduplicate Interceptor', () => {
       res.end(`response ${requestsToOrigin}`)
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -1177,7 +1178,7 @@ describe('Deduplicate Interceptor', () => {
       res.end('chunk-2')
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate())
 
     after(async () => {
@@ -1227,7 +1228,7 @@ describe('Deduplicate Interceptor', () => {
       res.end()
     }).listen(0)
 
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .compose(interceptors.deduplicate({ maxBufferSize: 16 * 1024 }))
 
     after(async () => {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -13,6 +13,7 @@ const pem = require('@metcoder95/https-pem')
 
 const { interceptors, Agent, request } = require('../..')
 const { dns } = interceptors
+const { LOOPBACK_HOST } = require('../utils/node-http')
 
 // Helper to check if IPv6 is available for localhost
 // This is called synchronously at test definition time
@@ -96,7 +97,7 @@ test('Should automatically resolve IPs (dual stack)', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -113,7 +114,7 @@ test('Should automatically resolve IPs (dual stack)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -121,7 +122,7 @@ test('Should automatically resolve IPs (dual stack)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -142,7 +143,7 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
   }
 
   server.on('request', (req, res) => {
-    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    t.equal(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
     res.writeHead(200, { 'content-type': 'text/plain' })
     res.end('hello world!')
   })
@@ -183,7 +184,7 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -200,7 +201,7 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `https://localhost:${server.address().port}`
+    origin: `https://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -208,7 +209,7 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `https://localhost:${server.address().port}`
+    origin: `https://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -272,7 +273,7 @@ test('Should recover on network errors (dual stack - 4)', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -289,7 +290,7 @@ test('Should recover on network errors (dual stack - 4)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -297,7 +298,7 @@ test('Should recover on network errors (dual stack - 4)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -322,7 +323,7 @@ test('Should recover on network errors (dual stack - 6)', async t => {
     res.end('hello world!')
   })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
 
   await once(server, 'listening')
 
@@ -361,7 +362,7 @@ test('Should recover on network errors (dual stack - 6)', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -378,7 +379,7 @@ test('Should recover on network errors (dual stack - 6)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -386,7 +387,7 @@ test('Should recover on network errors (dual stack - 6)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -536,7 +537,7 @@ test('Should automatically resolve IPs (dual stack disabled - 4)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -544,7 +545,7 @@ test('Should automatically resolve IPs (dual stack disabled - 4)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -608,7 +609,7 @@ test('Should automatically resolve IPs (dual stack disabled - 6)', { skip: !ipv6
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -616,7 +617,7 @@ test('Should automatically resolve IPs (dual stack disabled - 6)', { skip: !ipv6
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -643,7 +644,7 @@ test('Should we handle TTL (4)', async t => {
     res.end('hello world!')
   })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
 
   await once(server, 'listening')
 
@@ -697,7 +698,7 @@ test('Should we handle TTL (4)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -707,7 +708,7 @@ test('Should we handle TTL (4)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -717,7 +718,7 @@ test('Should we handle TTL (4)', async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -803,7 +804,7 @@ test('Should we handle TTL (6)', { skip: !ipv6Available }, async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -813,7 +814,7 @@ test('Should we handle TTL (6)', { skip: !ipv6Available }, async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -823,7 +824,7 @@ test('Should we handle TTL (6)', { skip: !ipv6Available }, async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -850,7 +851,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
     res.end('hello world!')
   })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
 
   await once(server, 'listening')
 
@@ -863,7 +864,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
         ++lookupCounter
         cb(null, [
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4,
             ttl: lookupCounter === 1 ? 50 : 500
           }
@@ -882,7 +883,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -893,7 +894,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
   // 100ms: lookup since ttl = Math.min(50, maxTTL: 200)
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -904,7 +905,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
   // 100ms: cached since ttl = Math.min(500, maxTTL: 200)
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -915,7 +916,7 @@ test('Should set lowest TTL between resolved and option maxTTL', async t => {
   // 250ms: lookup since ttl = Math.min(500, maxTTL: 200)
   const response4 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response4.statusCode, 200)
@@ -976,7 +977,7 @@ test('Should use all dns entries (dual stack)', async t => {
             t.fail('should not reach this point')
         }
 
-        url.hostname = '127.0.0.1'
+        url.hostname = LOOPBACK_HOST
         opts.origin = url.toString()
         return dispatch(opts, handler)
       }
@@ -1004,7 +1005,7 @@ test('Should use all dns entries (dual stack)', async t => {
   for (let i = 0; i < 5; i++) {
     const response = await client.request({
       ...requestOptions,
-      origin: `http://localhost:${server.address().port}`
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`
     })
 
     t.equal(response.statusCode, 200)
@@ -1059,7 +1060,7 @@ test('Should use all dns entries (dual stack disabled - 4)', async t => {
             t.fail('should not reach this point')
         }
 
-        url.hostname = '127.0.0.1'
+        url.hostname = LOOPBACK_HOST
         opts.origin = url.toString()
         return dispatch(opts, handler)
       }
@@ -1085,7 +1086,7 @@ test('Should use all dns entries (dual stack disabled - 4)', async t => {
 
   const response1 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response1.statusCode, 200)
@@ -1093,7 +1094,7 @@ test('Should use all dns entries (dual stack disabled - 4)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -1101,7 +1102,7 @@ test('Should use all dns entries (dual stack disabled - 4)', async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -1155,7 +1156,7 @@ test('Should use all dns entries (dual stack disabled - 6)', async t => {
             t.fail('should not reach this point')
         }
 
-        url.hostname = '127.0.0.1'
+        url.hostname = LOOPBACK_HOST
         opts.origin = url.toString()
         return dispatch(opts, handler)
       }
@@ -1182,7 +1183,7 @@ test('Should use all dns entries (dual stack disabled - 6)', async t => {
 
   const response1 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response1.statusCode, 200)
@@ -1190,7 +1191,7 @@ test('Should use all dns entries (dual stack disabled - 6)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -1198,7 +1199,7 @@ test('Should use all dns entries (dual stack disabled - 6)', async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -1258,7 +1259,7 @@ test('Should handle single family resolved (dual stack)', async t => {
         lookupCounter++
         if (lookupCounter === 1) {
           cb(null, [
-            { address: '127.0.0.1', family: 4, ttl: 50 }
+            { address: LOOPBACK_HOST, family: 4, ttl: 50 }
           ])
         } else {
           cb(null, [
@@ -1279,7 +1280,7 @@ test('Should handle single family resolved (dual stack)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -1289,7 +1290,7 @@ test('Should handle single family resolved (dual stack)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -1344,7 +1345,7 @@ test('Should prefer affinity (dual stack - 4)', async t => {
             t.fail('should not reach this point')
         }
 
-        url.hostname = '127.0.0.1'
+        url.hostname = LOOPBACK_HOST
         opts.origin = url.toString()
         return dispatch(opts, handler)
       }
@@ -1373,7 +1374,7 @@ test('Should prefer affinity (dual stack - 4)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -1383,7 +1384,7 @@ test('Should prefer affinity (dual stack - 4)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -1391,7 +1392,7 @@ test('Should prefer affinity (dual stack - 4)', async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -1446,7 +1447,7 @@ test('Should prefer affinity (dual stack - 6)', async t => {
             t.fail('should not reach this point')
         }
 
-        url.hostname = '127.0.0.1'
+        url.hostname = LOOPBACK_HOST
         opts.origin = url.toString()
         return dispatch(opts, handler)
       }
@@ -1475,7 +1476,7 @@ test('Should prefer affinity (dual stack - 6)', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -1485,7 +1486,7 @@ test('Should prefer affinity (dual stack - 6)', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -1493,7 +1494,7 @@ test('Should prefer affinity (dual stack - 6)', async t => {
 
   const response3 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response3.statusCode, 200)
@@ -1536,8 +1537,8 @@ test('Should use resolved ports (4)', async t => {
       lookup (origin, opts, cb) {
         lookupCounter++
         cb(null, [
-          { address: '127.0.0.1', family: 4, port: server1.address().port },
-          { address: '127.0.0.1', family: 4, port: server2.address().port }
+          { address: LOOPBACK_HOST, family: 4, port: server1.address().port },
+          { address: LOOPBACK_HOST, family: 4, port: server2.address().port }
         ])
       }
     })
@@ -1686,7 +1687,7 @@ test('Should handle max cached items', async t => {
           case 3:
             t.equal(url.hostname, 'developer.mozilla.org')
             // Rewrite origin to avoid reaching internet
-            opts.origin = `http://127.0.0.1:${server2.address().port}`
+            opts.origin = `http://${LOOPBACK_HOST}:${server2.address().port}`
             break
           default:
             t.fails('should not reach this point')
@@ -1704,7 +1705,7 @@ test('Should handle max cached items', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -1810,7 +1811,7 @@ test('Should support external storage', async t => {
           case 3:
             t.equal(url.hostname, 'developer.mozilla.org')
             // Rewrite origin to avoid reaching internet
-            opts.origin = `http://127.0.0.1:${server2.address().port}`
+            opts.origin = `http://${LOOPBACK_HOST}:${server2.address().port}`
             break
           default:
             t.fails('should not reach this point')
@@ -1828,7 +1829,7 @@ test('Should support external storage', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -1892,7 +1893,7 @@ test('retry once with dual-stack', async t => {
       lookup: (_origin, _opts, cb) => {
         cb(null, [
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             port: 3669,
             family: 4,
             ttl: 1000
@@ -1985,7 +1986,7 @@ test('#3937 - Handle host correctly', async t => {
   }
 
   server.on('request', (req, res) => {
-    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    t.equal(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
 
     res.writeHead(200, { 'content-type': 'text/plain' })
     res.end('hello world!')
@@ -2022,7 +2023,7 @@ test('#3937 - Handle host correctly', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -2039,7 +2040,7 @@ test('#3937 - Handle host correctly', async t => {
 
   const response = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response.statusCode, 200)
@@ -2047,7 +2048,7 @@ test('#3937 - Handle host correctly', async t => {
 
   const response2 = await client.request({
     ...requestOptions,
-    origin: `http://localhost:${server.address().port}`
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`
   })
 
   t.equal(response2.statusCode, 200)
@@ -2060,7 +2061,7 @@ test('#4444 - Should preserve tuple-style headers', async t => {
   const server = createServer({ joinDuplicateHeaders: true })
 
   server.on('request', (req, res) => {
-    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    t.equal(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
     t.equal(req.headers.foo, 'bar')
     t.equal(req.headers['0'], undefined)
 
@@ -2081,7 +2082,7 @@ test('#4444 - Should preserve tuple-style headers', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -2096,7 +2097,7 @@ test('#4444 - Should preserve tuple-style headers', async t => {
     await once(server, 'close')
   })
 
-  const response = await request(`http://localhost:${server.address().port}`, {
+  const response = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher: client,
     headers: [['foo', 'bar']]
   })
@@ -2111,7 +2112,7 @@ test('#4444 - Should preserve iterable headers', async t => {
   const server = createServer({ joinDuplicateHeaders: true })
 
   server.on('request', (req, res) => {
-    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    t.equal(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
     t.equal(req.headers.foo, 'bar')
     t.equal(req.headers['0'], undefined)
 
@@ -2132,7 +2133,7 @@ test('#4444 - Should preserve iterable headers', async t => {
             family: 6
           },
           {
-            address: '127.0.0.1',
+            address: LOOPBACK_HOST,
             family: 4
           }
         ])
@@ -2147,7 +2148,7 @@ test('#4444 - Should preserve iterable headers', async t => {
     await once(server, 'close')
   })
 
-  const response = await request(`http://localhost:${server.address().port}`, {
+  const response = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher: client,
     headers: new Map([['foo', 'bar']])
   })

--- a/test/interceptors/dump-interceptor.js
+++ b/test/interceptors/dump-interceptor.js
@@ -1,4 +1,5 @@
 'use strict'
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { platform } = require('node:os')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -64,7 +65,7 @@ test('Should handle preemptive network error', { skip }, async t => {
   await once(server, 'listening')
 
   const response = await client.request({
-    origin: `http://localhost:${server.address().port}`,
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
     ...requestOptions
   })
   const body = await response.body.text()
@@ -114,7 +115,7 @@ test('Should dump on abort', { skip }, async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump({ maxSize: 512 }))
 
   after(async () => {
@@ -180,7 +181,7 @@ test('Should dump on already aborted request', { skip }, async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump({ maxSize: 512 }))
 
   after(async () => {
@@ -221,7 +222,7 @@ test('Should dump response body up to limit (default)', { skip }, async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump())
 
   after(async () => {
@@ -265,7 +266,7 @@ test('Should dump response body up to limit and ignore trailers', { skip }, asyn
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump())
 
   after(async () => {
@@ -301,7 +302,7 @@ test('Should forward common error', { skip }, async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump())
 
   after(async () => {
@@ -439,7 +440,7 @@ test('Should dump response body up to limit (opts)', { skip }, async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump({ maxSize: 1 * 1024 }))
 
   after(async () => {
@@ -480,7 +481,7 @@ test('Should abort if content length grater than max size', { skip }, async t =>
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump({ maxSize: 1 * 1024, abortOnDumped: false }))
 
   after(async () => {
@@ -521,7 +522,7 @@ test('Should dump response body up to limit (dispatch opts)', { skip }, async t 
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump())
 
   after(async () => {
@@ -563,7 +564,7 @@ test('Should abort if content length grater than max size (dispatch opts)', { sk
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(dump())
 
   after(async () => {

--- a/test/interceptors/redirect-issue-3803.js
+++ b/test/interceptors/redirect-issue-3803.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { FormData, request, Agent, interceptors } = require('../..')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
@@ -26,14 +27,14 @@ test('redirecting works with a FormData body', async (t) => {
   const body = new FormData()
   body.append('hello', 'world')
 
-  const { context } = await request(`http://localhost:${server.address().port}/1`, {
+  const { context } = await request(`http://${LOOPBACK_HOST}:${server.address().port}/1`, {
     body,
     method: 'POST',
     dispatcher: agent
   })
 
   plan.deepStrictEqual(context.history, [
-    new URL(`http://localhost:${server.address().port}/1`),
-    new URL(`http://localhost:${server.address().port}/2`)
+    new URL(`http://${LOOPBACK_HOST}:${server.address().port}/1`),
+    new URL(`http://${LOOPBACK_HOST}:${server.address().port}/2`)
   ])
 })

--- a/test/interceptors/redirect.js
+++ b/test/interceptors/redirect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -837,7 +838,7 @@ test('same-origin redirect preserves plain object headers with polluted Object.p
   try {
     await once(server, 'listening')
 
-    const res = await undici.request(`http://localhost:${server.address().port}/redirect`, {
+    const res = await undici.request(`http://${LOOPBACK_HOST}:${server.address().port}/redirect`, {
       dispatcher: new undici.Agent({}).compose(redirect({ maxRedirections: 1 })),
       headers: {
         'X-Custom': 'ok'

--- a/test/interceptors/response-error.js
+++ b/test/interceptors/response-error.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const assert = require('node:assert')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -20,7 +21,7 @@ test('should throw error for error response', async () => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(responseError())
 
   after(async () => {
@@ -61,7 +62,7 @@ test('should not throw error for ok response', async () => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(responseError())
 
   after(async () => {
@@ -96,7 +97,7 @@ test('should throw error for error response, parsing JSON', async () => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(responseError())
 
   after(async () => {
@@ -139,7 +140,7 @@ test('should throw error for error response, parsing JSON without charset', asyn
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(responseError())
 
   after(async () => {
@@ -207,7 +208,7 @@ test('should throw error for error response without content type', async () => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(responseError())
 
   after(async () => {

--- a/test/interceptors/retry.js
+++ b/test/interceptors/retry.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -59,7 +60,7 @@ test('Should retry status code', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry(retryOptions))
 
   after(async () => {
@@ -158,7 +159,7 @@ test('Should use retry-after header for retries', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -216,7 +217,7 @@ test('Should use retry-after header for retries (date)', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -271,7 +272,7 @@ test('Should retry with defaults', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -306,7 +307,7 @@ test('Should pass context from other interceptors', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(redirect({ maxRedirections: 1 }), retry())
 
   after(async () => {
@@ -375,7 +376,7 @@ test('Should handle 206 partial content', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -438,7 +439,7 @@ test('Should handle 206 partial content - bad-etag', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -506,7 +507,7 @@ test('#4970 - Should reject resumed partial content when body exceeds Content-Ra
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -575,7 +576,7 @@ test('retrying a request with a body', async t => {
 
   await once(server, 'listening')
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {
@@ -604,7 +605,7 @@ test('should not error if request is not meant to be retried', async t => {
   await once(server, 'listening')
 
   const client = new Client(
-    `http://localhost:${server.address().port}`
+    `http://${LOOPBACK_HOST}:${server.address().port}`
   ).compose(retry())
 
   after(async () => {

--- a/test/ip-prioritization.js
+++ b/test/ip-prioritization.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after } = require('node:test')
 const { Client } = require('..')
 const { createServer } = require('node:http')
@@ -15,7 +16,7 @@ test('HTTP/1.1 Request Prioritization', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: (opts, cb) => {
       const socket = require('node:net').connect({
         ...opts,

--- a/test/issue-1270.js
+++ b/test/issue-1270.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -29,7 +30,7 @@ test('Pool.request() throws if opts.dispatcher is provided', async (t) => {
     await once(server, 'close')
   })
 
-  const pool = new Pool(`http://localhost:${server.address().port}`)
+  const pool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => pool.close())
 
   const otherAgent = new Agent()
@@ -63,10 +64,10 @@ test('Client.request() throws if opts.dispatcher is provided', async (t) => {
     await once(server, 'close')
   })
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
-  const otherPool = new Pool(`http://localhost:${server.address().port}`)
+  const otherPool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => otherPool.close())
 
   try {
@@ -92,7 +93,7 @@ test('Top-level request() still works with opts.dispatcher', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const pool = new Pool(`http://localhost:${server.address().port}`)
+  const pool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   after(async () => {
     await pool.close()
@@ -100,7 +101,7 @@ test('Top-level request() still works with opts.dispatcher', async (t) => {
     await once(server, 'close')
   })
 
-  const { statusCode, body } = await request(`http://localhost:${server.address().port}`, {
+  const { statusCode, body } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'GET',
     dispatcher: pool
   })

--- a/test/issue-2065.js
+++ b/test/issue-2065.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -20,7 +21,7 @@ test('undici.request with a FormData body should set content-length header', asy
   const body = new FormData()
   body.set('file', new File(['abc'], 'abc.txt'))
 
-  await request(`http://localhost:${server.address().port}`, {
+  await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     method: 'POST',
     body
   })

--- a/test/issue-2590.js
+++ b/test/issue-2590.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { request } = require('..')
@@ -21,17 +22,17 @@ test('aborting request with custom reason', async (t) => {
   ac2.abort() // no reason
 
   await t.rejects(
-    request(`http://localhost:${server.address().port}`, { signal: timeout }),
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`, { signal: timeout }),
     timeout.reason
   )
 
   await t.rejects(
-    request(`http://localhost:${server.address().port}`, { signal: ac.signal }),
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`, { signal: ac.signal }),
     /Error: aborted/
   )
 
   await t.rejects(
-    request(`http://localhost:${server.address().port}`, { signal: ac2.signal }),
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`, { signal: ac2.signal }),
     { name: 'AbortError' }
   )
 

--- a/test/issue-3356.js
+++ b/test/issue-3356.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -43,7 +44,7 @@ test('https://github.com/nodejs/undici/issues/3356', { skip: process.env.CITGM }
     await once(server, 'close')
   })
 
-  const response = await fetch(`http://localhost:${server.address().port}`, {
+  const response = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher: agent
   })
 

--- a/test/issue-3934.js
+++ b/test/issue-3934.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -26,7 +27,7 @@ test('request preserves multiple header values', async (t) => {
 
   const {
     headers
-  } = await request(`http://localhost:${server.address().port}`, { dispatcher: retryAgent })
+  } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: retryAgent })
 
   assert.deepStrictEqual(headers['set-cookie'], ['a', 'b', 'c'])
 })
@@ -50,7 +51,7 @@ test('WrapHandler preserves latin1 header bytes', async (t) => {
 
   const {
     headers
-  } = await request(`http://localhost:${server.address().port}`, { dispatcher: retryAgent })
+  } = await request(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: retryAgent })
 
   assert.strictEqual(headers['x-test'], expected)
 })

--- a/test/issue-4389.js
+++ b/test/issue-4389.js
@@ -1,4 +1,5 @@
 'use strict'
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const { once } = require('node:events')
@@ -23,7 +24,7 @@ describe('Interceptor should not break multi-value headers', () => {
 
     const dispatcher = new Agent().compose((dispatch) => dispatch)
 
-    const { headers } = await fetch(`http://localhost:${server.address().port}`, { dispatcher })
+    const { headers } = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
     assert.deepStrictEqual(headers.getSetCookie(), ['a=1', 'b=2', 'c=3'])
   })
 
@@ -40,7 +41,7 @@ describe('Interceptor should not break multi-value headers', () => {
 
     const dispatcher = new Agent().compose((dispatch) => dispatch)
 
-    const { headers } = await fetch(`http://localhost:${server.address().port}`, { dispatcher })
+    const { headers } = await fetch(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
     assert.deepStrictEqual(headers.get('x-test-header'), '1, 2, 3')
   })
 })

--- a/test/issue-4691.js
+++ b/test/issue-4691.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -37,7 +38,7 @@ test('Should retry status code with FormData body', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const agent = new RetryAgent(client, opts)
 
     after(async () => {

--- a/test/issue-4806.js
+++ b/test/issue-4806.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -25,7 +26,7 @@ test('Agent clientTtl cleanup does not trigger unhandled rejections', async (t) 
     process.once('unhandledRejection', onUnhandled)
     after(() => process.removeListener('unhandledRejection', onUnhandled))
 
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     const res1 = await request(origin, { dispatcher: agent })
     t.strictEqual(res1.statusCode, 200)

--- a/test/issue-4880.js
+++ b/test/issue-4880.js
@@ -26,6 +26,7 @@ const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Worker, isMainThread, parentPort } = require('node:worker_threads')
 const { Agent, interceptors } = require('..')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 // ── Server (runs in worker thread) ──────────────────────────────────────────
 if (!isMainThread) {
@@ -51,7 +52,7 @@ if (!isMainThread) {
       }
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       parentPort.postMessage({ port: server.address().port })
     })
   })
@@ -96,7 +97,7 @@ test('h2: no crash when data arrives after stream abort under high concurrency',
   const dispatcher = makeDispatcher(connections, maxConcurrentStreams)
   after(() => dispatcher.close())
 
-  const origin = `https://127.0.0.1:${port}`
+  const origin = `https://${LOOPBACK_HOST}:${port}`
   const count = 10_000
 
   const requests = Array.from({ length: count }, () =>

--- a/test/issue-5137.js
+++ b/test/issue-5137.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -39,7 +40,7 @@ test('RetryAgent rejects after exhausting retries on HTTP/2 stream timeout', asy
   await once(server.listen(0), 'listening')
 
   const client = new RetryAgent(
-    new Client(`https://localhost:${server.address().port}`, {
+    new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: { rejectUnauthorized: false },
       allowH2: true,
       bodyTimeout: 50

--- a/test/issue-803.js
+++ b/test/issue-803.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -36,7 +37,7 @@ test('https://github.com/nodejs/undici/issues/803', { timeout: 60000 }, async (t
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.on('disconnect', () => {

--- a/test/issue-810.js
+++ b/test/issue-810.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -26,7 +27,7 @@ test('https://github.com/mcollina/undici/issues/810', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`, { pipelining: 2 })
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { pipelining: 2 })
   after(() => client.close())
 
   client.request({
@@ -63,7 +64,7 @@ test('https://github.com/mcollina/undici/issues/810 no pipelining', async (t) =>
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   client.request({
     path: '/',
@@ -92,7 +93,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining', async (t) => {
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, { pipelining: true })
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { pipelining: true })
   after(() => client.close())
 
   client.request({
@@ -122,7 +123,7 @@ test('https://github.com/mcollina/undici/issues/810 pipelining 2', async (t) => 
 
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`, { pipelining: true })
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { pipelining: true })
   after(() => client.close())
 
   client.request({

--- a/test/jest/instanceof-error.test.js
+++ b/test/jest/instanceof-error.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
 
@@ -29,7 +30,7 @@ it('Real use-case', async () => {
 
   await once(server, 'listening')
 
-  const promise = fetch(`https://localhost:${server.address().port}`, {
+  const promise = fetch(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     signal: ac.signal
   })
 

--- a/test/jest/test.js
+++ b/test/jest/test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { Client } = require('../..')
 const { createServer } = require('node:http')
 /* global test, expect */
@@ -8,13 +9,13 @@ test('should work in jest', async () => {
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     expect(req.url).toBe('/')
     expect(req.method).toBe('POST')
-    expect(req.headers.host).toBe(`localhost:${server.address().port}`)
+    expect(req.headers.host).toBe(`${LOOPBACK_HOST}:${server.address().port}`)
     res.setHeader('Content-Type', 'text/plain')
     res.end('hello')
   })
   await expect(new Promise((resolve, reject) => {
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       client.request({
         path: '/',
         method: 'POST',

--- a/test/max-headers.js
+++ b/test/max-headers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -22,7 +23,7 @@ test('handle a lot of headers', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   client.on('disconnect', () => {

--- a/test/max-response-size.js
+++ b/test/max-response-size.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after, describe } = require('node:test')
 const { Client, errors } = require('..')
@@ -20,7 +21,7 @@ describe('max response size', async (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, { maxResponseSize: -1 })
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { maxResponseSize: -1 })
       after(() => client.close())
 
       client.on('disconnect', () => {
@@ -59,7 +60,7 @@ describe('max response size', async (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, { maxResponseSize: 0 })
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { maxResponseSize: 0 })
       after(() => client.close())
 
       client.on('disconnect', () => {
@@ -98,7 +99,7 @@ describe('max response size', async (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         maxResponseSize: 1
       })
 

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after, describe } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -282,7 +283,7 @@ test('MockAgent - [kClients] should match encapsulated agent', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const agent = new Agent()
   after(() => agent.close())
@@ -314,7 +315,7 @@ test('MockAgent - basic intercept with MockAgent.request', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())
@@ -360,7 +361,7 @@ test('MockAgent - basic intercept with request', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -405,7 +406,7 @@ test('MockAgent - should support local agents', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
 
@@ -453,7 +454,7 @@ test('MockAgent - should support specifying custom agents to mock', async (t) =>
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const agent = new Agent()
   after(() => agent.close())
@@ -502,7 +503,7 @@ test('MockAgent - basic Client intercept with request', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
@@ -549,7 +550,7 @@ test('MockAgent - basic intercept with multiple pools', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -603,7 +604,7 @@ test('MockAgent - should handle multiple responses for an interceptor', async (t
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -669,7 +670,7 @@ test('MockAgent - should call original Pool dispatch if request not found', asyn
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -701,7 +702,7 @@ test('MockAgent - should call original Client dispatch if request not found', as
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
@@ -732,7 +733,7 @@ test('MockAgent - should handle string responses', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -798,7 +799,7 @@ test('MockAgent - handle delays to simulate work', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -838,7 +839,7 @@ test('MockAgent - should persist requests', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1101,7 +1102,7 @@ test('MockAgent - handle persists with delayed requests', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1149,7 +1150,7 @@ test('MockAgent - calling close on a mock pool should not affect other mock pool
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1209,7 +1210,7 @@ test('MockAgent - close removes all registered mock clients', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   setGlobalDispatcher(mockAgent)
@@ -1267,7 +1268,7 @@ test('MockAgent - close removes all registered mock pools', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1303,7 +1304,7 @@ test('MockAgent - should handle replyWithError', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1334,7 +1335,7 @@ test('MockAgent - should support setting a reply to respond a set amount of time
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1387,7 +1388,7 @@ test('MockAgent - persist overrides times', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1445,7 +1446,7 @@ test('MockAgent - matcher should not find mock dispatch if path is of unsupporte
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1481,7 +1482,7 @@ test('MockAgent - should match path with regex', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1529,7 +1530,7 @@ test('MockAgent - should match path with function', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1565,7 +1566,7 @@ test('MockAgent - should match method with regex', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1601,7 +1602,7 @@ test('MockAgent - should match method with function', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1637,7 +1638,7 @@ test('MockAgent - should match body with regex', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1675,7 +1676,7 @@ test('MockAgent - should match body with function', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1712,7 +1713,7 @@ test('MockAgent - should match headers with string', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1787,7 +1788,7 @@ test('MockAgent - should match headers with regex', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1862,7 +1863,7 @@ test('MockAgent - should match headers with function', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1938,7 +1939,7 @@ test('MockAgent - should match url with regex', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -1974,7 +1975,7 @@ test('MockAgent - should match url with function', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2010,7 +2011,7 @@ test('MockAgent - handle default reply headers', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2050,7 +2051,7 @@ test('MockAgent - handle default reply trailers', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2090,7 +2091,7 @@ test('MockAgent - return calculated content-length if specified', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2130,7 +2131,7 @@ test('MockAgent - return calculated content-length for object response if specif
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2171,7 +2172,7 @@ test('MockAgent - should activate and deactivate mock clients', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2235,7 +2236,7 @@ test('MockAgent - enableNetConnect should allow all original dispatches to be ca
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2275,7 +2276,7 @@ test('MockAgent - enableNetConnect with a host string should allow all original 
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2287,7 +2288,7 @@ test('MockAgent - enableNetConnect with a host string should allow all original 
     method: 'GET'
   }).reply(200, 'foo')
 
-  mockAgent.enableNetConnect(`localhost:${server.address().port}`)
+  mockAgent.enableNetConnect(`${LOOPBACK_HOST}:${server.address().port}`)
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
@@ -2315,7 +2316,7 @@ test('MockAgent - enableNetConnect when called with host string multiple times s
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2328,7 +2329,7 @@ test('MockAgent - enableNetConnect when called with host string multiple times s
   }).reply(200, 'foo')
 
   mockAgent.enableNetConnect('example.com:9999')
-  mockAgent.enableNetConnect(`localhost:${server.address().port}`)
+  mockAgent.enableNetConnect(`${LOOPBACK_HOST}:${server.address().port}`)
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
@@ -2356,7 +2357,7 @@ test('MockAgent - enableNetConnect with a host regex should allow all original d
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2368,7 +2369,7 @@ test('MockAgent - enableNetConnect with a host regex should allow all original d
     method: 'GET'
   }).reply(200, 'foo')
 
-  mockAgent.enableNetConnect(new RegExp(`localhost:${server.address().port}`))
+  mockAgent.enableNetConnect(new RegExp(`${LOOPBACK_HOST}:${server.address().port}`))
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
@@ -2396,7 +2397,7 @@ test('MockAgent - enableNetConnect with a function should allow all original dis
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2408,7 +2409,7 @@ test('MockAgent - enableNetConnect with a function should allow all original dis
     method: 'GET'
   }).reply(200, 'foo')
 
-  mockAgent.enableNetConnect((value) => value === `localhost:${server.address().port}`)
+  mockAgent.enableNetConnect((value) => value === `${LOOPBACK_HOST}:${server.address().port}`)
 
   const { statusCode, headers, body } = await request(`${baseUrl}/foo`, {
     method: 'GET'
@@ -2450,7 +2451,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for path
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2483,7 +2484,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for meth
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2516,7 +2517,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for body
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2551,7 +2552,7 @@ test('MockAgent - enableNetConnect should throw if dispatch not matched for head
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2592,7 +2593,7 @@ test('MockAgent - disableNetConnect should throw if dispatch not found by net co
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2623,7 +2624,7 @@ test('MockAgent - headers function interceptor', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2684,7 +2685,7 @@ test('MockAgent - should include intercept count in error when intercepts are ex
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   setGlobalDispatcher(mockAgent)
@@ -2730,7 +2731,7 @@ test('MockAgent - clients are not garbage collected', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   // Create the dispatcher and disable net connect so we can make sure it matches properly
   const dispatcher = new MockAgent()
@@ -2991,7 +2992,7 @@ test('MockAgent - Sending ReadableStream body', async (t) => {
 
   await once(server.listen(0), 'listening')
 
-  const url = `http://localhost:${server.address().port}`
+  const url = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const response = await fetch(url, {
     method: 'POST',
@@ -3058,7 +3059,7 @@ test('MockAgent - headers should be array of strings (fetch)', async (t) => {
 
     await once(server.listen(0), 'listening')
 
-    const baseUrl = `http://localhost:${server.address().port}`
+    const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     const mockAgent = new MockAgent({ acceptNonStandardSearchParameters: true })
     after(() => mockAgent.close())
@@ -3105,7 +3106,7 @@ test('MockAgent - should not accept non-standard search parameters when acceptNo
 
   await once(server.listen(0), 'listening')
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())

--- a/test/mock-call-history.js
+++ b/test/mock-call-history.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, describe } = require('node:test')
 const { MockCallHistory, MockCallHistoryLog } = require('../lib/mock/mock-call-history')
 const { kMockCallHistoryAddLog } = require('../lib/mock/mock-symbols')
@@ -241,7 +242,7 @@ describe('MockCallHistory - filterCalls without options', () => {
 
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000' })
-    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: `https://${LOOPBACK_HOST}:4000` })
 
     const filtered = mockCallHistoryHello.filterCalls({ host: /localhost/ })
 
@@ -255,7 +256,7 @@ describe('MockCallHistory - filterCalls without options', () => {
 
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:1000' })
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000' })
-    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: `https://${LOOPBACK_HOST}:4000` })
 
     const filtered = mockCallHistoryHello.filterCalls({ port: '1000' })
 
@@ -269,7 +270,7 @@ describe('MockCallHistory - filterCalls without options', () => {
 
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/#hello', origin: 'http://localhost:1000' })
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000' })
-    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: `https://${LOOPBACK_HOST}:4000` })
 
     const filtered = mockCallHistoryHello.filterCalls({ hash: '#hello' })
 
@@ -283,7 +284,7 @@ describe('MockCallHistory - filterCalls without options', () => {
 
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '#hello', origin: 'http://localhost:1000' })
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000' })
-    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: `https://${LOOPBACK_HOST}:4000` })
 
     const filtered = mockCallHistoryHello.filterCalls({ fullUrl: 'http://localhost:1000/#hello' })
 
@@ -297,7 +298,7 @@ describe('MockCallHistory - filterCalls without options', () => {
 
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:1000', method: 'POST' })
     mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000', method: 'GET' })
-    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000', method: 'PUT' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: `https://${LOOPBACK_HOST}:4000`, method: 'PUT' })
 
     const filtered = mockCallHistoryHello.filterCalls({ method: /(PUT|GET)/ })
 

--- a/test/mock-client.js
+++ b/test/mock-client.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after, describe } = require('node:test')
 const { createServer } = require('node:http')
 const { promisify } = require('node:util')
@@ -213,7 +214,7 @@ test('MockClient - should be able to set as globalDispatcher', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -254,7 +255,7 @@ test('MockClient - should support query params', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -297,7 +298,7 @@ test('MockClient - should intercept query params with hardcoded path', async (t)
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -339,7 +340,7 @@ test('MockClient - should intercept query params regardless of key ordering', as
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -389,7 +390,7 @@ test('MockClient - should be able to use as a local dispatcher', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -427,7 +428,7 @@ test('MockClient - basic intercept with MockClient.request', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())
@@ -473,7 +474,7 @@ test('MockClient - cleans mocks', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent({ connections: 1 })
   after(() => mockAgent.close())

--- a/test/mock-pool.js
+++ b/test/mock-pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, after, describe } = require('node:test')
 const { createServer } = require('node:http')
 const { promisify } = require('node:util')
@@ -199,7 +200,7 @@ test('MockPool - should be able to set as globalDispatcher', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())
@@ -237,7 +238,7 @@ test('MockPool - should be able to use as a local dispatcher', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())
@@ -275,7 +276,7 @@ test('MockPool - basic intercept with MockPool.request', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())
@@ -383,7 +384,7 @@ test('MockPool - cleans mocks', async (t) => {
 
   await promisify(server.listen.bind(server))(0)
 
-  const baseUrl = `http://localhost:${server.address().port}`
+  const baseUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
 
   const mockAgent = new MockAgent()
   after(() => mockAgent.close())

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test, describe } = require('node:test')
 const { MockNotMatchedError } = require('../lib/mock/mock-errors')
 const {
@@ -337,7 +338,7 @@ describe('normalizeOrigin', () => {
     t.plan(2)
 
     t.assert.strictEqual(normalizeOrigin('http://192.168.1.1'), 'http://192.168.1.1')
-    t.assert.strictEqual(normalizeOrigin('http://127.0.0.1:3000'), 'http://127.0.0.1:3000')
+    t.assert.strictEqual(normalizeOrigin(`http://${LOOPBACK_HOST}:3000`), `http://${LOOPBACK_HOST}:3000`)
   })
 
   test('should handle IPv6 addresses', (t) => {

--- a/test/mock/issue-4663.js
+++ b/test/mock/issue-4663.js
@@ -15,6 +15,7 @@ const { unlink } = require('node:fs/promises')
 const { tmpdir } = require('node:os')
 const { join } = require('node:path')
 const { SnapshotAgent, setGlobalDispatcher, getGlobalDispatcher, request } = require('../..')
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 
 function snapshotPath (suffix) {
   return join(tmpdir(), `undici-issue-4663-${suffix}-${process.pid}-${Date.now()}.json`)
@@ -31,7 +32,7 @@ async function startLiveServer (t) {
     server.close()
   })
   const { port } = server.address()
-  return `http://127.0.0.1:${port}`
+  return `http://${LOOPBACK_HOST}:${port}`
 }
 
 function restoreGlobalDispatcher (t) {

--- a/test/no-strict-content-length.js
+++ b/test/no-strict-content-length.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { ok } = require('node:assert')
 const { test, after, describe } = require('node:test')
@@ -37,7 +38,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -158,7 +159,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -204,7 +205,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -250,7 +251,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -296,7 +297,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -342,7 +343,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())
@@ -387,7 +388,7 @@ describe('strictContentLength: false', () => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         strictContentLength: false
       })
       after(() => client.close())

--- a/test/node-fetch/main.js
+++ b/test/node-fetch/main.js
@@ -24,6 +24,7 @@ const RequestOrig = require('../../lib/web/fetch/request.js').Request
 const TestServer = require('./utils/server.js')
 const { createServer } = require('node:http')
 const { default: tspl } = require('@matteo.collina/tspl')
+const { LOOPBACK_HOST } = require('../utils/node-http')
 
 const {
   Uint8Array: VMUint8Array
@@ -1625,7 +1626,7 @@ describe('node-fetch', () => {
     })
     after(() => server.close())
     server.listen(0, () => {
-      const url = `http://localhost:${server.address().port}`
+      const url = `http://${LOOPBACK_HOST}:${server.address().port}`
       const options = {
         method: 'HEAD'
       }

--- a/test/node-fetch/utils/server.js
+++ b/test/node-fetch/utils/server.js
@@ -4,6 +4,7 @@ const http = require('node:http')
 const zlib = require('node:zlib')
 const { once } = require('node:events')
 const Busboy = require('@fastify/busboy')
+const { LOOPBACK_HOST } = require('../../utils/node-http')
 
 module.exports = class TestServer {
   constructor () {
@@ -20,7 +21,7 @@ module.exports = class TestServer {
   }
 
   async start () {
-    this.server.listen(0, 'localhost')
+    this.server.listen(0, LOOPBACK_HOST)
     return once(this.server, 'listening')
   }
 
@@ -37,7 +38,7 @@ module.exports = class TestServer {
   }
 
   get hostname () {
-    return 'localhost'
+    return LOOPBACK_HOST
   }
 
   mockState (responseHandler) {

--- a/test/node-test/abort-controller.js
+++ b/test/node-test/abort-controller.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { AbortController: NPMAbortController } = require('abort-controller')
 const { Client, errors } = require('../..')
@@ -30,7 +31,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       const abortController = new AbortControllerImpl()
       t.after(client.destroy.bind(client))
 
@@ -58,7 +59,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       const abortController = new AbortControllerImpl()
       t.after(client.destroy.bind(client))
 
@@ -95,7 +96,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
@@ -119,7 +120,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
@@ -141,7 +142,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'GET', signal: abortController.signal }, (err, response) => {
@@ -171,7 +172,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
       t.after(closeServerAsPromise(server))
 
       server.listen(0, () => {
-        const client = new Client(`http://localhost:${server.address().port}`)
+        const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         t.after(client.destroy.bind(client))
 
         client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
@@ -201,7 +202,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
       t.after(closeServerAsPromise(server))
 
       server.listen(0, () => {
-        const client = new Client(`http://localhost:${server.address().port}`)
+        const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         t.after(client.destroy.bind(client))
 
         client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {
@@ -229,7 +230,7 @@ for (const { AbortControllerImpl, controllerName } of controllers) {
       t.after(closeServerAsPromise(server))
 
       server.listen(0, () => {
-        const client = new Client(`http://localhost:${server.address().port}`)
+        const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
         t.after(client.destroy.bind(client))
 
         client.request({ path: '/', method: 'POST', body, signal: abortController.signal }, (err, response) => {

--- a/test/node-test/abort-event-emitter.js
+++ b/test/node-test/abort-event-emitter.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const EventEmitter = require('node:events')
 const { Client, errors } = require('../..')
@@ -25,7 +26,7 @@ test('Abort before sending request (no body)', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const ee = new EventEmitter()
     t.after(client.destroy.bind(client))
 
@@ -74,7 +75,7 @@ test('Abort before sending request (no body) async iterator', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const ee = new EventEmitter()
     t.after(client.destroy.bind(client))
 
@@ -117,7 +118,7 @@ test('Abort while waiting response (no body)', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: ee }, (err, response) => {
@@ -141,7 +142,7 @@ test('Abort while waiting response (write headers started) (no body)', async (t)
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: ee }, (err, response) => {
@@ -163,7 +164,7 @@ test('Abort while waiting response (write headers and write body started) (no bo
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET', signal: ee }, (err, response) => {
@@ -192,7 +193,7 @@ function waitingWithBody (body, type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'POST', body, signal: ee }, (err, response) => {
@@ -222,7 +223,7 @@ function writeHeadersStartedWithBody (body, type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'POST', body, signal: ee }, (err, response) => {
@@ -250,7 +251,7 @@ function writeBodyStartedWithBody (body, type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({ path: '/', method: 'POST', body, signal: ee }, (err, response) => {

--- a/test/node-test/agent.js
+++ b/test/node-test/agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { describe, test, after } = require('node:test')
 const assert = require('node:assert/strict')
 const { once } = require('node:events')
@@ -92,7 +93,7 @@ test('agent should call callback after closing internal pools', async (t) => {
   server.listen(0, () => {
     const dispatcher = new Agent()
 
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     request(origin, { dispatcher })
       .then(() => {
@@ -144,7 +145,7 @@ test('agent should close internal pools', async (t) => {
   server.listen(0, () => {
     const dispatcher = new Agent()
 
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     request(origin, { dispatcher })
       .then(() => {
@@ -185,7 +186,7 @@ test('agent should destroy internal pools and call callback', async (t) => {
   server.listen(0, () => {
     const dispatcher = new Agent()
 
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     request(origin, { dispatcher })
       .then(() => {
@@ -247,7 +248,7 @@ test('agent should destroy internal pools', async t => {
   server.listen(0, () => {
     const dispatcher = new Agent()
 
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
 
     request(origin, { dispatcher })
       .then(() => {
@@ -286,7 +287,7 @@ test('multiple connections', async t => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
     const dispatcher = new Agent({ connections })
 
     t.after(() => { dispatcher.close.bind(dispatcher)() })
@@ -343,7 +344,7 @@ test('agent factory supports URL parameter', async (t) => {
 
   server.listen(0, () => {
     p.doesNotThrow(() => dispatcher.dispatch({
-      origin: new URL(`http://localhost:${server.address().port}`),
+      origin: new URL(`http://${LOOPBACK_HOST}:${server.address().port}`),
       path: '/',
       method: 'GET'
     }, noopHandler))
@@ -381,7 +382,7 @@ test('agent factory supports string parameter', async (t) => {
 
   server.listen(0, () => {
     p.doesNotThrow(() => dispatcher.dispatch({
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       path: '/',
       method: 'GET'
     }, noopHandler))
@@ -397,7 +398,7 @@ test('with globalAgent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -405,7 +406,7 @@ test('with globalAgent', async t => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    request(`http://localhost:${server.address().port}`)
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`)
       .then(({ statusCode, headers, body }) => {
         p.strictEqual(statusCode, 200)
         p.strictEqual(headers['content-type'], 'text/plain')
@@ -432,7 +433,7 @@ test('with local agent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -446,7 +447,7 @@ test('with local agent', async t => {
   })
 
   server.listen(0, () => {
-    request(`http://localhost:${server.address().port}`, { dispatcher })
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
       .then(({ statusCode, headers, body }) => {
         p.strictEqual(statusCode, 200)
         p.strictEqual(headers['content-type'], 'text/plain')
@@ -483,7 +484,7 @@ test('with globalAgent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -492,7 +493,7 @@ test('with globalAgent', async t => {
 
   server.listen(0, () => {
     stream(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       {
         opaque: new PassThrough()
       },
@@ -524,7 +525,7 @@ test('with a local agent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -543,7 +544,7 @@ test('with a local agent', async t => {
 
   server.listen(0, () => {
     stream(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       {
         dispatcher,
         opaque: new PassThrough()
@@ -584,7 +585,7 @@ test('with globalAgent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -595,7 +596,7 @@ test('with globalAgent', async t => {
     const bufs = []
 
     pipeline(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       {},
       ({ statusCode, headers, body }) => {
         p.strictEqual(statusCode, 200)
@@ -625,7 +626,7 @@ test('with a local agent', async t => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     res.setHeader('Content-Type', 'text/plain')
     res.end(wanted)
   })
@@ -638,7 +639,7 @@ test('with a local agent', async t => {
     const bufs = []
 
     pipeline(
-      `http://localhost:${server.address().port}`,
+      `http://${LOOPBACK_HOST}:${server.address().port}`,
       { dispatcher },
       ({ statusCode, headers, body }) => {
         p.strictEqual(statusCode, 200)
@@ -734,7 +735,7 @@ test('dispatch validations', async t => {
 
   server.listen(0, () => {
     p.doesNotThrow(() => dispatcher.dispatch({
-      origin: new URL(`http://localhost:${server.address().port}`),
+      origin: new URL(`http://${LOOPBACK_HOST}:${server.address().port}`),
       path: '/',
       method: 'GET'
     }, noopHandler))
@@ -774,7 +775,7 @@ test('drain', async t => {
 
   server.listen(0, () => {
     p.strictEqual(dispatcher.dispatch({
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       method: 'GET',
       path: '/'
     }, new Handler()), false)
@@ -800,7 +801,7 @@ test('global api', async t => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const origin = `http://localhost:${server.address().port}`
+    const origin = `http://${LOOPBACK_HOST}:${server.address().port}`
     await request(origin, { path: '/foo' })
     await request(`${origin}/foo`)
     await request({ origin, path: '/foo' })
@@ -867,10 +868,10 @@ test('stats', async t => {
   })
 
   server.listen(0, () => {
-    request(`http://localhost:${server.address().port}`, { dispatcher })
+    request(`http://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
       .then(({ statusCode, headers, body }) => {
         p.strictEqual(statusCode, 200)
-        const originForStats = `http://localhost:${server.address().port}`
+        const originForStats = `http://${LOOPBACK_HOST}:${server.address().port}`
         const agentStats = dispatcher.stats[originForStats]
         p.strictEqual(agentStats.connected, 1)
         p.strictEqual(agentStats.pending, 0)

--- a/test/node-test/async_hooks.js
+++ b/test/node-test/async_hooks.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { Client } = require('../..')
 const { createServer } = require('node:http')
@@ -54,7 +55,7 @@ test('async hooks', async (t) => {
   t.after(() => server.close.bind(server)())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => client.destroy.bind(client)())
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
@@ -158,7 +159,7 @@ test('async hooks client is destroyed', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, { body }) => {
@@ -193,7 +194,7 @@ test('async hooks pipeline handler', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     setCurrentTransaction({ hello: 'world2' })

--- a/test/node-test/autoselectfamily.js
+++ b/test/node-test/autoselectfamily.js
@@ -7,6 +7,7 @@ const dnsPacket = require('dns-packet')
 const { createServer } = require('node:http')
 const { Client, Agent, request } = require('../..')
 const { tspl } = require('@matteo.collina/tspl')
+const { LOOPBACK_HOST } = require('../utils/node-http')
 
 /*
  * IMPORTANT
@@ -48,7 +49,7 @@ function createDnsServer (ipv6Addr, ipv4Addr, cb) {
       questions: parsed.questions,
       answers: [
         { type: 'AAAA', class: 'IN', name: 'example.org', data: '::1', ttl: 123 },
-        { type: 'A', class: 'IN', name: 'example.org', data: '127.0.0.1', ttl: 123 }
+        { type: 'A', class: 'IN', name: 'example.org', data: LOOPBACK_HOST, ttl: 123 }
       ]
     })
 
@@ -57,7 +58,7 @@ function createDnsServer (ipv6Addr, ipv4Addr, cb) {
 
   socket.bind(0, () => {
     const resolver = new Resolver()
-    resolver.setServers([`127.0.0.1:${socket.address().port}`])
+    resolver.setServers([`${LOOPBACK_HOST}:${socket.address().port}`])
 
     cb(null, { dnsServer: socket, lookup: _lookup.bind(null, resolver) })
   })
@@ -66,7 +67,7 @@ function createDnsServer (ipv6Addr, ipv4Addr, cb) {
 test('with autoSelectFamily enable the request succeeds when using request', { skip }, async (t) => {
   const p = tspl(t, { plan: 3 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -76,7 +77,7 @@ test('with autoSelectFamily enable the request succeeds when using request', { s
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const agent = new Agent({ connect: { lookup }, autoSelectFamily: true })
 
       request(
@@ -106,7 +107,7 @@ test('with autoSelectFamily enable the request succeeds when using request', { s
 test('with autoSelectFamily enable the request succeeds when using a client', { skip }, async (t) => {
   const p = tspl(t, { plan: 3 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -116,7 +117,7 @@ test('with autoSelectFamily enable the request succeeds when using a client', { 
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const client = new Client(`http://example.org:${server.address().port}`, { connect: { lookup }, autoSelectFamily: true })
 
       t.after(client.destroy.bind(client))
@@ -147,7 +148,7 @@ test('with autoSelectFamily enable the request succeeds when using a client', { 
 test('with autoSelectFamily disabled the request fails when using request', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -157,7 +158,7 @@ test('with autoSelectFamily disabled the request fails when using request', { sk
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const agent = new Agent({ connect: { lookup, autoSelectFamily: false } })
 
       request(`http://example.org:${server.address().port}`, {
@@ -175,7 +176,7 @@ test('with autoSelectFamily disabled the request fails when using request', { sk
 test('with autoSelectFamily disabled via Agent.Options["autoSelectFamily"] the request fails when using request', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -185,7 +186,7 @@ test('with autoSelectFamily disabled via Agent.Options["autoSelectFamily"] the r
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const agent = new Agent({ autoSelectFamily: false, connect: { lookup } })
 
       request(`http://example.org:${server.address().port}`, {
@@ -203,7 +204,7 @@ test('with autoSelectFamily disabled via Agent.Options["autoSelectFamily"] the r
 test('with autoSelectFamily disabled the request fails when using a client', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -213,7 +214,7 @@ test('with autoSelectFamily disabled the request fails when using a client', { s
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const client = new Client(`http://example.org:${server.address().port}`, { connect: { lookup, autoSelectFamily: false } })
       t.after(client.destroy.bind(client))
 
@@ -232,7 +233,7 @@ test('with autoSelectFamily disabled the request fails when using a client', { s
 test('with autoSelectFamily disabled via Client.Options["autoSelectFamily"] the request fails when using a client', { skip }, async (t) => {
   const p = tspl(t, { plan: 1 })
 
-  createDnsServer('::1', '127.0.0.1', function (_, { dnsServer, lookup }) {
+  createDnsServer('::1', LOOPBACK_HOST, function (_, { dnsServer, lookup }) {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.end('hello')
     })
@@ -242,7 +243,7 @@ test('with autoSelectFamily disabled via Client.Options["autoSelectFamily"] the 
       dnsServer.close()
     })
 
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, LOOPBACK_HOST, () => {
       const client = new Client(`http://example.org:${server.address().port}`, { autoSelectFamily: false, connect: { lookup } })
       t.after(client.destroy.bind(client))
 

--- a/test/node-test/balanced-pool.js
+++ b/test/node-test/balanced-pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { describe, test } = require('node:test')
 const assert = require('node:assert/strict')
 const { BalancedPool, Pool, Client, errors } = require('../..')
@@ -172,7 +173,7 @@ test('connect/disconnect event(s)', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const pool = new BalancedPool(`http://localhost:${server.address().port}`, {
+    const pool = new BalancedPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: clients,
       keepAliveTimeoutThreshold: 100
     })
@@ -213,7 +214,7 @@ test('busy', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, async () => {
-    const client = new BalancedPool(`http://localhost:${server.address().port}`, {
+    const client = new BalancedPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 2,
       pipelining: 2
     })
@@ -269,9 +270,9 @@ test('factory option with basic get request', async (t) => {
 
   await promisify(server.listen).call(server, 0)
 
-  client.addUpstream(`http://localhost:${server.address().port}`)
+  client.addUpstream(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
-  p.deepStrictEqual(client.upstreams, [`http://localhost:${server.address().port}`])
+  p.deepStrictEqual(client.upstreams, [`http://${LOOPBACK_HOST}:${server.address().port}`])
 
   t.after(client.destroy.bind(client))
 

--- a/test/node-test/ca-fingerprint.js
+++ b/test/node-test/ca-fingerprint.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const crypto = require('node:crypto')
 const https = require('node:https')
 const { test } = require('node:test')
@@ -24,7 +25,7 @@ test('Validate CA fingerprint with a custom connector', async t => {
 
   server.listen(0, function () {
     const connector = buildConnector({ rejectUnauthorized: false })
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect (opts, cb) {
         connector(opts, (err, socket) => {
           if (err) {
@@ -71,7 +72,7 @@ test('Bad CA fingerprint with a custom connector', async t => {
 
   server.listen(0, function () {
     const connector = buildConnector({ rejectUnauthorized: false })
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect (opts, cb) {
         connector(opts, (err, socket) => {
           if (err) {

--- a/test/node-test/client-abort.js
+++ b/test/node-test/client-abort.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { Client, errors } = require('../..')
 const { createServer } = require('node:http')
@@ -20,7 +21,7 @@ test('aborted response errors', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
@@ -48,7 +49,7 @@ test('aborted req', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({
@@ -78,7 +79,7 @@ test('abort', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.dispatch({
@@ -118,7 +119,7 @@ test('abort pipelined', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     t.after(client.destroy.bind(client))
@@ -189,7 +190,7 @@ test('propagate unallowed throws in request.onError', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.dispatch({

--- a/test/node-test/client-connect.js
+++ b/test/node-test/client-connect.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { Client, errors } = require('../..')
 const http = require('node:http')
@@ -29,7 +30,7 @@ test('basic connect', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const signal = new EE()
@@ -69,7 +70,7 @@ test('connect error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     try {
@@ -135,7 +136,7 @@ test('connect wait for empty pipeline', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     t.after(() => { return client.close() })
@@ -193,7 +194,7 @@ test('connect aborted', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     t.after(() => {
@@ -243,7 +244,7 @@ test('basic connect error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const _err = new Error()
@@ -273,7 +274,7 @@ test('connect invalid signal', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.on('disconnect', () => {

--- a/test/node-test/client-connector-throw.js
+++ b/test/node-test/client-connector-throw.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const { Client } = require('../..')
@@ -18,7 +19,7 @@ test('client does not hang when connector throws synchronously', async (t) => {
   after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: () => {
         throw new Error('connector boom')
       }
@@ -52,7 +53,7 @@ test('client recovers after connector stops throwing', async (t) => {
 
   server.listen(0, () => {
     let shouldThrow = true
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: (opts, cb) => {
         if (shouldThrow) {
           throw new Error('connector boom')

--- a/test/node-test/client-dispatch.js
+++ b/test/node-test/client-dispatch.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const assert = require('node:assert/strict')
 const http = require('node:http')
@@ -97,7 +98,7 @@ test('basic dispatch get', async (t) => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     p.strictEqual(undefined, req.headers.foo)
     p.strictEqual('bar', req.headers.bar)
     p.strictEqual('', req.headers.baz)
@@ -113,7 +114,7 @@ test('basic dispatch get', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const bufs = []
@@ -151,7 +152,7 @@ test('trailers dispatch get', async (t) => {
   const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
     p.strictEqual('/', req.url)
     p.strictEqual('GET', req.method)
-    p.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    p.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     p.strictEqual(undefined, req.headers.foo)
     p.strictEqual('bar', req.headers.bar)
     p.strictEqual(undefined, req.headers['content-length'])
@@ -168,7 +169,7 @@ test('trailers dispatch get', async (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const bufs = []
@@ -218,7 +219,7 @@ test('dispatch onResponseStart error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const _err = new Error()
@@ -255,7 +256,7 @@ test('dispatch onResponseEnd error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const _err = new Error()
@@ -292,7 +293,7 @@ test('dispatch onResponseData error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const _err = new Error()
@@ -329,7 +330,7 @@ test('dispatch onRequestStart error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     const _err = new Error()
@@ -379,7 +380,7 @@ test('connect call onRequestUpgrade once', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     let recvData = ''
@@ -431,7 +432,7 @@ test('dispatch onResponseStart missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.dispatch({
@@ -464,7 +465,7 @@ test('dispatch onResponseData missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.dispatch({
@@ -497,7 +498,7 @@ test('dispatch onResponseEnd missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.dispatch({
@@ -530,7 +531,7 @@ test('dispatch onResponseError missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     try {
@@ -567,7 +568,7 @@ test('dispatch CONNECT onRequestUpgrade missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => client.destroy.bind(client)())
 
     client.dispatch({
@@ -598,7 +599,7 @@ test('dispatch upgrade onRequestUpgrade missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.dispatch({
@@ -629,7 +630,7 @@ test('dispatch pool onResponseError missing', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     try {
@@ -656,7 +657,7 @@ test('dispatch onBodySent not a function', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.dispatch({
@@ -686,7 +687,7 @@ test('dispatch onBodySent buffer', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
     const body = 'hello 🚀'
     client.dispatch({
@@ -725,7 +726,7 @@ test('dispatch onBodySent stream', async (t) => {
   const toSendBytes = chunks.reduce((a, b) => a + Buffer.byteLength(b), 0)
   const body = stream.Readable.from(chunks)
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
     let sentBytes = 0
     let currentChunk = 0
@@ -766,7 +767,7 @@ test('dispatch onBodySent async-iterable', (t, done) => {
   const chunks = ['he', 'llo', 'world', '🚀']
   const toSendBytes = chunks.reduce((a, b) => a + Buffer.byteLength(b), 0)
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
     let sentBytes = 0
     let currentChunk = 0
@@ -801,7 +802,7 @@ test('dispatch onBodySent throws error', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
     const body = 'hello'
     client.dispatch({
@@ -834,7 +835,7 @@ test('dispatches in expected order', async (t) => {
   const p = tspl(t, { plan: 1 })
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
     t.after(() => { return client.close() })
 
@@ -882,7 +883,7 @@ test('onResponseStarted is called with interceptor', async (t) => {
   const p = tspl(t, { plan: 2 })
 
   server.listen(0, () => {
-    const pool = new Pool(`http://localhost:${server.address().port}`)
+    const pool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const client = pool.compose((dispatch) => (opts, handler) => dispatch(opts, handler))
 
     t.after(() => { return pool.close() })
@@ -925,7 +926,7 @@ test('dispatches in expected order for http2', async (t) => {
   const p = tspl(t, { plan: 1 })
 
   server.listen(0, () => {
-    const client = new Pool(`https://localhost:${server.address().port}`, {
+    const client = new Pool(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
@@ -977,7 +978,7 @@ test('Issue#3065 - fix bad destroy handling', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       }
@@ -1070,7 +1071,7 @@ test('Issue#3065 - fix bad destroy handling (h2)', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },

--- a/test/node-test/client-errors.js
+++ b/test/node-test/client-errors.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const assert = require('node:assert')
 const https = require('node:https')
 const net = require('node:net')
@@ -37,7 +38,7 @@ test('GET errors and reconnect with pipelining 1', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1
     })
     t.after(client.destroy.bind(client))
@@ -91,7 +92,7 @@ test('GET errors and reconnect with pipelining 3', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     t.after(client.destroy.bind(client))
@@ -153,7 +154,7 @@ function errorAndPipelining (type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({
@@ -228,7 +229,7 @@ function errorAndChunkedEncodingPipelining (type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       client.request({
@@ -673,7 +674,7 @@ test('POST which fails should error response', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     function checkError (err) {
@@ -768,7 +769,7 @@ test('client destroy cleanup', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    client = new Client(`http://localhost:${server.address().port}`)
+    client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     const body = new Readable({ read () {} })
@@ -798,7 +799,7 @@ test('throwing async-iterator causes error', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({
@@ -832,7 +833,7 @@ test('client async-iterator destroy cleanup', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    client = new Client(`http://localhost:${server.address().port}`)
+    client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     const body = wrapWithAsyncIterable(['asd'], true)
@@ -862,7 +863,7 @@ test('GET errors body', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
@@ -886,7 +887,7 @@ test('validate request body', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(() => { return client.close() })
 
     client.request({
@@ -954,7 +955,7 @@ function socketFailWrite (type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`)
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
       t.after(client.destroy.bind(client))
 
       const preBody = new Readable({ read () {} })
@@ -995,7 +996,7 @@ function socketFailEndWrite (type) {
     t.after(closeServerAsPromise(server))
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 2
       })
       t.after(client.destroy.bind(client))
@@ -1042,7 +1043,7 @@ test('queued request should not fail on socket destroy', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1
     })
     t.after(client.destroy.bind(client))
@@ -1081,7 +1082,7 @@ test('queued request should fail on client destroy', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1
     })
     t.after(client.destroy.bind(client))
@@ -1125,7 +1126,7 @@ test('retry idempotent inflight', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     t.after(() => { return client.close() })
@@ -1240,7 +1241,7 @@ test('CONNECT throws in next tick', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({
@@ -1304,7 +1305,7 @@ test('invalid body chunk does not crash', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({
@@ -1352,7 +1353,7 @@ test('headers overflow', (t, done) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       maxHeaderSize: 10
     })
     t.after(client.destroy.bind(client))
@@ -1376,15 +1377,15 @@ test('SocketError should expose socket details (net)', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     t.after(client.destroy.bind(client))
 
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       p.ok(err instanceof errors.SocketError)
       if (err.socket.remoteFamily === 'IPv4') {
         p.strictEqual(err.socket.remoteFamily, 'IPv4')
-        p.strictEqual(err.socket.localAddress, '127.0.0.1')
-        p.strictEqual(err.socket.remoteAddress, '127.0.0.1')
+        p.strictEqual(err.socket.localAddress, LOOPBACK_HOST)
+        p.strictEqual(err.socket.remoteAddress, LOOPBACK_HOST)
       } else {
         p.strictEqual(err.socket.remoteFamily, 'IPv6')
         p.strictEqual(err.socket.localAddress, '::1')
@@ -1410,7 +1411,7 @@ test('SocketError should expose socket details (tls)', async (t) => {
   t.after(closeServerAsPromise(server))
 
   server.listen(0, () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
       tls: {
         rejectUnauthorized: false
       }
@@ -1421,8 +1422,8 @@ test('SocketError should expose socket details (tls)', async (t) => {
       p.ok(err instanceof errors.SocketError)
       if (err.socket.remoteFamily === 'IPv4') {
         p.strictEqual(err.socket.remoteFamily, 'IPv4')
-        p.strictEqual(err.socket.localAddress, '127.0.0.1')
-        p.strictEqual(err.socket.remoteAddress, '127.0.0.1')
+        p.strictEqual(err.socket.localAddress, LOOPBACK_HOST)
+        p.strictEqual(err.socket.remoteAddress, LOOPBACK_HOST)
       } else {
         p.strictEqual(err.socket.remoteFamily, 'IPv6')
         p.strictEqual(err.socket.localAddress, '::1')
@@ -1448,7 +1449,7 @@ test('parser error', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({ path: '/', method: 'GET' }, (err) => {

--- a/test/node-test/diagnostics-channel/error.js
+++ b/test/node-test/diagnostics-channel/error.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -30,7 +31,7 @@ test('Diagnostics channel - error', (t) => {
 
   return new Promise((resolve) => {
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/diagnostics-channel/get-h2.js
+++ b/test/node-test/diagnostics-channel/get-h2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
@@ -26,7 +27,7 @@ test('Diagnostics channel - get support H2', async t => {
   await once(server, 'listening')
 
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
-    t.strictEqual(request.origin, `https://localhost:${server.address().port}`)
+    t.strictEqual(request.origin, `https://${LOOPBACK_HOST}:${server.address().port}`)
     t.strictEqual(request.completed, false)
     t.strictEqual(request.method, 'GET')
     t.strictEqual(request.path, '/')
@@ -41,7 +42,7 @@ test('Diagnostics channel - get support H2', async t => {
     t.strictEqual(_socket, socket)
     const expectedHeaders = [
       'x-my-header: foo',
-      `:authority: localhost:${server.address().port}`,
+      `:authority: ${LOOPBACK_HOST}:${server.address().port}`,
       ':method: GET',
       ':path: /',
       ':scheme: https'
@@ -49,7 +50,7 @@ test('Diagnostics channel - get support H2', async t => {
     t.strictEqual(headers, expectedHeaders.join('\r\n') + '\r\n')
   })
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },

--- a/test/node-test/diagnostics-channel/get.js
+++ b/test/node-test/diagnostics-channel/get.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -28,7 +29,7 @@ test('Diagnostics channel - get', (t) => {
   let _req
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
     _req = request
-    assert.equal(request.origin, `http://localhost:${server.address().port}`)
+    assert.equal(request.origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(request.completed, false)
     assert.equal(request.method, 'GET')
     assert.equal(request.path, '/')
@@ -46,7 +47,7 @@ test('Diagnostics channel - get', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -62,7 +63,7 @@ test('Diagnostics channel - get', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -75,7 +76,7 @@ test('Diagnostics channel - get', (t) => {
 
     const expectedHeaders = [
       'GET / HTTP/1.1',
-      `host: localhost:${server.address().port}`,
+      `host: ${LOOPBACK_HOST}:${server.address().port}`,
       'connection: keep-alive',
       'bar: bar',
       'hello: world'
@@ -138,7 +139,7 @@ test('Diagnostics channel - get', (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/diagnostics-channel/get.js
+++ b/test/node-test/diagnostics-channel/get.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -29,7 +28,7 @@ test('Diagnostics channel - get', (t) => {
   let _req
   diagnosticsChannel.channel('undici:request:create').subscribe(({ request }) => {
     _req = request
-    assert.equal(request.origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
+    assert.equal(request.origin, `http://localhost:${server.address().port}`)
     assert.equal(request.completed, false)
     assert.equal(request.method, 'GET')
     assert.equal(request.path, '/')
@@ -47,7 +46,7 @@ test('Diagnostics channel - get', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
+    assert.equal(host, `localhost:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -63,7 +62,7 @@ test('Diagnostics channel - get', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
+    assert.equal(host, `localhost:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -76,7 +75,7 @@ test('Diagnostics channel - get', (t) => {
 
     const expectedHeaders = [
       'GET / HTTP/1.1',
-      `host: ${LOOPBACK_HOST}:${server.address().port}`,
+      `host: localhost:${server.address().port}`,
       'connection: keep-alive',
       'bar: bar',
       'hello: world'
@@ -139,7 +138,7 @@ test('Diagnostics channel - get', (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
+      const client = new Client(`http://localhost:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/diagnostics-channel/post-stream.js
+++ b/test/node-test/diagnostics-channel/post-stream.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const { Readable } = require('node:stream')
@@ -48,7 +49,7 @@ test('Diagnostics channel - post stream', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -64,7 +65,7 @@ test('Diagnostics channel - post stream', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -77,7 +78,7 @@ test('Diagnostics channel - post stream', (t) => {
 
     const expectedHeaders = [
       'POST / HTTP/1.1',
-      `host: localhost:${server.address().port}`,
+      `host: ${LOOPBACK_HOST}:${server.address().port}`,
       'connection: keep-alive',
       'bar: bar',
       'hello: world'
@@ -148,7 +149,7 @@ test('Diagnostics channel - post stream', (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/diagnostics-channel/post.js
+++ b/test/node-test/diagnostics-channel/post.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -47,7 +46,7 @@ test('Diagnostics channel - post', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
+    assert.equal(host, `localhost:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -63,7 +62,7 @@ test('Diagnostics channel - post', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
+    assert.equal(host, `localhost:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -76,7 +75,7 @@ test('Diagnostics channel - post', (t) => {
 
     const expectedHeaders = [
       'POST / HTTP/1.1',
-      `host: ${LOOPBACK_HOST}:${server.address().port}`,
+      `host: localhost:${server.address().port}`,
       'connection: keep-alive',
       'bar: bar',
       'hello: world'
@@ -146,7 +145,7 @@ test('Diagnostics channel - post', (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
+      const client = new Client(`http://localhost:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/diagnostics-channel/post.js
+++ b/test/node-test/diagnostics-channel/post.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test, after } = require('node:test')
 const { tspl } = require('@matteo.collina/tspl')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -46,7 +47,7 @@ test('Diagnostics channel - post', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -62,7 +63,7 @@ test('Diagnostics channel - post', (t) => {
 
     const { host, hostname, protocol, port, servername } = connectParams
 
-    assert.equal(host, `localhost:${server.address().port}`)
+    assert.equal(host, `${LOOPBACK_HOST}:${server.address().port}`)
     assert.equal(hostname, 'localhost')
     assert.equal(port, String(server.address().port))
     assert.equal(protocol, 'http:')
@@ -75,7 +76,7 @@ test('Diagnostics channel - post', (t) => {
 
     const expectedHeaders = [
       'POST / HTTP/1.1',
-      `host: localhost:${server.address().port}`,
+      `host: ${LOOPBACK_HOST}:${server.address().port}`,
       'connection: keep-alive',
       'bar: bar',
       'hello: world'
@@ -145,7 +146,7 @@ test('Diagnostics channel - post', (t) => {
     })
 
     server.listen(0, () => {
-      const client = new Client(`http://localhost:${server.address().port}`, {
+      const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
         keepAliveTimeout: 300e3
       })
 

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const assert = require('node:assert')
 const { test } = require('node:test')
 const { spawnSync } = require('node:child_process')
@@ -26,7 +27,7 @@ test('setGlobalDispatcher does not break Node.js global fetch', () => {
       await once(server, 'listening')
 
       setGlobalDispatcher(new Agent())
-      const url = 'http://127.0.0.1:' + server.address().port
+      const url = 'http://${LOOPBACK_HOST}:' + server.address().port
       const res = await fetch(url)
       process.stdout.write(await res.text())
 
@@ -71,7 +72,7 @@ test('setGlobalDispatcher mirrors a v1-compatible dispatcher that Node.js global
         throw new Error('expected v1 global dispatcher to be a Dispatcher1Wrapper')
       }
 
-      const url = 'http://127.0.0.1:' + server.address().port
+      const url = 'http://${LOOPBACK_HOST}:' + server.address().port
       const res = await fetch(url)
       const body = await res.text()
 
@@ -111,7 +112,7 @@ test('Dispatcher1Wrapper bridges legacy handlers to a new Agent', () => {
       const dispatcherV1 = Symbol.for('undici.globalDispatcher.1')
       globalThis[dispatcherV1] = new Dispatcher1Wrapper(new Agent())
 
-      const url = 'http://127.0.0.1:' + server.address().port
+      const url = 'http://${LOOPBACK_HOST}:' + server.address().port
       const res = await fetch(url)
       process.stdout.write(await res.text())
 

--- a/test/node-test/validations.js
+++ b/test/node-test/validations.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { Client } = require('../../')
@@ -21,7 +22,7 @@ test('validations', async t => {
   })
 
   server.listen(0, async () => {
-    const url = `http://localhost:${server.address().port}`
+    const url = `http://${LOOPBACK_HOST}:${server.address().port}`
     client = new Client(url)
 
     await t.test('path', () => {

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const net = require('node:net')
@@ -23,7 +24,7 @@ test('https://github.com/mcollina/undici/issues/268', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.on('disconnect', () => {
@@ -59,7 +60,7 @@ test('parser fail', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -86,7 +87,7 @@ test('split header field', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -114,7 +115,7 @@ test('split header value', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.request({
@@ -157,7 +158,7 @@ test('refreshes wasm input view after reallocating parser buffer', async (t) => 
 
   await new Promise(resolve => server.listen(0, resolve))
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
 
   function request () {

--- a/test/pipeline-pipelining.js
+++ b/test/pipeline-pipelining.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -17,7 +18,7 @@ test('pipeline pipelining', async (t) => {
 
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 2
     })
     after(() => client.close())
@@ -70,7 +71,7 @@ test('pipeline pipelining retry', async (t) => {
 
   after(() => server.close())
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 3
     })
     after(() => client.destroy())

--- a/test/pool.js
+++ b/test/pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { EventEmitter } = require('node:events')
@@ -113,7 +114,7 @@ test('connect/disconnect event(s)', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const pool = new Pool(`http://localhost:${server.address().port}`, {
+    const pool = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: clients,
       keepAliveTimeoutThreshold: 100
     })
@@ -155,10 +156,10 @@ test('basic get', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
-    t.strictEqual(client[kUrl].origin, `http://localhost:${server.address().port}`)
+    t.strictEqual(client[kUrl].origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.ifError(err)
@@ -244,7 +245,7 @@ test('basic get error async/await', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     await client.request({ path: '/', method: 'GET' })
@@ -274,7 +275,7 @@ test('basic get with async/await', async (t) => {
   after(() => server.close())
 
   await promisify(server.listen.bind(server))(0)
-  const client = new Pool(`http://localhost:${server.address().port}`)
+  const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
 
   const { statusCode, headers, body } = await client.request({ path: '/', method: 'GET' })
@@ -300,7 +301,7 @@ test('stream get async/await', async (t) => {
   after(() => server.close())
 
   await promisify(server.listen.bind(server))(0)
-  const client = new Pool(`http://localhost:${server.address().port}`)
+  const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.destroy())
 
   await client.stream({ path: '/', method: 'GET' }, ({ statusCode, headers }) => {
@@ -321,7 +322,7 @@ test('stream get error async/await', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     await client.stream({ path: '/', method: 'GET' }, () => {
@@ -347,7 +348,7 @@ test('pipeline get', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const bufs = []
@@ -460,7 +461,7 @@ test('busy', async (t) => {
   const connections = 2
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections,
       pipelining: 2
     })
@@ -529,7 +530,7 @@ test('pool upgrade promise', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const { headers, socket } = await client.upgrade({
@@ -579,7 +580,7 @@ test('pool connect', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const { socket } = await client.connect({
@@ -621,7 +622,7 @@ test('pool connect with clientTtl specified', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       clientTtl: 10
     })
 
@@ -662,7 +663,7 @@ test('pool replaces stale client when connections limit is reached', async (t) =
 
   await new Promise(resolve => server.listen(0, resolve))
 
-  const client = new Pool(`http://localhost:${server.address().port}`, {
+  const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 1,
     clientTtl: 1
   })
@@ -756,7 +757,7 @@ test('pool dispatch', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     let buf = ''
@@ -806,7 +807,7 @@ test('300 requests succeed', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1
     })
     after(() => client.destroy())
@@ -841,7 +842,7 @@ test('pool connect error', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -875,7 +876,7 @@ test('pool upgrade error', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -901,7 +902,7 @@ test('pool dispatch error', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -959,7 +960,7 @@ test('pool request abort in queue', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1006,7 +1007,7 @@ test('pool stream abort in queue', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1053,7 +1054,7 @@ test('pool pipeline abort in queue', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1100,7 +1101,7 @@ test('pool stream constructor error destroy body', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1156,7 +1157,7 @@ test('pool request constructor error destroy body', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1208,7 +1209,7 @@ test('pool close waits for all requests', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1256,7 +1257,7 @@ test('pool destroyed', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1283,7 +1284,7 @@ test('pool destroy fails queued requests', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`, {
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 1,
       pipelining: 1
     })
@@ -1332,10 +1333,10 @@ test('stats', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
-    t.strictEqual(client[kUrl].origin, `http://localhost:${server.address().port}`)
+    t.strictEqual(client[kUrl].origin, `http://${LOOPBACK_HOST}:${server.address().port}`)
 
     client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
       t.ifError(err)

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, Pool } = require('..')
@@ -19,7 +20,7 @@ test('basic get, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -73,7 +74,7 @@ test('basic POST with string, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -109,7 +110,7 @@ test('basic POST with Buffer, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -145,7 +146,7 @@ test('basic POST with stream, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -188,7 +189,7 @@ test('basic POST with async-iterator, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {
@@ -252,7 +253,7 @@ test('20 times GET with pipelining 10, async await support', async (t) => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 10
     })
     after(() => client.close())
@@ -308,7 +309,7 @@ test('pool, async await support', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Pool(`http://localhost:${server.address().port}`)
+    const client = new Pool(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.on('disconnect', () => {

--- a/test/prototype-headers.js
+++ b/test/prototype-headers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test } = require('node:test')
 const assert = require('node:assert')
 const { promisify } = require('node:util')
@@ -32,7 +33,7 @@ test('request handles response headers that shadow Object.prototype', async (t) 
 
   await promisify(server.listen.bind(server))(0)
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   t.after(() => client.close())
 
   const { statusCode, headers, body } = await client.request({
@@ -69,7 +70,7 @@ test('request handles response trailers that shadow Object.prototype', async (t)
 
   await promisify(server.listen.bind(server))(0)
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   t.after(() => client.close())
 
   const { statusCode, trailers, body } = await client.request({

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -194,7 +195,7 @@ test('use proxy-agent to connect through proxy (keep alive)', async (t) => {
     _connectParams = connectParams
   })
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -239,7 +240,7 @@ test('use proxy-agent to connect through proxy', async (t) => {
   const proxy = await buildProxy()
   delete proxy.authenticate
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const parsedOrigin = new URL(serverUrl)
@@ -295,7 +296,7 @@ test('use proxy agent to connect through proxy using Pool', async (t) => {
     res.end()
   })
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const clientFactory = (url, options) => {
     return new Pool(url, options)
@@ -315,7 +316,7 @@ test('use proxy-agent to connect through proxy using path with params', async (t
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
@@ -351,7 +352,7 @@ test('use proxy-agent to connect through proxy using path with params with tunne
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const parsedOrigin = new URL(serverUrl)
@@ -387,7 +388,7 @@ test('use proxy-agent to connect through proxy with basic auth in URL', async (t
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = new URL(`http://user:pass@localhost:${proxy.address().port}`)
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
@@ -428,7 +429,7 @@ test('use proxy-agent to connect through proxy with username-only auth in URL', 
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = new URL(`http://user:@localhost:${proxy.address().port}`)
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
@@ -469,7 +470,7 @@ test('use proxy-agent to connect through proxy with username-only auth in URL wi
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = new URL(`http://user@localhost:${proxy.address().port}`)
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
@@ -510,7 +511,7 @@ test('use proxy-agent to connect through proxy with basic auth in URL with tunne
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = new URL(`http://user:pass@localhost:${proxy.address().port}`)
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const parsedOrigin = new URL(serverUrl)
@@ -551,7 +552,7 @@ test('use proxy-agent to connect through proxy with username-only auth in URL wi
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = new URL(`http://user:@localhost:${proxy.address().port}`)
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const parsedOrigin = new URL(serverUrl)
@@ -592,7 +593,7 @@ test('use proxy-agent with auth', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     auth: Buffer.from('user:pass').toString('base64'),
@@ -637,7 +638,7 @@ test('use proxy-agent with auth with tunneling enabled', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     auth: Buffer.from('user:pass').toString('base64'),
@@ -682,7 +683,7 @@ test('use proxy-agent with token', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     token: `Bearer ${Buffer.from('user:pass').toString('base64')}`,
@@ -727,7 +728,7 @@ test('use proxy-agent with token with tunneling enabled', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     token: `Bearer ${Buffer.from('user:pass').toString('base64')}`,
@@ -772,7 +773,7 @@ test('use proxy-agent with custom headers', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -806,7 +807,7 @@ test('use proxy-agent with custom headers with tunneling enabled', async (t) => 
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -840,7 +841,7 @@ test('sending proxy-authorization in request headers should throw', async (t) =>
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent(proxyUrl)
 
@@ -899,7 +900,7 @@ test('use proxy-agent with setGlobalDispatcher', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
   const parsedOrigin = new URL(serverUrl)
@@ -941,7 +942,7 @@ test('use proxy-agent with setGlobalDispatcher with tunneling enabled', async (t
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const parsedOrigin = new URL(serverUrl)
@@ -982,7 +983,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623', async
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
@@ -991,7 +992,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623', async
   after(() => setGlobalDispatcher(defaultDispatcher))
 
   const expectedHeaders = {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive',
     'test-header': 'value',
     accept: '*/*',
@@ -1032,7 +1033,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623 (with p
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
@@ -1041,7 +1042,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623 (with p
   after(() => setGlobalDispatcher(defaultDispatcher))
 
   const expectedHeaders = {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive',
     'test-header': 'value',
     accept: '*/*',
@@ -1053,7 +1054,7 @@ test('ProxyAgent correctly sends headers when using fetch - #1355, #1623 (with p
 
   const expectedProxyHeaders = {
     'proxy-connection': 'keep-alive',
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'close'
   }
 
@@ -1082,7 +1083,7 @@ test('should throw when proxy does not return 200', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   proxy.on('connect', () => {
@@ -1116,7 +1117,7 @@ test('should throw when proxy does not return 200 with tunneling enabled', async
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   proxy.authenticate = function (_req) {
@@ -1144,7 +1145,7 @@ test('pass ProxyAgent proxy status code error when using fetch - #2161', async (
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   proxy.authenticate = function (_req) {
@@ -1172,7 +1173,7 @@ test('Proxy via HTTP to HTTPS endpoint', async (t) => {
   const server = await buildSSLServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `https://localhost:${server.address().port}`
+  const serverUrl = `https://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -1208,7 +1209,7 @@ test('Proxy via HTTP to HTTPS endpoint', async (t) => {
   const data = await request(serverUrl, { dispatcher: proxyAgent })
   const json = await data.body.json()
   t.deepStrictEqual(json, {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive'
   })
 
@@ -1222,7 +1223,7 @@ test('Proxy via HTTPS to HTTPS endpoint', async (t) => {
   const server = await buildSSLServer()
   const proxy = await buildSSLProxy()
 
-  const serverUrl = `https://localhost:${server.address().port}`
+  const serverUrl = `https://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `https://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -1264,7 +1265,7 @@ test('Proxy via HTTPS to HTTPS endpoint', async (t) => {
   const data = await request(serverUrl, { dispatcher: proxyAgent })
   const json = await data.body.json()
   t.deepStrictEqual(json, {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive'
   })
 
@@ -1278,7 +1279,7 @@ test('Proxy via HTTPS to HTTP endpoint with tunneling enabled', async (t) => {
   const server = await buildServer()
   const proxy = await buildSSLProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `https://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -1311,7 +1312,7 @@ test('Proxy via HTTPS to HTTP endpoint with tunneling enabled', async (t) => {
   const data = await request(serverUrl, { dispatcher: proxyAgent })
   const json = await data.body.json()
   t.deepStrictEqual(json, {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive'
   })
 
@@ -1325,7 +1326,7 @@ test('Proxy via HTTP to HTTP endpoint with tunneling enabled', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
 
@@ -1353,7 +1354,7 @@ test('Proxy via HTTP to HTTP endpoint with tunneling enabled', async (t) => {
   const data = await request(serverUrl, { dispatcher: proxyAgent })
   const json = await data.body.json()
   t.deepStrictEqual(json, {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive'
   })
 
@@ -1367,7 +1368,7 @@ test('Proxy via HTTP to HTTP endpoint with tunneling disabled', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: false })
 
@@ -1400,7 +1401,7 @@ test('Proxy via HTTP to HTTP endpoint with tunneling disabled', async (t) => {
   const data = await request(serverUrl, { dispatcher: proxyAgent })
   const json = await data.body.json()
   t.deepStrictEqual(json, {
-    host: `localhost:${server.address().port}`,
+    host: `${LOOPBACK_HOST}:${server.address().port}`,
     connection: 'keep-alive'
   })
 
@@ -1414,7 +1415,7 @@ test('Proxy via HTTPS to HTTP fails on wrong SNI', async (t) => {
   const server = await buildServer()
   const proxy = await buildSSLProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `https://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({
     uri: proxyUrl,
@@ -1465,13 +1466,13 @@ test('ProxyAgent keeps customized host in request headers - #3019', async (t) =>
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
   const proxyAgent = new ProxyAgent({ uri: proxyUrl, proxyTunnel: true })
   const customHost = 'example.com'
 
   proxy.on('connect', (req) => {
-    t.strictEqual(req.headers.host, `localhost:${server.address().port}`)
+    t.strictEqual(req.headers.host, `${LOOPBACK_HOST}:${server.address().port}`)
   })
 
   server.on('request', (req, res) => {

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
 const { Client, Pool } = require('..')
@@ -12,7 +13,7 @@ test('connect through proxy', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   server.on('request', (req, res) => {
@@ -53,7 +54,7 @@ test('connect through proxy with auth', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   proxy.authenticate = function (req) {
@@ -101,7 +102,7 @@ test('connect through proxy with auth but invalid credentials', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   proxy.authenticate = function (req) {
@@ -141,7 +142,7 @@ test('connect through proxy (with pool)', async (t) => {
   const server = await buildServer()
   const proxy = await buildProxy()
 
-  const serverUrl = `http://localhost:${server.address().port}`
+  const serverUrl = `http://${LOOPBACK_HOST}:${server.address().port}`
   const proxyUrl = `http://localhost:${proxy.address().port}`
 
   server.on('request', (req, res) => {

--- a/test/request-crlf.js
+++ b/test/request-crlf.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { createServer } = require('node:http')
 const { test, after } = require('node:test')
@@ -21,7 +22,7 @@ test('should validate content-type CRLF Injection', async (t) => {
 
   await once(server, 'listening')
   try {
-    await request(`http://localhost:${server.address().port}`, {
+    await request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       method: 'GET',
       headers: {
         'content-type': 'application/json\r\n\r\nGET /foo2 HTTP/1.1'

--- a/test/request-timeout.js
+++ b/test/request-timeout.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { resolve: pathResolve } = require('node:path')
 const { test, after, beforeEach } = require('node:test')
@@ -41,7 +42,7 @@ test('request timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { headersTimeout: 500 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { headersTimeout: 500 })
     after(() => client.destroy())
 
     client.request({ path: '/', method: 'GET' }, (err, response) => {
@@ -64,7 +65,7 @@ test('request timeout with readable body', async (t) => {
   after(() => unlinkSync(tempfile))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { headersTimeout: 1e3 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { headersTimeout: 1e3 })
     after(() => client.destroy())
 
     const body = createReadStream(tempfile)
@@ -91,7 +92,7 @@ test('body timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { bodyTimeout: 50 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { bodyTimeout: 50 })
     after(() => client.destroy())
 
     tickOnConnect(client, () => {
@@ -132,7 +133,7 @@ test('overridden request timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { headersTimeout: 500 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { headersTimeout: 500 })
     after(() => client.destroy())
 
     tickOnConnect(client, () => {
@@ -163,7 +164,7 @@ test('overridden body timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { bodyTimeout: 500 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { bodyTimeout: 500 })
     after(() => client.destroy())
 
     tickOnConnect(client, () => {
@@ -204,7 +205,7 @@ test('With EE signal', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     const ee = new EventEmitter()
@@ -242,7 +243,7 @@ test('With abort-controller signal', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     const abortController = new AbortController()
@@ -282,7 +283,7 @@ test('Abort before timeout (EE)', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     after(() => client.destroy())
@@ -318,7 +319,7 @@ test('Abort before timeout (abort-controller)', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     after(() => client.destroy())
@@ -352,7 +353,7 @@ test('Timeout with pipelining', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 10,
       headersTimeout: 50
     })
@@ -393,7 +394,7 @@ test('Global option', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     after(() => client.destroy())
@@ -430,7 +431,7 @@ test('Request options overrides global option', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 50
     })
     after(() => client.destroy())
@@ -457,7 +458,7 @@ test('client.destroy should cancel the timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 100
     })
 
@@ -487,7 +488,7 @@ test('client.close should wait for the timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 100
     })
     after(() => client.destroy())
@@ -570,7 +571,7 @@ test('Disable request timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 0,
       connectTimeout: 0
     })
@@ -613,7 +614,7 @@ test('Disable request timeout for a single request', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 0,
       connectTimeout: 0
     })
@@ -656,7 +657,7 @@ test('stream timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, { connectTimeout: 0 })
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { connectTimeout: 0 })
     after(() => client.destroy())
 
     client.stream({
@@ -692,7 +693,7 @@ test('stream custom timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 30e3
     })
     after(() => client.destroy())
@@ -730,7 +731,7 @@ test('pipeline timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     const buf = Buffer.alloc(1e6).toString()
@@ -785,7 +786,7 @@ test('pipeline timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       headersTimeout: 30e3
     })
     after(() => client.destroy())
@@ -837,7 +838,7 @@ test('client.close should not deadlock', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 200,
       headersTimeout: 100
     })

--- a/test/request-timeout2.js
+++ b/test/request-timeout2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
@@ -22,7 +23,7 @@ test('request timeout with slow readable body', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`, { headersTimeout: 50 })
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, { headersTimeout: 50 })
   after(() => client.close())
 
   client.on('disconnect', () => {

--- a/test/request.js
+++ b/test/request.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { createServer } = require('node:http')
 const { test, after, describe } = require('node:test')
@@ -222,7 +223,7 @@ describe('DispatchOptions#maxRedirections', () => {
 
     const res = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       maxRedirections: 0
     })
 
@@ -250,7 +251,7 @@ describe('DispatchOptions#reset', () => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.connection, 'close')
       res.statusCode = 200
       res.end('hello')
@@ -270,7 +271,7 @@ describe('DispatchOptions#reset', () => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: true
     })
     await body.dump()
@@ -281,7 +282,7 @@ describe('DispatchOptions#reset', () => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.connection, 'keep-alive')
       res.statusCode = 200
       res.end('hello')
@@ -301,7 +302,7 @@ describe('DispatchOptions#reset', () => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: false
     })
     await body.dump()
@@ -312,7 +313,7 @@ describe('DispatchOptions#reset', () => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.connection, 'close')
       res.statusCode = 200
       res.end('hello')
@@ -332,7 +333,7 @@ describe('DispatchOptions#reset', () => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       headers: {
         connection: 'close'
       }
@@ -347,7 +348,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.hello, 'world')
       res.statusCode = 200
       res.end('hello')
@@ -370,7 +371,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: true,
       headers
     })
@@ -382,7 +383,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.hello, 'world')
       res.statusCode = 200
       res.end('hello')
@@ -405,7 +406,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: true,
       headers
     })
@@ -417,7 +418,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.hello, 'world')
       res.statusCode = 200
       res.end('hello')
@@ -443,7 +444,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const { body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: true,
       headers
     })
@@ -455,7 +456,7 @@ describe('Should include headers from iterable objects', scope => {
 
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       t.strictEqual('GET', req.method)
-      t.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+      t.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
       t.strictEqual(req.headers.hello, 'world')
       res.statusCode = 200
       res.end('hello')
@@ -484,7 +485,7 @@ describe('Should include headers from iterable objects', scope => {
 
       const { body } = await request({
         method: 'GET',
-        origin: `http://localhost:${server.address().port}`,
+        origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
         reset: true,
         headers
       })
@@ -526,7 +527,7 @@ describe('Should include headers from iterable objects', scope => {
 
     await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       reset: true,
       headers
     }).catch((err) => {
@@ -553,7 +554,7 @@ test('request should include statusText in response', async t => {
 
   const { statusText, body } = await request({
     method: 'GET',
-    origin: `http://localhost:${server.address().port}`,
+    origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
     path: '/'
   })
 
@@ -575,7 +576,7 @@ describe('connection header per RFC 7230', () => {
 
     const { statusCode, body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       headers: { connection: 'close' }
     })
     await body.dump()
@@ -594,7 +595,7 @@ describe('connection header per RFC 7230', () => {
 
     const { statusCode, body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       headers: { connection: 'keep-alive' }
     })
     await body.dump()
@@ -613,7 +614,7 @@ describe('connection header per RFC 7230', () => {
 
     const { statusCode, body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       headers: {
         'x-custom-header': 'value',
         connection: 'x-custom-header'
@@ -635,7 +636,7 @@ describe('connection header per RFC 7230', () => {
 
     const { statusCode, body } = await request({
       method: 'GET',
-      origin: `http://localhost:${server.address().port}`,
+      origin: `http://${LOOPBACK_HOST}:${server.address().port}`,
       headers: {
         'x-custom-header': 'value',
         connection: 'close, x-custom-header'

--- a/test/retry-agent.js
+++ b/test/retry-agent.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -36,7 +37,7 @@ test('Should retry status code', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const agent = new RetryAgent(client, opts)
 
     after(async () => {

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -57,7 +58,7 @@ test('Should retry status code', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -152,7 +153,7 @@ test('Should account for network and response errors', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -223,7 +224,7 @@ test('Issue #3288 - request with body (asynciterable)', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -300,7 +301,7 @@ test('Should use retry-after header for retries', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -385,7 +386,7 @@ test('Should use retry-after header for retries (date)', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -467,7 +468,7 @@ test('Should retry with defaults', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -560,7 +561,7 @@ test('Should handle 206 partial content', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -643,7 +644,7 @@ test('Should handle 206 partial content - bad-etag', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(
       dispatchOptions,
       {
@@ -744,7 +745,7 @@ test('retrying a request with a body', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -816,7 +817,7 @@ test('retrying a request with a body (stream)', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -890,7 +891,7 @@ test('retrying a request with a body (buffer)', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -934,7 +935,7 @@ test('should not error if request is not meant to be retried', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const chunks = []
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
@@ -1023,7 +1024,7 @@ test('Should be able to properly pass the minTimeout to the RetryContext when co
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -1100,7 +1101,7 @@ test('Issue#2986 - Handle custom 206', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1196,7 +1197,7 @@ test('Should resume 206 response with unknown complete length Content-Range', as
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1296,7 +1297,7 @@ test('Issue#3128 - Support if-match', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1396,7 +1397,7 @@ test('Issue#3128 - Should ignore weak etags', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1496,7 +1497,7 @@ test('Weak etags are ignored on range-requests', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1591,7 +1592,7 @@ test('Should throw RequestRetryError when Content-Range mismatch', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1686,7 +1687,7 @@ test('Should use retry-after header for retries (date) but date format is wrong'
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {

--- a/test/retry-handler2.js
+++ b/test/retry-handler2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -27,7 +28,7 @@ test('Reuses socket on retry instead of closing it', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const retryAgent = new RetryAgent(client, {
       throwOnError: false,
       maxRetries: 2
@@ -63,7 +64,7 @@ test('throws an error on network error', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const retryAgent = new RetryAgent(client, {
       throwOnError: false,
       maxRetries: 2
@@ -102,7 +103,7 @@ test('Show pass status code errors when not eligible for retry, as normal respon
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const retryAgent = new RetryAgent(client, {
       throwOnError: false,
       maxRetries: 2
@@ -182,7 +183,7 @@ test('Should retry status code without throwing an error | throwOnError: false',
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -278,7 +279,7 @@ test('Should account for network and response errors | throwOnError: false', asy
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -354,7 +355,7 @@ test('Issue #3288 - request with body (asynciterable) should fail, without throw
   const chunks = []
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -434,7 +435,7 @@ test('Should use retry-after header for retries | throwOnError: false', async t 
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -522,7 +523,7 @@ test('Should use retry-after header for retries (date) | throwOnError: false', a
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -607,7 +608,7 @@ test('Should retry with defaults | throwOnError: false', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {
@@ -702,7 +703,7 @@ test('Should handle 206 partial content | throwOnError: false', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -788,7 +789,7 @@ test('Should handle 206 partial content - bad-etag | throwOnError: false', async
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(
       dispatchOptions,
       {
@@ -890,7 +891,7 @@ test('retrying a request with a body | throwOnError: false', async t => {
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -963,7 +964,7 @@ test('retrying a request with a body (stream) | throwOnError: false', async t =>
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -1040,7 +1041,7 @@ test('retrying a request with a body (buffer) | throwOnError: false', async t =>
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -1085,7 +1086,7 @@ test('should not error if request is not meant to be retried | throwOnError: fal
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const chunks = []
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
@@ -1175,7 +1176,7 @@ test('Should be able to properly pass the minTimeout to the RetryContext when co
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: new RequestHandler(dispatchOptions, (err, data) => {
@@ -1254,7 +1255,7 @@ test('Issue#2986 - Handle custom 206 | throwOnError: false', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1355,7 +1356,7 @@ test('Issue#3128 - Support if-match | throwOnError: false', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1456,7 +1457,7 @@ test('Issue#3128 - Should ignore weak etags | throwOnError: false', async t => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1557,7 +1558,7 @@ test('Weak etags are ignored on range-requests | throwOnError: false', async t =
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1653,7 +1654,7 @@ test('Should throw RequestRetryError when Content-Range mismatch | throwOnError:
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: (...args) => {
         return client.dispatch(...args)
@@ -1749,7 +1750,7 @@ test('Should use retry-after header for retries (date) but date format is wrong 
   })
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     const handler = new RetryHandler(dispatchOptions, {
       dispatch: client.dispatch.bind(client),
       handler: {

--- a/test/round-robin-pool.js
+++ b/test/round-robin-pool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
@@ -81,7 +82,7 @@ test('basic get', async (t) => {
 
   await new Promise(resolve => server.listen(0, resolve))
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 1
   })
 
@@ -106,7 +107,7 @@ test('replaces stale client when connections limit is reached', async (t) => {
 
   await new Promise(resolve => server.listen(0, resolve))
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 1,
     clientTtl: 1
   })
@@ -148,7 +149,7 @@ test('connect/disconnect event(s)', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, () => {
-    const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+    const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: clients,
       keepAliveTimeoutThreshold: 100
     })
@@ -189,7 +190,7 @@ test('busy', async (t) => {
   t.after(server.close.bind(server))
 
   server.listen(0, async () => {
-    const client = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+    const client = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       connections: 2,
       pipelining: 2
     })
@@ -240,7 +241,7 @@ test('factory option with basic get request', async (t) => {
 
   await promisify(server.listen).call(server, 0)
 
-  const client = new RoundRobinPool(`http://localhost:${server.address().port}`, opts)
+  const client = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, opts)
 
   t.after(client.destroy.bind(client))
 
@@ -281,7 +282,7 @@ test('round-robin distribution with multiple requests', async (t) => {
 
   await new Promise(resolve => server.listen(0, resolve))
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 3
   })
 
@@ -323,7 +324,7 @@ test('round-robin wraps around correctly', async (t) => {
   after(() => server.close())
   await new Promise(resolve => server.listen(0, resolve))
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 2
   })
 
@@ -351,7 +352,7 @@ test('close/destroy behavior', async (t) => {
   after(() => server.close())
   await new Promise(resolve => server.listen(0, resolve))
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`)
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`)
 
   t.strictEqual(pool.destroyed, false)
   t.strictEqual(pool.closed, false)
@@ -377,7 +378,7 @@ test('verifies round-robin kGetDispatcher cycling algorithm', async (t) => {
   const clientOrder = []
   let clientIdCounter = 0
 
-  const pool = new RoundRobinPool(`http://localhost:${server.address().port}`, {
+  const pool = new RoundRobinPool(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     connections: 3,
     factory: (origin, opts) => {
       const client = new Client(origin, opts)

--- a/test/socket-back-pressure.js
+++ b/test/socket-back-pressure.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { once } = require('node:events')
 const { Client } = require('..')
@@ -32,7 +33,7 @@ test('socket back-pressure', async (t) => {
   server.listen(0)
 
   await once(server, 'listening')
-  const client = new Client(`http://localhost:${server.address().port}`, {
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     pipelining: 1
   })
   after(() => client.close())

--- a/test/socket-timeout.js
+++ b/test/socket-timeout.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -24,7 +25,7 @@ test('timeout with pipelining 1', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       pipelining: 1,
       headersTimeout: 500,
       bodyTimeout: 500
@@ -76,7 +77,7 @@ test('Disable socket timeout', async (t) => {
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`, {
       bodyTimeout: 0,
       headersTimeout: 0
     })

--- a/test/socks5-client.js
+++ b/test/socks5-client.js
@@ -5,6 +5,7 @@ const { test } = require('node:test')
 const net = require('node:net')
 const { Socks5Client, STATES, AUTH_METHODS, REPLY_CODES } = require('../lib/core/socks5-client')
 const { InvalidArgumentError, Socks5ProxyError } = require('../lib/core/errors')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 test('Socks5Client - constructor validation', async (t) => {
   const p = tspl(t, { plan: 1 })
@@ -36,11 +37,11 @@ test('Socks5Client - handshake flow', async (t) => {
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve)
+    server.listen(0, LOOPBACK_HOST, resolve)
   })
 
   const { port } = server.address()
-  const socket = net.connect(port, '127.0.0.1')
+  const socket = net.connect(port, LOOPBACK_HOST)
 
   await new Promise((resolve) => {
     socket.on('connect', resolve)
@@ -142,11 +143,11 @@ test('Socks5Client - username/password authentication', async (t) => {
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve)
+    server.listen(0, LOOPBACK_HOST, resolve)
   })
 
   const { port } = server.address()
-  const socket = net.connect(port, '127.0.0.1')
+  const socket = net.connect(port, LOOPBACK_HOST)
 
   await new Promise((resolve) => {
     socket.on('connect', resolve)
@@ -218,11 +219,11 @@ test('Socks5Client - connect command', async (t) => {
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve)
+    server.listen(0, LOOPBACK_HOST, resolve)
   })
 
   const { port } = server.address()
-  const socket = net.connect(port, '127.0.0.1')
+  const socket = net.connect(port, LOOPBACK_HOST)
 
   await new Promise((resolve) => {
     socket.on('connect', resolve)
@@ -235,7 +236,7 @@ test('Socks5Client - connect command', async (t) => {
   })
 
   client.on('connected', (info) => {
-    p.equal(info.address, '127.0.0.1', 'should return bound address')
+    p.equal(info.address, LOOPBACK_HOST, 'should return bound address')
     p.equal(info.port, 80, 'should return bound port')
     p.equal(client.buffer.length, 0, 'should clear SOCKS5 protocol buffer after connect')
     p.equal(socket.listenerCount('data'), 0, 'should stop parsing socket data after connect')
@@ -268,11 +269,11 @@ test('Socks5Client - authentication failure', async (t) => {
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve)
+    server.listen(0, LOOPBACK_HOST, resolve)
   })
 
   const { port } = server.address()
-  const socket = net.connect(port, '127.0.0.1')
+  const socket = net.connect(port, LOOPBACK_HOST)
 
   await new Promise((resolve) => {
     socket.on('connect', resolve)
@@ -327,11 +328,11 @@ test('Socks5Client - connection refused', async (t) => {
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', resolve)
+    server.listen(0, LOOPBACK_HOST, resolve)
   })
 
   const { port } = server.address()
-  const socket = net.connect(port, '127.0.0.1')
+  const socket = net.connect(port, LOOPBACK_HOST)
 
   await new Promise((resolve) => {
     socket.on('connect', resolve)

--- a/test/socks5-proxy-agent.js
+++ b/test/socks5-proxy-agent.js
@@ -8,6 +8,7 @@ const { InvalidArgumentError } = require('../lib/core/errors')
 const Socks5ProxyAgent = require('../lib/dispatcher/socks5-proxy-agent')
 const { createServer } = require('node:http')
 const { TestSocks5Server } = require('./fixtures/socks5-test-server')
+const { LOOPBACK_HOST } = require('./utils/node-http')
 
 test('Socks5ProxyAgent - constructor validation', async (t) => {
   const p = tspl(t, { plan: 4 })
@@ -302,8 +303,8 @@ test('Socks5ProxyAgent - requests to different origins are routed correctly', as
     res.end(JSON.stringify({ server: 'B', path: req.url }))
   })
 
-  await new Promise((resolve) => serverA.listen(0, '127.0.0.1', resolve))
-  await new Promise((resolve) => serverB.listen(0, '127.0.0.1', resolve))
+  await new Promise((resolve) => serverA.listen(0, LOOPBACK_HOST, resolve))
+  await new Promise((resolve) => serverB.listen(0, LOOPBACK_HOST, resolve))
   const portA = serverA.address().port
   const portB = serverB.address().port
 
@@ -314,15 +315,15 @@ test('Socks5ProxyAgent - requests to different origins are routed correctly', as
   after(() => serverA.close())
   after(() => serverB.close())
 
-  const proxyWrapper = new Socks5ProxyAgent(`socks5://127.0.0.1:${socksAddress.port}`)
+  const proxyWrapper = new Socks5ProxyAgent(`socks5://${LOOPBACK_HOST}:${socksAddress.port}`)
 
   // First request goes to server A — establishes a pool
-  const respA = await request(`http://127.0.0.1:${portA}/a`, { dispatcher: proxyWrapper })
+  const respA = await request(`http://${LOOPBACK_HOST}:${portA}/a`, { dispatcher: proxyWrapper })
   p.equal(respA.statusCode, 200)
   p.deepEqual(await respA.body.json(), { server: 'A', path: '/a' })
 
   // Second request goes to server B — must NOT reuse the pool from origin A
-  const respB = await request(`http://127.0.0.1:${portB}/b`, { dispatcher: proxyWrapper })
+  const respB = await request(`http://${LOOPBACK_HOST}:${portB}/b`, { dispatcher: proxyWrapper })
   p.equal(respB.statusCode, 200)
   p.deepEqual(await respB.body.json(), { server: 'B', path: '/b' }, 'request to origin B must reach server B, not server A')
 

--- a/test/stream-compat.js
+++ b/test/stream-compat.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
 const { Client } = require('..')
@@ -26,7 +27,7 @@ test('stream body without destroy', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   ctx.after(async () => {
     await client.destroy()
     await closeServer(server)
@@ -62,7 +63,7 @@ test('IncomingMessage', async (t) => {
   server.listen(0)
   await once(server, 'listening')
 
-  const proxyClient = new Client(`http://localhost:${server.address().port}`)
+  const proxyClient = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   proxyClient.on('disconnect', () => {
     if (!proxyClient.closed && !proxyClient.destroyed) {
       t.fail('unexpected disconnect')

--- a/test/sync-error-in-callback.js
+++ b/test/sync-error-in-callback.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -17,7 +18,7 @@ test('synchronous error in request callback should reach uncaughtException handl
     server.listen(0, resolve)
   })
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const testError = new Error('sync error in callback')
@@ -78,7 +79,7 @@ test('synchronous error thrown immediately in request callback', async (t) => {
     server.listen(0, resolve)
   })
 
-  const client = new Client(`http://localhost:${server.address().port}`)
+  const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
   after(() => client.close())
 
   const testError = new Error('immediate sync error')
@@ -134,7 +135,7 @@ test('synchronous error in request callback with error parameter', async (t) => 
   after(() => server.close())
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({

--- a/test/tls-cert-leak.js
+++ b/test/tls-cert-leak.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { test } = require('node:test')
 const assert = require('node:assert')
 const { tspl } = require('@matteo.collina/tspl')
@@ -35,7 +36,7 @@ test('no memory leak with TLS certificate errors', { timeout: 20000 }, async (t)
 
   // Start server on a random port
   await new Promise(resolve => server.listen(0, resolve))
-  const serverUrl = `https://localhost:${server.address().port}`
+  const serverUrl = `https://${LOOPBACK_HOST}:${server.address().port}`
 
   t.after(closeServerAsPromise(server))
 

--- a/test/tls-session-reuse.js
+++ b/test/tls-session-reuse.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after, describe } = require('node:test')
 const { readFileSync } = require('node:fs')
@@ -36,7 +37,7 @@ describe('A client should disable session caching', () => {
         rejectUnauthorized: false,
         servername: 'agent1'
       }
-      const client = new Client(`https://localhost:${server.address().port}`, {
+      const client = new Client(`https://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 0,
         tls,
         maxCachedSessions: 0
@@ -110,7 +111,7 @@ describe('A pool should be able to reuse TLS sessions between clients', () => {
     const sessions = []
 
     server.listen(0, async () => {
-      const poolWithSessionReuse = new Pool(`https://localhost:${server.address().port}`, {
+      const poolWithSessionReuse = new Pool(`https://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 0,
         connections: 100,
         maxCachedSessions: 1,
@@ -120,7 +121,7 @@ describe('A pool should be able to reuse TLS sessions between clients', () => {
           servername: 'agent1'
         }
       })
-      const poolWithoutSessionReuse = new Pool(`https://localhost:${server.address().port}`, {
+      const poolWithoutSessionReuse = new Pool(`https://${LOOPBACK_HOST}:${server.address().port}`, {
         pipelining: 0,
         connections: 100,
         maxCachedSessions: 0,
@@ -211,9 +212,9 @@ describe('A connector should enforce maxCachedSessions across hostnames', () => 
       ca,
       lookup (hostname, options, callback) {
         if (options?.all) {
-          callback(null, [{ address: '127.0.0.1', family: 4 }])
+          callback(null, [{ address: LOOPBACK_HOST, family: 4 }])
         } else {
-          callback(null, '127.0.0.1', 4)
+          callback(null, LOOPBACK_HOST, 4)
         }
       },
       maxCachedSessions: 1,

--- a/test/trailers.js
+++ b/test/trailers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client } = require('..')
@@ -16,7 +17,7 @@ test('response trailers missing is OK', async (t) => {
   })
   after(() => server.close())
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.on('disconnect', () => {
@@ -51,7 +52,7 @@ test('response trailers missing w trailers is OK', async (t) => {
   })
   after(() => server.close())
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.destroy())
 
     client.on('disconnect', () => {

--- a/test/upgrade-crlf.js
+++ b/test/upgrade-crlf.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -17,7 +18,7 @@ test('CRLF injection in upgrade header via CRLF sequence', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -48,7 +49,7 @@ test('CRLF injection in upgrade header via lone CR', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -79,7 +80,7 @@ test('CRLF injection in upgrade header via lone LF', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -110,7 +111,7 @@ test('CRLF injection in upgrade header via null byte', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -141,7 +142,7 @@ test('CRLF injection in upgrade option via client.request', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     try {
@@ -172,7 +173,7 @@ test('valid upgrade value is accepted', async (t) => {
   after(() => server.close())
 
   server.listen(0, async () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     const { socket } = await client.upgrade({

--- a/test/utils/esm-wrapper.mjs
+++ b/test/utils/esm-wrapper.mjs
@@ -1,5 +1,6 @@
 import { createServer } from 'node:http'
 import { test, after } from 'node:test'
+import nodeHttp from './node-http.js'
 import undici, {
   Agent,
   Client,
@@ -14,13 +15,15 @@ import undici, {
   stream
 } from '../../index.js'
 
+const { LOOPBACK_HOST } = nodeHttp
+
 test('imported Client works with basic GET', (t, done) => {
   t.plan(10)
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     t.assert.strictEqual('/', req.url)
     t.assert.strictEqual('GET', req.method)
-    t.assert.strictEqual(`localhost:${server.address().port}`, req.headers.host)
+    t.assert.strictEqual(`${LOOPBACK_HOST}:${server.address().port}`, req.headers.host)
     t.assert.strictEqual(undefined, req.headers.foo)
     t.assert.strictEqual('bar', req.headers.bar)
     t.assert.strictEqual(undefined, req.headers['content-length'])
@@ -36,7 +39,7 @@ test('imported Client works with basic GET', (t, done) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
+    const client = new Client(`http://${LOOPBACK_HOST}:${server.address().port}`)
     after(() => client.close())
 
     client.request({
@@ -118,7 +121,7 @@ test('default import top-level request works with opts.dispatcher', async (t) =>
     await new Promise((resolve) => server.close(resolve))
   })
 
-  const { statusCode, body } = await undici.request(`http://127.0.0.1:${server.address().port}`, {
+  const { statusCode, body } = await undici.request(`http://${LOOPBACK_HOST}:${server.address().port}`, {
     dispatcher
   })
 

--- a/test/utils/hello-world-server.js
+++ b/test/utils/hello-world-server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { createServer } = require('node:http')
-const hostname = '127.0.0.1'
+const { LOOPBACK_HOST } = require('./node-http')
 
 const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {
   res.statusCode = 200
@@ -21,10 +21,10 @@ async function sendInDelayedChunks (res, payload, delay) {
   }
 }
 
-server.listen(0, hostname, () => {
+server.listen(0, LOOPBACK_HOST, () => {
   if (process.send) {
-    process.send(`http://${hostname}:${server.address().port}/`)
+    process.send(`http://${LOOPBACK_HOST}:${server.address().port}/`)
   } else {
-    console.log(`http://${hostname}:${server.address().port}/`)
+    console.log(`http://${LOOPBACK_HOST}:${server.address().port}/`)
   }
 })

--- a/test/utils/node-http.js
+++ b/test/utils/node-http.js
@@ -2,6 +2,8 @@
 
 const util = require('node:util')
 
+const LOOPBACK_HOST = '127.0.0.1'
+
 function closeServerAsPromise (server) {
   return () => {
     server.closeIdleConnections()
@@ -19,6 +21,7 @@ function closeClientAndServerAsPromise (client, server) {
 }
 
 module.exports = {
+  LOOPBACK_HOST,
   closeServerAsPromise,
   closeClientAndServerAsPromise
 }

--- a/test/utils/redirecting-servers.js
+++ b/test/utils/redirecting-servers.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./node-http')
 const { createServer } = require('node:http')
 const { after } = require('node:test')
 
@@ -17,7 +18,7 @@ function startServer (handler) {
     const server = createServer({ joinDuplicateHeaders: true }, handler)
 
     server.listen(0, () => {
-      resolve(`localhost:${server.address().port}`)
+      resolve(`${LOOPBACK_HOST}:${server.address().port}`)
     })
 
     after(close(server))

--- a/test/websocket/client-received-masked-frame.js
+++ b/test/websocket/client-received-masked-frame.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -23,7 +24,7 @@ test('Client fails the connection if receiving a masked frame', async (t) => {
     socket.write(buffer, () => ws.close())
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.addEventListener('close', (e) => {
     t.assert.deepStrictEqual(e.code, 1006)

--- a/test/websocket/close-invalid-status-code.js
+++ b/test/websocket/close-invalid-status-code.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -17,7 +18,7 @@ test('Client fails the connection if receiving a masked frame', async (t) => {
     socket.write(Buffer.from([0x88, 0x02, 0x03, 0xee]), () => ws.close())
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.addEventListener('close', (e) => {
     t.assert.deepStrictEqual(e.code, 1006)

--- a/test/websocket/close-invalid-utf-8.js
+++ b/test/websocket/close-invalid-utf-8.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -23,7 +24,7 @@ test('Receiving a close frame with invalid utf-8', (t, done) => {
   })
 
   const events = []
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   t.after(() => { ws.close() })
 
   ws.addEventListener('close', (e) => {

--- a/test/websocket/close.js
+++ b/test/websocket/close.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test, after } = require('node:test')
 const { WebSocketServer } = require('ws')
@@ -18,7 +19,7 @@ describe('Close', () => {
         })
       })
 
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
       ws.addEventListener('open', () => ws.close(1000))
     })
   })
@@ -36,7 +37,7 @@ describe('Close', () => {
         })
       })
 
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
       ws.addEventListener('open', () => ws.close(1000, 'Goodbye'))
     })
   })
@@ -44,7 +45,7 @@ describe('Close', () => {
   test('Close with invalid code', (t) => {
     const server = new WebSocketServer({ port: 0 })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     return new Promise((resolve) => {
       ws.addEventListener('open', () => {
@@ -74,7 +75,7 @@ describe('Close', () => {
   test('Close with invalid reason', (t) => {
     const server = new WebSocketServer({ port: 0 })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     return new Promise((resolve) => {
       ws.addEventListener('open', () => {
@@ -106,7 +107,7 @@ describe('Close', () => {
         })
       })
 
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
       ws.addEventListener('open', () => ws.close())
     })
   })
@@ -124,7 +125,7 @@ describe('Close', () => {
         })
       })
 
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
       ws.addEventListener('open', () => ws.close(3000))
     })
   })
@@ -142,7 +143,7 @@ describe('Close', () => {
       })
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     ws.addEventListener('open', () => {
       ws.close(1000)
       ws.close(1000)

--- a/test/websocket/continuation-frames.js
+++ b/test/websocket/continuation-frames.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -24,7 +25,7 @@ test('Receiving multiple continuation frames works as expected', (t, done) => {
     }
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.onerror = t.assert.fail
   ws.onmessage = (e) => {

--- a/test/websocket/diagnostics-channel-handshake-response-h2.js
+++ b/test/websocket/diagnostics-channel-handshake-response-h2.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const dc = require('node:diagnostics_channel')
 const { once } = require('node:events')
@@ -65,7 +66,7 @@ test('diagnostics channel - undici:websocket:open includes handshake response ov
 
   dc.channel('undici:websocket:open').subscribe(openListener)
 
-  const ws = new WebSocket(`wss://localhost:${server.address().port}`, { dispatcher })
+  const ws = new WebSocket(`wss://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
 
   t.after(async () => {
     dc.channel('undici:websocket:open').unsubscribe(openListener)

--- a/test/websocket/events.js
+++ b/test/websocket/events.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, describe, after } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { MessageEvent, CloseEvent, ErrorEvent } = require('../../lib/web/websocket/events')
@@ -44,7 +45,7 @@ test('ErrorEvent', (t) => {
 
 describe('Event handlers', () => {
   const server = new WebSocketServer({ port: 0 })
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   after(() => {
     server.close()

--- a/test/websocket/fragments.js
+++ b/test/websocket/fragments.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, after } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -24,7 +25,7 @@ test('Fragmented frame with a ping frame in the middle of it', (t) => {
     server.close()
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   diagnosticsChannel.channel('undici:websocket:ping').subscribe(
     ({ payload }) => t.assert.deepStrictEqual(payload, Buffer.from('Hello'))

--- a/test/websocket/issue-2679.js
+++ b/test/websocket/issue-2679.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -19,7 +20,7 @@ test('Close without receiving code does not send an invalid payload', async (t) 
 
   server.on('error', (err) => t.assert.ifError(err))
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   await once(client, 'open')
 
   await once(client, 'close')

--- a/test/websocket/issue-2859.js
+++ b/test/websocket/issue-2859.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -23,7 +24,7 @@ test('Fragmented frame with a ping frame in the first of it', (t, done) => {
     ws.close()
   })
 
-  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   diagnosticsChannel.channel('undici:websocket:ping').subscribe(
     ({ payload }) => t.assert.deepStrictEqual(payload, Buffer.from('Hello'))

--- a/test/websocket/issue-3202.js
+++ b/test/websocket/issue-3202.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -20,7 +21,7 @@ test('Receiving frame with payload length 0 works', (t, done) => {
     ws.close()
   })
 
-  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.addEventListener('open', () => {
     ws.send('Hi')

--- a/test/websocket/issue-4889.js
+++ b/test/websocket/issue-4889.js
@@ -6,7 +6,7 @@ const { createServer } = require('node:http')
 const { WebSocketServer } = require('ws')
 
 const { WebSocket } = require('../..')
-const { closeServerAsPromise } = require('../utils/node-http')
+const { LOOPBACK_HOST, closeServerAsPromise } = require('../utils/node-http')
 
 // https://github.com/nodejs/undici/issues/4889
 test('websocket auth retry preserves path when URL contains credentials', async (t) => {
@@ -53,10 +53,10 @@ test('websocket auth retry preserves path when URL contains credentials', async 
     t.assert.fail(`unexpected upgrade attempt #${attempts}`)
   })
 
-  server.listen(0, '127.0.0.1')
+  server.listen(0, LOOPBACK_HOST)
   await once(server, 'listening')
 
-  const ws = new WebSocket(`ws://user:pass@127.0.0.1:${server.address().port}/path`)
+  const ws = new WebSocket(`ws://user:pass@${LOOPBACK_HOST}:${server.address().port}/path`)
 
   await new Promise((resolve, reject) => {
     ws.addEventListener('open', resolve, { once: true })

--- a/test/websocket/issue-4989.js
+++ b/test/websocket/issue-4989.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 // Regression test for https://github.com/nodejs/undici/issues/4989
 //
 // Importing undici v8 sets a global dispatcher (including the legacy
@@ -55,7 +56,7 @@ test('globalThis.WebSocket connects to h2+http1.1 server after undici import', a
 
   // globalThis.WebSocket is Node.js's native WebSocket (backed by bundled undici).
   // It reads the global dispatcher set by the undici v8 import above.
-  const ws = new globalThis.WebSocket(`wss://localhost:${server.address().port}`)
+  const ws = new globalThis.WebSocket(`wss://${LOOPBACK_HOST}:${server.address().port}`)
 
   await Promise.race([
     new Promise((resolve, reject) => {

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { createServer } = require('node:http')
@@ -27,7 +28,7 @@ test('WebSocket connecting to server that isn\'t a Websocket server', (t) => {
       res.end()
       server.unref()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
       // Server isn't a websocket server
       ws.onmessage = ws.onopen = reject
@@ -49,7 +50,7 @@ test('Open event is emitted', (t) => {
       ws.close(1000)
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     ws.onmessage = ws.onerror = reject
     ws.addEventListener('open', (t) => {
@@ -96,7 +97,7 @@ test('WebSocket on H2', { skip: crypto == null }, async (t) => {
       rejectUnauthorized: false
     }
   })
-  const ws = new WebSocket(`wss://localhost:${server.address().port}`, { dispatcher, protocols: ['chat'] })
+  const ws = new WebSocket(`wss://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher, protocols: ['chat'] })
 
   t.after(() => {
     // Cleanup - Seems that due to the nature of H2 we need to remove the error listener
@@ -236,7 +237,7 @@ test('WebSocket falls back to HTTP/1.1 upgrade when H2 extended CONNECT is unava
       rejectUnauthorized: false
     }
   })
-  const ws = new WebSocket(`wss://localhost:${server.address().port}`, { dispatcher })
+  const ws = new WebSocket(`wss://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
 
   t.after(async () => {
     ws.onerror = null
@@ -282,7 +283,7 @@ test('WebSocket falls back to HTTP/1.1 upgrade when H2 CONNECT support is omitte
       rejectUnauthorized: false
     }
   })
-  const ws = new WebSocket(`wss://localhost:${server.address().port}`, { dispatcher })
+  const ws = new WebSocket(`wss://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher })
 
   t.after(async () => {
     ws.onerror = null
@@ -316,7 +317,7 @@ test('Multiple protocols are joined by a comma', (t) => {
       resolve()
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`, ['chat', 'echo'])
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, ['chat', 'echo'])
     ws.addEventListener('open', () => ws.close())
   })
 })
@@ -328,7 +329,7 @@ test('Server doesn\'t send Sec-WebSocket-Protocol header when protocols are used
 
       req.socket.destroy()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`, 'chat')
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, 'chat')
 
       ws.onopen = reject
 
@@ -349,7 +350,7 @@ test('Server sends invalid Upgrade header', (t) => {
 
       req.socket.destroy()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
       ws.onopen = reject
 
@@ -371,7 +372,7 @@ test('Server sends invalid Connection header', (t) => {
 
       req.socket.destroy()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
       ws.onopen = reject
 
@@ -394,7 +395,7 @@ test('Server sends invalid Sec-WebSocket-Accept header', (t) => {
 
       req.socket.destroy()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
       ws.onopen = reject
 
@@ -425,7 +426,7 @@ test('Server sends invalid Sec-WebSocket-Extensions header', { skip: runtimeFeat
 
       res.end()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
       ws.onopen = reject
 
@@ -456,7 +457,7 @@ test('Server sends invalid Sec-WebSocket-Extensions header', { skip: runtimeFeat
 
       res.end()
     }).listen(0, () => {
-      const ws = new WebSocket(`ws://localhost:${server.address().port}`, 'chat')
+      const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, 'chat')
 
       ws.onopen = reject
 

--- a/test/websocket/permessage-deflate-config.js
+++ b/test/websocket/permessage-deflate-config.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -52,7 +53,7 @@ test('Custom maxPayloadSize allows messages under limit', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   const [event] = await once(client, 'message')
   t.assert.strictEqual(event.data.size, dataSize, 'Message under limit should be received')
@@ -81,7 +82,7 @@ test('Messages at exactly the limit succeed', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   const [event] = await once(client, 'message')
   t.assert.strictEqual(event.data.size, limit, 'Message at exactly the limit should succeed')

--- a/test/websocket/permessage-deflate-limit.js
+++ b/test/websocket/permessage-deflate-limit.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { randomFillSync } = require('node:crypto')
@@ -23,7 +24,7 @@ test('Compressed message under limit decompresses successfully', async (t) => {
     ws.send(Buffer.alloc(1024, 0x41), { binary: true })
   })
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   const [event] = await once(client, 'message')
   t.assert.strictEqual(event.data.size, 1024)
@@ -77,7 +78,7 @@ test('Custom maxPayloadSize allows messages under limit', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   const [event] = await once(client, 'message')
   t.assert.strictEqual(event.data.size, dataSize, 'Message under limit should be received')
@@ -106,7 +107,7 @@ test('Messages at exactly the limit succeed', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   const [event] = await once(client, 'message')
   t.assert.strictEqual(event.data.size, limit, 'Message at exactly the limit should succeed')
@@ -148,7 +149,7 @@ test('Compressed frame payload over wire-size limit is rejected', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true
@@ -189,7 +190,7 @@ test('Messages over the limit are rejected', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true
@@ -237,7 +238,7 @@ test('Limit can be disabled by setting maxPayloadSize to 0', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
   const timeout = Symbol('timeout')
 
   const result = await Promise.race([
@@ -285,7 +286,7 @@ test('Fragmented compressed payload over total limit is rejected', async (t) => 
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true
@@ -325,7 +326,7 @@ test('Raw uncompressed payload over immediate limit is rejected', async (t) => {
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true
@@ -365,7 +366,7 @@ test('Raw uncompressed payload over 16-bit extended limit is rejected', async (t
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true
@@ -405,7 +406,7 @@ test('Raw uncompressed payload over 64-bit extended limit is rejected', async (t
 
   t.after(() => agent.close())
 
-  const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`, { dispatcher: agent })
+  const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, { dispatcher: agent })
 
   client.addEventListener('message', () => {
     messageReceived = true

--- a/test/websocket/permessage-deflate-windowbits.js
+++ b/test/websocket/permessage-deflate-windowbits.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../utils/node-http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
 const http = require('node:http')
@@ -127,7 +128,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'message')
     t.assert.ok(event.data)
@@ -139,7 +140,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'message')
     t.assert.ok(event.data)
@@ -151,7 +152,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'error')
     t.assert.ok(event.error instanceof Error)
@@ -162,7 +163,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'error')
     t.assert.ok(event.error instanceof Error)
@@ -173,7 +174,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'error')
     t.assert.ok(event.error instanceof Error)
@@ -184,7 +185,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     const [event] = await once(client, 'error')
     // The key assertion: we got an error event instead of crashing
@@ -206,7 +207,7 @@ describe('permessage-deflate server_max_window_bits', () => {
       process.off('uncaughtException', handler)
     })
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     await Promise.race([
       once(client, 'error'),
@@ -222,7 +223,7 @@ describe('permessage-deflate server_max_window_bits', () => {
     await new Promise(resolve => server.listen(0, resolve))
     after(() => server.close())
 
-    const client = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+    const client = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
     // Wait for either error or close event
     const result = await Promise.race([

--- a/test/websocket/ping-pong.js
+++ b/test/websocket/ping-pong.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const diagnosticsChannel = require('node:diagnostics_channel')
@@ -13,7 +14,7 @@ test('Receives ping and parses body', (t) => {
       ws.ping('Hello, world')
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     ws.onerror = ws.onmessage = reject
 
     diagnosticsChannel.channel('undici:websocket:ping').subscribe(({ payload }) => {
@@ -33,7 +34,7 @@ test('Receives pong and parses body', (t) => {
       ws.pong('Pong')
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     ws.onerror = ws.onmessage = reject
 
     diagnosticsChannel.channel('undici:websocket:pong').subscribe(({ payload }) => {

--- a/test/websocket/receive.js
+++ b/test/websocket/receive.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -13,7 +14,7 @@ test('Receiving a frame with a payload length > 2^31-1 bytes', (t) => {
     socket.write(Buffer.from([0x81, 0x7F, 0xCA, 0xE5, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]))
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   return new Promise((resolve, reject) => {
     ws.onmessage = reject
@@ -36,7 +37,7 @@ test('Receiving a 64-bit payload length with a non-zero upper word', (t) => {
     socket.write(Buffer.from([0x82, 0x7F, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]))
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   return new Promise((resolve, reject) => {
     ws.onmessage = reject
@@ -61,7 +62,7 @@ test('Receiving an ArrayBuffer', (t) => {
     })
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.addEventListener('open', () => {
     ws.binaryType = 'what'

--- a/test/websocket/send-mutable.js
+++ b/test/websocket/send-mutable.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
@@ -18,7 +19,7 @@ test('check cloned', async (t) => {
     })
   })
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   ws.addEventListener('open', () => {
     ws.send(new Blob([buffer]))

--- a/test/websocket/send.js
+++ b/test/websocket/send.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { once } = require('node:events')
 const { test, describe } = require('node:test')
 const { WebSocketServer } = require('ws')
@@ -47,7 +48,7 @@ test('Sending >= 2^16 bytes', async (t) => {
 
   const payload = Buffer.allocUnsafe(2 ** 16).fill('Hello')
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   registerCleanup(t, ws, server)
 
   await once(ws, 'open')
@@ -71,7 +72,7 @@ test('Sending >= 126, < 2^16 bytes', async (t) => {
 
   const payload = Buffer.allocUnsafe(126).fill('Hello')
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   registerCleanup(t, ws, server)
 
   await once(ws, 'open')
@@ -95,7 +96,7 @@ test('Sending < 126 bytes', async (t) => {
 
   const payload = Buffer.allocUnsafe(125).fill('Hello')
 
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   registerCleanup(t, ws, server)
 
   await once(ws, 'open')
@@ -110,7 +111,7 @@ test('Sending < 126 bytes', async (t) => {
 
 test('Sending data after close', async (t) => {
   const server = new WebSocketServer({ port: 0 })
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   registerCleanup(t, ws, server)
 
   const connection = once(server, 'connection')
@@ -133,7 +134,7 @@ test('Sending data after close', async (t) => {
 
 test('Sending data before connected', (t) => {
   const server = new WebSocketServer({ port: 0 })
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   registerCleanup(t, ws, server)
 
@@ -151,7 +152,7 @@ test('Sending data before connected', (t) => {
 describe('Sending data to a server', () => {
   test('Send with string', async (t) => {
     const server = new WebSocketServer({ port: 0 })
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     registerCleanup(t, ws, server)
 
     const connection = once(server, 'connection')
@@ -172,7 +173,7 @@ describe('Sending data to a server', () => {
     new Uint8Array(ab).set(message)
 
     const server = new WebSocketServer({ port: 0 })
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     registerCleanup(t, ws, server)
 
     const connection = once(server, 'connection')
@@ -190,7 +191,7 @@ describe('Sending data to a server', () => {
   test('Send with Blob', async (t) => {
     const blob = new Blob(['hello'])
     const server = new WebSocketServer({ port: 0 })
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     registerCleanup(t, ws, server)
 
     const connection = once(server, 'connection')
@@ -208,7 +209,7 @@ describe('Sending data to a server', () => {
   test('Cannot send with SharedArrayBuffer', async (t) => {
     const sab = new SharedArrayBuffer(0)
     const server = new WebSocketServer({ port: 0 })
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`)
     registerCleanup(t, ws, server)
 
     const connection = once(server, 'connection')

--- a/test/websocket/stream/abort-before-open.js
+++ b/test/websocket/stream/abort-before-open.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 
@@ -25,7 +26,7 @@ test('WebSocketStream aborts before handshake completes', async (t) => {
   })
 
   const ac = new AbortController()
-  const wss = new WebSocketStream(`ws://localhost:${server.address().port}`, {
+  const wss = new WebSocketStream(`ws://${LOOPBACK_HOST}:${server.address().port}`, {
     signal: ac.signal
   })
 

--- a/test/websocket/stream/invalid-utf8-text-frame.js
+++ b/test/websocket/stream/invalid-utf8-text-frame.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test } = require('node:test')
 const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
@@ -19,7 +20,7 @@ test('WebSocketStream sends close code 1007 when receiving invalid UTF-8 in a te
     })
   })
 
-  const wss = new WebSocketStream(`ws://127.0.0.1:${server.address().port}`)
+  const wss = new WebSocketStream(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   // Swallow the expected unclean-close rejection on the client side.
   wss.closed.catch(() => {})
 

--- a/test/websocket/stream/issue-4958.js
+++ b/test/websocket/stream/issue-4958.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 
@@ -26,7 +27,7 @@ test('websocketstream opened.readable should expose text message payloads only',
     socket.send(JSON.stringify({ event: 'Ready', data: { id: 1010 } }))
   })
 
-  const url = `ws://127.0.0.1:${server.address().port}/`
+  const url = `ws://${LOOPBACK_HOST}:${server.address().port}/`
 
   for (let run = 1; run <= 100; run++) {
     const wss = new WebSocketStream(url)

--- a/test/websocket/stream/readable-cancel-before-clean-close.js
+++ b/test/websocket/stream/readable-cancel-before-clean-close.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 
@@ -36,7 +37,7 @@ test('WebSocketStream does not throw when readable is canceled before a clean cl
     server.close()
   })
 
-  const wss = new WebSocketStream(`ws://127.0.0.1:${server.address().port}`)
+  const wss = new WebSocketStream(`ws://${LOOPBACK_HOST}:${server.address().port}`)
   const { readable } = await wss.opened
 
   await readable.cancel(new Error('client cancel')).catch(() => {})

--- a/test/websocket/stream/readable-closed-after-close.js
+++ b/test/websocket/stream/readable-closed-after-close.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('./../../utils/node-http')
 const { test } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocketStream } = require('../../..')
@@ -8,7 +9,7 @@ const { WebSocketStream } = require('../../..')
 test('ReadableStream is closed properly', async (t) => {
   const server = new WebSocketServer({ port: 0 })
 
-  const wss = new WebSocketStream(`ws://localhost:${server.address().port}`)
+  const wss = new WebSocketStream(`ws://${LOOPBACK_HOST}:${server.address().port}`)
 
   t.after(() => server.close())
 

--- a/test/websocket/websocketinit.js
+++ b/test/websocket/websocketinit.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LOOPBACK_HOST } = require('../utils/node-http')
 const { test, describe } = require('node:test')
 const { WebSocketServer } = require('ws')
 const { WebSocket, Dispatcher, Agent } = require('../..')
@@ -23,7 +24,7 @@ describe('WebSocketInit', () => {
       ws.send(Buffer.from('hello, world'))
     })
 
-    const ws = new WebSocket(`ws://localhost:${server.address().port}`, {
+    const ws = new WebSocket(`ws://${LOOPBACK_HOST}:${server.address().port}`, {
       dispatcher: new WsDispatcher()
     })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Relates to https://github.com/nodejs/undici/issues/5177

## Rationale

Windows CI has intermittent failures around tests using `localhost`.

On Windows, localhost resolution can prefer IPv6 (`::1`) or otherwise depend on hosts/DNS behavior, while some tests bind/connect through IPv4 loopback. Using `127.0.0.1` removes name-resolution ambiguity and keeps the test server/client address family consistent.

## Changes

Centralizes the test loopback host as `LOOPBACK_HOST` and updates first-party tests to use it instead of inline `localhost`/`127.0.0.1` where appropriate.

### Features

N/A

### Bug Fixes

* Reduce Windows-specific CI flakes caused by localhost resolution/address-family ambiguity.
* Keep loopback test host selection consistent across first-party tests.

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5