### PR TITLE
fix(fetch): update FormData Content-Type after redirect

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1349,7 +1349,13 @@ function httpRedirectFetch (fetchParams, response) {
   // value of safely extracting request's body's source.
   if (request.body != null) {
     assert(request.body.source != null)
-    request.body = safelyExtractBody(request.body.source)[0]
+    const bodySource = request.body.source
+    const [body, contentType] = safelyExtractBody(bodySource)
+    request.body = body
+
+    if (contentType != null && webidl.is.FormData(bodySource)) {
+      request.headersList.set('content-type', contentType, true)
+    }
   }
 
   // 15. Let timingInfo be fetchParams’s timing info.

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -428,6 +428,45 @@ test('redirect with body', (t, done) => {
   })
 })
 
+test('redirect with FormData body updates content-type boundary', async (t) => {
+  t.plan(3)
+
+  let count = 0
+  const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {
+    let body = ''
+    for await (const chunk of req) {
+      body += chunk
+    }
+
+    if (count++ === 0) {
+      res.setHeader('location', '/target')
+      res.statusCode = 307
+      res.end()
+      return
+    }
+
+    const contentType = req.headers['content-type']
+    const boundary = /boundary=(.+)$/.exec(contentType)?.[1]
+
+    t.assert.ok(boundary)
+    t.assert.ok(body.includes(`--${boundary}`))
+    res.end('ok')
+  })
+  t.after(closeServerAsPromise(server))
+
+  await once(server.listen(0), 'listening')
+
+  const formData = new FormData()
+  formData.append('test', 'data')
+
+  const res = await fetch(`http://localhost:${server.address().port}/first`, {
+    method: 'POST',
+    body: formData
+  })
+
+  t.assert.strictEqual(await res.text(), 'ok')
+})
+
 test('redirect with stream', (t, done) => {
   t.plan(3)
 


### PR DESCRIPTION
## Summary
- Refresh the generated multipart `Content-Type` header when a redirect re-extracts a `FormData` request body.
- Add regression coverage ensuring the redirected request header boundary matches the resent multipart body boundary.

Fixes #4065.

## Validation
- `node --test --test-name-pattern "redirect with FormData body updates content-type boundary" test/fetch/client-fetch.js`
- `npm run lint -- lib/web/fetch/index.js test/fetch/client-fetch.js`