### PR TITLE
fix(fetch): keep cloned request signals alive

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -122,6 +122,7 @@ class Request {
 
     // 4. Let signal be null.
     let signal = null
+    let signalController = null
 
     // 5. If input is a string, then:
     if (typeof input === 'string') {
@@ -160,6 +161,7 @@ class Request {
 
       // 9. Set signal to input’s signal.
       signal = input.#signal
+      signalController = input[kAbortController]
 
       this.#dispatcher = init.dispatcher || input.#dispatcher
     }
@@ -405,6 +407,7 @@ class Request {
     // 26. If init["signal"] exists, then set signal to it.
     if (init.signal !== undefined) {
       signal = init.signal
+      signalController = null
     }
 
     // 27. Set this’s request to request.
@@ -426,7 +429,9 @@ class Request {
         // is alive. This is needed to prevent AbortController
         // from being prematurely garbage collected.
         // See, https://github.com/nodejs/undici/issues/1926.
-        this[kAbortController] = ac
+        this[kAbortController] = signalController == null
+          ? ac
+          : [ac, signalController]
 
         const acRef = new WeakRef(ac)
         const abort = buildAbort(acRef)
@@ -790,8 +795,16 @@ class Request {
       )
     }
 
+    // Keep a strong ref to ac and the parent signal controller chain while
+    // clonedRequestObject is alive. This matches the constructor path and
+    // prevents GC from breaking signal following.
+    const clonedRequestObject = fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    clonedRequestObject[kAbortController] = this[kAbortController] == null
+      ? ac
+      : [ac, this[kAbortController]]
+
     // 4. Return clonedRequestObject.
-    return fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    return clonedRequestObject
   }
 
   [nodeUtil.inspect.custom] (depth, options) {

--- a/test/fetch/request.js
+++ b/test/fetch/request.js
@@ -313,6 +313,46 @@ test('post aborted signal cloned', (t) => {
   ac.abort('gwak')
 })
 
+test('post aborted signal cloned after GC', async (t) => {
+  if (typeof globalThis.gc !== 'function') {
+    t.skip('requires --expose-gc')
+    return
+  }
+
+  const ac = new AbortController()
+  const req = new Request('http://asd', { signal: ac.signal }).clone()
+
+  for (let i = 0; i < 10; i++) {
+    globalThis.gc()
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  ac.abort('gwak')
+
+  t.assert.strictEqual(req.signal.aborted, true)
+  t.assert.strictEqual(req.signal.reason, 'gwak')
+})
+
+test('post aborted signal copied after GC', async (t) => {
+  if (typeof globalThis.gc !== 'function') {
+    t.skip('requires --expose-gc')
+    return
+  }
+
+  const ac = new AbortController()
+  const req = new Request(new Request('http://asd', { signal: ac.signal }))
+
+  for (let i = 0; i < 10; i++) {
+    globalThis.gc()
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  ac.abort('gwak')
+
+  t.assert.strictEqual(req.signal.aborted, true)
+  t.assert.strictEqual(req.signal.reason, 'gwak')
+})
+
 test('Passing headers in init', async (t) => {
   // https://github.com/nodejs/undici/issues/1400
   await t.test('Headers instance', (t) => {


### PR DESCRIPTION
## Summary
- Keep the abort-controller chain strongly reachable when cloning a Request or constructing a Request from another Request.
- Preserve abort propagation after garbage collection for cloned/copied requests.
- Add GC regression coverage for both clone() and constructor-copy paths.

Fixes #4068.

## Validation
- `node --expose-gc test\fetch\request.js`
- `npx borp --timeout 180000 --expose-gc -p "test/fetch/request.js"`
- `npm run lint -- lib/web/fetch/request.js test/fetch/request.js`

Note: the normal git pre-commit hook runs repo-wide lint and is currently blocked by unrelated baseline `no-undef` errors for `after` in `test/parser-issues.js`; changed-file lint passes.