### PR TITLE
docs: fix Cookie sameSite type - String should be Strict

### DIFF
--- a/docs/docs/api/Cookies.md
+++ b/docs/docs/api/Cookies.md
@@ -10,7 +10,7 @@
 * **path** `string` (optional)
 * **secure** `boolean` (optional)
 * **httpOnly** `boolean` (optional)
-* **sameSite** `'String'|'Lax'|'None'` (optional)
+* **sameSite** `'Strict'|'Lax'|'None'` (optional)
 * **unparsed** `string[]` (optional) Left over attributes that weren't parsed.
 
 ## `deleteCookie(headers, name[, attributes])`


### PR DESCRIPTION
Fixes issue #5380. The sameSite field was documented as "String" but the actual type is "Strict".