### PR TITLE
fix: decode split chunks after readable setEncoding

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -110,6 +110,9 @@ class BodyReadable extends Readable {
    */
   on (event, listener) {
     if (event === 'data' || event === 'readable') {
+      if (this._readableState.encoding && !this._readableState.decoder) {
+        super.setEncoding(this._readableState.encoding)
+      }
       this[kReading] = true
       this[kUsed] = true
     }
@@ -542,10 +545,14 @@ function consumeEnd (consume, encoding) {
 
 /**
  * @param {Consume} consume
- * @param {Buffer} chunk
+ * @param {Buffer|string} chunk
  * @returns {void}
  */
 function consumePush (consume, chunk) {
+  if (typeof chunk === 'string') {
+    chunk = Buffer.from(chunk, consume.stream._readableState.encoding || 'utf8')
+  }
+
   consume.length += chunk.length
   consume.body.push(chunk)
 }

--- a/test/readable.js
+++ b/test/readable.js
@@ -144,6 +144,122 @@ describe('Readable', () => {
     t.strictEqual(text, 'hello world')
   })
 
+  test('setEncoding buffers split multibyte utf8 characters', async function (t) {
+    t = tspl(t, { plan: 2 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const chunks = []
+
+    r.setEncoding('utf8')
+    r.on('data', chunk => {
+      chunks.push(chunk)
+    })
+    r.on('end', () => {
+      t.deepStrictEqual(chunks, ['傳'])
+      t.strictEqual(chunks.join(''), '傳')
+    })
+
+    r.push(Buffer.from([0xe5]))
+    r.push(Buffer.from([0x82, 0xb3]))
+    r.push(null)
+
+    await t.completed
+  })
+
+  test('setEncoding buffers already buffered split multibyte bytes', async function (t) {
+    t = tspl(t, { plan: 2 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const data = Buffer.from([0xe5, 0x82, 0xb3])
+    const chunks = []
+
+    r.push(data.subarray(0, 1))
+    r.setEncoding('utf8')
+    r.on('data', chunk => {
+      chunks.push(chunk)
+    })
+    r.on('end', () => {
+      t.deepStrictEqual(chunks, [data.toString('utf8')])
+      t.strictEqual(chunks.join(''), data.toString('utf8'))
+    })
+
+    r.push(data.subarray(1))
+    r.push(null)
+
+    await t.completed
+  })
+
+  test('.text() with setEncoding buffers split multibyte utf8 characters', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const data = Buffer.from([0xe5, 0x82, 0xb3])
+
+    r.setEncoding('utf8')
+    r.push(data.subarray(0, 1))
+    r.push(data.subarray(1))
+
+    process.nextTick(() => {
+      r.push(null)
+    })
+
+    t.strictEqual(await r.text(), data.toString('utf8'))
+  })
+
+  test('.text() with setEncoding preserves buffered split multibyte bytes', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const data = Buffer.from([0xe5, 0x82, 0xb3])
+
+    r.push(data.subarray(0, 1))
+    r.setEncoding('utf8')
+    r.push(data.subarray(1))
+
+    process.nextTick(() => {
+      r.push(null)
+    })
+
+    t.strictEqual(await r.text(), data.toString('utf8'))
+  })
+
+  test('.text() with setEncoding preserves hex output', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+    const data = Buffer.from([0xe5, 0x82, 0xb3])
+
+    r.setEncoding('hex')
+    r.push(data.subarray(0, 1))
+    r.push(data.subarray(1))
+
+    process.nextTick(() => {
+      r.push(null)
+    })
+
+    t.strictEqual(await r.text(), data.toString('hex'))
+  })
+
   test('ignore BOM', async function (t) {
     t = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
Fixes #5002.

## Summary
- route BodyReadable.setEncoding() through Readable.prototype.setEncoding() so Node installs its StringDecoder
- preserve the previous invalid-encoding no-op guard
- add a regression for a three-byte UTF-8 character split across response body chunks

## Tests
- NODE_PATH=C:\\hades\\oss\\undici\\node_modules node --test test\\readable.js
- NODE_PATH=C:\\hades\\oss\\undici\\node_modules C:\\hades\\oss\\undici\\node_modules\\.bin\\eslint.cmd --no-cache lib\\api\\readable.js test\\readable.js
- git diff --check