### PR TITLE
fix: retry requests when idle pooled socket closes

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -958,6 +958,47 @@ function onHttpSocketEnd () {
   util.destroy(this, new SocketError('other side closed', util.getSocketInfo(this)))
 }
 
+function canRetryRequestAfterSocketClose (request) {
+  const { body } = request
+
+  return request.idempotent === true && (
+    body == null ||
+    util.isBuffer(body) ||
+    util.isBlobLike(body)
+  )
+}
+
+function retryRequestsAfterSocketClose (client, err) {
+  const remainingPendingRequests = client[kQueue].slice(client[kPendingIdx])
+  const retriableRequests = []
+
+  for (let i = client[kRunningIdx]; i < client[kPendingIdx]; i++) {
+    const request = client[kQueue][i]
+
+    if (request == null) {
+      continue
+    }
+
+    if (!request.aborted && !request.completed && canRetryRequestAfterSocketClose(request)) {
+      retriableRequests.push(request)
+    } else {
+      util.errorRequest(client, request, err)
+    }
+  }
+
+  client[kQueue].length = client[kRunningIdx]
+  client[kQueue].push(...retriableRequests, ...remainingPendingRequests)
+  client[kPendingIdx] = client[kRunningIdx]
+}
+
+function failHeadOfPipeline (client, err) {
+  const request = client[kQueue][client[kRunningIdx]]
+  client[kQueue][client[kRunningIdx]++] = null
+
+  util.errorRequest(client, request, err)
+  client[kPendingIdx] = client[kRunningIdx]
+}
+
 function onHttpSocketClose () {
   const parser = this[kParser]
 
@@ -986,15 +1027,16 @@ function onHttpSocketClose () {
       const request = requests[i]
       util.errorRequest(client, request, err)
     }
+    client[kPendingIdx] = client[kRunningIdx]
   } else if (client[kRunning] > 0 && err.code !== 'UND_ERR_INFO') {
-    // Fail head of pipeline.
-    const request = client[kQueue][client[kRunningIdx]]
-    client[kQueue][client[kRunningIdx]++] = null
-
-    util.errorRequest(client, request, err)
+    if (parser?.statusCode) {
+      failHeadOfPipeline(client, err)
+    } else {
+      retryRequestsAfterSocketClose(client, err)
+    }
+  } else {
+    client[kPendingIdx] = client[kRunningIdx]
   }
-
-  client[kPendingIdx] = client[kRunningIdx]
 
   assert(client[kRunning] === 0)
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -170,6 +170,37 @@ function closeRequestStream (request, code = NGHTTP2_REFUSED_STREAM) {
   }
 }
 
+function canRetryRequestAfterSocketClose (request) {
+  return request.idempotent === true && canRetryRequestAfterGoAway(request)
+}
+
+function retryRequestsAfterSocketClose (client, err) {
+  const remainingPendingRequests = client[kQueue].slice(client[kPendingIdx])
+  const retriableRequests = []
+
+  for (let i = client[kRunningIdx]; i < client[kPendingIdx]; i++) {
+    const request = client[kQueue][i]
+
+    if (request == null) {
+      continue
+    }
+
+    const responseReceived = request[kRequestStream]?.[kRequestStreamState]?.responseReceived === true
+
+    closeRequestStream(request)
+
+    if (!responseReceived && !request.aborted && !request.completed && canRetryRequestAfterSocketClose(request)) {
+      retriableRequests.push(request)
+    } else {
+      util.errorRequest(client, request, err)
+    }
+  }
+
+  client[kQueue].length = client[kRunningIdx]
+  client[kQueue].push(...retriableRequests, ...remainingPendingRequests)
+  client[kPendingIdx] = client[kRunningIdx]
+}
+
 function connectH2 (client, socket) {
   client[kSocket] = socket
 
@@ -506,9 +537,13 @@ function onHttp2SocketClose () {
     client[kHTTP2Session] = null
   }
 
-  session.destroy(err)
+  if (client[kRunning] > 0 && err.code !== 'UND_ERR_INFO') {
+    retryRequestsAfterSocketClose(client, err)
+  } else {
+    client[kPendingIdx] = client[kRunningIdx]
+  }
 
-  client[kPendingIdx] = client[kRunningIdx]
+  session.destroy(err)
 
   assert(client[kRunning] === 0)
 
@@ -526,7 +561,15 @@ function onHttp2SocketError (err) {
 }
 
 function onHttp2SocketEnd () {
-  util.destroy(this, new SocketError('other side closed', util.getSocketInfo(this)))
+  const err = new SocketError('other side closed', util.getSocketInfo(this))
+  const session = this[kHTTP2Session]
+  const client = session?.[kClient]
+
+  if (session?.[kReceivedGoAway] !== true && client?.[kRunning] > 0) {
+    retryRequestsAfterSocketClose(client, err)
+  }
+
+  util.destroy(this, err)
 }
 
 function onSocketClose () {

--- a/test/issue-3492.js
+++ b/test/issue-3492.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Pool, request } = require('..')
+
+function immediateRequest (url, dispatcher) {
+  return new Promise((resolve, reject) => {
+    setImmediate(() => {
+      request(url, { dispatcher }).then(resolve, reject)
+    })
+  })
+}
+
+test('issue #3492 - retries idempotent HTTP/1.1 request when idle socket closes before reuse', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createServer((req, res) => {
+    res.end('ok')
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const url = `http://localhost:${server.address().port}`
+  const pool = new Pool(url)
+
+  try {
+    const first = await request(url, { dispatcher: pool })
+    await first.body.text()
+
+    server.closeIdleConnections()
+
+    const second = await immediateRequest(url, pool)
+    t.strictEqual(second.statusCode, 200)
+    t.strictEqual(await second.body.text(), 'ok')
+  } finally {
+    await pool.close()
+    await new Promise(resolve => server.close(resolve))
+  }
+})
+
+test('issue #3492 - retries idempotent HTTP/2 request when idle socket closes before reuse', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const sockets = new Set()
+  const server = createSecureServer({
+    ...await pem.generate({ opts: { keySize: 2048 } }),
+    allowHTTP1: false
+  })
+
+  server.on('connection', socket => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+  })
+
+  server.on('stream', stream => {
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const url = `https://localhost:${server.address().port}`
+  const pool = new Pool(url, {
+    allowH2: true,
+    connect: {
+      rejectUnauthorized: false
+    }
+  })
+
+  try {
+    const first = await request(url, { dispatcher: pool })
+    await first.body.text()
+
+    t.ok(sockets.size > 0)
+    for (const socket of sockets) {
+      socket.end()
+    }
+
+    const second = await immediateRequest(url, pool)
+    t.strictEqual(second.statusCode, 200)
+    t.strictEqual(await second.body.text(), 'ok')
+  } finally {
+    await pool.close()
+    await new Promise(resolve => server.close(resolve))
+  }
+})


### PR DESCRIPTION
## Summary

- retry idempotent HTTP/1.1 requests when an idle pooled socket closes before reuse
- retry idempotent HTTP/2 requests on abrupt idle socket close while preserving GOAWAY handling
- add separate regression coverage for the HTTP/1.1 and HTTP/2 races

Fixes: https://github.com/nodejs/undici/issues/3492

## Testing

- `./node_modules/.bin/borp --timeout 180000 --expose-gc -p "test/issue-3492.js"`
- `./node_modules/.bin/borp --timeout 300000 --expose-gc -p "test/http2-goaway.js"`
- `./node_modules/.bin/borp --timeout 180000 --expose-gc -p "test/http2-connection.js"`
- `npm run lint -- lib/dispatcher/client-h1.js lib/dispatcher/client-h2.js test/issue-3492.js`
