### PR TITLE
fix(websocket): preserve handshake failure message

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -304,6 +304,9 @@ function closeWebSocketConnection (object, code, reason, validate = false) {
  * @returns {void}
  */
 function failWebsocketConnection (handler, code, reason, cause) {
+  handler.failureReason = reason
+  handler.failureCause = cause
+
   // If _The WebSocket Connection is Established_ prior to the point where
   // the endpoint is required to _Fail the WebSocket Connection_, the
   // endpoint SHOULD send a Close frame with an appropriate status code

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -54,6 +54,8 @@ function getSocketAddress (socket) {
  * @property {Set<number>} closeState
  * @property {import('../fetch/index').Fetch} controller
  * @property {boolean} [wasEverConnected=false]
+ * @property {string|undefined} failureReason
+ * @property {unknown} failureCause
  */
 
 // https://websockets.spec.whatwg.org/#interface-definition
@@ -114,7 +116,9 @@ class WebSocket extends EventTarget {
     socket: null,
     closeState: new Set(),
     controller: null,
-    wasEverConnected: false
+    wasEverConnected: false,
+    failureReason: undefined,
+    failureCause: undefined
   }
 
   #url
@@ -602,9 +606,11 @@ class WebSocket extends EventTarget {
       // is lost), _The WebSocket Connection Close Code_ is considered to be
       // 1006.
       code = 1006
+      const error = createWebSocketError(this.#handler.failureReason ?? reason, this.#handler.failureCause)
 
       fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new TypeError(reason)
+        message: error.message,
+        error
       })
     }
 
@@ -748,6 +754,12 @@ webidl.converters.WebSocketSendData = function (V) {
   }
 
   return webidl.converters.USVString(V)
+}
+
+function createWebSocketError (message, cause) {
+  return cause === undefined
+    ? new TypeError(message)
+    : new TypeError(message, { cause })
 }
 
 module.exports = {

--- a/test/websocket/issue-4735.js
+++ b/test/websocket/issue-4735.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('node:test')
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const { WebSocket } = require('../..')
+
+test('failed WebSocket handshake exposes a non-empty TypeError message', async (t) => {
+  const server = createServer((req, res) => {
+    res.statusCode = 200
+    res.end('not a websocket')
+  }).listen(0)
+
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+  const errorPromise = once(ws, 'error')
+  const closePromise = once(ws, 'close')
+
+  ws.onopen = () => t.assert.fail('should not open')
+
+  const [{ error }] = await errorPromise
+  t.assert.ok(error instanceof TypeError)
+  t.assert.strictEqual(error.message, 'Received network error or non-101 status code.')
+
+  const [closeEvent] = await closePromise
+  t.assert.strictEqual(closeEvent.code, 1006)
+  t.assert.strictEqual(closeEvent.reason, '')
+})


### PR DESCRIPTION
Fixes #4735.
Refs #4625.

## Rationale
Failed WebSocket handshakes already pass a useful failure reason into `failWebsocketConnection()`, but the later `ErrorEvent` was built from the close-frame reason. For handshake failures there is no close-frame reason, so `event.error.message` was empty.

## Changes
- Store the WebSocket failure reason/cause on the shared handler.
- Build the emitted `TypeError` from the stored failure reason while leaving `CloseEvent.reason` tied to the actual close frame.
- Add a regression test for a local non-101 handshake failure and keep close code `1006` unchanged.

## Tests
- `npx borp --timeout 180000 -p "test/websocket/issue-4735.js"`
- `npm run lint -- --no-cache lib/web/websocket/connection.js lib/web/websocket/websocket.js test/websocket/issue-4735.js`
- `npx borp --timeout 180000 -p "test/websocket/events.js"`
- `npx borp --timeout 180000 -p "test/websocket/issue-3506.js"`
- `npx borp --timeout 180000 -p "test/websocket/issue-3546.js"`
- `git diff --check HEAD~1 HEAD`

I also tried broader local websocket coverage, but `npm run test:websocket` timed out after 5 minutes and `test/websocket/opening-handshake.js` timed out locally before producing a result.

This change was prepared with OpenAI Codex.