### PR TITLE
fix: drop response chunks after the response stream is destroyed (#5356)

### DIFF
--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -66,7 +66,13 @@ class RequestHandler extends AsyncResource {
       this.removeAbortListener = util.addAbortListener(signal, () => {
         this.reason = signal.reason ?? new RequestAbortedError()
         if (this.res) {
-          util.destroy(this.res.on('error', noop), this.reason)
+          // Null the reference before destroying, mirroring onResponseError, so
+          // that chunks flushed after the abort (e.g. an async decompressor
+          // flush) are dropped by the `!this.res` guard in onResponseData
+          // instead of being pushed into the torn-down stream.
+          const res = this.res
+          this.res = null
+          util.destroy(res.on('error', noop), this.reason)
         } else if (this.abort) {
           this.abort(this.reason)
         }
@@ -150,11 +156,7 @@ class RequestHandler extends AsyncResource {
   }
 
   onResponseData (controller, chunk) {
-    // The abort-signal listener destroys `this.res` in place without nulling
-    // it (unlike onResponseError). Drop chunks that arrive after the stream is
-    // gone - e.g. an async decompressor flush after an abort - instead of
-    // pushing them into the torn-down stream.
-    if (!this.res || this.res.destroyed) {
+    if (!this.res) {
       return
     }
 

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -150,7 +150,11 @@ class RequestHandler extends AsyncResource {
   }
 
   onResponseData (controller, chunk) {
-    if (!this.res) {
+    // The abort-signal listener destroys `this.res` in place without nulling
+    // it (unlike onResponseError). Drop chunks that arrive after the stream is
+    // gone - e.g. an async decompressor flush after an abort - instead of
+    // pushing them into the torn-down stream.
+    if (!this.res || this.res.destroyed) {
       return
     }
 

--- a/test/issue-5356.js
+++ b/test/issue-5356.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
+
+const { RequestHandler } = require('../lib/api/api-request')
+
+// Regression test for https://github.com/nodejs/undici/issues/5356
+//
+// When a request is aborted while its body is being consumed (e.g.
+// `body.json()`), the abort-signal listener destroys the response stream in
+// place but - unlike `onResponseError` - does not null `this.res`. A chunk that
+// arrives afterwards (for example flushed asynchronously by the decompress
+// interceptor) reached the destroyed stream and crashed synchronously with
+// "Cannot read properties of null (reading 'push')" instead of the consume
+// promise simply rejecting with the AbortError.
+test('a late chunk after an aborted consume is dropped, not pushed into the destroyed stream', { timeout: 30000 }, async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const ac = new AbortController()
+
+  let body = null
+  const handler = new RequestHandler(
+    { method: 'GET', path: '/', signal: ac.signal },
+    (err, data) => {
+      if (err == null && data != null) {
+        body = data.body
+      }
+    }
+  )
+
+  const controller = {
+    resume () {},
+    pause () {},
+    abort () {}
+  }
+
+  handler.onRequestStart(controller, null)
+  handler.onResponseStart(controller, 200, { 'content-type': 'application/json' }, 'OK')
+
+  // Start consuming the body, then abort while it is still in flight. The abort
+  // listener destroys `res` (the body) while `handler.res` keeps referencing it.
+  const consumed = body.json()
+  ac.abort()
+
+  // Wait for the destroy to tear the consume down (consume.body becomes null).
+  // Listen for 'close' directly: the stream emits 'error' first (the abort
+  // reason, already handled by the consume), and events.once would reject on it.
+  await new Promise(resolve => body.once('close', resolve))
+
+  // A late chunk - e.g. an asynchronous decompressor flush after teardown - must
+  // be dropped because the response stream is destroyed, not pushed into it.
+  t.doesNotThrow(() => {
+    handler.onResponseData(controller, Buffer.from('{"late":true}'))
+  })
+
+  await t.rejects(consumed, (err) => err.name === 'AbortError')
+
+  await t.completed
+})

--- a/test/issue-5356.js
+++ b/test/issue-5356.js
@@ -8,12 +8,15 @@ const { RequestHandler } = require('../lib/api/api-request')
 // Regression test for https://github.com/nodejs/undici/issues/5356
 //
 // When a request is aborted while its body is being consumed (e.g.
-// `body.json()`), the abort-signal listener destroys the response stream in
-// place but - unlike `onResponseError` - does not null `this.res`. A chunk that
-// arrives afterwards (for example flushed asynchronously by the decompress
-// interceptor) reached the destroyed stream and crashed synchronously with
-// "Cannot read properties of null (reading 'push')" instead of the consume
-// promise simply rejecting with the AbortError.
+// `body.json()`), a chunk flushed afterwards (for example asynchronously by the
+// decompress interceptor) reached the already torn-down response stream and
+// crashed synchronously with "Cannot read properties of null (reading 'push')"
+// instead of the consume promise simply rejecting with the AbortError.
+//
+// Root cause: the abort-signal listener destroyed the response stream in place
+// but, unlike `onResponseError`, left `this.res` set, so the late chunk slipped
+// past the `!this.res` guard in onResponseData. The fix nulls `this.res` in the
+// abort listener, so the guard drops the chunk at the handler.
 test('a late chunk after an aborted consume is dropped, not pushed into the destroyed stream', { timeout: 30000 }, async (t) => {
   t = tspl(t, { plan: 2 })
 
@@ -39,7 +42,7 @@ test('a late chunk after an aborted consume is dropped, not pushed into the dest
   handler.onResponseStart(controller, 200, { 'content-type': 'application/json' }, 'OK')
 
   // Start consuming the body, then abort while it is still in flight. The abort
-  // listener destroys `res` (the body) while `handler.res` keeps referencing it.
+  // listener destroys `res` (the body) and nulls `handler.res`.
   const consumed = body.json()
   ac.abort()
 
@@ -49,7 +52,7 @@ test('a late chunk after an aborted consume is dropped, not pushed into the dest
   await new Promise(resolve => body.once('close', resolve))
 
   // A late chunk - e.g. an asynchronous decompressor flush after teardown - must
-  // be dropped because the response stream is destroyed, not pushed into it.
+  // be dropped because `handler.res` is null, not pushed into the torn-down stream.
   t.doesNotThrow(() => {
     handler.onResponseData(controller, Buffer.from('{"late":true}'))
   })


### PR DESCRIPTION
## This relates to...

Fixes #5356

## Rationale

When a request is aborted mid-stream while its body is being consumed (e.g. `body.json()` with an `AbortSignal` timeout), a late chunk could crash the process with `TypeError: Cannot read properties of null (reading 'push')` instead of the consume promise simply rejecting with the `AbortError`.

Root cause: the abort-signal listener in `lib/api/api-request.js` destroys `this.res` in place but, unlike `onResponseError`, does **not** null it. So a chunk that arrives afterwards - for example flushed asynchronously by the decompress interceptor after the abort - passes the existing `if (!this.res)` guard in `onResponseData` (the reference is still set, just destroyed) and is pushed into the torn-down `BodyReadable`, reaching `consumePush` on a consume whose `body` has already been nulled.

> Note: this supersedes the earlier revision of this PR, which guarded `consumePush` in `readable.js`. As @mcollina pointed out, the bug is elsewhere - that function should not be called after teardown. The fix now stops the late chunk at the handler, so `consumePush` is never reached.

## Changes

- `lib/api/api-request.js`: `onResponseData` now returns early when the response stream is already destroyed (`!this.res || this.res.destroyed`), dropping late chunks at the handler instead of pushing them into a torn-down stream.

### Alternative considered

Nulling `this.res` in the abort-signal listener (to mirror `onResponseError`) also fixes it and removes the asymmetry directly. I chose the `onResponseData` guard because it is a smaller surface, uses the public `Readable.destroyed`, and matches the `destroyed`-aware request-body guard in `api-pipeline.js`. Happy to switch to nulling `this.res` if you prefer the symmetry - the regression test covers both.

### Bug Fixes

- A late chunk arriving after an aborted consume no longer crashes the process; the consume promise rejects with the `AbortError` as expected.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested (new regression test `test/issue-5356.js`, RED without the fix, GREEN with it; `readable`/`request`/`client-request`/`decompress`/abort+signal suites pass; lint clean)
- [S] Benchmarked (**optional**)
- [x] Documented (code comment; no public API change)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin