### PR TITLE
docs: clarify formData security considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ The `body` mixins are the most common way to format the request/response body. M
 > [!NOTE]
 > The body returned from `undici.request` does not implement `.formData()`.
 
+> [!WARNING]
+> Calling `body.formData()` on a fetch response causes undici to buffer and parse the entire body. Because multipart parsing has inherent security risks, `body.formData()` must only be called on responses from trusted servers.
+
 Example usage:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The `body` mixins are the most common way to format the request/response body. M
 > The body returned from `undici.request` does not implement `.formData()`.
 
 > [!WARNING]
-> Calling `body.formData()` on a fetch response causes undici to buffer and parse the entire body. Because multipart parsing has inherent security risks, `body.formData()` must only be called on responses from trusted servers.
+> Calling `body.formData()` on a fetch response causes undici to buffer and parse the entire body. Since this is dictated by the spec, `body.formData()` must only be called on responses from trusted servers.
 
 Example usage:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,7 +81,7 @@ meet the following criteria:
 **Undici trusts**:
 
 * The application code that uses its APIs, including all configuration,
-  options, and callbacks provided by the application.
+  options, callbacks, and decisions about which body-consuming APIs to call.
 * The operating system and its network stack.
 * The Node.js runtime undici is running on.
 * Dependencies installed by the application.
@@ -141,6 +141,17 @@ lead to a loss of confidentiality, integrity, or availability.
   large enough to impact performance or cause the runtime to run out of
   resources, that is not considered a vulnerability. Applications are
   responsible for setting appropriate limits on response sizes.
+
+#### Calling `body.formData()` on untrusted responses
+
+* `body.formData()` buffers and parses the entire response body. Multipart
+  parsing has inherent security risks, especially when the body is supplied by
+  an untrusted or user-controlled server. Applications must only call
+  `body.formData()` on responses from trusted servers. For untrusted responses,
+  applications should use a dedicated streaming multipart parser and enforce
+  application-specific limits. Resource exhaustion or parser exposure caused by
+  calling `body.formData()` on untrusted responses is considered an application
+  responsibility, not a vulnerability in undici.
 
 #### Application Misconfiguration
 

--- a/docs/docs/api/Fetch.md
+++ b/docs/docs/api/Fetch.md
@@ -41,7 +41,9 @@ This API is implemented as per the standard, you can find documentation on [MDN]
 - [`.json()`](https://fetch.spec.whatwg.org/#dom-body-json)
 - [`.text()`](https://fetch.spec.whatwg.org/#dom-body-text)
 
-There is an ongoing discussion regarding `.formData()` and its usefulness and performance in server environments. It is recommended to use a dedicated library for parsing `multipart/form-data` bodies, such as [Busboy](https://www.npmjs.com/package/busboy) or [@fastify/busboy](https://www.npmjs.com/package/@fastify/busboy).
+There is an ongoing discussion regarding `body.formData()` and its usefulness, performance, and security in server environments. Calling `body.formData()` causes undici to buffer and parse the entire body. Because multipart parsing has inherent security risks, `body.formData()` must only be called on responses from trusted servers.
+
+For responses from untrusted or user-controlled servers, use a dedicated streaming library for parsing `multipart/form-data` bodies, such as [Busboy](https://www.npmjs.com/package/busboy) or [@fastify/busboy](https://www.npmjs.com/package/@fastify/busboy), and apply application-specific limits.
 
 These libraries can be interfaced with fetch with the following example code:
 

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -36,7 +36,10 @@ export class BodyMixin {
   readonly bytes: () => Promise<Uint8Array>
   /**
    * @deprecated This method is not recommended for parsing multipart/form-data bodies in server environments.
-   * It is recommended to use a library such as [@fastify/busboy](https://www.npmjs.com/package/@fastify/busboy) as follows:
+   * Calling body.formData() buffers and parses the entire body. Because multipart parsing has inherent security risks,
+   * this method must only be called on responses from trusted servers.
+   * For responses from untrusted or user-controlled servers, use a dedicated streaming parser such as
+   * [@fastify/busboy](https://www.npmjs.com/package/@fastify/busboy) and apply application-specific limits as follows:
    *
    * @example
    * ```js

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -36,7 +36,7 @@ export class BodyMixin {
   readonly bytes: () => Promise<Uint8Array>
   /**
    * @deprecated This method is not recommended for parsing multipart/form-data bodies in server environments.
-   * Calling body.formData() buffers and parses the entire body. Because multipart parsing has inherent security risks,
+   * Calling body.formData() buffers and parses the entire body. Since this is dictated by the spec,
    * this method must only be called on responses from trusted servers.
    * For responses from untrusted or user-controlled servers, use a dedicated streaming parser such as
    * [@fastify/busboy](https://www.npmjs.com/package/@fastify/busboy) and apply application-specific limits as follows:


### PR DESCRIPTION
## Summary

- document that `body.formData()` buffers and parses the entire body
- clarify it must only be used on responses from trusted servers
- update the security threat model for untrusted `body.formData()` usage