### PR TITLE
fix: finish paused HTTP/1 parser on socket end

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -371,9 +371,14 @@ class Parser {
   finish () {
     assert(currentParser === null)
     assert(this.ptr != null)
-    assert(!this.paused)
 
     const { llhttp } = this
+
+    if (this.paused) {
+      llhttp.llhttp_resume(this.ptr)
+      this.paused = false
+      this.execute(this.socket.read() || EMPTY_BUF)
+    }
 
     let ret
 

--- a/test/client.js
+++ b/test/client.js
@@ -3,6 +3,7 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { readFileSync, createReadStream } = require('node:fs')
 const { createServer } = require('node:http')
+const { createServer: createNetServer } = require('node:net')
 const { Readable, PassThrough } = require('node:stream')
 const { test, after } = require('node:test')
 const { Client, errors } = require('..')
@@ -1185,6 +1186,52 @@ test('ignore request header mutations', async (t) => {
       body.resume()
     })
     headers.test = 'asd'
+  })
+
+  await t.completed
+})
+
+test('socket end completes response when body is paused by backpressure', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const payload = Buffer.from('aa')
+  const server = createNetServer((socket) => {
+    socket.once('data', () => {
+      socket.write(
+        'HTTP/1.1 200 OK\r\n' +
+        `Content-Length: ${payload.length}\r\n` +
+        'Connection: close\r\n\r\n'
+      )
+      socket.write(payload)
+      socket.end()
+    })
+  })
+  after(() => server.close())
+
+  server.listen(0, '127.0.0.1', () => {
+    const client = new Client(`http://127.0.0.1:${server.address().port}`)
+    after(() => client.close())
+
+    client.request({
+      path: '/',
+      method: 'GET',
+      highWaterMark: 1
+    }, (err, data) => {
+      t.ifError(err)
+
+      let body = ''
+      data.body.setEncoding('utf8')
+      data.body.on('end', () => {
+        t.strictEqual(body, payload.toString())
+      })
+
+      setTimeout(() => {
+        data.body.on('data', (chunk) => {
+          body += chunk
+        })
+        data.body.resume()
+      }, 50)
+    })
   })
 
   await t.completed


### PR DESCRIPTION
Fixes #5360.

When a response body applies backpressure, the HTTP/1 parser can be left paused. If the peer then closes the socket, `onHttpSocketEnd` calls `parser.finish()`, which previously asserted that the parser was not paused and could crash the process from the socket `end` handler.

This resumes the paused llhttp parser before finishing it, then lets the existing finish path handle EOF and completion normally.

Tests:
- `node --expose-gc --test --test-name-pattern "socket end completes response when body is paused by backpressure" test/client.js`
- `npm run lint -- --no-cache lib/dispatcher/client-h1.js test/client.js`
- `git diff --check`