### PR TITLE
fix(mock): restore single-arg MockCallHistory.filterCallsByX

### DIFF
--- a/lib/mock/mock-call-history.js
+++ b/lib/mock/mock-call-history.js
@@ -35,7 +35,7 @@ function buildAndValidateFilterCallsOptions (options = {}) {
 }
 
 function makeFilterCalls (parameterName) {
-  return (parameterValue, logs) => {
+  return (parameterValue, logs = this.logs) => {
     if (typeof parameterValue === 'string' || parameterValue == null) {
       return logs.filter((log) => {
         return log[parameterName] === parameterValue

--- a/test/mock-call-history.js
+++ b/test/mock-call-history.js
@@ -445,3 +445,138 @@ describe('MockCallHistory - filterCalls with options', () => {
     t.assert.strictEqual(filtered.length, 2)
   })
 })
+
+describe('MockCallHistory - filterCallsByX', () => {
+  test('filterCallsByProtocol should filter logs with a string', t => {
+    t.plan(2)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByProtocol('https:')
+
+    t.assert.strictEqual(filtered.length, 1)
+    t.assert.strictEqual(filtered[0]?.path, '/noop')
+  })
+
+  test('filterCallsByProtocol should filter logs with a regexp', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByProtocol(/^https:/)
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByHost should filter logs with a string', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://127.0.0.1:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByHost('127.0.0.1:4000')
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByPort should filter logs with a string', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:1000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByPort('1000')
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByOrigin should filter logs with a regexp', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'https://127.0.0.1:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByOrigin(/localhost/)
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByPath should filter logs with a string', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByPath('/noop')
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByHash should filter logs with a string', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/#hello', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByHash('#hello')
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByFullUrl should filter logs with a string', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://localhost:4000' })
+
+    const filtered = mockCallHistoryHello.filterCallsByFullUrl('http://localhost:4000/noop')
+
+    t.assert.strictEqual(filtered.length, 1)
+  })
+
+  test('filterCallsByMethod should filter logs with a regexp', t => {
+    t.plan(1)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000', method: 'POST' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/noop', origin: 'http://localhost:4000', method: 'GET' })
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/yes', origin: 'http://localhost:4000', method: 'PUT' })
+
+    const filtered = mockCallHistoryHello.filterCallsByMethod(/(POST|PUT)/)
+
+    t.assert.strictEqual(filtered.length, 2)
+  })
+
+  test('filterCallsByX should reflect logs added after the method was bound', t => {
+    t.plan(2)
+
+    const mockCallHistoryHello = new MockCallHistory('hello')
+
+    const before = mockCallHistoryHello.filterCallsByPath('/')
+    t.assert.strictEqual(before.length, 0)
+
+    mockCallHistoryHello[kMockCallHistoryAddLog]({ path: '/', origin: 'http://localhost:4000' })
+
+    const after = mockCallHistoryHello.filterCallsByPath('/')
+    t.assert.strictEqual(after.length, 1)
+  })
+})


### PR DESCRIPTION
## What

Restores the documented `mockCallHistory.filterCallsByX(value)` single-argument form. The helper returned by `makeFilterCalls` now defaults `logs` to `this.logs`, so external callers work again. Internal callers in `filterCalls` still pass `logs` explicitly, so the AND/OR semantics from #5045 are unchanged.

## Why

In 8.2.0, the `makeFilterCalls` helper was refactored to take a second `logs` argument used by the new AND/OR filter operators. The internal `handleFilterCallsWithOptions` always passes it, but the public methods (`filterCallsByPath`, `filterCallsByMethod`, etc.) are still documented to accept a single argument. Calling any `filterCallsByX('value')` since 8.2.0 throws `Cannot read properties of undefined (reading 'filter')`.

## Testing

- ran `node --test test/mock-call-history.js` — 46/46 green (10 new tests in the `MockCallHistory - filterCallsByX` block exercising each public filter helper plus a regression for "logs added after the method was bound")
- ran `node_modules/.bin/eslint --cache lib/mock/mock-call-history.js test/mock-call-history.js` — clean
- verified the issue's reproducer against the patched build

## Notes

The optional second `logs` parameter on the public methods wasn't documented, so no type-definition change is needed.

Fixes #5324.