### PR TITLE
fix(readable): ignore late consume chunks

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -546,6 +546,10 @@ function consumeEnd (consume, encoding) {
  * @returns {void}
  */
 function consumePush (consume, chunk) {
+  if (consume.body === null) {
+    return
+  }
+
   consume.length += chunk.length
   consume.body.push(chunk)
 }

--- a/test/readable.js
+++ b/test/readable.js
@@ -124,6 +124,24 @@ describe('Readable', () => {
     t.deepStrictEqual(obj, { hello: 'world' })
   })
 
+  test('.json() ignores late chunks after close', async function (t) {
+    t = tspl(t, { plan: 2 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const jsonPromise = r.json()
+
+    await new Promise(resolve => queueMicrotask(resolve))
+
+    r.emit('close')
+    t.strictEqual(r.push(Buffer.from('late chunk')), true)
+
+    await t.rejects(jsonPromise, { name: 'AbortError' })
+  })
+
   test('.text()', async function (t) {
     t = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
Fixes nodejs/undici#5356.

When a body consume helper such as `.json()` is torn down by `close`, `consumeFinish()` clears `consume.body` but leaves the consume object on the stream. If a late chunk arrives afterward, `BodyReadable.push()` still calls `consumePush()`, which dereferences `consume.body.push(...)` and throws a synchronous `TypeError` in addition to the expected `AbortError` rejection.

This drops chunks that arrive after the consume buffer has been cleared. The existing `AbortError` rejection path is unchanged.

Verification:

- Reproduced the issue path before the fix with `BodyReadable`, `.json()`, `close`, and a late `push()` causing `TypeError: Cannot read properties of null (reading 'push')`.
- Direct smoke after the fix confirms late `push()` no longer throws and the `.json()` promise rejects with `AbortError`.
- `node --test test\readable.js`
- `npm run lint -- --no-cache lib/api/readable.js test/readable.js`
- `git diff --check`
- Commit hook ran repository eslint successfully.

AI-assisted contribution: implemented with OpenAI Codex and manually verified with the commands above.