### PR TITLE
fix(dns): skip requests without origin

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -535,6 +535,10 @@ module.exports = interceptorOpts => {
 
   return dispatch => {
     return function dnsInterceptor (origDispatchOpts, handler) {
+      if (origDispatchOpts.origin == null) {
+        return dispatch(origDispatchOpts, handler)
+      }
+
       const origin =
         origDispatchOpts.origin.constructor === URL
           ? origDispatchOpts.origin

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -11,7 +11,7 @@ const { once } = require('node:events')
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
-const { interceptors, Agent, request } = require('../..')
+const { interceptors, Agent, Client, Pool, request } = require('../..')
 const { dns } = interceptors
 
 // Helper to check if IPv6 is available for localhost
@@ -2179,4 +2179,76 @@ test('#3951 - Should handle lookup errors correctly', async t => {
     ...requestOptions,
     origin: 'http://localhost'
   }), new Error('lookup error'))
+})
+
+test('#4234 - Should pass Client requests without origin through', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const server = createServer({ joinDuplicateHeaders: true })
+  server.on('request', (req, res) => {
+    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  let lookupCount = 0
+  const client = new Client(`http://localhost:${server.address().port}`).compose(dns({
+    lookup: (_origin, _opts, cb) => {
+      lookupCount++
+      cb(new Error('lookup should not run'))
+    }
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+  t.equal(lookupCount, 0)
+})
+
+test('#4234 - Should pass Pool requests without origin through', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const server = createServer({ joinDuplicateHeaders: true })
+  server.on('request', (req, res) => {
+    t.equal(req.headers.host, `localhost:${server.address().port}`)
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  let lookupCount = 0
+  const pool = new Pool(`http://localhost:${server.address().port}`).compose(dns({
+    lookup: (_origin, _opts, cb) => {
+      lookupCount++
+      cb(new Error('lookup should not run'))
+    }
+  }))
+
+  after(async () => {
+    await pool.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await pool.request({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+  t.equal(lookupCount, 0)
 })


### PR DESCRIPTION
## This relates to

Fixes #4234.
Relates to #3957.

## Rationale

`Client` and `Pool` requests do not include `origin` in the per-request dispatch options. The DNS interceptor currently dereferences `origDispatchOpts.origin.constructor`, so composing `dns()` with a `Client` or `Pool` and calling `.request({ method, path })` throws before the underlying dispatcher can handle the request.

Prior discussion in #3957 asked to keep this narrow: avoid overriding `Client.request()` / `Pool.request()`, and make the DNS interceptor ignore requests that do not carry an origin. This patch follows that direction.

## Changes

- Return the original dispatch unchanged when DNS interceptor receives dispatch options without `origin`.
- Add regression coverage for `Client(...).compose(dns()).request({ method, path })`.
- Add the same coverage for `Pool(...).compose(dns()).request({ method, path })`.
- Assert the custom lookup is not called in the no-origin path.

## Checks

- `node --test --test-name-pattern "#4234" test\interceptors\dns.js`
- `node --test --test-name-pattern "#4444|#3951|#4234" test\interceptors\dns.js`
- `node --test --test-name-pattern "Should handle ENOTFOUND response error" test\interceptors\dns.js`
- direct smoke for explicit-origin DNS lookup path with a local HTTP server
- `npm run lint -- --no-cache lib/interceptor/dns.js test/interceptors/dns.js`
- `git diff --cached --check`

Note: a full local `node --test test\interceptors\dns.js` run timed out in this Windows environment before producing a result; the focused regressions and adjacent DNS paths above passed.

## Status

- [x] I have read and agreed to the Developer's Certificate of Origin
- [x] Tested
- [x] Review ready

AI-assisted contribution disclosure: implementation prepared with OpenAI Codex and reviewed/tested locally before submission.