### PR TITLE
test: cover connect lookup option

### DIFF
--- a/docs/docs/api/Client.md
+++ b/docs/docs/api/Client.md
@@ -106,6 +106,24 @@ const client = new Client('http://localhost:3000', {
 })
 ```
 
+### Example - Custom DNS lookup
+
+Pass a `lookup` function in the object form when you need to control name resolution while still using Undici's built-in connector.
+
+```js
+'use strict'
+import { Client } from 'undici'
+import dns from 'node:dns'
+
+const client = new Client('https://example.com', {
+  connect: {
+    lookup (hostname, options, callback) {
+      dns.lookup(hostname, { ...options, family: 4 }, callback)
+    }
+  }
+})
+```
+
 ### Example - Custom connector (function form)
 
 Pass a function for full control over socket creation. This allows you to perform additional checks on the socket, use a proxy, or implement custom connection logic.

--- a/test/client.js
+++ b/test/client.js
@@ -115,6 +115,50 @@ test('passes socketPath to custom connect function', async (t) => {
   await t.completed
 })
 
+test('passes lookup from connect options to built connector', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.strictEqual(req.headers.host, `undici.test:${server.address().port}`)
+    res.end('lookup ok')
+  })
+  after(() => server.close())
+
+  server.listen(0, '127.0.0.1', () => {
+    const client = new Client(`http://undici.test:${server.address().port}`, {
+      connect: {
+        lookup (hostname, options, callback) {
+          t.strictEqual(hostname, 'undici.test')
+          if (options.all === true) {
+            callback(null, [{ address: '127.0.0.1', family: 4 }])
+          } else {
+            callback(null, '127.0.0.1', 4)
+          }
+        }
+      }
+    })
+    after(() => client.close())
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, body }) => {
+      t.ifError(err)
+      t.strictEqual(statusCode, 200)
+
+      const chunks = []
+      body.on('data', (chunk) => {
+        chunks.push(chunk)
+      })
+      body.on('end', () => {
+        t.strictEqual(Buffer.concat(chunks).toString(), 'lookup ok')
+      })
+    })
+  })
+
+  await t.completed
+})
+
 test('basic get with custom request.reset=true', async (t) => {
   t = tspl(t, { plan: 26 })
 


### PR DESCRIPTION
## Summary
- add direct regression coverage that object-form `connect.lookup` is forwarded to the built connector
- document the object-form `connect.lookup` pattern in `Client` docs

Refs: #886

## Verification
- `node --expose-gc --test --test-name-pattern "passes lookup from connect options" test/client.js`
- `./node_modules/.bin/borp --timeout 180000 --expose-gc -p test/client.js`
- `npm run lint -- test/client.js`
- `git diff --check`
