### PR TITLE
test: add Node.js global fetch regression coverage

### DIFF
--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -6,6 +6,7 @@ const { spawnSync } = require('node:child_process')
 const { join } = require('node:path')
 
 const cwd = join(__dirname, '../..')
+const isNode26Plus = Number(process.versions.node.split('.')[0]) >= 26
 
 function runNode (source) {
   return spawnSync(process.execPath, ['-e', source], {
@@ -125,4 +126,53 @@ test('Dispatcher1Wrapper bridges legacy handlers to a new Agent', () => {
   const result = runNode(script)
   assert.strictEqual(result.status, 0, result.stderr)
   assert.strictEqual(result.stdout, 'ok')
+})
+
+test('Node.js global fetch preserves headers and decoding with an undici Agent dispatcher', { skip: !isNode26Plus }, () => {
+  const script = `
+    const assert = require('node:assert')
+    const { createServer } = require('node:http')
+    const { once } = require('node:events')
+    const { brotliCompressSync } = require('node:zlib')
+    const { Agent } = require('./index.js')
+
+    ;(async () => {
+      const body = Buffer.from('body content')
+      const compressedBody = brotliCompressSync(body)
+      const server = createServer((_request, response) => {
+        response.writeHead(200, {
+          'content-type': 'application/x-ndjson',
+          'content-encoding': 'br',
+          'another-test-header': 'test-value'
+        })
+        response.end(compressedBody)
+      })
+      server.listen(0)
+      await once(server, 'listening')
+
+      const url = 'http://127.0.0.1:' + server.address().port
+      const cases = [
+        ['global dispatcher', {}],
+        ['custom dispatcher', { dispatcher: new Agent() }]
+      ]
+
+      for (const [label, init] of cases) {
+        const response = await fetch(url, init)
+        const responseBody = Buffer.from(await response.arrayBuffer()).toString('utf8')
+
+        assert.strictEqual(response.headers.get('content-type'), 'application/x-ndjson', label)
+        assert.strictEqual(response.headers.get('content-encoding'), 'br', label)
+        assert.strictEqual(response.headers.get('another-test-header'), 'test-value', label)
+        assert.strictEqual(responseBody, 'body content', label)
+      }
+
+      server.close()
+    })().catch((err) => {
+      console.error(err?.cause?.stack || err?.stack || err)
+      process.exit(1)
+    })
+  `
+
+  const result = runNode(script)
+  assert.strictEqual(result.status, 0, result.stderr)
 })


### PR DESCRIPTION
## Description

Add regression coverage for the Node.js built-in `fetch` + Undici `Agent` combination discussed in #5341.

This does not change runtime behavior on `main`; it just locks in that response headers remain visible and compressed bodies continue to decode correctly when `fetch()` is used with:

- the default global dispatcher
- an explicit `dispatcher: new Agent()`

The new test is skipped on Node.js versions before 26, since the specific built-in fetch/dispatcher bridge path under test is the Node 26 behavior.

## Testing

- `npm run lint -- test/node-test/global-dispatcher-version.js`
- `npx borp -p "test/node-test/global-dispatcher-version.js"`
- `source ~/.nvm/nvm.sh && nvm use 26.3.0 >/dev/null && npx borp -p "test/node-test/global-dispatcher-version.js"`
