### PR TITLE
fix: use legacy global dispatcher in v7

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -32,7 +32,7 @@ function setGlobalDispatcher (agent) {
 }
 
 function getGlobalDispatcher () {
-  return globalThis[globalDispatcher]
+  return globalThis[legacyGlobalDispatcher]
 }
 
 // These are the globals that can be installed by undici.install().

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -94,6 +94,75 @@ test('setGlobalDispatcher mirrors the dispatcher under the v1 symbol that Node.j
   assert.strictEqual(payload.mirroredV2, true)
 })
 
+test('undici fetch always uses the v1 global dispatcher', () => {
+  const script = `
+    const assert = require('node:assert')
+    const { createServer } = require('node:http')
+    const { once } = require('node:events')
+    const Agent = require('./lib/dispatcher/agent')
+
+    ;(async () => {
+      const dispatcherV1Symbol = Symbol.for('undici.globalDispatcher.1')
+      const dispatcherV2Symbol = Symbol.for('undici.globalDispatcher.2')
+      const agent = new Agent()
+      let v1Dispatches = 0
+      let v2Dispatches = 0
+
+      const v2Dispatcher = {
+        dispatch () {
+          v2Dispatches++
+          throw new Error('v2 global dispatcher should not be used')
+        }
+      }
+
+      const v1Dispatcher = {
+        dispatch (opts, handler) {
+          v1Dispatches++
+          return agent.dispatch(opts, handler)
+        },
+        close: (...args) => agent.close(...args),
+        destroy: (...args) => agent.destroy(...args)
+      }
+
+      Object.defineProperty(globalThis, dispatcherV2Symbol, {
+        value: v2Dispatcher,
+        writable: true,
+        enumerable: false,
+        configurable: false
+      })
+      Object.defineProperty(globalThis, dispatcherV1Symbol, {
+        value: v1Dispatcher,
+        writable: true,
+        enumerable: false,
+        configurable: false
+      })
+
+      const { fetch, getGlobalDispatcher } = require('./index.js')
+      const server = createServer((_request, response) => response.end('ok'))
+      server.listen(0, '127.0.0.1')
+      await once(server, 'listening')
+
+      const response = await fetch('http://127.0.0.1:' + server.address().port)
+      const body = await response.text()
+
+      assert.strictEqual(body, 'ok')
+      assert.strictEqual(getGlobalDispatcher(), v1Dispatcher)
+      assert.strictEqual(v1Dispatches, 1)
+      assert.strictEqual(v2Dispatches, 0)
+
+      server.close()
+      await once(server, 'close')
+      await agent.close()
+    })().catch((err) => {
+      console.error(err?.cause?.stack || err?.stack || err)
+      process.exit(1)
+    })
+  `
+
+  const result = runNode(script)
+  assert.strictEqual(result.status, 0, result.stderr)
+})
+
 test('Node.js global fetch preserves headers and decoding with an undici Agent dispatcher', () => {
   const script = `
     const assert = require('node:assert')


### PR DESCRIPTION
## Summary

- make v7 `getGlobalDispatcher()` always read `Symbol.for('undici.globalDispatcher.1')`
- add a regression test that poisons the v2 global dispatcher slot and verifies v7 fetch still uses the v1 dispatcher

## Reproduction

A minimal reproduction is available at:

https://github.com/mcollina/undici-7-8-global-dispatcher-repro

It installs only `undici@7.27.1` and `undici@8.3.0`. The failure happens when undici v8 installs the global dispatcher and undici v7 fetch reads the v2 dispatcher slot while still using the v1 handler shape.

## Tests

- `npx borp --timeout 180000 -p "test/node-test/global-dispatcher-version.js"`
- `npm run lint -- test/node-test/global-dispatcher-version.js lib/global.js`
