### PR TITLE
test: fail on unexpected reconnect disconnect

### DIFF
--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -48,6 +48,8 @@ test('multiple reconnect', async (t) => {
   client.on('disconnect', () => {
     if (++n === 1) {
       t.ok(true, 'pass')
+    } else if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
     }
     process.nextTick(() => {
       clock.tick(1000)


### PR DESCRIPTION
## Summary
- make the reconnect regression fail if the client emits an extra unexpected `disconnect`
- keep the existing expected first disconnect assertion intact

Refs: #251

## Verification
- `./node_modules/.bin/borp --timeout 180000 --expose-gc -p test/client-reconnect.js`
- `npm run lint -- test/client-reconnect.js`
- `git diff --check`
