### PR TITLE
test: avoid localhost lookup in fetch cookies tests

### DIFF
--- a/test/fetch/cookies.js
+++ b/test/fetch/cookies.js
@@ -8,6 +8,8 @@ const { Client, fetch, Headers } = require('../..')
 const pem = require('@metcoder95/https-pem')
 const { createSecureServer } = require('node:http2')
 
+const loopback = '127.0.0.1'
+
 describe('cookies', () => {
   let server
 
@@ -20,7 +22,7 @@ describe('cookies', () => {
       res.end(req.headers.cookie)
     })
 
-    return once(server.listen(0), 'listening')
+    return once(server.listen(0, loopback), 'listening')
   })
 
   after(() => {
@@ -32,12 +34,12 @@ describe('cookies', () => {
     const query = qsStringify({
       'set-cookie': 'name=value; Domain=example.com'
     })
-    const response = await fetch(`http://localhost:${server.address().port}?${query}`)
+    const response = await fetch(`http://${loopback}:${server.address().port}?${query}`)
 
     t.assert.strictEqual(response.headers.get('set-cookie'), 'name=value; Domain=example.com')
     t.assert.strictEqual(await response.text(), '')
 
-    const response2 = await fetch(`http://localhost:${server.address().port}?${query}`, {
+    const response2 = await fetch(`http://${loopback}:${server.address().port}?${query}`, {
       credentials: 'include'
     })
 
@@ -53,14 +55,14 @@ describe('cookies', () => {
     ]
 
     for (const headers of headersInit) {
-      const response = await fetch(`http://localhost:${server.address().port}`, { headers })
+      const response = await fetch(`http://${loopback}:${server.address().port}`, { headers })
       const text = await response.text()
       t.assert.strictEqual(text, 'value')
     }
   })
 
   test('Cookie header is delimited with a semicolon rather than a comma - issue #1905', async (t) => {
-    const response = await fetch(`http://localhost:${server.address().port}`, {
+    const response = await fetch(`http://${loopback}:${server.address().port}`, {
       headers: [
         ['cookie', 'FOO=lorem-ipsum-dolor-sit-amet'],
         ['cookie', 'BAR=the-quick-brown-fox']
@@ -83,17 +85,22 @@ describe('cookies', () => {
       stream.end('test')
     })
 
-    await once(server.listen(0), 'listening')
+    await once(server.listen(0, loopback), 'listening')
 
-    const client = new Client(`https://localhost:${server.address().port}`, {
+    const client = new Client(`https://${loopback}:${server.address().port}`, {
       connect: {
         rejectUnauthorized: false
       },
       allowH2: true
     })
 
+    t.after(async () => {
+      await client.close()
+      await new Promise((resolve, reject) => server.close(err => err ? reject(err) : resolve()))
+    })
+
     const response = await fetch(
-      `https://localhost:${server.address().port}/`,
+      `https://${loopback}:${server.address().port}/`,
       // Needs to be passed to disable the reject unauthorized
       {
         method: 'GET',
@@ -106,8 +113,5 @@ describe('cookies', () => {
 
     t.assert.deepStrictEqual(response.headers.getSetCookie(), ['Space=Cat; Secure; HttpOnly'])
     t.assert.strictEqual(await response.text(), 'test')
-
-    await client.close()
-    await new Promise((resolve, reject) => server.close(err => err ? reject(err) : resolve()))
   })
 })


### PR DESCRIPTION
## Summary
- bind the fetch cookie tests to IPv4 loopback instead of relying on `localhost` resolution
- use the same loopback literal for the HTTP/2 client/fetch URL
- register HTTP/2 test cleanup with `t.after()` so failures still close the client/server

## Why
The macOS Node.js 20 CI failure timed out while connecting to `::1:<port>` in `test/fetch/cookies.js`. The test server was started without an explicit host and the client used `localhost`, so the test could depend on platform-specific localhost address selection. Binding and connecting to `127.0.0.1` removes that ambiguity.

## Test
- `npx borp --timeout 180000 --expose-gc -p "test/fetch/cookies.js"`
- `npx eslint test/fetch/cookies.js`
