### PR TITLE
test: use test context cleanup hooks in parser issue tests

### DIFF
--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -255,17 +255,18 @@ test('refreshes wasm input view after reallocating parser buffer', async (t) => 
 })
 
 test('truncated chunked responses terminated by EOF error the response body', async (t) => {
+  const ctx = t
   t = tspl(t, { plan: 3 })
 
   const server = net.createServer((socket) => {
     socket.end(truncatedChunkedResponse)
   })
-  after(() => server.close())
+  ctx.after(() => server.close())
 
   await new Promise(resolve => server.listen(0, resolve))
 
   const client = new Client(`http://localhost:${server.address().port}`)
-  after(() => client.destroy())
+  ctx.after(() => client.destroy())
 
   client.request({
     method: 'GET',
@@ -287,12 +288,13 @@ test('truncated chunked responses terminated by EOF error the response body', as
 })
 
 test('fetch rejects truncated chunked responses terminated by EOF', async (t) => {
+  const ctx = t
   t = tspl(t, { plan: 3 })
 
   const server = net.createServer((socket) => {
     socket.end(truncatedChunkedResponse)
   })
-  after(() => server.close())
+  ctx.after(() => server.close())
 
   await new Promise(resolve => server.listen(0, resolve))
 


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

`test/parser-issues.js` was using bare `after()` calls even though the file only imports `test` from `node:test`. That caused lint failures (`no-undef`) and made the affected tests fail at runtime with `ReferenceError: after is not defined`.

## Changes

- capture the original test context before wrapping it with `tspl`
- replace bare `after()` calls with `ctx.after(...)` in the affected parser issue tests

### Features

N/A

### Bug Fixes

- fix cleanup registration in the truncated chunked response parser tests so linting passes and the tests run successfully

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
