### PR TITLE
fix(types): remove throwOnError from Dispatcher.RequestOptions

### DIFF
--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -85,7 +85,6 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET' }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', query: {} }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', query: { pageNum: 1, id: 'abc' } }))
-  expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: '', path: '', method: 'GET', throwOnError: true }))
   expectAssignable<Promise<Dispatcher.ResponseData>>(dispatcher.request({ origin: new URL('http://localhost'), path: '', method: 'GET' }))
   expectAssignable<void>(dispatcher.request({ origin: '', path: '', method: 'GET', reset: true }, (err, data) => {
     expectAssignable<Error | null>(err)

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -121,8 +121,6 @@ declare namespace Dispatcher {
     bodyTimeout?: number | null;
     /** Whether the request should stablish a keep-alive or not. Default `false` */
     reset?: boolean;
-    /** Whether Undici should throw an error upon receiving a 4xx or 5xx response from the server. Defaults to false */
-    throwOnError?: boolean;
     /** For H2, it appends the expect: 100-continue header, and halts the request body until a 100-continue is received from the remote server */
     expectContinue?: boolean;
   }


### PR DESCRIPTION
## This relates to...

Fixes #5270. `throwOnError` was moved to the `responseError` interceptor in v7 (#3451), but the `Dispatcher.RequestOptions` type definition and its type test weren't updated at the time.

## Rationale

Passing `throwOnError` to `dispatcher.request()` on v7+ produces no TypeScript error today, even though the option does nothing at runtime. Removing it from `RequestOptions` lets the compiler catch the mistake and point people to the interceptor API, where the behavior actually lives.

I also verified: `RetryHandler.RetryOptions.throwOnError` (`types/retry-handler.d.ts`) and `Interceptors.ResponseErrorInterceptorOpts.throwOnError` (`types/interceptors.d.ts`) are both still implemented and untouched by this PR.

## Changes

### Features

N/A

### Bug Fixes

- `types/dispatcher.d.ts`: remove stale `throwOnError?: boolean` and its JSDoc from `RequestOptions`
- `test/types/dispatcher.test-d.ts`: remove the `throwOnError: true` assertion for `dispatcher.request()`

### Breaking Changes and Deprecations

`Dispatcher.RequestOptions.throwOnError` is removed from the types. Since the runtime dropped it in v7, anyone passing it today gets no behavior anyway. The replacement is `undici.interceptors.responseError({ throwOnError: true })`.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin