### PR TITLE
fix(websocket): preserve failed connection error message

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -314,6 +314,8 @@ function failWebsocketConnection (handler, code, reason, cause) {
 
   handler.controller.abort()
 
+  handler.closeReason = reason
+
   if (isConnecting(handler.readyState)) {
     // If the connection was not established, we must still emit an 'error' and 'close' events
     handler.onSocketClose()

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -52,6 +52,7 @@ function getSocketAddress (socket) {
  * @property {number} readyState
  * @property {import('stream').Duplex} socket
  * @property {Set<number>} closeState
+ * @property {string} [closeReason]
  * @property {import('../fetch/index').Fetch} controller
  * @property {boolean} [wasEverConnected=false]
  */
@@ -113,6 +114,7 @@ class WebSocket extends EventTarget {
     readyState: states.CONNECTING,
     socket: null,
     closeState: new Set(),
+    closeReason: '',
     controller: null,
     wasEverConnected: false
   }
@@ -579,7 +581,7 @@ class WebSocket extends EventTarget {
       this.#handler.closeState.has(sentCloseFrameState.RECEIVED)
 
     let code = 1005
-    let reason = ''
+    let reason = this.#handler.closeReason ?? ''
 
     const result = this.#parser?.closingInfo
 
@@ -604,7 +606,8 @@ class WebSocket extends EventTarget {
       code = 1006
 
       fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new TypeError(reason)
+        error: new TypeError(reason),
+        message: reason
       })
     }
 

--- a/test/websocket/issue-4735.js
+++ b/test/websocket/issue-4735.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { test } = require('node:test')
+const { WebSocket } = require('../..')
+const { once } = require('node:events')
+
+test('WebSocket emits error with message when connection cannot be opened', async (t) => {
+  t.plan(2)
+
+  const ws = new WebSocket('ws://localhost:1')
+
+  ws.addEventListener('error', ({ error, message }) => {
+    t.assert.strictEqual(error.message, 'Received network error or non-101 status code.')
+    t.assert.strictEqual(message, 'Received network error or non-101 status code.')
+  })
+
+  await once(ws, 'close')
+})


### PR DESCRIPTION
## Summary

When a WebSocket connection fails before a parser is available, Undici had the failure reason in `failWebsocketConnection()` but `WebSocket#onSocketClose()` initialized the close reason from parser state only. That produced an `ErrorEvent` with an empty message.

This stores the failed-connection reason on the WebSocket handler and uses it when firing the `error` event, setting both `error.message` and the `ErrorEvent.message` field.

Fixes #4735.

## Validation

- `npm run lint -- lib/web/websocket/connection.js lib/web/websocket/websocket.js test/websocket/issue-4735.js`
- `npx borp --timeout 180000 -p "test/websocket/issue-4735.js"`
- `npx borp --timeout 180000 -p "test/websocket/issue-3546.js"`
- `npx borp --timeout 180000 -p "test/websocket/issue-4273.js"`
- git commit pre-hook: `npm run lint`