### PR TITLE
fix(mock): emit request body lifecycle hooks

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -380,11 +380,17 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
 
   // Call onRequestStart to allow the handler to receive the controller
   handler.onRequestStart?.(controller, null)
+  if (aborted) {
+    return true
+  }
 
-  const requestBody = dispatchRequestBody(opts.body, handler, controller)
+  const requestBody = dispatchRequestBody(opts.body, handler, controller, () => aborted)
 
   if (isPromise(requestBody)) {
     requestBody.then((body) => {
+      if (body === null) {
+        return
+      }
       if (body !== opts.body) {
         replyOpts = { ...opts, body }
       }
@@ -461,7 +467,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
   return true
 }
 
-function dispatchRequestBody (body, handler, controller) {
+function dispatchRequestBody (body, handler, controller, isAborted) {
   if (typeof handler.onBodySent !== 'function' && typeof handler.onRequestSent !== 'function') {
     return body
   }
@@ -471,40 +477,49 @@ function dispatchRequestBody (body, handler, controller) {
   }
 
   if (body && typeof body[Symbol.asyncIterator] === 'function') {
-    return dispatchAsyncIterableBody(body, handler, controller)
+    return dispatchAsyncIterableBody(body, handler, controller, isAborted)
   }
 
   if (isIterableBody(body)) {
     const chunks = []
 
     for (const chunk of body) {
+      if (isAborted()) {
+        return null
+      }
       chunks.push(chunk)
       if (!callOnBodySent(handler, controller, chunk)) {
         return null
       }
     }
 
-    return callOnRequestSent(handler, controller) ? chunks : null
+    return !isAborted() && callOnRequestSent(handler, controller) ? chunks : null
   }
 
+  if (isAborted()) {
+    return null
+  }
   if (!callOnBodySent(handler, controller, body)) {
     return null
   }
 
-  return callOnRequestSent(handler, controller) ? body : null
+  return !isAborted() && callOnRequestSent(handler, controller) ? body : null
 }
 
-async function dispatchAsyncIterableBody (body, handler, controller) {
+async function dispatchAsyncIterableBody (body, handler, controller, isAborted) {
   const chunks = []
 
   for await (const chunk of body) {
+    if (isAborted()) {
+      return null
+    }
     chunks.push(chunk)
     if (!callOnBodySent(handler, controller, chunk)) {
       return null
     }
   }
 
-  if (!callOnRequestSent(handler, controller)) {
+  if (isAborted() || !callOnRequestSent(handler, controller)) {
     return null
   }
 

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -304,31 +304,6 @@ function mockDispatch (opts, handler) {
   mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
   mockDispatch.pending = timesInvoked < times
 
-  // Here's where we resolve a callback if a callback is present for the dispatch data.
-  if (mockDispatch.data.callback) {
-    const callbackResult = mockDispatch.data.callback(opts)
-
-    // An asynchronous reply options callback resolves to the reply data, so
-    // the dispatch can only continue once the returned promise settles.
-    // A rejection cannot be thrown synchronously from the dispatch at that
-    // point, so it is surfaced as a response error instead.
-    if (isPromise(callbackResult)) {
-      callbackResult.then(
-        (resolvedData) => {
-          mockDispatch.data = { ...mockDispatch.data, ...resolvedData }
-          dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
-        },
-        (error) => {
-          deleteMockDispatch(mockDispatches, key)
-          handler.onResponseError(null, error)
-        }
-      )
-      return true
-    }
-
-    mockDispatch.data = { ...mockDispatch.data, ...callbackResult }
-  }
-
   return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
 }
 
@@ -377,7 +352,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
   }
 
   let replyOpts = opts
-  const dispatches = this[kDispatches]
+  const dispatches = mockDispatches
 
   // Call onRequestStart to allow the handler to receive the controller
   handler.onRequestStart?.(controller, null)

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -1,132 +1,152 @@
-'use strict'
-const { MockNotMatchedError } = require('./mock-errors')
-const {
-  kDispatches,
-  kMockAgent,
-  kOriginalDispatch,
-  kOrigin,
-  kGetNetConnect,
-  kTotalDispatchCount
-} = require('./mock-symbols')
-const { serializePathWithQuery, parseHeaders } = require('../core/util')
-const { STATUS_CODES } = require('node:http')
-const {
-  types: {
-    isPromise
-  }
-} = require('node:util')
-const { InvalidArgumentError } = require('../core/errors')
-const requestAborted = Symbol('request aborted')
+'use strict'
+
+const { MockNotMatchedError } = require('./mock-errors')
+const {
+  kDispatches,
+  kMockAgent,
+  kOriginalDispatch,
+  kOrigin,
+  kGetNetConnect,
+  kTotalDispatchCount
+} = require('./mock-symbols')
+const { serializePathWithQuery, parseHeaders } = require('../core/util')
+const { STATUS_CODES } = require('node:http')
+const {
+  types: {
+    isPromise
+  }
+} = require('node:util')
+const { InvalidArgumentError } = require('../core/errors')
+const requestAborted = Symbol('request aborted')
+
 function matchValue (match, value) {
   if (typeof match === 'string') {
     return match === value
-  }
+  }
   if (match instanceof RegExp) {
     return match.test(value)
-  }
+  }
   if (typeof match === 'function') {
     return match(value) === true
-  }
+  }
   return false
-}
+}
+
 function lowerCaseEntries (headers) {
-  return Object.fromEntries(
+  return Object.fromEntries(
     Object.entries(headers).map(([headerName, headerValue]) => {
       return [headerName.toLocaleLowerCase(), headerValue]
-    })
+    })
   )
-}
-/**
- * @param {import('../../index').Headers|string[]|Record<string, string>} headers
- * @param {string} key
- */
+}
+
+/**
+ * @param {import('../../index').Headers|string[]|Record<string, string>} headers
+ * @param {string} key
+ */
 function getHeaderByName (headers, key) {
   if (Array.isArray(headers)) {
     for (let i = 0; i < headers.length; i += 2) {
       if (headers[i].toLocaleLowerCase() === key.toLocaleLowerCase()) {
         return headers[i + 1]
       }
-    }
+    }
+
     return undefined
   } else if (typeof headers.get === 'function') {
     return headers.get(key)
   } else {
     return lowerCaseEntries(headers)[key.toLocaleLowerCase()]
   }
-}
-/** @param {string[]} headers */
+}
+
+/** @param {string[]} headers */
 function buildHeadersFromArray (headers) { // fetch HeadersList
-  const clone = headers.slice()
-  const entries = []
+  const clone = headers.slice()
+  const entries = []
   for (let index = 0; index < clone.length; index += 2) {
     entries.push([clone[index], clone[index + 1]])
-  }
+  }
   return Object.fromEntries(entries)
-}
+}
+
 function matchHeaders (mockDispatch, headers) {
   if (typeof mockDispatch.headers === 'function') {
     if (Array.isArray(headers)) { // fetch HeadersList
       headers = buildHeadersFromArray(headers)
-    }
+    }
     return mockDispatch.headers(headers ? lowerCaseEntries(headers) : {})
-  }
+  }
   if (typeof mockDispatch.headers === 'undefined') {
     return true
-  }
+  }
   if (typeof headers !== 'object' || typeof mockDispatch.headers !== 'object') {
     return false
-  }
+  }
+
   for (const [matchHeaderName, matchHeaderValue] of Object.entries(mockDispatch.headers)) {
-    const headerValue = getHeaderByName(headers, matchHeaderName)
+    const headerValue = getHeaderByName(headers, matchHeaderName)
+
     if (!matchValue(matchHeaderValue, headerValue)) {
       return false
     }
-  }
+  }
   return true
-}
+}
+
 function normalizeSearchParams (query) {
   if (typeof query !== 'string') {
     return query
-  }
-  const originalQp = new URLSearchParams(query)
-  const normalizedQp = new URLSearchParams()
+  }
+
+  const originalQp = new URLSearchParams(query)
+  const normalizedQp = new URLSearchParams()
+
   for (let [key, value] of originalQp.entries()) {
-    key = key.replace('[]', '')
-    const valueRepresentsString = /^(['"]).*\1$/.test(value)
+    key = key.replace('[]', '')
+
+    const valueRepresentsString = /^(['"]).*\1$/.test(value)
     if (valueRepresentsString) {
-      normalizedQp.append(key, value)
+      normalizedQp.append(key, value)
       continue
-    }
+    }
+
     if (value.includes(',')) {
-      const values = value.split(',')
+      const values = value.split(',')
       for (const v of values) {
         normalizedQp.append(key, v)
-      }
+      }
       continue
-    }
+    }
+
     normalizedQp.append(key, value)
-  }
+  }
+
   return normalizedQp
-}
+}
+
 function safeUrl (path) {
   if (typeof path !== 'string') {
     return path
-  }
-  const pathSegments = path.split('?', 3)
+  }
+  const pathSegments = path.split('?', 3)
   if (pathSegments.length !== 2) {
     return path
-  }
-  const qp = new URLSearchParams(pathSegments.pop())
-  qp.sort()
+  }
+
+  const qp = new URLSearchParams(pathSegments.pop())
+  qp.sort()
   return [...pathSegments, qp.toString()].join('?')
-}
+}
+
 function matchKey (mockDispatch, { path, method, body, headers }) {
-  const pathMatch = matchValue(mockDispatch.path, path)
-  const methodMatch = matchValue(mockDispatch.method, method)
-  const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
-  const headersMatch = matchHeaders(mockDispatch, headers)
+  const pathMatch = matchValue(mockDispatch.path, path)
+  const methodMatch = matchValue(mockDispatch.method, method)
+  const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
+  const headersMatch = matchHeaders(mockDispatch, headers)
   return pathMatch && methodMatch && bodyMatch && headersMatch
-}
+}
+
 function getResponseData (data) {
   if (Buffer.isBuffer(data)) {
     return data
@@ -141,89 +161,104 @@ function getResponseData (data) {
   } else {
     return ''
   }
-}
+}
+
 function getMockDispatch (mockDispatches, key) {
-  const basePath = key.query ? serializePathWithQuery(key.path, key.query) : key.path
-  const resolvedPath = typeof basePath === 'string' ? safeUrl(basePath) : basePath
-  const resolvedPathWithoutTrailingSlash = removeTrailingSlash(resolvedPath)
-  // Match path
-  let matchedMockDispatches = mockDispatches
-    .filter(({ consumed }) => !consumed)
+  const basePath = key.query ? serializePathWithQuery(key.path, key.query) : key.path
+  const resolvedPath = typeof basePath === 'string' ? safeUrl(basePath) : basePath
+
+  const resolvedPathWithoutTrailingSlash = removeTrailingSlash(resolvedPath)
+
+  // Match path
+  let matchedMockDispatches = mockDispatches
+    .filter(({ consumed }) => !consumed)
     .filter(({ path, ignoreTrailingSlash }) => {
-      return ignoreTrailingSlash
-        ? matchValue(removeTrailingSlash(safeUrl(path)), resolvedPathWithoutTrailingSlash)
+      return ignoreTrailingSlash
+        ? matchValue(removeTrailingSlash(safeUrl(path)), resolvedPathWithoutTrailingSlash)
         : matchValue(safeUrl(path), resolvedPath)
-    })
+    })
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`)
-  }
-  // Match method
-  matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
+  }
+
+  // Match method
+  matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}' on path '${resolvedPath}'`)
-  }
-  // Match body
-  matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
+  }
+
+  // Match body
+  matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}' on path '${resolvedPath}'`)
-  }
-  // Match headers
-  matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
+  }
+
+  // Match headers
+  matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
   if (matchedMockDispatches.length === 0) {
-    const headers = typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers
+    const headers = typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers
     throw new MockNotMatchedError(`Mock dispatch not matched for headers '${headers}' on path '${resolvedPath}'`)
-  }
+  }
+
   return matchedMockDispatches[0]
-}
+}
+
 function addMockDispatch (mockDispatches, key, data, opts) {
-  const baseData = { timesInvoked: 0, times: 1, persist: false, consumed: false, ...opts }
-  const replyData = typeof data === 'function' ? { callback: data } : { ...data }
-  const newMockDispatch = { ...baseData, ...key, pending: true, data: { error: null, ...replyData } }
-  mockDispatches.push(newMockDispatch)
-  // Track total number of intercepts ever registered for better error messages
-  mockDispatches[kTotalDispatchCount] = (mockDispatches[kTotalDispatchCount] || 0) + 1
+  const baseData = { timesInvoked: 0, times: 1, persist: false, consumed: false, ...opts }
+  const replyData = typeof data === 'function' ? { callback: data } : { ...data }
+  const newMockDispatch = { ...baseData, ...key, pending: true, data: { error: null, ...replyData } }
+  mockDispatches.push(newMockDispatch)
+  // Track total number of intercepts ever registered for better error messages
+  mockDispatches[kTotalDispatchCount] = (mockDispatches[kTotalDispatchCount] || 0) + 1
   return newMockDispatch
-}
+}
+
 function deleteMockDispatch (mockDispatches, key) {
   const index = mockDispatches.findIndex(dispatch => {
     if (!dispatch.consumed) {
       return false
-    }
+    }
     return matchKey(dispatch, key)
-  })
+  })
   if (index !== -1) {
     mockDispatches.splice(index, 1)
   }
-}
-/**
- * @param {string} path Path to remove trailing slash from
- */
+}
+
+/**
+ * @param {string} path Path to remove trailing slash from
+ */
 function removeTrailingSlash (path) {
   while (path.endsWith('/')) {
     path = path.slice(0, -1)
-  }
+  }
+
   if (path.length === 0) {
     path = '/'
-  }
-  return path
-}
-function buildKey (opts) {
-  const { path, method, body, headers, query } = opts
-  return {
-    path,
-    method,
-    body,
-    headers,
-    query
   }
-}
+
+  return path
+}
+
+function buildKey (opts) {
+  const { path, method, body, headers, query } = opts
+
+  return {
+    path,
+    method,
+    body,
+    headers,
+    query
+  }
+}
+
 function generateKeyValues (data) {
-  const keys = Object.keys(data)
-  const result = []
+  const keys = Object.keys(data)
+  const result = []
   for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i]
-    const value = data[key]
-    const name = Buffer.from(`${key}`)
+    const key = keys[i]
+    const value = data[key]
+    const name = Buffer.from(`${key}`)
     if (Array.isArray(value)) {
       for (let j = 0; j < value.length; ++j) {
         result.push(name, Buffer.from(`${value[j]}`))
@@ -231,311 +266,373 @@ function generateKeyValues (data) {
     } else {
       result.push(name, Buffer.from(`${value}`))
     }
-  }
+  }
   return result
-}
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
- * @param {number} statusCode
- */
+}
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+ * @param {number} statusCode
+ */
 function getStatusText (statusCode) {
   return STATUS_CODES[statusCode] || 'unknown'
-}
+}
+
 async function getResponse (body) {
-  const buffers = []
+  const buffers = []
   for await (const data of body) {
     buffers.push(data)
-  }
+  }
   return Buffer.concat(buffers).toString('utf8')
-}
-/**
- * Mock dispatch function used to simulate undici dispatches
- */
+}
+
+/**
+ * Mock dispatch function used to simulate undici dispatches
+ */
 function mockDispatch (opts, handler) {
-  // Get mock dispatch from built key
-  const key = buildKey(opts)
-  const mockDispatch = getMockDispatch(this[kDispatches], key)
-  const mockDispatches = this[kDispatches]
-  mockDispatch.timesInvoked++
-  const { timesInvoked, times } = mockDispatch
-  // If it's used up and not persistent, mark as consumed
-  mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
-  mockDispatch.pending = timesInvoked < times
-  // Resolve callback early if no body hooks are present
-  const hasBodyHooks = typeof handler.onBodySent === 'function' ||
-    typeof handler.onRequestSent === 'function'
+  // Get mock dispatch from built key
+  const key = buildKey(opts)
+  const mockDispatch = getMockDispatch(this[kDispatches], key)
+  const mockDispatches = this[kDispatches]
+
+  mockDispatch.timesInvoked++
+
+  const { timesInvoked, times } = mockDispatch
+
+  // If it's used up and not persistent, mark as consumed
+  mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
+  mockDispatch.pending = timesInvoked < times
+
+  const hasBodyHooks = typeof handler.onBodySent === 'function' ||
+    typeof handler.onRequestSent === 'function'
+
+  // Here's where we resolve a callback if a callback is present for the dispatch data.
   if (mockDispatch.data.callback && (!hasBodyHooks || opts.body == null)) {
-    const { callback, ...responseDefaults } = mockDispatch.data
-    const callbackResult = callback(opts)
+    const { callback, ...responseDefaults } = mockDispatch.data
+    const callbackResult = callback(opts)
+
+    // An asynchronous reply options callback resolves to the reply data, so
+    // the dispatch can only continue once the returned promise settles.
+    // A rejection cannot be thrown synchronously from the dispatch at that
+    // point, so it is surfaced as a response error instead.
     if (isPromise(callbackResult)) {
-      // Async callback without body hooks: defer via promise
-      callbackResult.then(
+      callbackResult.then(
         (resolvedData) => {
           if (resolvedData == null || typeof resolvedData !== 'object') {
-            handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+            handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
             return
-          }
-          mockDispatch.data = { ...responseDefaults, ...resolvedData }
+          }
+          mockDispatch.data = { ...responseDefaults, ...resolvedData }
           dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
-        },
-        (err) => {
-          handler.onResponseError(null, err)
-        }
-      )
+        },
+        (error) => {
+          handler.onResponseError(null, error)
+        }
+      )
       return true
-    }
-    // Sync path: validate and merge, then fall through to dispatchMockReply
+    }
+
     if (callbackResult == null || typeof callbackResult !== 'object') {
       throw new InvalidArgumentError('reply options callback must return an object')
-    }
+    }
+
     mockDispatch.data = { ...responseDefaults, ...callbackResult }
-  }
+  }
+
   return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
-}
-/**
- * Replies to a request once the mock dispatch data is fully resolved
- */
+}
+
+/**
+ * Replies to a request once the mock dispatch data is fully resolved
+ */
 function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
-  const { data: response, delay } = mockDispatch
-  // If specified, trigger dispatch error
+  // Parse mockDispatch data
+  const { data: response, delay } = mockDispatch
+
+  // If specified, trigger dispatch error
   if (response.error !== null) {
-    deleteMockDispatch(mockDispatches, key)
-    handler.onResponseError(null, response.error)
+    deleteMockDispatch(mockDispatches, key)
+    handler.onResponseError(null, response.error)
     return true
-  }
-  // Track whether the request has been aborted
-  let aborted = false
-  let timer = null
-  // Create the controller early so abort can use it
-  const controller = {
-    paused: false,
-    rawHeaders: null,
-    rawTrailers: null,
+  }
+
+  // Track whether the request has been aborted
+  let aborted = false
+  let timer = null
+
+  // Create the controller early so abort can use it
+  const controller = {
+    paused: false,
+    rawHeaders: null,
+    rawTrailers: null,
     pause () {
       this.paused = true
-    },
+    },
     resume () {
       this.paused = false
-    },
+    },
     abort: (reason) => {
       if (aborted) {
         return
-      }
-      aborted = true
-      // Clear the pending delayed response if any
+      }
+      aborted = true
+
+      // Clear the pending delayed response if any
       if (timer !== null) {
-        clearTimeout(timer)
+        clearTimeout(timer)
         timer = null
-      }
+      }
+
       handler.onResponseError?.(controller, reason)
-    }
-  }
-  let replyOpts = opts
-  const dispatches = mockDispatches
-  // Call onRequestStart to allow the handler to receive the controller
-  handler.onRequestStart?.(controller, null)
+    }
+  }
+
+  let replyOpts = opts
+  const dispatches = mockDispatches
+
+  // Call onRequestStart to allow the handler to receive the controller
+  handler.onRequestStart?.(controller, null)
+
   if (aborted) {
     return true
-  }
-  const requestBody = dispatchRequestBody(opts.body, handler, controller, () => aborted)
+  }
+
+  const requestBody = dispatchRequestBody(opts.body, handler, controller, () => aborted)
+
   if (isPromise(requestBody)) {
     requestBody.then((body) => {
       if (body === requestAborted) {
         return
-      }
+      }
+
       if (body !== opts.body) {
         replyOpts = { ...opts, body }
-      }
+      }
+
       sendReply()
-    }, (error) => controller.abort(error))
+    }, (error) => controller.abort(error))
     return true
-  }
+  }
+
   if (requestBody === requestAborted) {
     return true
-  }
+  }
+
   if (requestBody !== opts.body) {
     replyOpts = { ...opts, body: requestBody }
-  }
-  sendReply()
+  }
+
+  sendReply()
+
   function sendReply () {
-    // Resolve callback after request body dispatch
     if (response.callback) {
-      const { callback, ...responseDefaults } = response
-      let callbackResult
+      const { callback, ...responseDefaults } = response
+      let callbackResult
       try {
         callbackResult = callback(replyOpts)
       } catch (err) {
-        deleteMockDispatch(mockDispatches, key)
-        handler.onResponseError(null, err)
+        deleteMockDispatch(mockDispatches, key)
+        handler.onResponseError(null, err)
         return
-      }
+      }
+
       if (isPromise(callbackResult)) {
-        callbackResult.then(
+        callbackResult.then(
           (resolvedData) => {
             if (resolvedData == null || typeof resolvedData !== 'object') {
-              handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+              handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
               return
-            }
-            mockDispatch.data = { ...responseDefaults, ...resolvedData }
+            }
+            mockDispatch.data = { ...responseDefaults, ...resolvedData }
             handleReply(dispatches, mockDispatch.data)
-          },
+          },
           (err) => {
             handler.onResponseError(null, err)
-          }
-        )
+          }
+        )
         return
-      }
+      }
+
       if (callbackResult == null || typeof callbackResult !== 'object') {
         throw new InvalidArgumentError('reply options callback must return an object')
-      }
-      mockDispatch.data = { ...responseDefaults, ...callbackResult }
-      handleReply(dispatches, mockDispatch.data)
+      }
+
+      mockDispatch.data = { ...responseDefaults, ...callbackResult }
+      handleReply(dispatches, mockDispatch.data)
       return
-    }
-    // Handle the request with a delay if necessary
+    }
+
+    // Handle the request with a delay if necessary
     if (typeof delay === 'number' && delay > 0) {
       timer = setTimeout(() => {
-        timer = null
+        timer = null
         handleReply(dispatches)
       }, delay)
     } else {
       handleReply(dispatches)
     }
-  }
+  }
+
   function handleReply (mockDispatches, _response = response) {
-    // Don't send response if the request was aborted
+    // Don't send response if the request was aborted
     if (aborted) {
       return
-    }
-    const { statusCode, data, headers, trailers } = _response
-    // fetch's HeadersList is a 1D string array
-    const optsHeaders = Array.isArray(opts.headers)
-      ? buildHeadersFromArray(opts.headers)
-      : opts.headers
-    const body = typeof data === 'function'
-      ? data({ ...replyOpts, headers: optsHeaders })
-      : data
-    // util.types.isPromise is likely needed for jest.
+    }
+
+    const { statusCode, data, headers, trailers } = _response
+
+    // fetch's HeadersList is a 1D string array
+    const optsHeaders = Array.isArray(opts.headers)
+      ? buildHeadersFromArray(opts.headers)
+      : opts.headers
+    const body = typeof data === 'function'
+      ? data({ ...replyOpts, headers: optsHeaders })
+      : data
+
+    // util.types.isPromise is likely needed for jest.
     if (isPromise(body)) {
-      // If handleReply is asynchronous, throwing an error
-      // in the callback will reject the promise, rather than
-      // synchronously throw the error, which breaks some tests.
-      // Rather, we wait for the callback to resolve if it is a
-      // promise, and then re-run handleReply with the new body.
+      // If handleReply is asynchronous, throwing an error
+      // in the callback will reject the promise, rather than
+      // synchronously throw the error, which breaks some tests.
+      // Rather, we wait for the callback to resolve if it is a
+      // promise, and then re-run handleReply with the new body.
       return body.then((newData) => handleReply(mockDispatches, { ..._response, data: newData }))
-    }
-    // Check again if aborted after async body resolution
+    }
+
+    // Check again if aborted after async body resolution
     if (aborted) {
       return
-    }
-    const responseData = getResponseData(body)
-    const responseHeaders = generateKeyValues(headers ?? {})
-    const responseTrailers = generateKeyValues(trailers ?? {})
-    // Update the controller with response data
-    controller.rawHeaders = responseHeaders
-    controller.rawTrailers = responseTrailers
-    handler.onResponseStart?.(controller, statusCode, parseHeaders(responseHeaders), getStatusText(statusCode))
-    handler.onResponseData?.(controller, Buffer.from(responseData))
-    handler.onResponseEnd?.(controller, parseHeaders(responseTrailers))
+    }
+
+    const responseData = getResponseData(body)
+    const responseHeaders = generateKeyValues(headers ?? {})
+    const responseTrailers = generateKeyValues(trailers ?? {})
+
+    // Update the controller with response data
+    controller.rawHeaders = responseHeaders
+    controller.rawTrailers = responseTrailers
+
+    handler.onResponseStart?.(controller, statusCode, parseHeaders(responseHeaders), getStatusText(statusCode))
+    handler.onResponseData?.(controller, Buffer.from(responseData))
+    handler.onResponseEnd?.(controller, parseHeaders(responseTrailers))
     deleteMockDispatch(mockDispatches, key)
-  }
+  }
+
   return true
-}
+}
+
 function dispatchRequestBody (body, handler, controller, isAborted) {
   if (typeof handler.onBodySent !== 'function' && typeof handler.onRequestSent !== 'function') {
     return body
-  }
+  }
+
   if (body == null) {
     return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
-  }
+  }
+
   if (body && typeof body[Symbol.asyncIterator] === 'function') {
     return dispatchAsyncIterableBody(body, handler, controller, isAborted)
-  }
+  }
+
   if (isIterableBody(body)) {
-    const chunks = []
+    const chunks = []
+
     for (const chunk of body) {
       if (isAborted()) {
         return requestAborted
-      }
-      chunks.push(chunk)
+      }
+      chunks.push(chunk)
       if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
         return requestAborted
       }
-    }
+    }
+
     return callOnRequestSent(handler, controller, isAborted) ? chunks : requestAborted
-  }
+  }
+
   if (isAborted()) {
     return requestAborted
-  }
+  }
+
   if (!callOnBodySent(handler, controller, body)) {
     return requestAborted
-  }
+  }
+
   return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
-}
+}
+
 async function dispatchAsyncIterableBody (body, handler, controller, isAborted) {
-  const chunks = []
+  const chunks = []
+
   for await (const chunk of body) {
     if (isAborted()) {
       return requestAborted
-    }
-    chunks.push(chunk)
+    }
+    chunks.push(chunk)
     if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
       return requestAborted
     }
-  }
+  }
+
   if (!callOnRequestSent(handler, controller, isAborted)) {
     return requestAborted
-  }
-  return {
+  }
+
+  return {
     async * [Symbol.asyncIterator] () {
       yield * chunks
-    }
+    }
   }
-}
+}
+
 function callOnBodySent (handler, controller, chunk) {
   try {
-    handler.onBodySent?.(chunk)
+    handler.onBodySent?.(chunk)
     return true
   } catch (error) {
-    controller.abort(error)
+    controller.abort(error)
     return false
   }
-}
+}
+
 function callOnRequestSent (handler, controller, isAborted) {
   try {
-    handler.onRequestSent?.()
+    handler.onRequestSent?.()
     return !isAborted()
   } catch (error) {
-    controller.abort(error)
+    controller.abort(error)
     return false
   }
-}
+}
+
 function isIterableBody (body) {
-  return typeof body !== 'string' &&
-    !Buffer.isBuffer(body) &&
-    !ArrayBuffer.isView(body) &&
+  return typeof body !== 'string' &&
+    !Buffer.isBuffer(body) &&
+    !ArrayBuffer.isView(body) &&
     typeof body[Symbol.iterator] === 'function'
-}
+}
+
 function buildMockDispatch () {
-  const agent = this[kMockAgent]
-  const origin = this[kOrigin]
-  const originalDispatch = this[kOriginalDispatch]
+  const agent = this[kMockAgent]
+  const origin = this[kOrigin]
+  const originalDispatch = this[kOriginalDispatch]
+
   return function dispatch (opts, handler) {
     if (agent.isMockActive) {
       try {
         mockDispatch.call(this, opts, handler)
       } catch (error) {
         if (error.code === 'UND_MOCK_ERR_MOCK_NOT_MATCHED') {
-          const netConnect = agent[kGetNetConnect]()
-          const totalInterceptsCount = this[kDispatches][kTotalDispatchCount] || this[kDispatches].length
-          const pendingInterceptsCount = this[kDispatches].filter(({ consumed }) => !consumed).length
-          const interceptsMessage = `, ${pendingInterceptsCount} interceptor(s) remaining out of ${totalInterceptsCount} defined`
+          const netConnect = agent[kGetNetConnect]()
+          const totalInterceptsCount = this[kDispatches][kTotalDispatchCount] || this[kDispatches].length
+          const pendingInterceptsCount = this[kDispatches].filter(({ consumed }) => !consumed).length
+          const interceptsMessage = `, ${pendingInterceptsCount} interceptor(s) remaining out of ${totalInterceptsCount} defined`
           if (netConnect === false) {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)${interceptsMessage}`)
-          }
+          }
           if (checkNetConnect(netConnect, origin)) {
-            originalDispatch.call(this, '__mockAgentBodyForDispatch' in opts
-              ? { ...opts, body: opts.__mockAgentBodyForDispatch }
+            originalDispatch.call(this, '__mockAgentBodyForDispatch' in opts
+              ? { ...opts, body: opts.__mockAgentBodyForDispatch }
               : opts, handler)
           } else {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)${interceptsMessage}`)
@@ -548,54 +645,64 @@ function buildMockDispatch () {
       originalDispatch.call(this, opts, handler)
     }
   }
-}
+}
+
 function checkNetConnect (netConnect, origin) {
-  const url = new URL(origin)
+  const url = new URL(origin)
   if (netConnect === true) {
     return true
   } else if (Array.isArray(netConnect) && netConnect.some((matcher) => matchValue(matcher, url.host))) {
     return true
-  }
+  }
   return false
-}
+}
+
 function normalizeOrigin (origin) {
   if (typeof origin !== 'string' && !(origin instanceof URL)) {
     return origin
-  }
+  }
+
   if (origin instanceof URL) {
     return origin.origin
-  }
+  }
+
   return origin.toLowerCase()
-}
+}
+
 function buildAndValidateMockOptions (opts) {
-  const { agent, ...mockOptions } = opts
+  const { agent, ...mockOptions } = opts
+
   if ('enableCallHistory' in mockOptions && typeof mockOptions.enableCallHistory !== 'boolean') {
     throw new InvalidArgumentError('options.enableCallHistory must to be a boolean')
-  }
+  }
+
   if ('acceptNonStandardSearchParameters' in mockOptions && typeof mockOptions.acceptNonStandardSearchParameters !== 'boolean') {
     throw new InvalidArgumentError('options.acceptNonStandardSearchParameters must to be a boolean')
-  }
+  }
+
   if ('ignoreTrailingSlash' in mockOptions && typeof mockOptions.ignoreTrailingSlash !== 'boolean') {
     throw new InvalidArgumentError('options.ignoreTrailingSlash must to be a boolean')
-  }
+  }
+
   return mockOptions
-}
-module.exports = {
-  getResponseData,
-  getMockDispatch,
-  addMockDispatch,
-  deleteMockDispatch,
-  buildKey,
-  generateKeyValues,
-  matchValue,
-  getResponse,
-  getStatusText,
-  mockDispatch,
-  buildMockDispatch,
-  checkNetConnect,
-  buildAndValidateMockOptions,
-  getHeaderByName,
-  buildHeadersFromArray,
-  normalizeSearchParams,
-  normalizeOrigin
+}
+
+module.exports = {
+  getResponseData,
+  getMockDispatch,
+  addMockDispatch,
+  deleteMockDispatch,
+  buildKey,
+  generateKeyValues,
+  matchValue,
+  getResponse,
+  getStatusText,
+  mockDispatch,
+  buildMockDispatch,
+  checkNetConnect,
+  buildAndValidateMockOptions,
+  getHeaderByName,
+  buildHeadersFromArray,
+  normalizeSearchParams,
+  normalizeOrigin
 }

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -375,17 +375,44 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
     }
   }
 
+  let replyOpts = opts
+  const dispatches = this[kDispatches]
+
   // Call onRequestStart to allow the handler to receive the controller
   handler.onRequestStart?.(controller, null)
 
-  // Handle the request with a delay if necessary
-  if (typeof delay === 'number' && delay > 0) {
-    timer = setTimeout(() => {
-      timer = null
-      handleReply(mockDispatches)
-    }, delay)
-  } else {
-    handleReply(mockDispatches)
+  const requestBody = dispatchRequestBody(opts.body, handler, controller)
+
+  if (isPromise(requestBody)) {
+    requestBody.then((body) => {
+      if (body !== opts.body) {
+        replyOpts = { ...opts, body }
+      }
+      sendReply()
+    }, (error) => controller.abort(error))
+    return true
+  }
+
+  if (requestBody === null) {
+    return true
+  }
+
+  if (requestBody !== opts.body) {
+    replyOpts = { ...opts, body: requestBody }
+  }
+
+  sendReply()
+
+  function sendReply () {
+    // Handle the request with a delay if necessary
+    if (typeof delay === 'number' && delay > 0) {
+      timer = setTimeout(() => {
+        timer = null
+        handleReply(dispatches)
+      }, delay)
+    } else {
+      handleReply(dispatches)
+    }
   }
 
   function handleReply (mockDispatches, _data = data) {
@@ -399,7 +426,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
       ? buildHeadersFromArray(opts.headers)
       : opts.headers
     const body = typeof _data === 'function'
-      ? _data({ ...opts, headers: optsHeaders })
+      ? _data({ ...replyOpts, headers: optsHeaders })
       : _data
 
     // util.types.isPromise is likely needed for jest.
@@ -432,6 +459,87 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
   }
 
   return true
+}
+
+function dispatchRequestBody (body, handler, controller) {
+  if (typeof handler.onBodySent !== 'function' && typeof handler.onRequestSent !== 'function') {
+    return body
+  }
+
+  if (body == null) {
+    return callOnRequestSent(handler, controller) ? body : null
+  }
+
+  if (body && typeof body[Symbol.asyncIterator] === 'function') {
+    return dispatchAsyncIterableBody(body, handler, controller)
+  }
+
+  if (isIterableBody(body)) {
+    const chunks = []
+
+    for (const chunk of body) {
+      chunks.push(chunk)
+      if (!callOnBodySent(handler, controller, chunk)) {
+        return null
+      }
+    }
+
+    return callOnRequestSent(handler, controller) ? chunks : null
+  }
+
+  if (!callOnBodySent(handler, controller, body)) {
+    return null
+  }
+
+  return callOnRequestSent(handler, controller) ? body : null
+}
+
+async function dispatchAsyncIterableBody (body, handler, controller) {
+  const chunks = []
+
+  for await (const chunk of body) {
+    chunks.push(chunk)
+    if (!callOnBodySent(handler, controller, chunk)) {
+      return null
+    }
+  }
+
+  if (!callOnRequestSent(handler, controller)) {
+    return null
+  }
+
+  return {
+    async * [Symbol.asyncIterator] () {
+      yield * chunks
+    }
+  }
+}
+
+function callOnBodySent (handler, controller, chunk) {
+  try {
+    handler.onBodySent?.(chunk)
+    return true
+  } catch (error) {
+    controller.abort(error)
+    return false
+  }
+}
+
+function callOnRequestSent (handler, controller) {
+  try {
+    handler.onRequestSent?.()
+    return true
+  } catch (error) {
+    controller.abort(error)
+    return false
+  }
+}
+
+function isIterableBody (body) {
+  return typeof body !== 'string' &&
+    !Buffer.isBuffer(body) &&
+    !ArrayBuffer.isView(body) &&
+    typeof body[Symbol.iterator] === 'function'
 }
 
 function buildMockDispatch () {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -1,153 +1,132 @@
-'use strict'
-
-const { MockNotMatchedError } = require('./mock-errors')
-const {
-  kDispatches,
-  kMockAgent,
-  kOriginalDispatch,
-  kOrigin,
-  kGetNetConnect,
-  kTotalDispatchCount
-} = require('./mock-symbols')
-const { serializePathWithQuery, parseHeaders } = require('../core/util')
-const { STATUS_CODES } = require('node:http')
-const {
-  types: {
-    isPromise
-  }
-} = require('node:util')
-const { InvalidArgumentError } = require('../core/errors')
-
-const requestAborted = Symbol('request aborted')
-
+'use strict'
+const { MockNotMatchedError } = require('./mock-errors')
+const {
+  kDispatches,
+  kMockAgent,
+  kOriginalDispatch,
+  kOrigin,
+  kGetNetConnect,
+  kTotalDispatchCount
+} = require('./mock-symbols')
+const { serializePathWithQuery, parseHeaders } = require('../core/util')
+const { STATUS_CODES } = require('node:http')
+const {
+  types: {
+    isPromise
+  }
+} = require('node:util')
+const { InvalidArgumentError } = require('../core/errors')
+const requestAborted = Symbol('request aborted')
 function matchValue (match, value) {
   if (typeof match === 'string') {
     return match === value
-  }
+  }
   if (match instanceof RegExp) {
     return match.test(value)
-  }
+  }
   if (typeof match === 'function') {
     return match(value) === true
-  }
+  }
   return false
-}
-
+}
 function lowerCaseEntries (headers) {
-  return Object.fromEntries(
+  return Object.fromEntries(
     Object.entries(headers).map(([headerName, headerValue]) => {
       return [headerName.toLocaleLowerCase(), headerValue]
-    })
+    })
   )
-}
-
-/**
- * @param {import('../../index').Headers|string[]|Record<string, string>} headers
- * @param {string} key
- */
+}
+/**
+ * @param {import('../../index').Headers|string[]|Record<string, string>} headers
+ * @param {string} key
+ */
 function getHeaderByName (headers, key) {
   if (Array.isArray(headers)) {
     for (let i = 0; i < headers.length; i += 2) {
       if (headers[i].toLocaleLowerCase() === key.toLocaleLowerCase()) {
         return headers[i + 1]
       }
-    }
-
+    }
     return undefined
   } else if (typeof headers.get === 'function') {
     return headers.get(key)
   } else {
     return lowerCaseEntries(headers)[key.toLocaleLowerCase()]
   }
-}
-
-/** @param {string[]} headers */
+}
+/** @param {string[]} headers */
 function buildHeadersFromArray (headers) { // fetch HeadersList
-  const clone = headers.slice()
-  const entries = []
+  const clone = headers.slice()
+  const entries = []
   for (let index = 0; index < clone.length; index += 2) {
     entries.push([clone[index], clone[index + 1]])
-  }
+  }
   return Object.fromEntries(entries)
-}
-
+}
 function matchHeaders (mockDispatch, headers) {
   if (typeof mockDispatch.headers === 'function') {
     if (Array.isArray(headers)) { // fetch HeadersList
       headers = buildHeadersFromArray(headers)
-    }
+    }
     return mockDispatch.headers(headers ? lowerCaseEntries(headers) : {})
-  }
+  }
   if (typeof mockDispatch.headers === 'undefined') {
     return true
-  }
+  }
   if (typeof headers !== 'object' || typeof mockDispatch.headers !== 'object') {
     return false
-  }
-
+  }
   for (const [matchHeaderName, matchHeaderValue] of Object.entries(mockDispatch.headers)) {
-    const headerValue = getHeaderByName(headers, matchHeaderName)
-
+    const headerValue = getHeaderByName(headers, matchHeaderName)
     if (!matchValue(matchHeaderValue, headerValue)) {
       return false
     }
-  }
+  }
   return true
-}
-
+}
 function normalizeSearchParams (query) {
   if (typeof query !== 'string') {
     return query
-  }
-
-  const originalQp = new URLSearchParams(query)
-  const normalizedQp = new URLSearchParams()
-
+  }
+  const originalQp = new URLSearchParams(query)
+  const normalizedQp = new URLSearchParams()
   for (let [key, value] of originalQp.entries()) {
-    key = key.replace('[]', '')
-
-    const valueRepresentsString = /^(['"]).*\1$/.test(value)
+    key = key.replace('[]', '')
+    const valueRepresentsString = /^(['"]).*\1$/.test(value)
     if (valueRepresentsString) {
-      normalizedQp.append(key, value)
+      normalizedQp.append(key, value)
       continue
-    }
-
+    }
     if (value.includes(',')) {
-      const values = value.split(',')
+      const values = value.split(',')
       for (const v of values) {
         normalizedQp.append(key, v)
-      }
+      }
       continue
-    }
-
+    }
     normalizedQp.append(key, value)
-  }
-
+  }
   return normalizedQp
-}
-
+}
 function safeUrl (path) {
   if (typeof path !== 'string') {
     return path
-  }
-  const pathSegments = path.split('?', 3)
+  }
+  const pathSegments = path.split('?', 3)
   if (pathSegments.length !== 2) {
     return path
-  }
-
-  const qp = new URLSearchParams(pathSegments.pop())
-  qp.sort()
+  }
+  const qp = new URLSearchParams(pathSegments.pop())
+  qp.sort()
   return [...pathSegments, qp.toString()].join('?')
-}
-
+}
 function matchKey (mockDispatch, { path, method, body, headers }) {
-  const pathMatch = matchValue(mockDispatch.path, path)
-  const methodMatch = matchValue(mockDispatch.method, method)
-  const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
-  const headersMatch = matchHeaders(mockDispatch, headers)
+  const pathMatch = matchValue(mockDispatch.path, path)
+  const methodMatch = matchValue(mockDispatch.method, method)
+  const bodyMatch = typeof mockDispatch.body !== 'undefined' ? matchValue(mockDispatch.body, body) : true
+  const headersMatch = matchHeaders(mockDispatch, headers)
   return pathMatch && methodMatch && bodyMatch && headersMatch
-}
-
+}
 function getResponseData (data) {
   if (Buffer.isBuffer(data)) {
     return data
@@ -162,104 +141,89 @@ function getResponseData (data) {
   } else {
     return ''
   }
-}
-
+}
 function getMockDispatch (mockDispatches, key) {
-  const basePath = key.query ? serializePathWithQuery(key.path, key.query) : key.path
-  const resolvedPath = typeof basePath === 'string' ? safeUrl(basePath) : basePath
-
-  const resolvedPathWithoutTrailingSlash = removeTrailingSlash(resolvedPath)
-
-  // Match path
-  let matchedMockDispatches = mockDispatches
-    .filter(({ consumed }) => !consumed)
+  const basePath = key.query ? serializePathWithQuery(key.path, key.query) : key.path
+  const resolvedPath = typeof basePath === 'string' ? safeUrl(basePath) : basePath
+  const resolvedPathWithoutTrailingSlash = removeTrailingSlash(resolvedPath)
+  // Match path
+  let matchedMockDispatches = mockDispatches
+    .filter(({ consumed }) => !consumed)
     .filter(({ path, ignoreTrailingSlash }) => {
-      return ignoreTrailingSlash
-        ? matchValue(removeTrailingSlash(safeUrl(path)), resolvedPathWithoutTrailingSlash)
+      return ignoreTrailingSlash
+        ? matchValue(removeTrailingSlash(safeUrl(path)), resolvedPathWithoutTrailingSlash)
         : matchValue(safeUrl(path), resolvedPath)
-    })
+    })
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`)
-  }
-
-  // Match method
-  matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
+  }
+  // Match method
+  matchedMockDispatches = matchedMockDispatches.filter(({ method }) => matchValue(method, key.method))
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for method '${key.method}' on path '${resolvedPath}'`)
-  }
-
-  // Match body
-  matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
+  }
+  // Match body
+  matchedMockDispatches = matchedMockDispatches.filter(({ body }) => typeof body !== 'undefined' ? matchValue(body, key.body) : true)
   if (matchedMockDispatches.length === 0) {
     throw new MockNotMatchedError(`Mock dispatch not matched for body '${key.body}' on path '${resolvedPath}'`)
-  }
-
-  // Match headers
-  matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
+  }
+  // Match headers
+  matchedMockDispatches = matchedMockDispatches.filter((mockDispatch) => matchHeaders(mockDispatch, key.headers))
   if (matchedMockDispatches.length === 0) {
-    const headers = typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers
+    const headers = typeof key.headers === 'object' ? JSON.stringify(key.headers) : key.headers
     throw new MockNotMatchedError(`Mock dispatch not matched for headers '${headers}' on path '${resolvedPath}'`)
-  }
-
+  }
   return matchedMockDispatches[0]
-}
-
+}
 function addMockDispatch (mockDispatches, key, data, opts) {
-  const baseData = { timesInvoked: 0, times: 1, persist: false, consumed: false, ...opts }
-  const replyData = typeof data === 'function' ? { callback: data } : { ...data }
-  const newMockDispatch = { ...baseData, ...key, pending: true, data: { error: null, ...replyData } }
-  mockDispatches.push(newMockDispatch)
-  // Track total number of intercepts ever registered for better error messages
-  mockDispatches[kTotalDispatchCount] = (mockDispatches[kTotalDispatchCount] || 0) + 1
+  const baseData = { timesInvoked: 0, times: 1, persist: false, consumed: false, ...opts }
+  const replyData = typeof data === 'function' ? { callback: data } : { ...data }
+  const newMockDispatch = { ...baseData, ...key, pending: true, data: { error: null, ...replyData } }
+  mockDispatches.push(newMockDispatch)
+  // Track total number of intercepts ever registered for better error messages
+  mockDispatches[kTotalDispatchCount] = (mockDispatches[kTotalDispatchCount] || 0) + 1
   return newMockDispatch
-}
-
+}
 function deleteMockDispatch (mockDispatches, key) {
   const index = mockDispatches.findIndex(dispatch => {
     if (!dispatch.consumed) {
       return false
-    }
+    }
     return matchKey(dispatch, key)
-  })
+  })
   if (index !== -1) {
     mockDispatches.splice(index, 1)
   }
-}
-
-/**
- * @param {string} path Path to remove trailing slash from
- */
+}
+/**
+ * @param {string} path Path to remove trailing slash from
+ */
 function removeTrailingSlash (path) {
   while (path.endsWith('/')) {
     path = path.slice(0, -1)
-  }
-
+  }
   if (path.length === 0) {
     path = '/'
-  }
-
+  }
   return path
-}
-
+}
 function buildKey (opts) {
-  const { path, method, body, headers, query } = opts
-
-  return {
-    path,
-    method,
-    body,
-    headers,
-    query
+  const { path, method, body, headers, query } = opts
+  return {
+    path,
+    method,
+    body,
+    headers,
+    query
   }
-}
-
+}
 function generateKeyValues (data) {
-  const keys = Object.keys(data)
-  const result = []
+  const keys = Object.keys(data)
+  const result = []
   for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i]
-    const value = data[key]
-    const name = Buffer.from(`${key}`)
+    const key = keys[i]
+    const value = data[key]
+    const name = Buffer.from(`${key}`)
     if (Array.isArray(value)) {
       for (let j = 0; j < value.length; ++j) {
         result.push(name, Buffer.from(`${value[j]}`))
@@ -267,373 +231,311 @@ function generateKeyValues (data) {
     } else {
       result.push(name, Buffer.from(`${value}`))
     }
-  }
+  }
   return result
-}
-
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
- * @param {number} statusCode
- */
+}
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+ * @param {number} statusCode
+ */
 function getStatusText (statusCode) {
   return STATUS_CODES[statusCode] || 'unknown'
-}
-
+}
 async function getResponse (body) {
-  const buffers = []
+  const buffers = []
   for await (const data of body) {
     buffers.push(data)
-  }
+  }
   return Buffer.concat(buffers).toString('utf8')
-}
-
-/**
- * Mock dispatch function used to simulate undici dispatches
- */
+}
+/**
+ * Mock dispatch function used to simulate undici dispatches
+ */
 function mockDispatch (opts, handler) {
-  // Get mock dispatch from built key
-  const key = buildKey(opts)
-  const mockDispatch = getMockDispatch(this[kDispatches], key)
-  const mockDispatches = this[kDispatches]
-
-  mockDispatch.timesInvoked++
-
-  const { timesInvoked, times } = mockDispatch
-
-  // If it's used up and not persistent, mark as consumed
-  mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
-  mockDispatch.pending = timesInvoked < times
-
-  // If the reply was registered as a callback and the request has no body
-  // lifecycle hooks (or no body), resolve the callback now — synchronously and
-  // outside of dispatcher-base's try/catch — so that invalid callbacks throw
-  // directly to the caller.  When body hooks ARE present, the callback is
-  // instead resolved inside sendReply() (after the body has been dispatched)
-  // so that the callback receives the fully-consumed opts.body.
-  const hasBodyHooks = typeof handler.onBodySent === 'function' ||
-    typeof handler.onRequestSent === 'function'
+  // Get mock dispatch from built key
+  const key = buildKey(opts)
+  const mockDispatch = getMockDispatch(this[kDispatches], key)
+  const mockDispatches = this[kDispatches]
+  mockDispatch.timesInvoked++
+  const { timesInvoked, times } = mockDispatch
+  // If it's used up and not persistent, mark as consumed
+  mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
+  mockDispatch.pending = timesInvoked < times
+  // Resolve callback early if no body hooks are present
+  const hasBodyHooks = typeof handler.onBodySent === 'function' ||
+    typeof handler.onRequestSent === 'function'
   if (mockDispatch.data.callback && (!hasBodyHooks || opts.body == null)) {
-    const { callback, ...responseDefaults } = mockDispatch.data
-    const callbackResult = callback(opts)
-
+    const { callback, ...responseDefaults } = mockDispatch.data
+    const callbackResult = callback(opts)
     if (isPromise(callbackResult)) {
-      // Async callback without body hooks: defer via promise
-      callbackResult.then(
+      // Async callback without body hooks: defer via promise
+      callbackResult.then(
         (resolvedData) => {
           if (resolvedData == null || typeof resolvedData !== 'object') {
-            handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+            handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
             return
-          }
-          mockDispatch.data = { ...responseDefaults, ...resolvedData }
+          }
+          mockDispatch.data = { ...responseDefaults, ...resolvedData }
           dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
-        },
+        },
         (err) => {
           handler.onResponseError(null, err)
-        }
-      )
+        }
+      )
       return true
-    }
-
-    // Sync path: validate and merge, then fall through to dispatchMockReply
+    }
+    // Sync path: validate and merge, then fall through to dispatchMockReply
     if (callbackResult == null || typeof callbackResult !== 'object') {
       throw new InvalidArgumentError('reply options callback must return an object')
-    }
+    }
     mockDispatch.data = { ...responseDefaults, ...callbackResult }
-  }
-
+  }
   return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
-}
-
-/**
- * Replies to a request once the mock dispatch data is fully resolved
- */
+}
+/**
+ * Replies to a request once the mock dispatch data is fully resolved
+ */
 function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
-  const { data: response, delay } = mockDispatch
-
-  // If specified, trigger dispatch error
+  const { data: response, delay } = mockDispatch
+  // If specified, trigger dispatch error
   if (response.error !== null) {
-    deleteMockDispatch(mockDispatches, key)
-    handler.onResponseError(null, response.error)
+    deleteMockDispatch(mockDispatches, key)
+    handler.onResponseError(null, response.error)
     return true
-  }
-
-  // Track whether the request has been aborted
-  let aborted = false
-  let timer = null
-
-  // Create the controller early so abort can use it
-  const controller = {
-    paused: false,
-    rawHeaders: null,
-    rawTrailers: null,
+  }
+  // Track whether the request has been aborted
+  let aborted = false
+  let timer = null
+  // Create the controller early so abort can use it
+  const controller = {
+    paused: false,
+    rawHeaders: null,
+    rawTrailers: null,
     pause () {
       this.paused = true
-    },
+    },
     resume () {
       this.paused = false
-    },
+    },
     abort: (reason) => {
       if (aborted) {
         return
-      }
-      aborted = true
-
-      // Clear the pending delayed response if any
+      }
+      aborted = true
+      // Clear the pending delayed response if any
       if (timer !== null) {
-        clearTimeout(timer)
+        clearTimeout(timer)
         timer = null
-      }
-
+      }
       handler.onResponseError?.(controller, reason)
-    }
-  }
-
-  let replyOpts = opts
-  const dispatches = mockDispatches
-
-  // Call onRequestStart to allow the handler to receive the controller
-  handler.onRequestStart?.(controller, null)
+    }
+  }
+  let replyOpts = opts
+  const dispatches = mockDispatches
+  // Call onRequestStart to allow the handler to receive the controller
+  handler.onRequestStart?.(controller, null)
   if (aborted) {
     return true
-  }
-
-  const requestBody = dispatchRequestBody(opts.body, handler, controller, () => aborted)
-
+  }
+  const requestBody = dispatchRequestBody(opts.body, handler, controller, () => aborted)
   if (isPromise(requestBody)) {
     requestBody.then((body) => {
       if (body === requestAborted) {
         return
-      }
+      }
       if (body !== opts.body) {
         replyOpts = { ...opts, body }
-      }
+      }
       sendReply()
-    }, (error) => controller.abort(error))
+    }, (error) => controller.abort(error))
     return true
-  }
-
+  }
   if (requestBody === requestAborted) {
     return true
-  }
-
+  }
   if (requestBody !== opts.body) {
     replyOpts = { ...opts, body: requestBody }
-  }
-
-  sendReply()
-
+  }
+  sendReply()
   function sendReply () {
-    // If the reply was registered as a callback, invoke it now — after the
-    // request body has been dispatched so replyOpts.body is already consumed.
-    // Sync callbacks that return an invalid value throw here; sendReply is
-    // called synchronously for bodyless requests so the throw reaches the
-    // original caller unchanged. Async callbacks (Promise) defer the rest.
+    // Resolve callback after request body dispatch
     if (response.callback) {
-      const { callback, ...responseDefaults } = response
-      let callbackResult
+      const { callback, ...responseDefaults } = response
+      let callbackResult
       try {
         callbackResult = callback(replyOpts)
       } catch (err) {
-        deleteMockDispatch(mockDispatches, key)
-        handler.onResponseError(null, err)
+        deleteMockDispatch(mockDispatches, key)
+        handler.onResponseError(null, err)
         return
-      }
-
+      }
       if (isPromise(callbackResult)) {
-        callbackResult.then(
+        callbackResult.then(
           (resolvedData) => {
             if (resolvedData == null || typeof resolvedData !== 'object') {
-              handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+              handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
               return
-            }
-            mockDispatch.data = { ...responseDefaults, ...resolvedData }
+            }
+            mockDispatch.data = { ...responseDefaults, ...resolvedData }
             handleReply(dispatches, mockDispatch.data)
-          },
+          },
           (err) => {
             handler.onResponseError(null, err)
-          }
-        )
+          }
+        )
         return
-      }
-
+      }
       if (callbackResult == null || typeof callbackResult !== 'object') {
         throw new InvalidArgumentError('reply options callback must return an object')
-      }
-      mockDispatch.data = { ...responseDefaults, ...callbackResult }
-      handleReply(dispatches, mockDispatch.data)
+      }
+      mockDispatch.data = { ...responseDefaults, ...callbackResult }
+      handleReply(dispatches, mockDispatch.data)
       return
-    }
-
-    // Handle the request with a delay if necessary
+    }
+    // Handle the request with a delay if necessary
     if (typeof delay === 'number' && delay > 0) {
       timer = setTimeout(() => {
-        timer = null
+        timer = null
         handleReply(dispatches)
       }, delay)
     } else {
       handleReply(dispatches)
     }
-  }
-
+  }
   function handleReply (mockDispatches, _response = response) {
-    // Don't send response if the request was aborted
+    // Don't send response if the request was aborted
     if (aborted) {
       return
-    }
-
-    const { statusCode, data, headers, trailers } = _response
-
-    // fetch's HeadersList is a 1D string array
-    const optsHeaders = Array.isArray(opts.headers)
-      ? buildHeadersFromArray(opts.headers)
-      : opts.headers
-    const body = typeof data === 'function'
-      ? data({ ...replyOpts, headers: optsHeaders })
-      : data
-
-    // util.types.isPromise is likely needed for jest.
+    }
+    const { statusCode, data, headers, trailers } = _response
+    // fetch's HeadersList is a 1D string array
+    const optsHeaders = Array.isArray(opts.headers)
+      ? buildHeadersFromArray(opts.headers)
+      : opts.headers
+    const body = typeof data === 'function'
+      ? data({ ...replyOpts, headers: optsHeaders })
+      : data
+    // util.types.isPromise is likely needed for jest.
     if (isPromise(body)) {
-      // If handleReply is asynchronous, throwing an error
-      // in the callback will reject the promise, rather than
-      // synchronously throw the error, which breaks some tests.
-      // Rather, we wait for the callback to resolve if it is a
-      // promise, and then re-run handleReply with the new body.
+      // If handleReply is asynchronous, throwing an error
+      // in the callback will reject the promise, rather than
+      // synchronously throw the error, which breaks some tests.
+      // Rather, we wait for the callback to resolve if it is a
+      // promise, and then re-run handleReply with the new body.
       return body.then((newData) => handleReply(mockDispatches, { ..._response, data: newData }))
-    }
-
-    // Check again if aborted after async body resolution
+    }
+    // Check again if aborted after async body resolution
     if (aborted) {
       return
-    }
-
-    const responseData = getResponseData(body)
-    const responseHeaders = generateKeyValues(headers ?? {})
-    const responseTrailers = generateKeyValues(trailers ?? {})
-
-    // Update the controller with response data
-    controller.rawHeaders = responseHeaders
-    controller.rawTrailers = responseTrailers
-
-    handler.onResponseStart?.(controller, statusCode, parseHeaders(responseHeaders), getStatusText(statusCode))
-    handler.onResponseData?.(controller, Buffer.from(responseData))
-    handler.onResponseEnd?.(controller, parseHeaders(responseTrailers))
+    }
+    const responseData = getResponseData(body)
+    const responseHeaders = generateKeyValues(headers ?? {})
+    const responseTrailers = generateKeyValues(trailers ?? {})
+    // Update the controller with response data
+    controller.rawHeaders = responseHeaders
+    controller.rawTrailers = responseTrailers
+    handler.onResponseStart?.(controller, statusCode, parseHeaders(responseHeaders), getStatusText(statusCode))
+    handler.onResponseData?.(controller, Buffer.from(responseData))
+    handler.onResponseEnd?.(controller, parseHeaders(responseTrailers))
     deleteMockDispatch(mockDispatches, key)
-  }
-
+  }
   return true
-}
-
+}
 function dispatchRequestBody (body, handler, controller, isAborted) {
   if (typeof handler.onBodySent !== 'function' && typeof handler.onRequestSent !== 'function') {
     return body
-  }
-
+  }
   if (body == null) {
     return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
-  }
-
+  }
   if (body && typeof body[Symbol.asyncIterator] === 'function') {
     return dispatchAsyncIterableBody(body, handler, controller, isAborted)
-  }
-
+  }
   if (isIterableBody(body)) {
-    const chunks = []
-
+    const chunks = []
     for (const chunk of body) {
       if (isAborted()) {
         return requestAborted
-      }
-      chunks.push(chunk)
+      }
+      chunks.push(chunk)
       if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
         return requestAborted
       }
-    }
-
+    }
     return callOnRequestSent(handler, controller, isAborted) ? chunks : requestAborted
-  }
-
+  }
   if (isAborted()) {
     return requestAborted
-  }
+  }
   if (!callOnBodySent(handler, controller, body)) {
     return requestAborted
-  }
-
+  }
   return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
-}
-
+}
 async function dispatchAsyncIterableBody (body, handler, controller, isAborted) {
-  const chunks = []
-
+  const chunks = []
   for await (const chunk of body) {
     if (isAborted()) {
       return requestAborted
-    }
-    chunks.push(chunk)
+    }
+    chunks.push(chunk)
     if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
       return requestAborted
     }
-  }
-
+  }
   if (!callOnRequestSent(handler, controller, isAborted)) {
     return requestAborted
-  }
-
-  return {
+  }
+  return {
     async * [Symbol.asyncIterator] () {
       yield * chunks
-    }
+    }
   }
-}
-
+}
 function callOnBodySent (handler, controller, chunk) {
   try {
-    handler.onBodySent?.(chunk)
+    handler.onBodySent?.(chunk)
     return true
   } catch (error) {
-    controller.abort(error)
+    controller.abort(error)
     return false
   }
-}
-
+}
 function callOnRequestSent (handler, controller, isAborted) {
   try {
-    handler.onRequestSent?.()
+    handler.onRequestSent?.()
     return !isAborted()
   } catch (error) {
-    controller.abort(error)
+    controller.abort(error)
     return false
   }
-}
-
+}
 function isIterableBody (body) {
-  return typeof body !== 'string' &&
-    !Buffer.isBuffer(body) &&
-    !ArrayBuffer.isView(body) &&
+  return typeof body !== 'string' &&
+    !Buffer.isBuffer(body) &&
+    !ArrayBuffer.isView(body) &&
     typeof body[Symbol.iterator] === 'function'
-}
-
+}
 function buildMockDispatch () {
-  const agent = this[kMockAgent]
-  const origin = this[kOrigin]
-  const originalDispatch = this[kOriginalDispatch]
-
+  const agent = this[kMockAgent]
+  const origin = this[kOrigin]
+  const originalDispatch = this[kOriginalDispatch]
   return function dispatch (opts, handler) {
     if (agent.isMockActive) {
       try {
         mockDispatch.call(this, opts, handler)
       } catch (error) {
         if (error.code === 'UND_MOCK_ERR_MOCK_NOT_MATCHED') {
-          const netConnect = agent[kGetNetConnect]()
-          const totalInterceptsCount = this[kDispatches][kTotalDispatchCount] || this[kDispatches].length
-          const pendingInterceptsCount = this[kDispatches].filter(({ consumed }) => !consumed).length
-          const interceptsMessage = `, ${pendingInterceptsCount} interceptor(s) remaining out of ${totalInterceptsCount} defined`
+          const netConnect = agent[kGetNetConnect]()
+          const totalInterceptsCount = this[kDispatches][kTotalDispatchCount] || this[kDispatches].length
+          const pendingInterceptsCount = this[kDispatches].filter(({ consumed }) => !consumed).length
+          const interceptsMessage = `, ${pendingInterceptsCount} interceptor(s) remaining out of ${totalInterceptsCount} defined`
           if (netConnect === false) {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)${interceptsMessage}`)
-          }
+          }
           if (checkNetConnect(netConnect, origin)) {
-            originalDispatch.call(this, '__mockAgentBodyForDispatch' in opts
-              ? { ...opts, body: opts.__mockAgentBodyForDispatch }
+            originalDispatch.call(this, '__mockAgentBodyForDispatch' in opts
+              ? { ...opts, body: opts.__mockAgentBodyForDispatch }
               : opts, handler)
           } else {
             throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)${interceptsMessage}`)
@@ -646,64 +548,54 @@ function buildMockDispatch () {
       originalDispatch.call(this, opts, handler)
     }
   }
-}
-
+}
 function checkNetConnect (netConnect, origin) {
-  const url = new URL(origin)
+  const url = new URL(origin)
   if (netConnect === true) {
     return true
   } else if (Array.isArray(netConnect) && netConnect.some((matcher) => matchValue(matcher, url.host))) {
     return true
-  }
+  }
   return false
-}
-
+}
 function normalizeOrigin (origin) {
   if (typeof origin !== 'string' && !(origin instanceof URL)) {
     return origin
-  }
-
+  }
   if (origin instanceof URL) {
     return origin.origin
-  }
-
+  }
   return origin.toLowerCase()
-}
-
+}
 function buildAndValidateMockOptions (opts) {
-  const { agent, ...mockOptions } = opts
-
+  const { agent, ...mockOptions } = opts
   if ('enableCallHistory' in mockOptions && typeof mockOptions.enableCallHistory !== 'boolean') {
     throw new InvalidArgumentError('options.enableCallHistory must to be a boolean')
-  }
-
+  }
   if ('acceptNonStandardSearchParameters' in mockOptions && typeof mockOptions.acceptNonStandardSearchParameters !== 'boolean') {
     throw new InvalidArgumentError('options.acceptNonStandardSearchParameters must to be a boolean')
-  }
-
+  }
   if ('ignoreTrailingSlash' in mockOptions && typeof mockOptions.ignoreTrailingSlash !== 'boolean') {
     throw new InvalidArgumentError('options.ignoreTrailingSlash must to be a boolean')
-  }
-
+  }
   return mockOptions
-}
-
-module.exports = {
-  getResponseData,
-  getMockDispatch,
-  addMockDispatch,
-  deleteMockDispatch,
-  buildKey,
-  generateKeyValues,
-  matchValue,
-  getResponse,
-  getStatusText,
-  mockDispatch,
-  buildMockDispatch,
-  checkNetConnect,
-  buildAndValidateMockOptions,
-  getHeaderByName,
-  buildHeadersFromArray,
-  normalizeSearchParams,
-  normalizeOrigin
+}
+module.exports = {
+  getResponseData,
+  getMockDispatch,
+  addMockDispatch,
+  deleteMockDispatch,
+  buildKey,
+  generateKeyValues,
+  matchValue,
+  getResponse,
+  getStatusText,
+  mockDispatch,
+  buildMockDispatch,
+  checkNetConnect,
+  buildAndValidateMockOptions,
+  getHeaderByName,
+  buildHeadersFromArray,
+  normalizeSearchParams,
+  normalizeOrigin
 }

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -18,6 +18,8 @@ const {
 } = require('node:util')
 const { InvalidArgumentError } = require('../core/errors')
 
+const requestAborted = Symbol('request aborted')
+
 function matchValue (match, value) {
   if (typeof match === 'string') {
     return match === value
@@ -334,13 +336,12 @@ function mockDispatch (opts, handler) {
  * Replies to a request once the mock dispatch data is fully resolved
  */
 function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
-  // Parse mockDispatch data
-  const { data: { statusCode, data, headers, trailers, error }, delay } = mockDispatch
+  const { data: response, delay } = mockDispatch
 
   // If specified, trigger dispatch error
-  if (error !== null) {
+  if (response.error !== null) {
     deleteMockDispatch(mockDispatches, key)
-    handler.onResponseError(null, error)
+    handler.onResponseError(null, response.error)
     return true
   }
 
@@ -388,7 +389,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
 
   if (isPromise(requestBody)) {
     requestBody.then((body) => {
-      if (body === null) {
+      if (body === requestAborted) {
         return
       }
       if (body !== opts.body) {
@@ -399,7 +400,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
     return true
   }
 
-  if (requestBody === null) {
+  if (requestBody === requestAborted) {
     return true
   }
 
@@ -421,19 +422,27 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
     }
   }
 
-  function handleReply (mockDispatches, _data = data) {
+  function handleReply (mockDispatches, _response = response) {
     // Don't send response if the request was aborted
     if (aborted) {
       return
     }
 
+    if (_response.callback) {
+      const { callback, ...responseDefaults } = _response
+      mockDispatch.data = { ...responseDefaults, ...callback(replyOpts) }
+      return handleReply(mockDispatches, mockDispatch.data)
+    }
+
+    const { statusCode, data, headers, trailers } = _response
+
     // fetch's HeadersList is a 1D string array
     const optsHeaders = Array.isArray(opts.headers)
       ? buildHeadersFromArray(opts.headers)
       : opts.headers
-    const body = typeof _data === 'function'
-      ? _data({ ...replyOpts, headers: optsHeaders })
-      : _data
+    const body = typeof data === 'function'
+      ? data({ ...replyOpts, headers: optsHeaders })
+      : data
 
     // util.types.isPromise is likely needed for jest.
     if (isPromise(body)) {
@@ -442,7 +451,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
       // synchronously throw the error, which breaks some tests.
       // Rather, we wait for the callback to resolve if it is a
       // promise, and then re-run handleReply with the new body.
-      return body.then((newData) => handleReply(mockDispatches, newData))
+      return body.then((newData) => handleReply(mockDispatches, { ..._response, data: newData }))
     }
 
     // Check again if aborted after async body resolution
@@ -473,7 +482,7 @@ function dispatchRequestBody (body, handler, controller, isAborted) {
   }
 
   if (body == null) {
-    return callOnRequestSent(handler, controller) ? body : null
+    return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
   }
 
   if (body && typeof body[Symbol.asyncIterator] === 'function') {
@@ -485,25 +494,25 @@ function dispatchRequestBody (body, handler, controller, isAborted) {
 
     for (const chunk of body) {
       if (isAborted()) {
-        return null
+        return requestAborted
       }
       chunks.push(chunk)
-      if (!callOnBodySent(handler, controller, chunk)) {
-        return null
+      if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
+        return requestAborted
       }
     }
 
-    return !isAborted() && callOnRequestSent(handler, controller) ? chunks : null
+    return callOnRequestSent(handler, controller, isAborted) ? chunks : requestAborted
   }
 
   if (isAborted()) {
-    return null
+    return requestAborted
   }
   if (!callOnBodySent(handler, controller, body)) {
-    return null
+    return requestAborted
   }
 
-  return !isAborted() && callOnRequestSent(handler, controller) ? body : null
+  return callOnRequestSent(handler, controller, isAborted) ? body : requestAborted
 }
 
 async function dispatchAsyncIterableBody (body, handler, controller, isAborted) {
@@ -511,16 +520,16 @@ async function dispatchAsyncIterableBody (body, handler, controller, isAborted) 
 
   for await (const chunk of body) {
     if (isAborted()) {
-      return null
+      return requestAborted
     }
     chunks.push(chunk)
-    if (!callOnBodySent(handler, controller, chunk)) {
-      return null
+    if (!callOnBodySent(handler, controller, chunk) || isAborted()) {
+      return requestAborted
     }
   }
 
-  if (isAborted() || !callOnRequestSent(handler, controller)) {
-    return null
+  if (!callOnRequestSent(handler, controller, isAborted)) {
+    return requestAborted
   }
 
   return {
@@ -540,10 +549,10 @@ function callOnBodySent (handler, controller, chunk) {
   }
 }
 
-function callOnRequestSent (handler, controller) {
+function callOnRequestSent (handler, controller, isAborted) {
   try {
     handler.onRequestSent?.()
-    return true
+    return !isAborted()
   } catch (error) {
     controller.abort(error)
     return false

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -304,6 +304,43 @@ function mockDispatch (opts, handler) {
   mockDispatch.consumed = !mockDispatch.persist && timesInvoked >= times
   mockDispatch.pending = timesInvoked < times
 
+  // If the reply was registered as a callback and the request has no body
+  // lifecycle hooks (or no body), resolve the callback now — synchronously and
+  // outside of dispatcher-base's try/catch — so that invalid callbacks throw
+  // directly to the caller.  When body hooks ARE present, the callback is
+  // instead resolved inside sendReply() (after the body has been dispatched)
+  // so that the callback receives the fully-consumed opts.body.
+  const hasBodyHooks = typeof handler.onBodySent === 'function' ||
+    typeof handler.onRequestSent === 'function'
+  if (mockDispatch.data.callback && (!hasBodyHooks || opts.body == null)) {
+    const { callback, ...responseDefaults } = mockDispatch.data
+    const callbackResult = callback(opts)
+
+    if (isPromise(callbackResult)) {
+      // Async callback without body hooks: defer via promise
+      callbackResult.then(
+        (resolvedData) => {
+          if (resolvedData == null || typeof resolvedData !== 'object') {
+            handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+            return
+          }
+          mockDispatch.data = { ...responseDefaults, ...resolvedData }
+          dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
+        },
+        (err) => {
+          handler.onResponseError(null, err)
+        }
+      )
+      return true
+    }
+
+    // Sync path: validate and merge, then fall through to dispatchMockReply
+    if (callbackResult == null || typeof callbackResult !== 'object') {
+      throw new InvalidArgumentError('reply options callback must return an object')
+    }
+    mockDispatch.data = { ...responseDefaults, ...callbackResult }
+  }
+
   return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
 }
 
@@ -386,6 +423,47 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
   sendReply()
 
   function sendReply () {
+    // If the reply was registered as a callback, invoke it now — after the
+    // request body has been dispatched so replyOpts.body is already consumed.
+    // Sync callbacks that return an invalid value throw here; sendReply is
+    // called synchronously for bodyless requests so the throw reaches the
+    // original caller unchanged. Async callbacks (Promise) defer the rest.
+    if (response.callback) {
+      const { callback, ...responseDefaults } = response
+      let callbackResult
+      try {
+        callbackResult = callback(replyOpts)
+      } catch (err) {
+        deleteMockDispatch(mockDispatches, key)
+        handler.onResponseError(null, err)
+        return
+      }
+
+      if (isPromise(callbackResult)) {
+        callbackResult.then(
+          (resolvedData) => {
+            if (resolvedData == null || typeof resolvedData !== 'object') {
+              handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
+              return
+            }
+            mockDispatch.data = { ...responseDefaults, ...resolvedData }
+            handleReply(dispatches, mockDispatch.data)
+          },
+          (err) => {
+            handler.onResponseError(null, err)
+          }
+        )
+        return
+      }
+
+      if (callbackResult == null || typeof callbackResult !== 'object') {
+        throw new InvalidArgumentError('reply options callback must return an object')
+      }
+      mockDispatch.data = { ...responseDefaults, ...callbackResult }
+      handleReply(dispatches, mockDispatch.data)
+      return
+    }
+
     // Handle the request with a delay if necessary
     if (typeof delay === 'number' && delay > 0) {
       timer = setTimeout(() => {
@@ -401,12 +479,6 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
     // Don't send response if the request was aborted
     if (aborted) {
       return
-    }
-
-    if (_response.callback) {
-      const { callback, ...responseDefaults } = _response
-      mockDispatch.data = { ...responseDefaults, ...callback(replyOpts) }
-      return handleReply(mockDispatches, mockDispatch.data)
     }
 
     const { statusCode, data, headers, trailers } = _response
@@ -435,8 +507,8 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
     }
 
     const responseData = getResponseData(body)
-    const responseHeaders = generateKeyValues(headers)
-    const responseTrailers = generateKeyValues(trailers)
+    const responseHeaders = generateKeyValues(headers ?? {})
+    const responseTrailers = generateKeyValues(trailers ?? {})
 
     // Update the controller with response data
     controller.rawHeaders = responseHeaders

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -321,6 +321,48 @@ describe('MockAgent - dispatch', () => {
     t.assert.deepStrictEqual(events, ['start', 'body:he', 'body:llo', 'sent'])
   })
 
+  test('should call request sent hook for requests without a body', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'GET'
+    }).reply(200, 'hello')
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'GET'
+      }, {
+        onRequestStart () {
+          events.push('start')
+        },
+        onBodySent () {
+          events.push('body')
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData () {},
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['start', 'sent'])
+  })
+
   test('should replay async iterable request bodies to reply callbacks after lifecycle hooks', async (t) => {
     const baseUrl = 'http://localhost:9999'
     const events = []
@@ -400,6 +442,55 @@ describe('MockAgent - dispatch', () => {
       }, {
         onBodySent () {
           throw expected
+        },
+        onRequestSent () {
+          reject(new Error('request should not be marked sent'))
+        },
+        onResponseStart () {
+          reject(new Error('response should not start'))
+        },
+        onResponseData () {},
+        onResponseEnd () {},
+        onResponseError (_controller, error) {
+          try {
+            t.assert.strictEqual(error, expected)
+            resolve()
+          } catch (assertionError) {
+            reject(assertionError)
+          }
+        }
+      })
+    })
+  })
+
+  test('should not send request body lifecycle hooks after request start aborts', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const expected = new Error('fail')
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: 'hello'
+      }, {
+        onRequestStart (controller) {
+          controller.abort(expected)
+        },
+        onBodySent () {
+          reject(new Error('body should not be sent'))
+        },
+        onRequestSent () {
+          reject(new Error('request should not be sent'))
         },
         onResponseStart () {
           reject(new Error('response should not start'))

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -273,6 +273,56 @@ describe('MockAgent - dispatch', () => {
     t.assert.deepStrictEqual(events, ['start', 'body:hello', 'sent'])
   })
 
+  test('should call request sent lifecycle hook for null bodies', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+    const chunks = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('mock response did not complete'))
+      }, 1000)
+
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: null
+      }, {
+        onRequestStart () {
+          events.push('start')
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData (_controller, chunk) {
+          chunks.push(chunk)
+        },
+        onResponseEnd () {
+          clearTimeout(timeout)
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          clearTimeout(timeout)
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['start', 'sent'])
+    t.assert.strictEqual(Buffer.concat(chunks).toString(), 'hello')
+  })
+
   test('should call request body lifecycle hooks for async iterable bodies', async (t) => {
     const baseUrl = 'http://localhost:9999'
     const events = []
@@ -414,6 +464,105 @@ describe('MockAgent - dispatch', () => {
     t.assert.deepStrictEqual(events, ['body:he'])
   })
 
+  test('should pass replayed async iterable bodies to reply option callbacks', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+    let callbackBody
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(({ body }) => {
+      events.push('callback')
+      callbackBody = body
+      return { statusCode: 200, data: 'hello' }
+    })
+
+    async function * body () {
+      yield Buffer.from('he')
+      yield Buffer.from('llo')
+    }
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: body()
+      }, {
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData () {},
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    const chunks = []
+    for await (const chunk of callbackBody) {
+      chunks.push(chunk)
+    }
+
+    t.assert.deepStrictEqual(events, ['body:he', 'body:llo', 'sent', 'callback'])
+    t.assert.strictEqual(Buffer.concat(chunks).toString(), 'hello')
+  })
+
+  test('should match request bodies when lifecycle hooks are present', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST',
+      body: /hello/
+    }).reply(200, 'matched')
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: 'hello=there'
+      }, {
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData (_controller, chunk) {
+          events.push(`response:${chunk.toString()}`)
+        },
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['body:hello=there', 'sent', 'response:matched'])
+  })
+
   test('should replay async iterable request bodies to reply callbacks after lifecycle hooks', async (t) => {
     const baseUrl = 'http://localhost:9999'
     const events = []
@@ -512,6 +661,115 @@ describe('MockAgent - dispatch', () => {
         }
       })
     })
+  })
+
+  test('should not send delayed replies after request sent aborts', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const expected = new Error('fail')
+    const events = []
+    let requestController
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello').delay(20)
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: 'hello'
+      }, {
+        onRequestStart (controller) {
+          requestController = controller
+        },
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+          requestController.abort(expected)
+        },
+        onResponseStart () {
+          reject(new Error('response should not start'))
+        },
+        onResponseData () {},
+        onResponseEnd () {},
+        onResponseError (_controller, error) {
+          try {
+            t.assert.strictEqual(error, expected)
+            setTimeout(resolve, 40)
+          } catch (assertionError) {
+            reject(assertionError)
+          }
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['body:hello', 'sent'])
+  })
+
+  test('should stop reading async iterable request bodies after body hook aborts', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const expected = new Error('fail')
+    const events = []
+    let requestController
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    async function * body () {
+      events.push('pull:he')
+      yield Buffer.from('he')
+      events.push('pull:llo')
+      yield Buffer.from('llo')
+    }
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: body()
+      }, {
+        onRequestStart (controller) {
+          requestController = controller
+        },
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+          requestController.abort(expected)
+        },
+        onRequestSent () {
+          reject(new Error('request should not be marked sent'))
+        },
+        onResponseStart () {
+          reject(new Error('response should not start'))
+        },
+        onResponseData () {},
+        onResponseEnd () {},
+        onResponseError (_controller, error) {
+          try {
+            t.assert.strictEqual(error, expected)
+            resolve()
+          } catch (assertionError) {
+            reject(assertionError)
+          }
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['pull:he', 'body:he'])
   })
 
   test('should not send request body lifecycle hooks after request start aborts', async (t) => {

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -229,6 +229,194 @@ describe('MockAgent - dispatch', () => {
       onResponseError () {}
     }))
   })
+
+  test('should call request body lifecycle hooks', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: 'hello'
+      }, {
+        onRequestStart () {
+          events.push('start')
+        },
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData () {},
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['start', 'body:hello', 'sent'])
+  })
+
+  test('should call request body lifecycle hooks for async iterable bodies', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    async function * body () {
+      yield Buffer.from('he')
+      yield Buffer.from('llo')
+    }
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: body()
+      }, {
+        onRequestStart () {
+          events.push('start')
+        },
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData () {},
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['start', 'body:he', 'body:llo', 'sent'])
+  })
+
+  test('should replay async iterable request bodies to reply callbacks after lifecycle hooks', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const events = []
+    const response = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, async ({ body }) => {
+      const chunks = []
+
+      for await (const chunk of body) {
+        chunks.push(chunk)
+      }
+
+      return Buffer.concat(chunks).toString()
+    })
+
+    async function * body () {
+      yield Buffer.from('he')
+      yield Buffer.from('llo')
+    }
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: body()
+      }, {
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          events.push('sent')
+        },
+        onResponseStart () {},
+        onResponseData (_controller, chunk) {
+          response.push(chunk)
+        },
+        onResponseEnd () {
+          resolve()
+        },
+        onResponseError (_controller, error) {
+          reject(error)
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['body:he', 'body:llo', 'sent'])
+    t.assert.strictEqual(Buffer.concat(response).toString(), 'hello')
+  })
+
+  test('should report request body lifecycle hook errors', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const expected = new Error('fail')
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: 'hello'
+      }, {
+        onBodySent () {
+          throw expected
+        },
+        onResponseStart () {
+          reject(new Error('response should not start'))
+        },
+        onResponseData () {},
+        onResponseEnd () {},
+        onResponseError (_controller, error) {
+          try {
+            t.assert.strictEqual(error, expected)
+            resolve()
+          } catch (assertionError) {
+            reject(assertionError)
+          }
+        }
+      })
+    })
+  })
 })
 
 test('MockAgent - .close should clean up registered pools', async (t) => {

--- a/test/mock-agent.js
+++ b/test/mock-agent.js
@@ -363,6 +363,57 @@ describe('MockAgent - dispatch', () => {
     t.assert.deepStrictEqual(events, ['start', 'sent'])
   })
 
+  test('should report async iterable request body errors', async (t) => {
+    const baseUrl = 'http://localhost:9999'
+    const expected = new Error('fail')
+    const events = []
+
+    const mockAgent = new MockAgent()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+    mockPool.intercept({
+      path: '/foo',
+      method: 'POST'
+    }).reply(200, 'hello')
+
+    async function * body () {
+      yield Buffer.from('he')
+      throw expected
+    }
+
+    await new Promise((resolve, reject) => {
+      mockAgent.dispatch({
+        origin: baseUrl,
+        path: '/foo',
+        method: 'POST',
+        body: body()
+      }, {
+        onBodySent (chunk) {
+          events.push(`body:${chunk.toString()}`)
+        },
+        onRequestSent () {
+          reject(new Error('request should not be marked sent'))
+        },
+        onResponseStart () {
+          reject(new Error('response should not start'))
+        },
+        onResponseData () {},
+        onResponseEnd () {},
+        onResponseError (_controller, error) {
+          try {
+            t.assert.strictEqual(error, expected)
+            resolve()
+          } catch (assertionError) {
+            reject(assertionError)
+          }
+        }
+      })
+    })
+
+    t.assert.deepStrictEqual(events, ['body:he'])
+  })
+
   test('should replay async iterable request bodies to reply callbacks after lifecycle hooks', async (t) => {
     const baseUrl = 'http://localhost:9999'
     const events = []


### PR DESCRIPTION
## This relates to...

Fixes #3843.

## Rationale

`MockAgent` dispatches currently skip request body lifecycle callbacks, so code that works with real dispatchers cannot be tested accurately with mocks. The mock dispatcher should emit `onBodySent(chunk)` for request body chunks and `onRequestSent()` once request body dispatch has completed, while preserving the existing mocked reply behavior.

## Changes

### Features

N/A

### Bug Fixes

- emit `onBodySent(chunk)` and `onRequestSent()` from `MockAgent` dispatches before resolving the mocked reply
- support string/buffer-like bodies, sync iterables, async iterables, and requests without a body
- preserve async iterable request bodies for functional mock reply callbacks and reply-options callbacks by replaying consumed chunks
- keep request body matching behavior intact when lifecycle hooks are present
- route body lifecycle hook errors and async iterable producer errors through `onResponseError`
- stop body dispatch and response delivery after request-start, request-sent, or body-hook aborts, including delayed replies

### Breaking Changes and Deprecations

N/A

## Validation

- `node --test --test-timeout=30000 --test-name-pattern "request body lifecycle hooks|request sent hook|async iterable request body errors|replayed async iterable bodies|match request bodies when lifecycle hooks|replay async iterable request bodies|request body lifecycle hook errors|delayed replies after request sent aborts|stop reading async iterable request bodies|request start aborts" test/mock-agent.js`
- `node --test --test-timeout=30000 --test-name-pattern "dispatch onBodySent" test/node-test/client-dispatch.js`
- `npm run lint -- --no-cache lib/mock/mock-utils.js test/mock-agent.js`
- `git diff --check origin/main..HEAD`

Note: `npx borp --timeout 180000 --expose-gc -p "test/mock-agent.js"` did not complete locally before the wrapper timeout in this Windows environment, so I used focused Node test runs for the changed behavior and adjacent dispatcher behavior.

AI-assisted contribution: implemented with OpenAI Codex and reviewed locally before submission.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin