### PR TITLE
fix(client): reject pipelined TLS altname errors

### DIFF
--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -568,9 +568,15 @@ function handleConnectError (client, err, { host, hostname, protocol, port }) {
   }
 
   if (err.code === 'ERR_TLS_CERT_ALTNAME_INVALID') {
-    assert(client[kRunning] === 0)
+    const running = client[kQueue].splice(client[kRunningIdx], client[kRunning])
+    client[kPendingIdx] = client[kRunningIdx]
+
+    for (let i = 0; i < running.length; i++) {
+      util.errorRequest(client, running[i], err)
+    }
+
     while (client[kPending] > 0 && client[kQueue][client[kPendingIdx]].servername === client[kServerName]) {
-      const request = client[kQueue][client[kPendingIdx]++]
+      const request = client[kQueue].splice(client[kPendingIdx], 1)[0]
       util.errorRequest(client, request, err)
     }
   } else {

--- a/test/node-test/client-tls.js
+++ b/test/node-test/client-tls.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+const fs = require('node:fs')
+const https = require('node:https')
+const path = require('node:path')
+const { Pool } = require('../..')
+
+test('TLS altname errors reject pipelined requests', async (t) => {
+  const server = https.createServer({
+    key: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'key.pem')),
+    cert: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'cert.pem'))
+  }, (req, res) => {
+    res.end('ok')
+  })
+
+  t.after(() => {
+    server.close()
+  })
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const pool = new Pool(`https://localhost:${server.address().port}`, {
+    connections: 1,
+    pipelining: 10,
+    connect: {
+      ca: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'ca.pem'))
+    }
+  })
+
+  t.after(async () => {
+    await pool.close().catch(() => {})
+  })
+
+  const settled = await Promise.allSettled(
+    Array.from({ length: 20 }, () => pool.request({ path: '/', method: 'GET' }))
+  )
+
+  assert.ok(settled.every(({ status }) => status === 'rejected'))
+  assert.ok(settled.every(({ reason }) => reason.code === 'ERR_TLS_CERT_ALTNAME_INVALID'))
+})


### PR DESCRIPTION
## This relates to...

Fixes #5355

## Rationale

`ERR_TLS_CERT_ALTNAME_INVALID` had a special connect-error path that asserted `client[kRunning] === 0` before rejecting pending requests for the current server name. With `pipelining > 1`, requests can already be in the running segment when the TLS hostname validation error is reported, so the assertion can crash the process instead of rejecting the affected request promises.

## Changes

### Features

N/A

### Bug Fixes

- drain and reject already-running requests when a TLS altname error is reported
- remove same-servername pending requests from the queue while rejecting them, preserving later pending requests for other server names
- add a regression test using a local HTTPS server and pipelined requests

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented - not applicable; this fixes internal error handling
- [x] Review ready
- [ ] In review
- [ ] Merge ready

## Tested

- `node --test test\node-test\client-tls.js`
- `NODE_OPTIONS=--expose-gc node --test test\tls-cert-leak.js`
- `node --test test\client-connect.js`
- `node --test --test-name-pattern servername test\node-test\client-dispatch.js`
- `eslint lib\dispatcher\client.js test\node-test\client-tls.js`
- `git diff --check`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin