### PR TITLE
ci: retry flaky tests on Windows Node.js 24

### DIFF
--- a/scripts/platform-shell.js
+++ b/scripts/platform-shell.js
@@ -5,8 +5,13 @@ const { writeFileSync } = require('node:fs')
 const { resolve } = require('node:path')
 
 if (platform() === 'win32') {
+  const shouldRetryTests = process.env.GITHUB_ACTIONS === 'true' && process.versions.node.split('.')[0] === '24'
+  const scriptShell = shouldRetryTests
+    ? resolve(__dirname, 'retry-test-shell.cmd')
+    : 'C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
   writeFileSync(
-    resolve(__dirname, '.npmrc'),
-    'script-shell = "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"\n'
+    resolve(__dirname, shouldRetryTests ? '..' : '.', '.npmrc'),
+    `script-shell = ${scriptShell}\n`
   )
 }

--- a/scripts/retry-test-shell.cmd
+++ b/scripts/retry-test-shell.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0retry-test-shell.ps1" %*

--- a/scripts/retry-test-shell.ps1
+++ b/scripts/retry-test-shell.ps1
@@ -1,0 +1,48 @@
+$testScripts = @(
+  'test:cache',
+  'test:cache-interceptor',
+  'test:cache-tests',
+  'test:cookies',
+  'test:eventsource',
+  'test:fetch',
+  'test:infra',
+  'test:interceptors',
+  'test:jest',
+  'test:node-fetch',
+  'test:node-test',
+  'test:subresource-integrity',
+  'test:unit',
+  'test:websocket',
+  'test:wpt'
+)
+
+$commandIndex = -1
+for ($i = 0; $i -lt $args.Length; $i++) {
+  if ($args[$i] -ieq '/c' -or $args[$i] -ieq '-c') {
+    $commandIndex = $i
+    break
+  }
+}
+
+if ($args.Length -eq 0 -or $commandIndex -eq $args.Length - 1) {
+  exit 1
+}
+
+if ($commandIndex -eq -1) {
+  $command = $args -join ' '
+} else {
+  $command = $args[($commandIndex + 1)..($args.Length - 1)] -join ' '
+}
+$shouldRetry = $testScripts -contains $env:npm_lifecycle_event
+
+cmd.exe /d /s /c $command
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -eq 0 -or -not $shouldRetry) {
+  exit $exitCode
+}
+
+Write-Host "Command failed with exit code $exitCode. Retrying once on Windows with Node.js 24."
+
+cmd.exe /d /s /c $command
+exit $LASTEXITCODE


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Refs: https://github.com/nodejs/undici/issues/5177

## Rationale

Most of the tracked flaky CI failures are on Windows with Node.js 24. This adds a single retry for those CI test failures only, without changing behavior for other platforms or Node.js versions.

## Changes

- Add one retry for npm test scripts on GitHub Actions when running on Windows with Node.js 24.
- Keep the retry scoped through the Windows npm script shell setup so existing CI test commands do not need to change.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5