### PR TITLE
fix: preserve raw headers in dispatch handler bridge

### DIFF
--- a/lib/handler/unwrap-handler.js
+++ b/lib/handler/unwrap-handler.js
@@ -13,6 +13,9 @@ class UnwrapController {
 
   [kResume] = null
 
+  rawHeaders = null
+  rawTrailers = null
+
   constructor (abort) {
     this.#abort = abort
   }
@@ -72,11 +75,13 @@ module.exports = class UnwrapHandler {
   }
 
   onUpgrade (statusCode, rawHeaders, socket) {
+    this.#controller.rawHeaders = rawHeaders
     this.#handler.onRequestUpgrade?.(this.#controller, statusCode, parseHeaders(rawHeaders), socket)
   }
 
   onHeaders (statusCode, rawHeaders, resume, statusMessage) {
     this.#controller[kResume] = resume
+    this.#controller.rawHeaders = rawHeaders
     this.#handler.onResponseStart?.(this.#controller, statusCode, parseHeaders(rawHeaders), statusMessage)
     return !this.#controller.paused
   }
@@ -87,6 +92,7 @@ module.exports = class UnwrapHandler {
   }
 
   onComplete (rawTrailers) {
+    this.#controller.rawTrailers = rawTrailers
     this.#handler.onResponseEnd?.(this.#controller, parseHeaders(rawTrailers))
   }
 

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -93,3 +93,52 @@ test('setGlobalDispatcher mirrors the dispatcher under the v1 symbol that Node.j
   assert.strictEqual(payload.mirroredV1, true)
   assert.strictEqual(payload.mirroredV2, true)
 })
+
+test('Node.js global fetch preserves headers and decoding with an undici Agent dispatcher', () => {
+  const script = `
+    const assert = require('node:assert')
+    const { createServer } = require('node:http')
+    const { once } = require('node:events')
+    const { brotliCompressSync } = require('node:zlib')
+    const { Agent } = require('./index.js')
+
+    ;(async () => {
+      const body = Buffer.from('body content')
+      const compressedBody = brotliCompressSync(body)
+      const server = createServer((_request, response) => {
+        response.writeHead(200, {
+          'content-type': 'application/x-ndjson',
+          'content-encoding': 'br',
+          'another-test-header': 'test-value'
+        })
+        response.end(compressedBody)
+      })
+      server.listen(0)
+      await once(server, 'listening')
+
+      const url = 'http://127.0.0.1:' + server.address().port
+      const cases = [
+        ['global dispatcher', {}],
+        ['custom dispatcher', { dispatcher: new Agent() }]
+      ]
+
+      for (const [label, init] of cases) {
+        const response = await fetch(url, init)
+        const responseBody = Buffer.from(await response.arrayBuffer()).toString('utf8')
+
+        assert.strictEqual(response.headers.get('content-type'), 'application/x-ndjson', label)
+        assert.strictEqual(response.headers.get('content-encoding'), 'br', label)
+        assert.strictEqual(response.headers.get('another-test-header'), 'test-value', label)
+        assert.strictEqual(responseBody, 'body content', label)
+      }
+
+      server.close()
+    })().catch((err) => {
+      console.error(err?.cause?.stack || err?.stack || err)
+      process.exit(1)
+    })
+  `
+
+  const result = runNode(script)
+  assert.strictEqual(result.status, 0, result.stderr)
+})

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -212,6 +212,8 @@ declare namespace Dispatcher {
     get aborted(): boolean
     get paused(): boolean
     get reason(): Error | null
+    rawHeaders?: Buffer[] | string[] | IncomingHttpHeaders | null
+    rawTrailers?: Buffer[] | string[] | IncomingHttpHeaders | null
     abort(reason: Error): void
     pause(): void
     resume(): void


### PR DESCRIPTION
## Description

Preserve `rawHeaders` and `rawTrailers` on the synthetic controller used by `UnwrapHandler` when bridging modern dispatch handlers to the legacy handler interface.

This keeps Node.js bundled `fetch` compatible with an imported Undici v7 `Agent`, so response headers remain visible and compressed bodies continue to be decoded.

Fixes: #5341

## Changes

- store `rawHeaders` on the controller before invoking `onRequestUpgrade` / `onResponseStart`
- store `rawTrailers` before invoking `onResponseEnd`
- expose the optional controller fields in `types/dispatcher.d.ts`
- add a regression test covering Node.js global `fetch` with both the global dispatcher and an explicit `dispatcher: new Agent()`

## Testing

- `npm run lint -- lib/handler/unwrap-handler.js test/node-test/global-dispatcher-version.js types/dispatcher.d.ts`
- `npx borp -p "test/node-test/global-dispatcher-version.js"`
- `source ~/.nvm/nvm.sh && nvm use 26.3.0 >/dev/null && npx borp -p "test/node-test/global-dispatcher-version.js"`
