### PR TITLE
fix: preserve queued request ordering after stream body errors

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1088,11 +1088,6 @@ function writeH1 (client, request) {
     headers.push('content-type', body.type)
   }
 
-  if (body && typeof body.read === 'function') {
-    // Try to read EOF in order to get length.
-    body.read(0)
-  }
-
   const bodyLength = util.bodyLength(body)
 
   contentLength = bodyLength ?? contentLength

--- a/test/node-test/client-errors.js
+++ b/test/node-test/client-errors.js
@@ -122,71 +122,33 @@ test('GET errors and reconnect with pipelining 3', async (t) => {
   await p.completed
 })
 
-function installErrorAndReconnectServer (server, p, { contentLength, trackPostWithPlan }) {
-  let sawPost = false
-  let sawGet = false
-
-  server.on('request', (req, res) => {
-    if (req.method === 'GET') {
-      if (sawGet) {
-        req.socket?.destroy()
-        return
-      }
-
-      sawGet = true
-      p.strictEqual('/', req.url)
-      p.strictEqual('GET', req.method)
-      res.setHeader('content-type', 'text/plain')
-      res.end('hello')
-      return
-    }
-
-    if (sawPost) {
-      // Node.js 26 can surface additional POST attempts around the queued GET.
-      // Tear them down and keep the test focused on the reconnect behavior.
-      req.resume()
-      req.socket?.destroy()
-      return
-    }
-
-    sawPost = true
-
-    if (trackPostWithPlan) {
-      p.strictEqual('/', req.url)
-      p.strictEqual('POST', req.method)
-      p.strictEqual(req.headers['content-length'], contentLength)
-    } else {
-      assert.strictEqual('/', req.url)
-      assert.strictEqual('POST', req.method)
-      assert.strictEqual(req.headers['content-length'], contentLength)
-    }
-
-    const bufs = []
-    req.on('data', (buf) => {
-      bufs.push(buf)
-    })
-
-    req.on('aborted', () => {
-      // we will abruptly close the connection here
-      // but this will still end
-      if (trackPostWithPlan) {
-        p.strictEqual('a string', Buffer.concat(bufs).toString('utf8'))
-      } else {
-        assert.strictEqual('a string', Buffer.concat(bufs).toString('utf8'))
-      }
-    })
-  })
-}
-
 function errorAndPipelining (type) {
   test(`POST with a ${type} that errors and pipelining 1 should reconnect`, async (t) => {
-    const trackPostWithPlan = type !== consts.STREAM
-    const p = tspl(t, { plan: trackPostWithPlan ? 12 : 8 })
+    const p = tspl(t, { plan: 12 })
 
     const server = createServer({ joinDuplicateHeaders: true })
-    installErrorAndReconnectServer(server, p, {
-      contentLength: '42',
-      trackPostWithPlan
+    server.once('request', (req, res) => {
+      p.strictEqual('/', req.url)
+      p.strictEqual('POST', req.method)
+      p.strictEqual('42', req.headers['content-length'])
+
+      const bufs = []
+      req.on('data', (buf) => {
+        bufs.push(buf)
+      })
+
+      req.on('aborted', () => {
+        // we will abruptly close the connection here
+        // but this will still end
+        p.strictEqual('a string', Buffer.concat(bufs).toString('utf8'))
+      })
+
+      server.once('request', (req, res) => {
+        p.strictEqual('/', req.url)
+        p.strictEqual('GET', req.method)
+        res.setHeader('content-type', 'text/plain')
+        res.end('hello')
+      })
     })
     t.after(closeServerAsPromise(server))
 
@@ -237,13 +199,31 @@ errorAndPipelining(consts.ASYNC_ITERATOR)
 
 function errorAndChunkedEncodingPipelining (type) {
   test(`POST with chunked encoding, ${type} body that errors and pipelining 1 should reconnect`, async (t) => {
-    const trackPostWithPlan = type !== consts.STREAM
-    const p = tspl(t, { plan: trackPostWithPlan ? 12 : 8 })
+    const p = tspl(t, { plan: 12 })
 
     const server = createServer({ joinDuplicateHeaders: true })
-    installErrorAndReconnectServer(server, p, {
-      contentLength: undefined,
-      trackPostWithPlan
+    server.once('request', (req, res) => {
+      p.strictEqual('/', req.url)
+      p.strictEqual('POST', req.method)
+      p.strictEqual(req.headers['content-length'], undefined)
+
+      const bufs = []
+      req.on('data', (buf) => {
+        bufs.push(buf)
+      })
+
+      req.on('aborted', () => {
+        // we will abruptly close the connection here
+        // but this will still end
+        p.strictEqual('a string', Buffer.concat(bufs).toString('utf8'))
+      })
+
+      server.once('request', (req, res) => {
+        p.strictEqual('/', req.url)
+        p.strictEqual('GET', req.method)
+        res.setHeader('content-type', 'text/plain')
+        res.end('hello')
+      })
     })
     t.after(closeServerAsPromise(server))
 


### PR DESCRIPTION
## Summary

- avoid eager HTTP/1 `Readable` body probing before undici attaches body/error handlers
- restore strict `client-errors` expectations for the failed POST / queued GET ordering
- stop tolerating extra POST attempts in the reconnect test

Fixes #5335.

## Testing

- `node --test --test-reporter=spec --test-timeout=180000 test/node-test/client-errors.js`
- `~/.nvm/versions/node/v25.2.1/bin/node --test --test-reporter=spec --test-timeout=180000 test/node-test/client-errors.js`
- `~/.nvm/versions/node/v26.1.0/bin/node --test --test-reporter=spec --test-timeout=180000 test/node-test/client-errors.js`
- `PATH="$HOME/.nvm/versions/node/v26.1.0/bin:$PATH" npm run test:node-test`
- `npx eslint lib/dispatcher/client-h1.js test/node-test/client-errors.js`
