### PR TITLE
fix: preserve utf8 decoding across response chunks

### DIFF
--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1494,6 +1494,39 @@ test('request multibyte text with setEncoding', async (t) => {
   await t.completed
 })
 
+test('request multibyte text with async iteration and setEncoding', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const data = Buffer.from('abc傳def')
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.write(data.subarray(0, 5))
+    setTimeout(() => {
+      res.end(data.subarray(5))
+    }, 100)
+  })
+  after(server.close.bind(server))
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(client.destroy.bind(client))
+
+    const { body } = await client.request({
+      path: '/',
+      method: 'GET'
+    })
+    body.setEncoding('utf8')
+
+    let text = ''
+    for await (const chunk of body) {
+      text += chunk
+    }
+
+    t.deepStrictEqual(text, data.toString('utf8'))
+  })
+
+  await t.completed
+})
+
 test('request multibyte text with setEncoding', async (t) => {
   t = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
## This relates to...

Fixes #5002

## Rationale

BodyReadable#setEncoding() only stored the encoding on the readable state. That made streamed consumers decode each buffered chunk independently, so an incomplete UTF-8 sequence at a response chunk boundary produced replacement characters.

The internal body consumers still need raw Buffer chunks so body.text() and body.json() can aggregate and decode the full payload.

## Changes

### Features

N/A

### Bug Fixes

- Keep raw Buffer chunks for internal body consumption.
- Use a StringDecoder when BodyReadable is consumed through the Readable API after setEncoding().
- Add a regression test for async iteration over a response body where a 3-byte UTF-8 character spans response chunks.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the Developer's Certificate of Origin
- [x] Tested
- [ ] Benchmarked (optional)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Verification:

- node --test --test-name-pattern "request multibyte (json|text) with setEncoding|async iteration and setEncoding" test/client-request.js
- npx borp --timeout 180000 -p test/client-request.js
- npm run lint
- npm run test:typescript
- git diff --check

Note: npm ci --ignore-scripts was used locally because npm install exited with "Exit handler never called!" after dependency extraction. The test/lint commands above were run against the installed dependency tree. Local Node.js is v22.17.0 while the package currently requires >=22.19.0.
