### PR TITLE
fix(fetch): preserve stack context for ESM import path

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -3,25 +3,31 @@
 const { getGlobalDispatcher, setGlobalDispatcher } = require('./lib/global')
 const EnvHttpProxyAgent = require('./lib/dispatcher/env-http-proxy-agent')
 const fetchImpl = require('./lib/web/fetch').fetch
+const noCurrentFilename = typeof __filename === 'undefined'
 
 // Capture __filename at module load time for stack trace augmentation.
 // This may be undefined when bundled in environments like Node.js internals.
 const currentFilename = typeof __filename !== 'undefined' ? __filename : undefined
 
-function appendFetchStackTrace (err, filename) {
+function appendFetchStackTrace (err, filename, stackTrace) {
   if (!err || typeof err !== 'object') {
     return
   }
 
   const stack = typeof err.stack === 'string' ? err.stack : ''
-  const normalizedFilename = filename.replace(/\\/g, '/')
+  const normalizedFilename = filename ? filename.replace(/\\/g, '/') : undefined
 
-  if (stack && (stack.includes(filename) || stack.includes(normalizedFilename))) {
+  if (stack && filename && (stack.includes(filename) || stack.includes(normalizedFilename))) {
     return
   }
 
   const capture = {}
-  Error.captureStackTrace(capture, appendFetchStackTrace)
+
+  if (stackTrace) {
+    capture.stack = stackTrace
+  } else {
+    Error.captureStackTrace(capture, noCurrentFilename ? module.exports.fetch : appendFetchStackTrace)
+  }
 
   if (!capture.stack) {
     return
@@ -33,11 +39,13 @@ function appendFetchStackTrace (err, filename) {
 }
 
 module.exports.fetch = function fetch (init, options = undefined) {
+  const stack = noCurrentFilename ? new Error().stack : undefined
+
   return fetchImpl(init, options).catch(err => {
     if (currentFilename) {
       appendFetchStackTrace(err, currentFilename)
     } else if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, module.exports.fetch)
+      appendFetchStackTrace(err, undefined, stack)
     }
     throw err
   })

--- a/index.js
+++ b/index.js
@@ -124,25 +124,31 @@ module.exports.setGlobalDispatcher = setGlobalDispatcher
 module.exports.getGlobalDispatcher = getGlobalDispatcher
 
 const fetchImpl = require('./lib/web/fetch').fetch
+const noCurrentFilename = typeof __filename === 'undefined'
 
 // Capture __filename at module load time for stack trace augmentation.
 // This may be undefined when bundled in environments like Node.js internals.
 const currentFilename = typeof __filename !== 'undefined' ? __filename : undefined
 
-function appendFetchStackTrace (err, filename) {
+function appendFetchStackTrace (err, filename, stackTrace) {
   if (!err || typeof err !== 'object') {
     return
   }
 
   const stack = typeof err.stack === 'string' ? err.stack : ''
-  const normalizedFilename = filename.replace(/\\/g, '/')
+  const normalizedFilename = filename ? filename.replace(/\\/g, '/') : undefined
 
-  if (stack && (stack.includes(filename) || stack.includes(normalizedFilename))) {
+  if (stack && filename && (stack.includes(filename) || stack.includes(normalizedFilename))) {
     return
   }
 
   const capture = {}
-  Error.captureStackTrace(capture, appendFetchStackTrace)
+
+  if (stackTrace) {
+    capture.stack = stackTrace
+  } else {
+    Error.captureStackTrace(capture, noCurrentFilename ? module.exports.fetch : appendFetchStackTrace)
+  }
 
   if (!capture.stack) {
     return
@@ -154,11 +160,13 @@ function appendFetchStackTrace (err, filename) {
 }
 
 module.exports.fetch = function fetch (init, options = undefined) {
+  const stack = noCurrentFilename ? new Error().stack : undefined
+
   return fetchImpl(init, options).catch(err => {
     if (currentFilename) {
       appendFetchStackTrace(err, currentFilename)
     } else if (err && typeof err === 'object') {
-      Error.captureStackTrace(err, module.exports.fetch)
+      appendFetchStackTrace(err, undefined, stack)
     }
     throw err
   })

--- a/test/fetch/client-error-stack-trace.js
+++ b/test/fetch/client-error-stack-trace.js
@@ -40,3 +40,16 @@ test('FETCH-index: request errors and prints trimmed stack trace', async (t) => 
     t.assert.ok(stackLines.some(line => line.includes(__filename)))
   }
 })
+
+test('FETCH-index-mjs: request errors contain callsite', async (t) => {
+  const { fetch: fetchESM } = await import('../../index.js')
+
+  try {
+    await fetchESM('http://a.com')
+  } catch (error) {
+    const stackLines = error.stack.split('\n')
+    t.assert.ok(stackLines[0].includes('TypeError: fetch failed'))
+    t.assert.ok(stackLines.some(line => line.includes('client-error-stack-trace.js')))
+    t.assert.ok(stackLines.some(line => line.includes('index.js')))
+  }
+})


### PR DESCRIPTION
## Summary
- Preserve fetch error stack context when the public fetch wrapper needs to append the caller stack.
- Apply the same behavior through both `index.js` and `index-fetch.js` entry points.
- Add regression coverage that verifies a dynamic import fetch failure retains the test callsite.

Fixes #2331.

## Validation
- `node --test test/fetch/client-error-stack-trace.js`
- `npm run lint -- index.js index-fetch.js test/fetch/client-error-stack-trace.js`