### PR TITLE
fix(websocket): serialize connecting handshakes per host

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -15,6 +15,105 @@ const crypto = runtimeFeatures.has('crypto')
   : null
 
 let warningEmitted = false
+const connectingWebSockets = new Map()
+
+/**
+ * @param {URL} url
+ * @returns {string}
+ */
+function getConnectingWebSocketKey (url) {
+  const port = url.port || (url.protocol === 'wss:' ? '443' : '80')
+
+  return `${url.hostname.toLowerCase()}:${port}`
+}
+
+/**
+ * @param {string} key
+ * @param {any} dispatcher
+ * @param {(release: () => void) => any} fn
+ * @returns {{ abort: (error?: Error) => void, dispatcher: any, state: string }}
+ */
+function runAfterConnectingWebSocketsToHostHaveSettled (key, dispatcher, fn) {
+  const previous = connectingWebSockets.get(key)
+  let controller = null
+  let done
+  let settled = false
+  let aborted = false
+  let abortReason
+
+  const entry = new Promise((resolve) => {
+    done = resolve
+  })
+  const queueEntry = previous == null ? entry : previous.then(() => entry, () => entry)
+
+  connectingWebSockets.set(key, queueEntry)
+
+  const proxy = {
+    dispatcher,
+    state: 'ongoing',
+    abort (error) {
+      if (proxy.state !== 'ongoing') {
+        return
+      }
+
+      proxy.state = 'aborted'
+      aborted = true
+      abortReason = error
+
+      if (controller !== null) {
+        controller.abort(error)
+        release()
+      } else {
+        settle()
+      }
+    }
+  }
+
+  if (previous == null) {
+    run()
+  } else {
+    previous.then(run, run)
+  }
+
+  return proxy
+
+  function run () {
+    if (aborted) {
+      release()
+      return
+    }
+
+    try {
+      controller = fn(release)
+    } catch (err) {
+      release()
+      throw err
+    }
+
+    proxy.dispatcher = controller.dispatcher
+
+    if (aborted) {
+      controller.abort(abortReason)
+    }
+  }
+
+  function release () {
+    if (connectingWebSockets.get(key) === queueEntry) {
+      connectingWebSockets.delete(key)
+    }
+
+    settle()
+  }
+
+  function settle () {
+    if (settled) {
+      return
+    }
+
+    settled = true
+    done()
+  }
+}
 
 /**
  * @see https://websockets.spec.whatwg.org/#concept-websocket-establish
@@ -24,6 +123,8 @@ let warningEmitted = false
  * @param {Partial<import('../../../types/websocket').WebSocketInit>} options
  */
 function establishWebSocketConnection (url, protocols, client, handler, options) {
+  const connectingWebSocketKey = getConnectingWebSocketKey(url)
+
   // 1. Let requestURL be a copy of url, with its scheme set to "http", if url’s
   //    scheme is "ws", and to "https" otherwise.
   const requestURL = url
@@ -89,131 +190,135 @@ function establishWebSocketConnection (url, protocols, client, handler, options)
 
   // 11. Fetch request with useParallelQueue set to true, and
   //     processResponse given response being these steps:
-  const controller = fetching({
+  const controller = runAfterConnectingWebSocketsToHostHaveSettled(connectingWebSocketKey, options.dispatcher, (release) => fetching({
     request,
     useParallelQueue: true,
     dispatcher: options.dispatcher,
     processResponse (response) {
-      // 1. If response is a network error or its status is not 101,
-      //    fail the WebSocket connection.
-      // if (response.type === 'error' || ((response.socket?.session != null && response.status !== 200) && response.status !== 101)) {
-      if (response.type === 'error' || response.status !== 101) {
-        // The presence of a session property on the socket indicates HTTP2
-        // HTTP1
-        if (response.socket?.session == null) {
-          failWebsocketConnection(handler, 1002, 'Received network error or non-101 status code.', response.error)
+      try {
+        // 1. If response is a network error or its status is not 101,
+        //    fail the WebSocket connection.
+        // if (response.type === 'error' || ((response.socket?.session != null && response.status !== 200) && response.status !== 101)) {
+        if (response.type === 'error' || response.status !== 101) {
+          // The presence of a session property on the socket indicates HTTP2
+          // HTTP1
+          if (response.socket?.session == null) {
+            failWebsocketConnection(handler, 1002, 'Received network error or non-101 status code.', response.error)
+            return
+          }
+
+          // HTTP2
+          if (response.status !== 200) {
+            failWebsocketConnection(handler, 1002, 'Received network error or non-200 status code.', response.error)
+            return
+          }
+        }
+
+        if (warningEmitted === false && response.socket?.session != null) {
+          process.emitWarning('WebSocket over HTTP2 is experimental, and subject to change.', 'ExperimentalWarning')
+          warningEmitted = true
+        }
+
+        // 2. If protocols is not the empty list and extracting header
+        //    list values given `Sec-WebSocket-Protocol` and response’s
+        //    header list results in null, failure, or the empty byte
+        //    sequence, then fail the WebSocket connection.
+        if (protocols.length !== 0 && !response.headersList.get('Sec-WebSocket-Protocol')) {
+          failWebsocketConnection(handler, 1002, 'Server did not respond with sent protocols.')
           return
         }
 
-        // HTTP2
-        if (response.status !== 200) {
-          failWebsocketConnection(handler, 1002, 'Received network error or non-200 status code.', response.error)
+        // 3. Follow the requirements stated step 2 to step 6, inclusive,
+        //    of the last set of steps in section 4.1 of The WebSocket
+        //    Protocol to validate response. This either results in fail
+        //    the WebSocket connection or the WebSocket connection is
+        //    established.
+
+        // 2. If the response lacks an |Upgrade| header field or the |Upgrade|
+        //    header field contains a value that is not an ASCII case-
+        //    insensitive match for the value "websocket", the client MUST
+        //    _Fail the WebSocket Connection_.
+        //    For H2, no upgrade header is expected.
+        if (response.socket.session == null && response.headersList.get('Upgrade')?.toLowerCase() !== 'websocket') {
+          failWebsocketConnection(handler, 1002, 'Server did not set Upgrade header to "websocket".')
           return
         }
-      }
 
-      if (warningEmitted === false && response.socket?.session != null) {
-        process.emitWarning('WebSocket over HTTP2 is experimental, and subject to change.', 'ExperimentalWarning')
-        warningEmitted = true
-      }
-
-      // 2. If protocols is not the empty list and extracting header
-      //    list values given `Sec-WebSocket-Protocol` and response’s
-      //    header list results in null, failure, or the empty byte
-      //    sequence, then fail the WebSocket connection.
-      if (protocols.length !== 0 && !response.headersList.get('Sec-WebSocket-Protocol')) {
-        failWebsocketConnection(handler, 1002, 'Server did not respond with sent protocols.')
-        return
-      }
-
-      // 3. Follow the requirements stated step 2 to step 6, inclusive,
-      //    of the last set of steps in section 4.1 of The WebSocket
-      //    Protocol to validate response. This either results in fail
-      //    the WebSocket connection or the WebSocket connection is
-      //    established.
-
-      // 2. If the response lacks an |Upgrade| header field or the |Upgrade|
-      //    header field contains a value that is not an ASCII case-
-      //    insensitive match for the value "websocket", the client MUST
-      //    _Fail the WebSocket Connection_.
-      //    For H2, no upgrade header is expected.
-      if (response.socket.session == null && response.headersList.get('Upgrade')?.toLowerCase() !== 'websocket') {
-        failWebsocketConnection(handler, 1002, 'Server did not set Upgrade header to "websocket".')
-        return
-      }
-
-      // 3. If the response lacks a |Connection| header field or the
-      //    |Connection| header field doesn't contain a token that is an
-      //    ASCII case-insensitive match for the value "Upgrade", the client
-      //    MUST _Fail the WebSocket Connection_.
-      //    For H2, no connection header is expected.
-      if (response.socket.session == null && response.headersList.get('Connection')?.toLowerCase() !== 'upgrade') {
-        failWebsocketConnection(handler, 1002, 'Server did not set Connection header to "upgrade".')
-        return
-      }
-
-      // 4. If the response lacks a |Sec-WebSocket-Accept| header field or
-      //    the |Sec-WebSocket-Accept| contains a value other than the
-      //    base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-
-      //    Key| (as a string, not base64-decoded) with the string "258EAFA5-
-      //    E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and
-      //    trailing whitespace, the client MUST _Fail the WebSocket
-      //    Connection_.
-      const secWSAccept = response.headersList.get('Sec-WebSocket-Accept')
-      const digest = crypto.hash('sha1', keyValue + uid, 'base64')
-      if (secWSAccept !== digest) {
-        failWebsocketConnection(handler, 1002, 'Incorrect hash received in Sec-WebSocket-Accept header.')
-        return
-      }
-
-      // 5. If the response includes a |Sec-WebSocket-Extensions| header
-      //    field and this header field indicates the use of an extension
-      //    that was not present in the client's handshake (the server has
-      //    indicated an extension not requested by the client), the client
-      //    MUST _Fail the WebSocket Connection_.  (The parsing of this
-      //    header field to determine which extensions are requested is
-      //    discussed in Section 9.1.)
-      const secExtension = response.headersList.get('Sec-WebSocket-Extensions')
-      let extensions
-
-      if (secExtension !== null) {
-        extensions = parseExtensions(secExtension)
-
-        if (!extensions.has('permessage-deflate')) {
-          failWebsocketConnection(handler, 1002, 'Sec-WebSocket-Extensions header does not match.')
+        // 3. If the response lacks a |Connection| header field or the
+        //    |Connection| header field doesn't contain a token that is an
+        //    ASCII case-insensitive match for the value "Upgrade", the client
+        //    MUST _Fail the WebSocket Connection_.
+        //    For H2, no connection header is expected.
+        if (response.socket.session == null && response.headersList.get('Connection')?.toLowerCase() !== 'upgrade') {
+          failWebsocketConnection(handler, 1002, 'Server did not set Connection header to "upgrade".')
           return
         }
-      }
 
-      // 6. If the response includes a |Sec-WebSocket-Protocol| header field
-      //    and this header field indicates the use of a subprotocol that was
-      //    not present in the client's handshake (the server has indicated a
-      //    subprotocol not requested by the client), the client MUST _Fail
-      //    the WebSocket Connection_.
-      const secProtocol = response.headersList.get('Sec-WebSocket-Protocol')
-
-      if (secProtocol !== null) {
-        const requestProtocols = getDecodeSplit('sec-websocket-protocol', request.headersList)
-
-        // The client can request that the server use a specific subprotocol by
-        // including the |Sec-WebSocket-Protocol| field in its handshake.  If it
-        // is specified, the server needs to include the same field and one of
-        // the selected subprotocol values in its response for the connection to
-        // be established.
-        if (!requestProtocols.includes(secProtocol)) {
-          failWebsocketConnection(handler, 1002, 'Protocol was not set in the opening handshake.')
+        // 4. If the response lacks a |Sec-WebSocket-Accept| header field or
+        //    the |Sec-WebSocket-Accept| contains a value other than the
+        //    base64-encoded SHA-1 of the concatenation of the |Sec-WebSocket-
+        //    Key| (as a string, not base64-decoded) with the string "258EAFA5-
+        //    E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and
+        //    trailing whitespace, the client MUST _Fail the WebSocket
+        //    Connection_.
+        const secWSAccept = response.headersList.get('Sec-WebSocket-Accept')
+        const digest = crypto.hash('sha1', keyValue + uid, 'base64')
+        if (secWSAccept !== digest) {
+          failWebsocketConnection(handler, 1002, 'Incorrect hash received in Sec-WebSocket-Accept header.')
           return
         }
+
+        // 5. If the response includes a |Sec-WebSocket-Extensions| header
+        //    field and this header field indicates the use of an extension
+        //    that was not present in the client's handshake (the server has
+        //    indicated an extension not requested by the client), the client
+        //    MUST _Fail the WebSocket Connection_.  (The parsing of this
+        //    header field to determine which extensions are requested is
+        //    discussed in Section 9.1.)
+        const secExtension = response.headersList.get('Sec-WebSocket-Extensions')
+        let extensions
+
+        if (secExtension !== null) {
+          extensions = parseExtensions(secExtension)
+
+          if (!extensions.has('permessage-deflate')) {
+            failWebsocketConnection(handler, 1002, 'Sec-WebSocket-Extensions header does not match.')
+            return
+          }
+        }
+
+        // 6. If the response includes a |Sec-WebSocket-Protocol| header field
+        //    and this header field indicates the use of a subprotocol that was
+        //    not present in the client's handshake (the server has indicated a
+        //    subprotocol not requested by the client), the client MUST _Fail
+        //    the WebSocket Connection_.
+        const secProtocol = response.headersList.get('Sec-WebSocket-Protocol')
+
+        if (secProtocol !== null) {
+          const requestProtocols = getDecodeSplit('sec-websocket-protocol', request.headersList)
+
+          // The client can request that the server use a specific subprotocol by
+          // including the |Sec-WebSocket-Protocol| field in its handshake.  If it
+          // is specified, the server needs to include the same field and one of
+          // the selected subprotocol values in its response for the connection to
+          // be established.
+          if (!requestProtocols.includes(secProtocol)) {
+            failWebsocketConnection(handler, 1002, 'Protocol was not set in the opening handshake.')
+            return
+          }
+        }
+
+        response.socket.on('data', handler.onSocketData)
+        response.socket.on('close', handler.onSocketClose)
+        response.socket.on('error', handler.onSocketError)
+
+        handler.wasEverConnected = true
+        handler.onConnectionEstablished(response, extensions)
+      } finally {
+        release()
       }
-
-      response.socket.on('data', handler.onSocketData)
-      response.socket.on('close', handler.onSocketClose)
-      response.socket.on('error', handler.onSocketError)
-
-      handler.wasEverConnected = true
-      handler.onConnectionEstablished(response, extensions)
     }
-  })
+  }))
 
   return controller
 }

--- a/test/websocket/issue-4743.js
+++ b/test/websocket/issue-4743.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const { setTimeout: delay } = require('node:timers/promises')
+const { WebSocketServer } = require('ws')
+const { WebSocket } = require('../..')
+
+test('WebSocket serializes CONNECTING connections to the same host and port', async (t) => {
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+  const upgrades = []
+  const sockets = new Set()
+  let firstConnectionOpen = false
+
+  t.after(async () => {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+
+    await new Promise((resolve) => wss.close(resolve))
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  server.on('upgrade', (req, socket, head) => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+
+    const upgrade = { req, socket, head, beforeFirstConnectionOpen: !firstConnectionOpen }
+    upgrades.push(upgrade)
+
+    server.emit('upgrade-recorded', upgrade)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const first = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => {
+    first.onerror = null
+    first.close()
+  })
+
+  const [firstUpgrade] = await once(server, 'upgrade-recorded')
+  const second = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => {
+    second.onerror = null
+    second.close()
+  })
+
+  await delay(100)
+  t.assert.strictEqual(upgrades.length, 1)
+
+  handleUpgrade(firstUpgrade)
+  await once(first, 'open')
+  firstConnectionOpen = true
+
+  const [secondUpgrade] = await once(server, 'upgrade-recorded')
+  t.assert.strictEqual(secondUpgrade.beforeFirstConnectionOpen, false)
+
+  handleUpgrade(secondUpgrade)
+  await once(second, 'open')
+
+  first.close()
+  second.close()
+
+  function handleUpgrade ({ req, socket, head }) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.close()
+    })
+  }
+})
+
+test('closing a queued WebSocket does not unblock a later connection to the same host and port', async (t) => {
+  const server = createServer()
+  const wss = new WebSocketServer({ noServer: true })
+  const upgrades = []
+  const sockets = new Set()
+  let firstConnectionOpen = false
+
+  t.after(async () => {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+
+    await new Promise((resolve) => wss.close(resolve))
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  server.on('upgrade', (req, socket, head) => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+
+    const upgrade = { req, socket, head, beforeFirstConnectionOpen: !firstConnectionOpen }
+    upgrades.push(upgrade)
+
+    server.emit('upgrade-recorded', upgrade)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const first = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => {
+    first.onerror = null
+    first.close()
+  })
+
+  const [firstUpgrade] = await once(server, 'upgrade-recorded')
+  const second = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  second.onerror = () => {}
+  second.close()
+
+  const third = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => {
+    third.onerror = null
+    third.close()
+  })
+
+  await delay(100)
+  t.assert.strictEqual(upgrades.length, 1)
+
+  handleUpgrade(firstUpgrade)
+  await once(first, 'open')
+  firstConnectionOpen = true
+
+  const [thirdUpgrade] = await once(server, 'upgrade-recorded')
+  t.assert.strictEqual(thirdUpgrade.beforeFirstConnectionOpen, false)
+
+  handleUpgrade(thirdUpgrade)
+  await once(third, 'open')
+
+  first.close()
+  third.close()
+
+  function handleUpgrade ({ req, socket, head }) {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.close()
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Serialize WebSocket handshakes while another connection to the same host and port is still CONNECTING.
- Release the queue once the handshake succeeds or fails, so established sockets do not block later connections.
- Cover the regression from #4743, including closing a queued WebSocket without letting later same-host connections bypass the active handshake.

Fixes #4743

## Checks

- `npm run lint -- lib/web/websocket/connection.js test/websocket/issue-4743.js`
- `node --test test/websocket/issue-4743.js`
- `node --test test/websocket/*.js`
- `git diff --check`