### PR TITLE
fix(websocket): defer close events while connecting

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -92,7 +92,17 @@ class WebSocket extends EventTarget {
 
       this.#handler.socket.destroy()
     },
-    onSocketClose: () => this.#onSocketClose(),
+    onSocketClose: () => {
+      if (isConnecting(this.#handler.readyState)) {
+        setImmediate(() => {
+          if (!isClosed(this.#handler.readyState)) {
+            this.#onSocketClose()
+          }
+        })
+      } else {
+        this.#onSocketClose()
+      }
+    },
     onPing: (body) => {
       if (channels.ping.hasSubscribers) {
         channels.ping.publish({

--- a/test/websocket/issue-4628.js
+++ b/test/websocket/issue-4628.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const assert = require('node:assert')
+const { once } = require('node:events')
 const { test } = require('node:test')
 const { WebSocket } = require('../..')
 
-test('closing before connection is established should only fire error and close events once', (t) => {
-  t.plan(2)
-
-  t.after(() => assert.deepStrictEqual(events, ['error', 'close']))
+test('closing before connection is established should only fire error and close events once', async (t) => {
+  t.plan(3)
 
   const events = []
   const ws = new WebSocket('wss://example.com/')
@@ -24,5 +22,47 @@ test('closing before connection is established should only fire error and close 
     events.push('close')
   })
 
+  const closed = once(ws, 'close')
+
   ws.close()
+
+  await closed
+
+  t.assert.deepStrictEqual(events, ['error', 'close'])
+})
+
+test('closing before connection is established fires events asynchronously', async (t) => {
+  t.plan(5)
+
+  const events = []
+  const ws = new WebSocket('wss://example.com/')
+  let closeMethodReturned = false
+
+  ws.onopen = t.assert.fail
+
+  ws.addEventListener('error', () => {
+    events.push(['error', closeMethodReturned])
+  })
+
+  ws.addEventListener('close', () => {
+    events.push(['close', closeMethodReturned])
+  })
+
+  t.assert.strictEqual(ws.readyState, WebSocket.CONNECTING)
+
+  const closed = once(ws, 'close')
+
+  ws.close()
+  closeMethodReturned = true
+
+  t.assert.deepStrictEqual(events, [])
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSING)
+
+  await closed
+
+  t.assert.deepStrictEqual(events, [
+    ['error', true],
+    ['close', true]
+  ])
+  t.assert.strictEqual(ws.readyState, WebSocket.CLOSED)
 })


### PR DESCRIPTION
Fixes #4741.

## Summary
- defer `error` and `close` dispatch for `WebSocket.close()` while the socket is still `CONNECTING`
- keep `readyState` at `CLOSING` immediately after `close()` returns, then move to `CLOSED` when the queued close task runs
- keep the existing once-only error/close behavior and avoid changing `WebSocketStream` connection failure ordering

## Verification
- red before fix: `node test\websocket\issue-4628.js` failed because `error`/`close` fired before `close()` returned
- `node test\websocket\issue-4628.js`
- `node test\websocket\issue-3546.js`
- `node test\websocket\issue-4273.js`
- `node test\websocket\stream\abort-before-open.js`
- `npx borp --timeout 180000 -p "test/websocket/issue-4628.js"`
- `npx borp --timeout 180000 -p "test/websocket/issue-3546.js" -p "test/websocket/issue-4273.js"`
- `npm run test:websocket` (131 passed)
- `npx eslint lib/web/websocket/websocket.js test/websocket/issue-4628.js`
- `npm run lint`
- `git diff --check`