### PR TITLE
fix: handle all HTTP/2 request stream sync errors

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -736,10 +736,6 @@ function writeH2 (client, request) {
     try {
       return session.request(headers, options)
     } catch (err) {
-      if (err?.code !== 'ERR_HTTP2_INVALID_CONNECTION_HEADERS') {
-        throw err
-      }
-
       const wrappedErr = new InformationalError(err.message, { cause: err })
       session[kError] = wrappedErr
       session[kSocket][kError] = wrappedErr

--- a/test/http2-invalid-connection-headers.js
+++ b/test/http2-invalid-connection-headers.js
@@ -91,3 +91,57 @@ test('should surface invalid HTTP/2 connection headers as a catchable error and 
 
   await t.completed
 })
+
+test('should surface HTTP/2 request header validation errors as a catchable error and resume queued requests', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  let streamCount = 0
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    streamCount++
+    stream.respond({
+      ':status': 200,
+      'content-type': 'text/plain; charset=utf-8'
+    })
+    stream.end('hello world')
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  after(() => client.close())
+
+  const firstRequest = client.request({
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-type': 'foo/bar',
+      'Content-Type': 'foo/bar'
+    },
+    body: 'foo-bar'
+  }).catch(err => err)
+
+  const secondRequest = client.request({
+    path: '/',
+    method: 'GET'
+  })
+
+  const err = await firstRequest
+  t.ok(err instanceof InformationalError)
+  t.strictEqual(err.code, 'UND_ERR_INFO')
+  t.strictEqual(err.cause.code, 'ERR_HTTP2_HEADER_SINGLE_VALUE')
+
+  const response = await secondRequest
+  t.strictEqual(streamCount, 1)
+  t.strictEqual(await response.body.text(), 'hello world')
+
+  await t.completed
+})


### PR DESCRIPTION
## Summary

- handle every synchronous `session.request()` failure in the HTTP/2 dispatcher via Undici's normal request error path
- preserve the original Node.js error as the `InformationalError` cause
- add a regression test for `ERR_HTTP2_HEADER_SINGLE_VALUE` from duplicate single-value HTTP/2 headers and verify queued requests resume

Fixes #4356

## Testing

- `npx borp -p "test/http2-invalid-connection-headers.js"`
- `npx eslint lib/dispatcher/client-h2.js test/http2-invalid-connection-headers.js`
- `npm run test:h2:core`
