### PR TITLE
docs: document missing error types in Errors.md

### DIFF
--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -27,6 +27,13 @@ import { errors } from 'undici'
 | `ResponseExceededMaxSizeError`       | `UND_ERR_RES_EXCEEDED_MAX_SIZE`       | response body exceed the max size allowed                                 |
 | `SecureProxyConnectionError`         | `UND_ERR_PRX_TLS`                     | tls connection to a proxy failed                                          |
 | `MessageSizeExceededError`           | `UND_ERR_WS_MESSAGE_SIZE_EXCEEDED`    | WebSocket decompressed message exceeded the maximum allowed size          |
+| `AbortError`                         | `UND_ERR_ABORT`                       | the operation was aborted (base class of `RequestAbortedError`).          |
+| `RequestRetryError`                  | `UND_ERR_REQ_RETRY`                   | request failed and could not be retried; carries `statusCode`, `headers` and `data`. |
+| `ResponseError`                      | `UND_ERR_RESPONSE`                    | response returned an error status code; carries `statusCode`, `headers` and `body`.  |
+| `MaxOriginsReachedError`             | `UND_ERR_MAX_ORIGINS_REACHED`         | the maximum number of allowed origins has been reached.                   |
+| `BalancedPoolMissingUpstreamError`   | `UND_ERR_BPL_MISSING_UPSTREAM`        | no upstream has been added to the `BalancedPool`.                         |
+| `Socks5ProxyError`                   | `UND_ERR_SOCKS5*`                     | an error occurred during SOCKS5 proxy negotiation.                        |
+| `HTTPParserError`                    | `HPE_*`                               | an error occurred while parsing the HTTP response (extends `Error`, not `UndiciError`). |
 
 Be aware of the possible difference between the global dispatcher version and the actual undici version you might be using. We recommend to avoid the check `instanceof errors.UndiciError` and seek for the `error.code === '<error_code>'` instead to avoid inconsistencies.
 


### PR DESCRIPTION
## This relates to...

The `errors` documentation, which was missing several exported error classes. Closely related to the documentation gap noted in #1865 (timeout/error code explanations).

## Rationale

`docs/docs/api/Errors.md` documents the error objects exposed via the `errors` key, but several classes that are actually exported from `lib/core/errors.js` were absent from the table. Users hitting these errors (`error.code === '...'`) had no reference for them. This adds the missing rows so the table matches what `undici` exports.

## Changes

Added the following rows to the errors table in `docs/docs/api/Errors.md`, with codes and descriptions matching the definitions in `lib/core/errors.js`:

| Error | Code |
| --- | --- |
| `AbortError` | `UND_ERR_ABORT` |
| `RequestRetryError` | `UND_ERR_REQ_RETRY` |
| `ResponseError` | `UND_ERR_RESPONSE` |
| `MaxOriginsReachedError` | `UND_ERR_MAX_ORIGINS_REACHED` |
| `BalancedPoolMissingUpstreamError` | `UND_ERR_BPL_MISSING_UPSTREAM` |
| `Socks5ProxyError` | `UND_ERR_SOCKS5*` |
| `HTTPParserError` | `HPE_*` |

Notes:
- `HTTPParserError` extends `Error` (not `UndiciError`) and uses `HPE_*` codes; called out in its description so it doesn't contradict the existing "all errors below are extended from `UndiciError`" note.
- `Socks5ProxyError` uses `UND_ERR_SOCKS5*` codes (e.g. `UND_ERR_SOCKS5`, `UND_ERR_SOCKS5_AUTH_REJECTED`).

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A — documentation only, no API changes.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested (docs-only, no code changed)
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin