### PR TITLE
fix(mock): do not persist snapshots on close in playback mode

### DIFF
--- a/lib/mock/snapshot-agent.js
+++ b/lib/mock/snapshot-agent.js
@@ -354,7 +354,15 @@ class SnapshotAgent extends MockAgent {
    * @returns {Promise<void>}
    */
   async close () {
-    await this[kSnapshotRecorder].close()
+    // In playback mode the recorder must not persist to disk. findSnapshot()
+    // mutates each matched snapshot's callCount, so saving on close would
+    // rewrite the snapshot file even though nothing new was recorded. Only
+    // record/update modes should write snapshots; playback just cleans up.
+    if (this[kSnapshotMode] === 'playback') {
+      this[kSnapshotRecorder].destroy()
+    } else {
+      await this[kSnapshotRecorder].close()
+    }
     await this[kRealAgent]?.close()
     await super.close()
   }

--- a/test/snapshot-testing.js
+++ b/test/snapshot-testing.js
@@ -1560,6 +1560,55 @@ describe('SnapshotAgent - Close Method', () => {
     }, 'Should not throw when closing agent without snapshot path')
   })
 
+  it('close() does not rewrite the snapshot file in playback mode', async (t) => {
+    const snapshotPath = createSnapshotPath('close-playback-no-rewrite')
+    setupCleanup(t, { snapshotPath })
+
+    const server = createTestServer(createDefaultHandler())
+    const { origin } = await setupServer(server)
+    setupCleanup(t, { server })
+
+    const originalDispatcher = getGlobalDispatcher()
+    setupCleanup(t, { originalDispatcher })
+
+    // Record a snapshot so there is a file on disk to play back.
+    const recordingAgent = new SnapshotAgent({
+      mode: 'record',
+      snapshotPath,
+      autoFlush: false
+    })
+    setGlobalDispatcher(recordingAgent)
+    await request(`${origin}/test`)
+    await recordingAgent.close()
+
+    // Capture the exact bytes written by the recording session.
+    const recordedContent = await readFile(snapshotPath, 'utf8')
+
+    // Play the snapshot back. Each matched request increments the snapshot's
+    // callCount in memory, so a save on close would change the file on disk.
+    const playbackAgent = new SnapshotAgent({
+      mode: 'playback',
+      snapshotPath,
+      autoFlush: false
+    })
+    setGlobalDispatcher(playbackAgent)
+
+    await request(`${origin}/test`)
+    await request(`${origin}/test`)
+    await request(`${origin}/test`)
+
+    await playbackAgent.close()
+
+    // The file must be byte-for-byte identical: playback is a read-only path
+    // and must never rewrite the fixture (and thus never churn its callCount).
+    const contentAfterPlayback = await readFile(snapshotPath, 'utf8')
+    assert.strictEqual(
+      contentAfterPlayback,
+      recordedContent,
+      'Playback close() should not modify the snapshot file on disk'
+    )
+  })
+
   it('recorder close() method works independently', async (t) => {
     const { SnapshotRecorder } = require('../lib/mock/snapshot-recorder')
     const snapshotPath = createSnapshotPath('recorder-close')


### PR DESCRIPTION
## Problem

`SnapshotAgent.close()` unconditionally delegates to the recorder's `close()`, which saves snapshots to disk whenever any are held — with no regard for the current mode:

```js
// lib/mock/snapshot-recorder.js
async close () {
  if (this.#snapshotPath && this.#snapshots.size !== 0) {
    await this.saveSnapshots()
  }
  this.destroy()
}
```

In **playback** mode this is a problem because `findSnapshot()` mutates each matched snapshot on every call:

```js
// lib/mock/snapshot-recorder.js — findSnapshot()
const currentCallCount = snapshot.callCount || 0
const responseIndex = Math.min(currentCallCount, snapshot.responses.length - 1)
snapshot.callCount = currentCallCount + 1
```

And `callCount` is serialized by `saveSnapshots()`. So the chain is:

> playback run → every matched request bumps `callCount` in memory → `close()` flushes unconditionally → the snapshot file is rewritten on disk.

The result is spurious diffs in committed snapshot fixtures after a plain playback run (no recording involved). For projects that store fixtures in git (e.g. via Git LFS), every test run produces a new file hash and noisy, meaningless diffs. The persisted `callCount` is also stale state — `loadSnapshots()` does not reset it — so it has no business being written back during playback.

## Fix

Gate persistence at `SnapshotAgent.close()`, which is the only layer that knows the mode. Record/update modes still save via `recorder.close()`; playback only cleans up timers via `recorder.destroy()`:

```js
async close () {
  if (this[kSnapshotMode] === 'playback') {
    this[kSnapshotRecorder].destroy()
  } else {
    await this[kSnapshotRecorder].close()
  }
  await this[kRealAgent]?.close()
  await super.close()
}
```

The public `saveSnapshots()` is intentionally left untouched, so an explicit save still works in any mode — only the *automatic* save-on-close is suppressed during playback.

## Test

Added a regression test in the existing *Close Method* block (`test/snapshot-testing.js`): record a fixture, capture its exact on-disk bytes, run a playback session with several matched requests (mutating `callCount` in memory), `close()`, and assert the file is byte-for-byte unchanged. It fails on `main` and passes with this change.

## Note / possible follow-up

The opt-in auto-flush timer (`autoFlush: true`) also calls `saveSnapshots()` and is likewise not mode-gated, so it could still rewrite a fixture during a long-running playback session. That's a separate, opt-in path (default off) and out of scope here, but worth flagging — happy to address it in a follow-up if maintainers prefer.