### PR TITLE
fix(websocket): preserve handshake failure reason

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -304,6 +304,9 @@ function closeWebSocketConnection (object, code, reason, validate = false) {
  * @returns {void}
  */
 function failWebsocketConnection (handler, code, reason, cause) {
+  handler.failureReason = reason
+  handler.failureCause = cause
+
   // If _The WebSocket Connection is Established_ prior to the point where
   // the endpoint is required to _Fail the WebSocket Connection_, the
   // endpoint SHOULD send a Close frame with an appropriate status code

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -54,6 +54,8 @@ function getSocketAddress (socket) {
  * @property {Set<number>} closeState
  * @property {import('../fetch/index').Fetch} controller
  * @property {boolean} [wasEverConnected=false]
+ * @property {string|undefined} failureReason
+ * @property {unknown} failureCause
  */
 
 // https://websockets.spec.whatwg.org/#interface-definition
@@ -114,7 +116,9 @@ class WebSocket extends EventTarget {
     socket: null,
     closeState: new Set(),
     controller: null,
-    wasEverConnected: false
+    wasEverConnected: false,
+    failureReason: undefined,
+    failureCause: undefined
   }
 
   #url
@@ -603,8 +607,10 @@ class WebSocket extends EventTarget {
       // 1006.
       code = 1006
 
+      const failureReason = this.#handler.failureReason ?? reason
+
       fireEvent('error', this, (type, init) => new ErrorEvent(type, init), {
-        error: new TypeError(reason)
+        error: new TypeError(failureReason, { cause: this.#handler.failureCause })
       })
     }
 

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -33,7 +33,8 @@ test('WebSocket connecting to server that isn\'t a Websocket server', (t) => {
       ws.onmessage = ws.onopen = reject
 
       ws.addEventListener('error', ({ error }) => {
-        t.assert.ok(error)
+        t.assert.ok(error instanceof TypeError)
+        t.assert.strictEqual(error.message, 'Received network error or non-101 status code.')
         server.close()
         resolve()
       })


### PR DESCRIPTION
Fixes #4625. Also addresses the duplicate regression report in #4735.

When the opening handshake fails before the WebSocket is established, Undici already computes a specific failure reason, for example:

```text
Received network error or non-101 status code.
```

But that reason was not preserved for the later `ErrorEvent`, so users received a `TypeError` with an empty message. This stores the failure reason/cause on the handler before closing and uses it when creating the `ErrorEvent.error`, while keeping the error type as `TypeError`.

Local validation:

- Red repro before fix: connecting WebSocket to a plain HTTP 200 server emitted `TypeError` with an empty message.
- `node --test test\websocket\opening-handshake.js` -> 14 passed
- `npm run test:websocket` -> 130 passed
- `npm run lint -- --no-cache lib/web/websocket/connection.js lib/web/websocket/websocket.js test/websocket/opening-handshake.js`
- commit hook ran `npm run lint` successfully
- `git diff --check`

Authored with assistance from OpenAI Codex.