### PR TITLE
ci: extend Windows Node.js workflow timeout

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   test:
     name: Test ${{ inputs.codecov == true && 'and Coverage ' || '' }}with Node.js ${{ inputs.node-version }} on ${{ inputs.runs-on }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.runs-on == 'windows-latest' && 30 || 20 }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

Increase the reusable Node.js workflow timeout from 20 to 30 minutes for Windows jobs only.

## Motivation

Windows CI on `main` has been getting cancelled while running WPT near the 20-minute job timeout. The WPT server shutdown lines in the logs are cleanup during cancellation, not a separate WPT assertion failure.

Evidence from the first affected run (`0d6ecc571095`, run `27418354554`):

- Windows Node.js 22 job started at `13:21:40`.
- `npm run test:wpt` started at `13:30:42`.
- WPT was still running at `13:41:40`.
- WPT server cleanup logged at `13:41:40`.
- The job was cancelled at `13:41:42`, right at the 20-minute job timeout boundary.

This keeps the existing 20-minute timeout for non-Windows jobs and gives Windows enough budget to finish WPT and cleanup reliably.

## Validation

- `git diff --check`
- Parsed `.github/workflows/nodejs.yml` with the repository `yaml` package
- Commit hook ran `npm run lint`
