### PR TITLE
perf(fetch): lazily initialize Request/Response internals

### DIFF
--- a/index-fetch.js
+++ b/index-fetch.js
@@ -43,9 +43,20 @@ module.exports.fetch = function fetch (init, options = undefined) {
   })
 }
 module.exports.FormData = require('./lib/web/fetch/formdata').FormData
-module.exports.Headers = require('./lib/web/fetch/headers').Headers
-module.exports.Response = require('./lib/web/fetch/response').Response
-module.exports.Request = require('./lib/web/fetch/request').Request
+const { Headers, HeadersList } = require('./lib/web/fetch/headers')
+module.exports.Headers = Headers
+module.exports.HeadersList = HeadersList
+const { Response, getResponseState } = require('./lib/web/fetch/response')
+module.exports.Response = Response
+module.exports.getResponseState = getResponseState
+const {
+  Request,
+  makeRequest,
+  fromInnerRequest
+} = require('./lib/web/fetch/request')
+module.exports.Request = Request
+module.exports.makeRequest = makeRequest
+module.exports.fromInnerRequest = fromInnerRequest
 
 const { CloseEvent, ErrorEvent, MessageEvent, createFastMessageEvent } = require('./lib/web/websocket/events')
 module.exports.WebSocket = require('./lib/web/websocket/websocket').WebSocket

--- a/lib/web/cache/cache.js
+++ b/lib/web/cache/cache.js
@@ -4,9 +4,10 @@ const assert = require('node:assert')
 
 const { kConstruct } = require('../../core/symbols')
 const { urlEquals, getFieldValues } = require('./util')
-const { kEnumerableProperty, isDisturbed } = require('../../core/util')
+const { kEnumerableProperty } = require('../../core/util')
 const { webidl } = require('../webidl')
 const { cloneResponse, fromInnerResponse, getResponseState } = require('../fetch/response')
+const { isBodyStreamDisturbedOrLocked } = require('../fetch/body')
 const { Request, fromInnerRequest, getRequestState } = require('../fetch/request')
 const { fetching } = require('../fetch/index')
 const { urlIsHttpHttpsScheme, readAllBytes } = require('../fetch/util')
@@ -312,11 +313,9 @@ class Cache {
     }
 
     // 8.
-    // A lazily-materialized response body (e.g. `new Response('...')`) has a
-    // null stream until it is first observed; an unobserved body cannot be
-    // disturbed or locked, so treat a null stream as neither. The subsequent
-    // clone (step 9) materializes the stream before it is read in step 11.
-    if (innerResponse.body && innerResponse.body.stream != null && (isDisturbed(innerResponse.body.stream) || innerResponse.body.stream.locked)) {
+    // The subsequent clone (step 9) materializes a lazy body's stream before it
+    // is read in step 11, so an as-yet-unobserved (null) stream is fine here.
+    if (isBodyStreamDisturbedOrLocked(innerResponse.body)) {
       throw webidl.errors.exception({
         header: prefix,
         message: 'Response body is locked or disturbed'

--- a/lib/web/cache/cache.js
+++ b/lib/web/cache/cache.js
@@ -312,7 +312,11 @@ class Cache {
     }
 
     // 8.
-    if (innerResponse.body && (isDisturbed(innerResponse.body.stream) || innerResponse.body.stream.locked)) {
+    // A lazily-materialized response body (e.g. `new Response('...')`) has a
+    // null stream until it is first observed; an unobserved body cannot be
+    // disturbed or locked, so treat a null stream as neither. The subsequent
+    // clone (step 9) materializes the stream before it is read in step 11.
+    if (innerResponse.body && innerResponse.body.stream != null && (isDisturbed(innerResponse.body.stream) || innerResponse.body.stream.locked)) {
       throw webidl.errors.exception({
         header: prefix,
         message: 'Response body is locked or disturbed'

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -37,21 +37,21 @@ const streamRegistry = new FinalizationRegistry((weakRef) => {
  *
  * @see https://fetch.spec.whatwg.org/#concept-bodyinit-extract
  */
-function extractBody (object, keepalive = false) {
+// When `lazyByteStream` is true, byte-sequence sources (string / Uint8Array)
+// are wrapped in a lazy body whose ReadableStream is only built when the body
+// is read or its `body` getter is observed — see `makeLazyByteStreamBody`.
+// This avoids constructing a ReadableStream (and its controller) for the
+// common case where a Request/Response body is consumed directly (e.g. via
+// `.text()`) and the stream is never touched.
+function extractBody (object, keepalive = false, lazyByteStream = false) {
   // 1. Let stream be null.
   let stream = null
   let controller = null
 
-  // 2. If object is a ReadableStream object, then set stream to object.
-  if (webidl.is.ReadableStream(object)) {
-    stream = object
-  } else if (webidl.is.Blob(object)) {
-    // 3. Otherwise, if object is a Blob object, set stream to the
-    //    result of running object’s get stream.
-    stream = object.stream()
-  } else {
-    // 4. Otherwise, set stream to a new ReadableStream object, and set
-    //    up stream with byte reading support.
+  // Step 4 (otherwise: set up a new byte ReadableStream) is deferred behind
+  // this helper so the stream is only created once we know it's needed. For a
+  // lazy byte stream we skip it entirely and hand the source to the body.
+  const makeStream = () => {
     stream = new ReadableStream({
       pull () {},
       start (c) {
@@ -60,10 +60,22 @@ function extractBody (object, keepalive = false) {
       cancel () {},
       type: 'bytes'
     })
+    return stream
+  }
+
+  // 2. If object is a ReadableStream object, then set stream to object.
+  if (webidl.is.ReadableStream(object)) {
+    stream = object
+  } else if (webidl.is.Blob(object)) {
+    // 3. Otherwise, if object is a Blob object, set stream to the
+    //    result of running object’s get stream.
+    stream = object.stream()
   }
 
   // 5. Assert: stream is a ReadableStream object.
-  assert(webidl.is.ReadableStream(stream))
+  // `stream` may legitimately be null here: for non-stream/non-Blob sources we
+  // no longer eagerly create it (see makeStream above), so only assert when set.
+  assert(stream === null || webidl.is.ReadableStream(stream))
 
   // 6. Let action be null.
   let action = null
@@ -212,27 +224,41 @@ function extractBody (object, keepalive = false) {
 
   // 12. If action is non-null, then run these steps in parallel:
   if (action != null) {
-    ;(async () => {
-      // 1. Run action.
-      const result = action()
+    // Fast path: for a fully-buffered byte source we already hold every byte,
+    // so there is no work to run "in parallel". Defer both the stream and the
+    // enqueue/close dance to first read by returning a lazy body instead.
+    if (lazyByteStream && (typeof source === 'string' || isUint8Array(source))) {
+      return [makeLazyByteStreamBody(source), type]
+    }
 
-      // 2. Whenever one or more bytes are available and stream is not errored,
-      //    enqueue the result of creating a Uint8Array from the available bytes into stream.
-      const iterator = result?.[Symbol.asyncIterator]?.()
-      if (iterator) {
-        for await (const bytes of iterator) {
-          if (isErrored(stream)) break
-          if (bytes.length) {
-            controller.enqueue(new Uint8Array(bytes))
+    // Otherwise build the stream now and pump the action's bytes into it.
+    const runAction = () => {
+      ;(async () => {
+        // 1. Run action.
+        const result = action()
+
+        // 2. Whenever one or more bytes are available and stream is not
+        //    errored, enqueue the result of creating a Uint8Array from the
+        //    available bytes into stream.
+        const iterator = result?.[Symbol.asyncIterator]?.()
+        if (iterator) {
+          for await (const bytes of iterator) {
+            if (isErrored(stream)) break
+            if (bytes.length) {
+              controller.enqueue(new Uint8Array(bytes))
+            }
           }
+        } else if (result?.length && !isErrored(stream)) {
+          controller.enqueue(typeof result === 'string' ? textEncoder.encode(result) : new Uint8Array(result))
         }
-      } else if (result?.length && !isErrored(stream)) {
-        controller.enqueue(typeof result === 'string' ? textEncoder.encode(result) : new Uint8Array(result))
-      }
 
-      // 3. When running action is done, close stream.
-      queueMicrotask(() => readableStreamClose(controller))
-    })()
+        // 3. When running action is done, close stream.
+        queueMicrotask(() => readableStreamClose(controller))
+      })()
+    }
+
+    makeStream()
+    runAction()
   }
 
   // 13. Let body be a body whose stream is stream, source is source,
@@ -274,13 +300,60 @@ function safelyExtractBody (object, keepalive = false) {
   return extractBody(object, keepalive)
 }
 
+// Construct a byte-sequence body without creating its ReadableStream up front.
+// The source bytes are fully buffered, so the spec's stream is purely an
+// observation surface here: consumers that read the body directly (`.text()`,
+// `.arrayBuffer()`, …) read `source` and never touch the stream. The stream is
+// only built — and the bytes enqueued and closed — the first time `getStream`
+// is called, i.e. when `.body` is actually observed.
+function makeLazyByteStreamBody (source) {
+  let stream = null
+  let controller = null
+  const length = typeof source === 'string' ? Buffer.byteLength(source) : source.length
+
+  const getStream = () => {
+    if (stream !== null) {
+      return stream
+    }
+
+    stream = new ReadableStream({
+      pull () {},
+      start (c) {
+        controller = c
+      },
+      cancel () {},
+      type: 'bytes'
+    })
+
+    // Enqueue the whole buffered source and close on a microtask, mirroring the
+    // eager byte-stream path in extractBody so observable behaviour is identical.
+    if (source.length) {
+      controller.enqueue(typeof source === 'string' ? textEncoder.encode(source) : new Uint8Array(source))
+    }
+    queueMicrotask(() => readableStreamClose(controller))
+    return stream
+  }
+
+  return {
+    // `stream` starts null and is filled in lazily by getStream(); callers must
+    // go through getStream() (or the `body` getters) rather than reading it.
+    stream: null,
+    getStream,
+    source,
+    length
+  }
+}
+
 function cloneBody (body) {
   // To clone a body body, run these steps:
 
   // https://fetch.spec.whatwg.org/#concept-body-clone
 
   // 1. Let « out1, out2 » be the result of teeing body’s stream.
-  const { 0: out1, 1: out2 } = ReadableStreamTee?.(body.stream, true) ?? body.stream.tee()
+  // Materialize a lazy body's stream before teeing it, then use the fast
+  // ReadableStreamTee path when available.
+  const stream = body.stream ?? (body.stream = body.getStream())
+  const { 0: out1, 1: out2 } = ReadableStreamTee?.(stream, true) ?? stream.tee()
 
   // 2. Set body’s stream to out1.
   body.stream = out1
@@ -291,6 +364,14 @@ function cloneBody (body) {
     length: body.length,
     source: body.source
   }
+}
+
+function bytesToArrayBuffer (bytes) {
+  return new Uint8Array(bytes).buffer
+}
+
+function bytesToUint8Array (bytes) {
+  return new Uint8Array(bytes)
 }
 
 function bodyMixinMethods (instance, getInternalState) {
@@ -321,9 +402,7 @@ function bodyMixinMethods (instance, getInternalState) {
       // of running consume body with this and the following step
       // given a byte sequence bytes: return a new ArrayBuffer
       // whose contents are bytes.
-      return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes).buffer
-      }, instance, getInternalState)
+      return consumeBody(this, bytesToArrayBuffer, instance, getInternalState)
     },
 
     text () {
@@ -390,9 +469,7 @@ function bodyMixinMethods (instance, getInternalState) {
       // The bytes() method steps are to return the result of running consume body
       // with this and the following step given a byte sequence bytes: return the
       // result of creating a Uint8Array from bytes in this’s relevant realm.
-      return consumeBody(this, (bytes) => {
-        return new Uint8Array(bytes)
-      }, instance, getInternalState)
+      return consumeBody(this, bytesToUint8Array, instance, getInternalState)
     },
 
     textStream () {
@@ -468,6 +545,30 @@ function consumeBody (object, convertBytesToJSValue, instance, getInternalState)
     return Promise.reject(new TypeError('Body is unusable: Body has already been read'))
   }
 
+  // Fast paths for bodies that can convert their buffered bytes directly,
+  // skipping the ReadableStream.
+  // These `consume*` hooks are optional extension points an embedder (e.g.
+  // Node.js) can put on a body whose stream has not been materialized; undici's
+  // own lazy bodies don't define them, so these branches are simply skipped
+  // here. We compare `convertBytesToJSValue` by reference against the hoisted
+  // converters to pick the matching hook, and mark the body consumed so a
+  // second read correctly throws.
+  if (object.body != null &&
+      object.body.stream == null &&
+      object.body.consumeArrayBuffer != null &&
+      convertBytesToJSValue === bytesToArrayBuffer) {
+    object.body.consumed = true
+    return object.body.consumeArrayBuffer()
+  }
+
+  if (object.body != null &&
+      object.body.stream == null &&
+      object.body.consumeUint8Array != null &&
+      convertBytesToJSValue === bytesToUint8Array) {
+    object.body.consumed = true
+    return object.body.consumeUint8Array()
+  }
+
   // 2. Let promise be a new promise.
   const promise = Promise.withResolvers()
 
@@ -493,6 +594,20 @@ function consumeBody (object, convertBytesToJSValue, instance, getInternalState)
     return promise.promise
   }
 
+  // Generic direct-consume hook (any convertBytesToJSValue), same idea as the
+  // typed fast paths above: let an embedder yield the buffered bytes without a
+  // stream. successSteps still applies the requested conversion to them.
+  if (object.body.stream == null && object.body.consumeBytes != null) {
+    object.body.consumed = true
+    object.body.consumeBytes().then(successSteps, errorSteps)
+    return promise.promise
+  }
+
+  // No fast path applied: materialize the lazy body's stream so it can be read.
+  if (object.body.stream == null) {
+    object.body.stream = object.body.getStream()
+  }
+
   // 6. Otherwise, fully read object’s body given successSteps,
   //    errorSteps, and object’s relevant global object.
   fullyReadBody(object.body, successSteps, errorSteps)
@@ -511,7 +626,12 @@ function bodyUnusable (object) {
   // An object including the Body interface mixin is
   // said to be unusable if its body is non-null and
   // its body’s stream is disturbed or locked.
-  return body != null && (body.stream.locked || util.isDisturbed(body.stream))
+  // A lazy body that was consumed via a fast path (above) has its stream null
+  // but is still unusable, so check the `consumed` flag first; only inspect the
+  // stream once it has actually been materialized.
+  return body != null && (body.consumed === true ||
+    (body.stream != null &&
+      (body.stream.locked || util.isDisturbed(body.stream))))
 }
 
 /**
@@ -522,8 +642,12 @@ function bodyMimeType (requestOrResponse) {
   // 1. Let headers be null.
   // 2. If requestOrResponse is a Request object, then set headers to requestOrResponse’s request’s header list.
   // 3. Otherwise, set headers to requestOrResponse’s response’s header list.
+  // The header list may be lazily initialized (null until first needed, see
+  // request.js); materialize and cache it on demand before extracting from it.
   /** @type {import('./headers').HeadersList} */
-  const headers = requestOrResponse.headersList
+  const headers = requestOrResponse.headersList === null
+    ? (requestOrResponse.headersList = requestOrResponse.getHeadersList())
+    : requestOrResponse.headersList
 
   // 4. Let mimeType be the result of extracting a MIME type from headers.
   const mimeType = extractMimeType(headers)
@@ -540,6 +664,7 @@ function bodyMimeType (requestOrResponse) {
 module.exports = {
   extractBody,
   safelyExtractBody,
+  makeLazyByteStreamBody,
   cloneBody,
   mixinBody,
   streamRegistry,

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -617,6 +617,21 @@ function consumeBody (object, convertBytesToJSValue, instance, getInternalState)
 }
 
 /**
+ * Whether a body's stream is disturbed or locked.
+ *
+ * A lazily-materialized body (e.g. `new Response('...')`) has a null stream
+ * until it is first observed; an unobserved stream can be neither disturbed nor
+ * locked, so a null stream counts as neither.
+ *
+ * @param {{ stream: ReadableStream | null } | null | undefined} body a body, or null
+ * @returns {boolean}
+ */
+function isBodyStreamDisturbedOrLocked (body) {
+  return body != null && body.stream != null &&
+    (util.isDisturbed(body.stream) || body.stream.locked)
+}
+
+/**
  * @see https://fetch.spec.whatwg.org/#body-unusable
  * @param {any} object internal state
  */
@@ -665,6 +680,7 @@ module.exports = {
   extractBody,
   safelyExtractBody,
   makeLazyByteStreamBody,
+  isBodyStreamDisturbedOrLocked,
   cloneBody,
   mixinBody,
   streamRegistry,

--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -95,6 +95,13 @@ class Request {
   /** @type {Headers} */
   #headers
 
+  // The headers guard is tracked separately so it survives when #headers is
+  // lazily constructed: a Request built from an inner request defers creating
+  // its Headers wrapper, but the guard must still be known to build it later
+  // (and is the source of truth read by getHeadersGuard on the wrapper).
+  /** @type {'request' | 'immutable' | 'request-no-cors' | 'response' | 'none'} */
+  #headersGuard = 'request'
+
   #state
 
   /**
@@ -204,7 +211,7 @@ class Request {
       method: request.method,
       // header list A copy of request’s header list.
       // undici implementation note: headersList is cloned in makeRequest
-      headersList: request.headersList,
+      headersList: getRequestHeadersList(request),
       // unsafe-request flag Set.
       unsafeRequest: request.unsafeRequest,
       // client This’s relevant settings object.
@@ -238,7 +245,8 @@ class Request {
       // history-navigation flag request’s history-navigation flag.
       historyNavigation: request.historyNavigation,
       // URL list A clone of request’s URL list.
-      urlList: [...request.urlList]
+      urlList: [...getRequestURLList(request)],
+      urlString: request.urlString
     })
 
     const initHasKey = Object.keys(init).length !== 0
@@ -266,7 +274,7 @@ class Request {
       request.referrerPolicy = ''
 
       // 7. Set request’s URL to request’s current URL.
-      request.url = request.urlList[request.urlList.length - 1]
+      request.url = getRequestURLList(request)[request.urlList.length - 1]
 
       // 8. Set request’s URL list to « request’s URL ».
       request.urlList = [request.url]
@@ -469,6 +477,7 @@ class Request {
     this.#headers = new Headers(kConstruct)
     setHeadersList(this.#headers, request.headersList)
     setHeadersGuard(this.#headers, 'request')
+    this.#headersGuard = 'request'
 
     // 31. If this’s request’s mode is "no-cors", then:
     if (mode === 'no-cors') {
@@ -482,6 +491,7 @@ class Request {
 
       // 2. Set this’s headers’s guard to "request-no-cors".
       setHeadersGuard(this.#headers, 'request-no-cors')
+      this.#headersGuard = 'request-no-cors'
     }
 
     // 32. If init is not empty, then:
@@ -611,7 +621,9 @@ class Request {
     webidl.brandCheck(this, Request)
 
     // The url getter steps are to return this’s request’s URL, serialized.
-    return URLSerializer(this.#state.url)
+    // Uses the deferred URL string when available, avoiding building/serializing
+    // a `URL` object just to read `.url`.
+    return getRequestURLString(this.#state)
   }
 
   // Returns a Headers object consisting of the headers associated with request.
@@ -621,7 +633,10 @@ class Request {
     webidl.brandCheck(this, Request)
 
     // The headers getter steps are to return this’s headers.
-    return this.#headers
+    // The Headers wrapper isn't built when the Request is created from an inner
+    // request (fromInnerRequest); construct it on first access from the inner
+    // header list and the tracked guard (#headersGuard).
+    return this.#headers ?? (this.#headers = makeRequestHeaders(this.#state, this.#headersGuard))
   }
 
   // Returns the kind of resource requested by request, e.g., "document"
@@ -755,19 +770,35 @@ class Request {
     webidl.brandCheck(this, Request)
 
     // The signal getter steps are to return this’s signal.
-    return this.#signal
+    // Requests created without an explicit signal (e.g. via fromInnerRequest)
+    // don't allocate an AbortController up front; create one on first access.
+    return this.#signal ?? (this.#signal = new AbortController().signal)
   }
 
   get body () {
     webidl.brandCheck(this, Request)
 
-    return this.#state.body ? this.#state.body.stream : null
+    // A lazy byte-sequence body has no `stream` until observed; materialize and
+    // cache it here so reading `.body` behaves like an eagerly-built stream.
+    const body = this.#state.body
+    if (body == null) {
+      return null
+    }
+
+    if (body.stream == null) {
+      body.stream = body.getStream()
+    }
+    return body.stream
   }
 
   get bodyUsed () {
     webidl.brandCheck(this, Request)
 
-    return !!this.#state.body && util.isDisturbed(this.#state.body.stream)
+    // `consumed` covers lazy bodies read via a fast path (stream never built);
+    // otherwise fall back to the stream's disturbed state once it exists.
+    const body = this.#state.body
+    return !!body && (body.consumed === true ||
+      (body.stream != null && util.isDisturbed(body.stream)))
   }
 
   get duplex () {
@@ -809,7 +840,15 @@ class Request {
     }
 
     // 4. Return clonedRequestObject.
-    return fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    // Read the guard from the Headers wrapper if it was built, otherwise from
+    // the tracked #headersGuard — avoids forcing lazy header construction just
+    // to clone.
+    return fromInnerRequest(
+      clonedRequest,
+      this.#dispatcher,
+      ac.signal,
+      this.#headers === undefined ? this.#headersGuard : getHeadersGuard(this.#headers)
+    )
   }
 
   [nodeUtil.inspect.custom] (depth, options) {
@@ -866,10 +905,10 @@ class Request {
 
   /**
    * @param {Request} request
-   * @param {Headers} newHeaders
+   * @param {'request' | 'immutable' | 'request-no-cors' | 'response' | 'none'} guard
    */
-  static setRequestHeaders (request, newHeaders) {
-    request.#headers = newHeaders
+  static setRequestHeadersGuard (request, guard) {
+    request.#headersGuard = guard
   }
 
   /**
@@ -897,19 +936,60 @@ class Request {
   }
 }
 
-const { setRequestSignal, getRequestDispatcher, setRequestDispatcher, setRequestHeaders, getRequestState, setRequestState, removeRequestAbortListener } = Request
+const { setRequestSignal, getRequestDispatcher, setRequestDispatcher, setRequestHeadersGuard, getRequestState, setRequestState, removeRequestAbortListener } = Request
 Reflect.deleteProperty(Request, 'setRequestSignal')
 Reflect.deleteProperty(Request, 'getRequestDispatcher')
 Reflect.deleteProperty(Request, 'setRequestDispatcher')
-Reflect.deleteProperty(Request, 'setRequestHeaders')
+Reflect.deleteProperty(Request, 'setRequestHeadersGuard')
 Reflect.deleteProperty(Request, 'getRequestState')
 Reflect.deleteProperty(Request, 'setRequestState')
 Reflect.deleteProperty(Request, 'removeRequestAbortListener')
 
 mixinBody(Request, getRequestState)
 
+// The following three helpers back the inner request's lazy URL and header
+// state. An inner request may be created with its URL/headers represented only
+// as a deferred string or a provider callback (urlString/getURLString,
+// getHeadersList) — typically by an embedder that already holds the parsed
+// values — so the expensive `URL` object and `HeadersList` are built only when
+// an algorithm actually needs them, and cached back onto the inner request.
+
+// Materialize the URL list: if the first entry is the null placeholder, parse
+// the (possibly deferred) URL string into a `URL` and adopt it as the current url.
+function getRequestURLList (request) {
+  if (request.urlList[0] === null) {
+    request.urlList = [new URL(getRequestURLString(request))]
+    request.url = request.urlList[0]
+  }
+  return request.urlList
+}
+
+// Return the serialized URL, preferring a precomputed/deferred string over
+// serializing a `URL` object. Resolves and caches a `getURLString` provider on
+// first use; falls back to serializing the parsed url when no string is available.
+function getRequestURLString (request) {
+  if (request.urlString === undefined && request.getURLString !== undefined) {
+    request.urlString = request.getURLString()
+  }
+  return request.urlString ?? URLSerializer(request.url)
+}
+
+// Materialize the header list from a `getHeadersList` provider on first use
+// (null means "not yet built"), caching it back onto the inner request.
+function getRequestHeadersList (request) {
+  if (request.headersList === null) {
+    request.headersList = request.getHeadersList()
+  }
+  return request.headersList
+}
+
 // https://fetch.spec.whatwg.org/#requests
 function makeRequest (init) {
+  // Default to a single null-placeholder URL so the real `URL` can be built
+  // lazily from urlString/getURLString (see getRequestURLList). `url` likewise
+  // defaults to that placeholder unless an explicit one is supplied.
+  const urlList = init.urlList ?? [null]
+
   return {
     method: init.method ?? 'GET',
     localURLsOnly: init.localURLsOnly ?? false,
@@ -949,11 +1029,20 @@ function makeRequest (init) {
     timingAllowFailed: init.timingAllowFailed ?? false,
     useURLCredentials: init.useURLCredentials ?? undefined,
     traversableForUserPrompts: init.traversableForUserPrompts ?? 'client',
-    urlList: init.urlList,
-    url: init.urlList[0],
-    headersList: init.headersList
-      ? new HeadersList(init.headersList)
-      : new HeadersList()
+    urlList,
+    url: init.url ?? urlList[0],
+    // Deferred URL representation: a precomputed serialized string and/or a
+    // provider that produces it, used to avoid eagerly building a `URL`.
+    urlString: init.urlString,
+    getURLString: init.getURLString,
+    // An explicit null headersList means "build it lazily via getHeadersList";
+    // otherwise clone the provided list, or start with an empty one.
+    headersList: init.headersList === null
+      ? null
+      : init.headersList
+        ? new HeadersList(init.headersList)
+        : new HeadersList(),
+    getHeadersList: init.getHeadersList
   }
 }
 
@@ -974,6 +1063,15 @@ function cloneRequest (request) {
   return newRequest
 }
 
+// Build the public `Headers` wrapper for a Request on demand (used by the
+// lazy `headers` getter), materializing the inner header list if needed.
+function makeRequestHeaders (innerRequest, guard) {
+  const headers = new Headers(kConstruct)
+  setHeadersList(headers, getRequestHeadersList(innerRequest))
+  setHeadersGuard(headers, guard)
+  return headers
+}
+
 /**
  * @see https://fetch.spec.whatwg.org/#request-create
  * @param {any} innerRequest
@@ -985,12 +1083,19 @@ function cloneRequest (request) {
 function fromInnerRequest (innerRequest, dispatcher, signal, guard) {
   const request = new Request(kConstruct)
   setRequestState(request, innerRequest)
-  setRequestDispatcher(request, dispatcher)
-  setRequestSignal(request, signal)
-  const headers = new Headers(kConstruct)
-  setRequestHeaders(request, headers)
-  setHeadersList(headers, innerRequest.headersList)
-  setHeadersGuard(headers, guard)
+  // Only set what differs from the lazy defaults, so a Request created from an
+  // inner request stays cheap: no Headers wrapper, no AbortController, and no
+  // guard write are forced here. The `headers`/`signal` getters fill these in
+  // on first access, and the guard defaults to 'request' (#headersGuard).
+  if (dispatcher !== undefined) {
+    setRequestDispatcher(request, dispatcher)
+  }
+  if (signal !== undefined) {
+    setRequestSignal(request, signal)
+  }
+  if (guard !== 'request') {
+    setRequestHeadersGuard(request, guard)
+  }
   return request
 }
 

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Headers, HeadersList, fill, getHeadersGuard, setHeadersGuard, setHeadersList } = require('./headers')
-const { extractBody, cloneBody, mixinBody, streamRegistry, bodyUnusable } = require('./body')
+const { extractBody, cloneBody, mixinBody, streamRegistry, bodyUnusable, makeLazyByteStreamBody } = require('./body')
 const util = require('../../core/util')
 const nodeUtil = require('node:util')
 const { kEnumerableProperty } = util
@@ -53,7 +53,9 @@ class Response {
     )
 
     // 2. Let body be the result of extracting bytes.
-    const body = extractBody(bytes)
+    // The third argument requests a lazy byte-sequence body: the backing
+    // ReadableStream is not created here, only when `.body` is observed.
+    const body = extractBody(bytes, false, true)
 
     // 3. Let responseObject be the result of creating a Response object, given a new response,
     //    "response", and this’s relevant Realm.
@@ -114,6 +116,29 @@ class Response {
       return
     }
 
+    // Fast path for `new Response(someString)`, by far the most common shape
+    // on the server (e.g. returning a string from a request handler). The
+    // generic path below runs the body through the BodyInit converter and the
+    // full `extractBody` algorithm, both of which are comparatively expensive.
+    // This branch is observably equivalent to that path for a bare string:
+    //  - `toWellFormed()` matches the USVString coercion the BodyInit converter
+    //    would apply to a string.
+    //  - the body is stored as a lazy byte-sequence body, so the backing
+    //    ReadableStream is only created if `.body` is actually read.
+    //  - the `content-type` is the same `text/plain;charset=UTF-8` that
+    //    extracting a string body assigns.
+    if (typeof body === 'string' && init === undefined) {
+      body = body.toWellFormed()
+      this.#state = makeResponse({
+        body: makeLazyByteStreamBody(body)
+      })
+      this.#headers = new Headers(kConstruct)
+      setHeadersGuard(this.#headers, 'response')
+      setHeadersList(this.#headers, this.#state.headersList)
+      this.#state.headersList.append('content-type', 'text/plain;charset=UTF-8', true)
+      return
+    }
+
     if (body !== null) {
       body = webidl.converters.BodyInit(body, 'Response', 'body')
     }
@@ -134,8 +159,10 @@ class Response {
     let bodyWithType = null
 
     // 4. If body is non-null, then set bodyWithType to the result of extracting body.
+    // Pass lazyByteStream=true so string/Uint8Array bodies defer creating their
+    // ReadableStream until `.body` is read (see extractBody).
     if (body != null) {
-      const [extractedBody, type] = extractBody(body)
+      const [extractedBody, type] = extractBody(body, false, true)
       bodyWithType = { body: extractedBody, type }
     }
 
@@ -215,13 +242,20 @@ class Response {
   get body () {
     webidl.brandCheck(this, Response)
 
-    return this.#state.body ? this.#state.body.stream : null
+    // A lazy byte-sequence body has no `stream` until first observed here;
+    // materialize it on demand and cache it on the body.
+    const body = this.#state.body
+    return body ? body.stream ?? (body.stream = body.getStream()) : null
   }
 
   get bodyUsed () {
     webidl.brandCheck(this, Response)
 
-    return !!this.#state.body && util.isDisturbed(this.#state.body.stream)
+    // If the stream was never materialized it cannot have been disturbed, so a
+    // null stream means the body is unused (avoids forcing stream creation).
+    return !!this.#state.body &&
+      this.#state.body.stream != null &&
+      util.isDisturbed(this.#state.body.stream)
   }
 
   // Returns a clone of response.

--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -251,11 +251,12 @@ class Response {
   get bodyUsed () {
     webidl.brandCheck(this, Response)
 
-    // If the stream was never materialized it cannot have been disturbed, so a
-    // null stream means the body is unused (avoids forcing stream creation).
-    return !!this.#state.body &&
-      this.#state.body.stream != null &&
-      util.isDisturbed(this.#state.body.stream)
+    // `consumed` covers lazy bodies read via an embedder fast path where the stream is never built;
+    // otherwise fall back to the stream's disturbed state once it exists. A never-materialized
+    // stream cannot have been disturbed, so it reads as unused.
+    const body = this.#state.body
+    return !!body && (body.consumed === true ||
+      (body.stream != null && util.isDisturbed(body.stream)))
   }
 
   // Returns a clone of response.


### PR DESCRIPTION
I'm working on a HTTP server-side implementation in Nodejs.
Constructing a `Request`/`Response` eagerly allocates a few things
that can be lazily observed:
the body's `ReadableStream`, the `Headers` wrapper, an `AbortController`, and a
parsed `URL`. This PR defers each of those until it's actually accessed, with no
observable change to the Fetch API.

- **Lazy byte-sequence Response bodies.** `extractBody` gains a `lazyByteStream`
  flag, for buffered `string`/`Uint8Array` sources the `ReadableStream` is built
  on first observation instead of up front.

- **Lazy Request headers, URL, and signal.** A `Request` built from an inner
  request (`fromInnerRequest`) no longer eagerly creates its `Headers`,
  `AbortController`, `URL`, or body stream, each is created on first
  access.

No observable Fetch API changes or public API changes.
