### PR TITLE
fix: normalize HTTP/2 request header casing

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -546,7 +546,7 @@ function buildRequestHeaders (reqHeaders) {
   const headers = {}
 
   for (let n = 0; n < reqHeaders.length; n += 2) {
-    const key = reqHeaders[n + 0]
+    const key = reqHeaders[n + 0].toLowerCase()
     const val = reqHeaders[n + 1]
     const current = headers[key]
 
@@ -557,6 +557,11 @@ function buildRequestHeaders (reqHeaders) {
         headers[key] = val
       }
 
+      continue
+    }
+
+    if (key === 'content-type') {
+      headers[key] = Array.isArray(val) ? val[val.length - 1] : val
       continue
     }
 

--- a/test/http2-body.js
+++ b/test/http2-body.js
@@ -71,6 +71,47 @@ test('Should handle h2 request without body', async t => {
   await t.completed
 })
 
+test('Should tolerate duplicated single-value request headers with h2', async t => {
+  const assert = tspl(t, { plan: 3 })
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream, headers) => {
+    assert.strictEqual(headers['content-type'], 'application/json')
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(async () => {
+    server.close()
+    await client.close()
+  })
+
+  const response = await client.request({
+    path: '/',
+    method: 'POST',
+    body: '{}',
+    headers: {
+      'Content-Type': 'application/json',
+      'content-type': 'application/json'
+    }
+  })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(await response.body.text(), 'ok')
+
+  await assert.completed
+})
+
 test('Should send content-length: 0 for empty h2 requests with payload-expecting methods', async t => {
   const assert = tspl(t, { plan: 18 })
   const methods = ['PUT', 'POST', 'PATCH', 'QUERY', 'PROPFIND', 'PROPPATCH']


### PR DESCRIPTION
## Summary

Normalize outgoing HTTP/2 request header names before building the header object and keep a single content-type value when callers provide the same header with different casing.

Fixes #5175.

## Validation

node --test --test-name-pattern "duplicated single-value" test\http2-body.js
node --test test\http2-body.js
npm run lint -- lib/dispatcher/client-h2.js test/http2-body.js
git commit pre-hook repo-wide lint is blocked by an unrelated baseline no-undef in test/parser-issues.js