### PR TITLE
fix(h2): do not rewind kPendingIdx past in-flight requests

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -744,7 +744,7 @@ function writeH2 (client, request) {
     requestFinalized = true
     client[kQueue][client[kRunningIdx]++] = null
 
-    if (resetPendingIdx) {
+    if (resetPendingIdx && client[kPendingIdx] < client[kRunningIdx]) {
       client[kPendingIdx] = client[kRunningIdx]
     }
 

--- a/test/http2-destroy-after-failed-stream.js
+++ b/test/http2-destroy-after-failed-stream.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { createServer } = require('node:http2')
+const { once } = require('node:events')
+const { setTimeout: sleep } = require('node:timers/promises')
+const { Agent } = require('..')
+
+test('closing dispatcher after one multiplexed stream failed pre-response does not crash', async (t) => {
+  const server = createServer()
+  server.on('stream', async (stream, headers) => {
+    if (headers[':path'] === '/slow') {
+      await sleep(50)
+      stream.respond({ ':status': 200 })
+      stream.end('slow')
+    } else {
+      stream.close()
+    }
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  const origin = `http://localhost:${server.address().port}`
+  const dispatcher = new Agent({ connections: 1, useH2c: true })
+
+  const slow = dispatcher
+    .request({ origin, path: '/slow', method: 'GET' })
+    .then((res) => res.body.text())
+
+  await assert.rejects(
+    dispatcher.request({ origin, path: '/bad', method: 'GET' }),
+    { name: 'InformationalError' }
+  )
+
+  assert.strictEqual(await slow, 'slow')
+
+  await dispatcher.close()
+})


### PR DESCRIPTION
## This relates to...

Fixes #5404

## Rationale

`Client[kDestroy]` splices the queue from `kPendingIdx` and calls `util.errorRequest` on each entry. When `kPendingIdx` has been rewound past a nulled slot, this crashes the whole process with an `error` event on `Client`:

```
TypeError: Cannot read properties of null (reading 'onResponseError')
    at Object.errorRequest (lib/core/util.js:843:13)
    at [destroy] (lib/dispatcher/client.js:394)
```

Root cause: when two requests are multiplexed on one HTTP/2 session and one stream is closed by the server before response headers, `onEnd` calls `state.abort(err, true)` → `finalizeRequest(true)`, which unconditionally reset `kPendingIdx` back to `kRunningIdx` while the other request was still in flight. Once the surviving request finalized, `kRunningIdx` advanced past `kPendingIdx`, breaking the `kPendingIdx >= kRunningIdx` invariant (`kRunning` becomes -1, and a nulled slot is reported as pending).

The reset was introduced in #5090 to restore `kPendingIdx` after the GOAWAY handler rewinds it — i.e. it is only meaningful when `kPendingIdx` has fallen *behind* `kRunningIdx`. Guarding it with that condition fixes the crash and is a no-op in every case where the invariant already holds. This is a regression in 8.4.x; earlier 8.x releases did not crash, matching the report.

## Changes

- `lib/dispatcher/client-h2.js`: only reset `kPendingIdx` when `kPendingIdx < kRunningIdx`.
- `test/http2-destroy-after-failed-stream.js`: regression test using only the public API (one connection, two multiplexed requests, one stream closed pre-response, then `dispatcher.close()`). On unpatched `main` it crashes with the TypeError above and times out; with the fix it passes in ~150ms.

### Features

N/A

### Bug Fixes

- Fix process crash (`TypeError: Cannot read properties of null (reading 'onResponseError')`) on `close()`/`destroy()` after a multiplexed HTTP/2 stream failed before response headers (#5404).

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

`borp test/http2-destroy-after-failed-stream.js` → 1 pass; `borp -p "test/http2-*.js"` → 67 pass, 0 fail (includes the GOAWAY tests from #5090); `eslint` clean.

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
