### PR TITLE
http2: remove redundant request stream binding

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -929,7 +929,6 @@ function writeH2 (client, request) {
   stream[kHTTP2Stream] = true
   stream[kRequestStreamState] = state
   state.stream = stream
-  bindRequestToStream(request, stream, null)
 
   // Increment counter as we have new streams open
   ++session[kOpenStreams]

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -673,6 +673,105 @@ test('Should clear h2 request stream references before completing a response', a
   await t.completed
 })
 
+test('Should clear h2 request stream references after abort before response', async t => {
+  t = tspl(t, { plan: 5 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const abortReason = new Error('abort after h2 stream assigned')
+  let abortRequest = null
+
+  const waitFor = async (fn) => {
+    for (let i = 0; i < 100; i++) {
+      const value = fn()
+      if (value != null) {
+        return value
+      }
+      await sleep(10)
+    }
+    throw new Error('timed out waiting for h2 request stream')
+  }
+
+  const responseError = new Promise(resolve => {
+    client.dispatch({
+      path: '/',
+      method: 'GET'
+    }, {
+      onRequestStart (controller) {
+        abortRequest = controller.abort.bind(controller)
+      },
+      onResponseStart () {
+        t.fail('unexpected response')
+      },
+      onResponseData () {
+        return true
+      },
+      onResponseEnd () {
+        t.fail('unexpected response end')
+      },
+      onResponseError (_controller, err) {
+        resolve(err)
+      }
+    })
+  })
+
+  const {
+    request,
+    requestStreamIdSymbol,
+    requestStreamSymbol,
+    requestStreamCleanupSymbol
+  } = await waitFor(() => {
+    const request = client[kQueue][client[kRunningIdx]]
+    if (request == null) {
+      return null
+    }
+
+    const symbols = Object.getOwnPropertySymbols(request)
+    const requestStreamIdSymbol = symbols.find((symbol) => symbol.description === 'request stream id')
+    const requestStreamSymbol = symbols.find((symbol) => symbol.description === 'request stream')
+    const requestStreamCleanupSymbol = symbols.find((symbol) => symbol.description === 'request stream cleanup')
+
+    if (requestStreamIdSymbol == null || requestStreamSymbol == null || requestStreamCleanupSymbol == null) {
+      return null
+    }
+
+    return {
+      request,
+      requestStreamIdSymbol,
+      requestStreamSymbol,
+      requestStreamCleanupSymbol
+    }
+  })
+
+  t.ok(await waitFor(() => request[requestStreamSymbol]))
+
+  abortRequest = await waitFor(() => abortRequest)
+  abortRequest(abortReason)
+
+  const err = await responseError
+  t.strictEqual(err, abortReason)
+  t.strictEqual(request[requestStreamIdSymbol], null)
+  t.strictEqual(request[requestStreamSymbol], null)
+  t.strictEqual(request[requestStreamCleanupSymbol], null)
+
+  await t.completed
+})
+
 test('Should only accept valid ping interval values', async t => {
   const planner = tspl(t, { plan: 3 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Redundant HTTP/2 request-stream binding in `client-h2.js`.

## Rationale

The normal HTTP/2 request path was calling `bindRequestToStream()` twice for the same stream. The first call used `null` cleanup and was immediately replaced by the second binding with `releaseRequestStream`, so it was redundant.

## Changes

- Remove the redundant initial `bindRequestToStream(request, stream, null)` call from the HTTP/2 request path.
- Add regression coverage for abort-before-response handling after an HTTP/2 stream has been assigned, ensuring request stream references are cleared.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5