### PR TITLE
fix: replace tspl with native test context in test/examples.js

### DIFF
--- a/test/examples.js
+++ b/test/examples.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { tspl } = require('@matteo.collina/tspl')
 const { createServer } = require('node:http')
 const { test, after } = require('node:test')
 const { once } = require('node:events')
 const examples = require('../docs/examples/request.js')
 
 test('request examples', async (t) => {
-  t = tspl(t, { plan: 7 })
+  t.plan(7)
 
   let lastReq
   const exampleServer = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -48,21 +47,19 @@ test('request examples', async (t) => {
   ])
 
   await examples.getRequest(exampleServer.address().port)
-  t.strictEqual(lastReq.method, 'GET')
+  t.assert.strictEqual(lastReq.method, 'GET')
 
   await examples.postJSONRequest(exampleServer.address().port)
-  t.strictEqual(lastReq.method, 'POST')
-  t.strictEqual(lastReq.headers['content-type'], 'application/json')
+  t.assert.strictEqual(lastReq.method, 'POST')
+  t.assert.strictEqual(lastReq.headers['content-type'], 'application/json')
 
   await examples.postFormRequest(exampleServer.address().port)
-  t.strictEqual(lastReq.method, 'POST')
-  t.strictEqual(lastReq.headers['content-type'], 'application/x-www-form-urlencoded')
+  t.assert.strictEqual(lastReq.method, 'POST')
+  t.assert.strictEqual(lastReq.headers['content-type'], 'application/x-www-form-urlencoded')
 
   await examples.deleteRequest(exampleServer.address().port)
-  t.strictEqual(lastReq.method, 'DELETE')
+  t.assert.strictEqual(lastReq.method, 'DELETE')
 
   await examples.deleteRequest(errorServer.address().port)
-  t.strictEqual(lastReq.method, 'DELETE')
-
-  await t.completed
+  t.assert.strictEqual(lastReq.method, 'DELETE')
 })


### PR DESCRIPTION
Fix flaky test/examples.js on Windows CI.

## Changes

- Migrate `test/examples.js` from `tspl` to native Node.js test runner features (`t.plan`, `t.assert`)
- Fix missing `after` import in `test/parser-issues.js` (pre-existing lint error)

## Why

The `tspl` proxy reassigns the test context variable (`t = tspl(t, { plan: 7 })`), which can cause issues with execution context resolution on Windows when combined with module-level `after()` calls for teardown hooks.

This matches the pattern already used in other tests in the codebase (e.g. `test/mock-agent.js`) and follows the ongoing migration from tspl to native test context.

Closes #5267
