### PR TITLE
fix: keep idle validation on global timers

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -3,7 +3,6 @@
 /* global WebAssembly */
 
 const assert = require('node:assert')
-const { setTimeout: setTimeoutNative, clearTimeout: clearTimeoutNative } = require('node:timers')
 const util = require('../core/util.js')
 const { channels } = require('../core/diagnostics.js')
 const timers = require('../util/timers.js')
@@ -1012,7 +1011,7 @@ function onSocketClose () {
 
 function clearIdleSocketValidation (socket) {
   if (socket[kIdleSocketValidationTimeout]) {
-    clearTimeoutNative(socket[kIdleSocketValidationTimeout])
+    clearTimeout(socket[kIdleSocketValidationTimeout])
     socket[kIdleSocketValidationTimeout] = null
   }
 
@@ -1021,7 +1020,7 @@ function clearIdleSocketValidation (socket) {
 
 function scheduleIdleSocketValidation (client, socket) {
   socket[kIdleSocketValidation] = 1
-  socket[kIdleSocketValidationTimeout] = setTimeoutNative(() => {
+  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
     socket[kIdleSocketValidationTimeout] = null
     socket[kIdleSocketValidation] = 2
 

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -171,7 +171,7 @@ describe('Cache Interceptor', () => {
 
   test('expires caching', async () => {
     const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
+      toFake: ['Date']
     })
 
     let requestsToOrigin = 0
@@ -248,7 +248,7 @@ describe('Cache Interceptor', () => {
 
   test('expires caching with Etag', async () => {
     const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
+      toFake: ['Date']
     })
 
     let requestsToOrigin = 0
@@ -326,7 +326,7 @@ describe('Cache Interceptor', () => {
 
   test('max-age caching', async () => {
     const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
+      toFake: ['Date']
     })
 
     let requestsToOrigin = 0
@@ -390,7 +390,7 @@ describe('Cache Interceptor', () => {
 
   test('vary headers are present in revalidation request', async () => {
     const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
+      toFake: ['Date']
     })
 
     let requestsToOrigin = 0
@@ -669,7 +669,7 @@ describe('Cache Interceptor', () => {
 
   test('stale-if-error (response)', async () => {
     const clock = FakeTimers.install({
-      shouldClearNativeTimers: true
+      toFake: ['Date']
     })
 
     let requestsToOrigin = 0
@@ -751,7 +751,7 @@ describe('Cache Interceptor', () => {
   describe('Client-side directives', () => {
     test('max-age', async () => {
       const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
+        toFake: ['Date']
       })
 
       let requestsToOrigin = 0
@@ -812,7 +812,7 @@ describe('Cache Interceptor', () => {
 
     test('max-stale', async () => {
       const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
+        toFake: ['Date']
       })
 
       let requestsToOrigin = 0
@@ -885,7 +885,7 @@ describe('Cache Interceptor', () => {
 
     test('min-fresh', async () => {
       const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
+        toFake: ['Date']
       })
 
       let requestsToOrigin = 0
@@ -1103,7 +1103,7 @@ describe('Cache Interceptor', () => {
 
     test('stale-if-error', async () => {
       const clock = FakeTimers.install({
-        shouldClearNativeTimers: true
+        toFake: ['Date']
       })
 
       let requestsToOrigin = 0
@@ -1988,7 +1988,7 @@ describe('Cache Interceptor', () => {
 
   describe('determineDeleteAt', () => {
     test('max-age response has deleteAt proportional to freshness lifetime, not 1 year', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ now: 1000, toFake: ['Date'] })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()
@@ -2024,7 +2024,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('immutable response has deleteAt of ~1 year', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ now: 1000, toFake: ['Date'] })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()
@@ -2058,7 +2058,7 @@ describe('Cache Interceptor', () => {
     })
 
     test('stale-while-revalidate extends deleteAt beyond staleAt', async () => {
-      const clock = FakeTimers.install({ now: 1000 })
+      const clock = FakeTimers.install({ now: 1000, toFake: ['Date'] })
       after(() => clock.uninstall())
 
       const store = new MemoryCacheStore()


### PR DESCRIPTION
## Summary
- backport #5407 to v7.x
- restore idle socket validation to use the normal global timer APIs instead of bypassing fake timers through `node:timers`
- update cache interceptor tests to fake only `Date`, which is the only clock behavior they need to control

## Tests
- `node --test test/interceptors/cache.js`
- `node --test test/response-queue-poisoning.js test/issue-810.js`
- `npm run lint -- --quiet`
