### PR TITLE
Improve fetch TLS certificate error messages

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -68,6 +68,15 @@ const { isomorphicEncode } = require('../infra')
 
 const GET_OR_HEAD = ['GET', 'HEAD']
 
+const tlsCertificateErrorCodes = new Set([
+  'CERT_SIGNATURE_FAILURE',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+])
+
 const defaultUserAgent = typeof __UNDICI_IS_NODE__ !== 'undefined' || typeof esbuildDetection !== 'undefined'
   ? 'node'
   : 'undici'
@@ -153,6 +162,14 @@ class Fetch extends EE {
 
 function handleFetchDone (response) {
   finalizeAndReportTiming(response, 'fetch')
+}
+
+function makeFetchError (error) {
+  const message = tlsCertificateErrorCodes.has(error?.code) && error.message
+    ? `fetch failed: ${error.message}`
+    : 'fetch failed'
+
+  return new TypeError(message, { cause: error })
 }
 
 // https://fetch.spec.whatwg.org/#fetch-method
@@ -258,7 +275,7 @@ function fetch (input, init = undefined) {
     // 3. If response is a network error, then reject p with a TypeError
     // and terminate these substeps.
     if (response.type === 'error') {
-      p.reject(new TypeError('fetch failed', { cause: response.error }))
+      p.reject(makeFetchError(response.error))
       return
     }
 

--- a/test/fetch/tls-certificate-error.js
+++ b/test/fetch/tls-certificate-error.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const https = require('node:https')
+const fs = require('node:fs')
+const path = require('node:path')
+const { fetch } = require('../..')
+
+test('fetch includes TLS certificate error details in the error message', async (t) => {
+  const server = https.createServer({
+    key: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'key.pem')),
+    cert: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'cert.pem')),
+    joinDuplicateHeaders: true
+  }, (req, res) => {
+    res.end('ok')
+  })
+
+  await new Promise(resolve => server.listen(0, resolve))
+  t.after(() => server.close())
+
+  await assert.rejects(
+    fetch(`https://localhost:${server.address().port}`),
+    (error) => {
+      assert.strictEqual(error.name, 'TypeError')
+      assert.match(error.message, /^fetch failed: /)
+      assert.strictEqual(error.message, `fetch failed: ${error.cause.message}`)
+      assert.ok([
+        'DEPTH_ZERO_SELF_SIGNED_CERT',
+        'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+      ].includes(error.cause.code))
+      return true
+    }
+  )
+})


### PR DESCRIPTION
Fixes #2199.

This keeps the fetch TypeError shape and cause intact while surfacing TLS certificate verification details in the top-level error message for known certificate-related failures.

Tests:
- node --test test\fetch\tls-certificate-error.js
- node --test test\fetch\client-error-stack-trace.js
- borp focused test/fetch/tls-certificate-error.js
- borp focused test/fetch/client-error-stack-trace.js
- eslint lib/web/fetch/index.js test/fetch/tls-certificate-error.js

Note: npm run build:node could not be executed in this Windows sandbox because npm/esbuild attempted to access a denied path outside the workspace before compiling.