### PR TITLE
fix: use createHash fallback for WebSocket accept digest

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -160,7 +160,9 @@ function establishWebSocketConnection (url, protocols, client, handler, options)
       //    trailing whitespace, the client MUST _Fail the WebSocket
       //    Connection_.
       const secWSAccept = response.headersList.get('Sec-WebSocket-Accept')
-      const digest = crypto.hash('sha1', keyValue + uid, 'base64')
+      const digest = typeof crypto.hash === 'function'
+        ? crypto.hash('sha1', keyValue + uid, 'base64')
+        : crypto.createHash('sha1').update(keyValue + uid).digest('base64')
       if (secWSAccept !== digest) {
         failWebsocketConnection(handler, 1002, 'Incorrect hash received in Sec-WebSocket-Accept header.')
         return

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -16,6 +16,12 @@ const crypto = runtimeFeatures.has('crypto')
   ? require('node:crypto')
   : null
 
+function createSha1Base64Hash (value) {
+  return typeof crypto.hash === 'function'
+    ? crypto.hash('sha1', value, 'base64')
+    : crypto.createHash('sha1').update(value).digest('base64')
+}
+
 test('WebSocket connecting to server that isn\'t a Websocket server', (t) => {
   return new Promise((resolve, reject) => {
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -59,6 +65,40 @@ test('Open event is emitted', (t) => {
   })
 })
 
+test('Open event is emitted when crypto.hash is unavailable', { skip: crypto == null }, async (t) => {
+  const planner = tspl(t, { plan: 1 })
+  const hash = crypto.hash
+
+  crypto.hash = undefined
+
+  t.after(() => {
+    crypto.hash = hash
+  })
+
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (ws) => {
+    ws.close(1000)
+  })
+
+  t.after(() => {
+    server.close()
+  })
+
+  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+  t.after(() => {
+    ws.close()
+  })
+
+  ws.onerror = ({ error }) => planner.fail(error)
+  ws.addEventListener('open', () => {
+    planner.ok(true)
+  })
+
+  await planner.completed
+})
+
 test('WebSocket on H2', { skip: crypto == null }, async (t) => {
   const planner = tspl(t, { plan: 6 })
   const server = createSecureServer({ cert, key, allowHTTP1: true, settings: { enableConnectProtocol: true } })
@@ -72,7 +112,7 @@ test('WebSocket on H2', { skip: crypto == null }, async (t) => {
     stream.respond({
       ':status': 200,
       'sec-websocket-protocol': headers['sec-websocket-protocol'],
-      'sec-websocket-accept': crypto.hash('sha1', `${headers['sec-websocket-key']}${uid}`, 'base64')
+      'sec-websocket-accept': createSha1Base64Hash(`${headers['sec-websocket-key']}${uid}`)
     })
     const ws = new WSWebsocket(null, null, { autoPong: true })
     ws.setSocket(stream, Buffer.alloc(0), {
@@ -415,7 +455,7 @@ test('Server sends invalid Sec-WebSocket-Extensions header', { skip: runtimeFeat
       const key = req.headers['sec-websocket-key']
       t.assert.ok(key)
 
-      const accept = require('node:crypto').hash('sha1', key + uid, 'base64')
+      const accept = createSha1Base64Hash(key + uid)
 
       res.setHeader('Upgrade', 'websocket')
       res.setHeader('Connection', 'upgrade')
@@ -446,7 +486,7 @@ test('Server sends invalid Sec-WebSocket-Extensions header', { skip: runtimeFeat
       const key = req.headers['sec-websocket-key']
       t.assert.ok(key)
 
-      const accept = require('node:crypto').hash('sha1', key + uid, 'base64')
+      const accept = createSha1Base64Hash(key + uid)
 
       res.setHeader('Upgrade', 'websocket')
       res.setHeader('Connection', 'upgrade')


### PR DESCRIPTION
Fixes #5333.

## Summary
- use feature detection for `crypto.hash` when validating the WebSocket accept digest
- fall back to `crypto.createHash` when `crypto.hash` is unavailable
- add a regression test that simulates `crypto.hash` being absent

## Tests
- `npm run lint`
- `npx borp --timeout 180000 -p "test/websocket/opening-handshake.js"`
- `npm run test:websocket`
