### PR TITLE
fix: keep idle validation on native timers

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -3,6 +3,7 @@
 /* global WebAssembly */
 
 const assert = require('node:assert')
+const { setTimeout: setTimeoutNative, clearTimeout: clearTimeoutNative } = require('node:timers')
 const util = require('../core/util.js')
 const { channels } = require('../core/diagnostics.js')
 const timers = require('../util/timers.js')
@@ -1027,7 +1028,7 @@ function onSocketClose () {
 
 function clearIdleSocketValidation (socket) {
   if (socket[kIdleSocketValidationTimeout]) {
-    clearTimeout(socket[kIdleSocketValidationTimeout])
+    clearTimeoutNative(socket[kIdleSocketValidationTimeout])
     socket[kIdleSocketValidationTimeout] = null
   }
 
@@ -1036,7 +1037,7 @@ function clearIdleSocketValidation (socket) {
 
 function scheduleIdleSocketValidation (client, socket) {
   socket[kIdleSocketValidation] = 1
-  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+  socket[kIdleSocketValidationTimeout] = setTimeoutNative(() => {
     socket[kIdleSocketValidationTimeout] = null
     socket[kIdleSocketValidation] = 2
 

--- a/test/response-queue-poisoning.js
+++ b/test/response-queue-poisoning.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
+const { once } = require('node:events')
 const { createServer } = require('node:http')
 const { after, test } = require('node:test')
 const { Client } = require('..')
@@ -37,6 +38,8 @@ test('should not reuse an idle socket with buffered unsolicited response bytes',
   const response1 = await client.request({ path: '/request1', method: 'GET' })
   assert.strictEqual(await readBody(response1.body), '/request1')
 
+  const disconnected = once(client, 'disconnect')
+
   evilServerSocket.write(
     'HTTP/1.1 200 OK\r\n' +
     'Poison-Free-Socket: true\r\n' +
@@ -45,6 +48,8 @@ test('should not reuse an idle socket with buffered unsolicited response bytes',
     'Content-Length: 0\r\n' +
     '\r\n'
   )
+
+  await disconnected
 
   const response2 = await client.request({ path: '/request2', method: 'GET' })
   assert.strictEqual(response2.headers['poison-free-socket'], undefined)


### PR DESCRIPTION
## Summary
- use native timers for idle socket validation so fake timers do not block background cache revalidation

## Tests
- node --test test/interceptors/cache.js
- node --test test/response-queue-poisoning.js test/issue-810.js
- npm run lint -- --quiet
