### PR TITLE
test: retry crashed cache-test workers once

### DIFF
--- a/test/cache-interceptor/cache-tests.mjs
+++ b/test/cache-interceptor/cache-tests.mjs
@@ -140,7 +140,8 @@ for (let i = 0; i < testEnvironments.length; i++) {
   const environment = testEnvironments[i]
   const port = PORT + i
 
-  const promise = new Promise((resolve) => {
+  const runWorker = () => {
+    const { promise, resolve } = Promise.withResolvers()
     const cacheTestsWorkerProcess = fork(join(import.meta.dirname, 'cache-tests-worker.mjs'), {
       stdio: 'pipe',
       env: {
@@ -177,7 +178,26 @@ for (let i = 0; i < testEnvironments.length; i++) {
         port
       })
     })
-  })
+
+    return promise
+  }
+
+  const promise = (async () => {
+    const result = await runWorker()
+    if (result.signal === null && (result.code === 0 || result.code === 1)) {
+      return result
+    }
+
+    const retryResult = await runWorker()
+    return {
+      ...retryResult,
+      stdout: [
+        ...result.stdout,
+        Buffer.from(`cache-tests worker crashed, retrying once: port=${port} store=${environment.cacheStore ?? 'default'} type=${environment.opts.type ?? 'default'} code=${result.code ?? 'null'} signal=${result.signal ?? 'null'}\n`),
+        ...retryResult.stdout
+      ]
+    }
+  })()
 
   results.push(promise)
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Refs: https://github.com/nodejs/undici/issues/5199

## Rationale

`test:cache-tests` can intermittently fail when a worker process exits from a native/runtime crash, such as Windows exit code `3221226505`. Retrying once lets transient worker crashes recover while preserving normal test failures.

## Changes

- Retry a crashed `cache-tests` worker once.
- Keep regular test failures, such as exit code `1`, failing without retry.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5