### PR TITLE
fix(websocket): enforce deflate remaining payload budget

### DIFF
--- a/lib/web/websocket/permessage-deflate.js
+++ b/lib/web/websocket/permessage-deflate.js
@@ -16,6 +16,10 @@ class PerMessageDeflate {
 
   #maxPayloadSize = 0
 
+  #currentCallback = null
+
+  #currentPayloadSize = 0
+
   /**
    * @param {Map<string, string>} extensions
    */
@@ -31,12 +35,16 @@ class PerMessageDeflate {
    * @param {Buffer} chunk Compressed data
    * @param {boolean} fin Final fragment flag
    * @param {Function} callback Callback function
+   * @param {number} currentPayloadSize Current decompressed message size
    */
-  decompress (chunk, fin, callback) {
+  decompress (chunk, fin, callback, currentPayloadSize = 0) {
     // An endpoint uses the following algorithm to decompress a message.
     // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
     //     payload of the message.
     // 2.  Decompress the resulting data using DEFLATE.
+    this.#currentCallback = callback
+    this.#currentPayloadSize = currentPayloadSize
+
     if (!this.#inflate) {
       let windowBits = Z_DEFAULT_WINDOWBITS
 
@@ -61,10 +69,15 @@ class PerMessageDeflate {
       this.#inflate.on('data', (data) => {
         this.#inflate[kLength] += data.length
 
-        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
-          callback(new MessageSizeExceededError())
+        if (this.#maxPayloadSize > 0 && this.#currentPayloadSize + this.#inflate[kLength] > this.#maxPayloadSize) {
+          const currentCallback = this.#currentCallback
+
+          this.#currentCallback = null
+          this.#currentPayloadSize = 0
           this.#inflate.removeAllListeners()
           this.#inflate = null
+
+          currentCallback?.(new MessageSizeExceededError())
           return
         }
 
@@ -72,14 +85,25 @@ class PerMessageDeflate {
       })
 
       this.#inflate.on('error', (err) => {
+        const currentCallback = this.#currentCallback
+
+        this.#currentCallback = null
+        this.#currentPayloadSize = 0
         this.#inflate = null
-        callback(err)
+        currentCallback?.(err)
       })
     }
 
     this.#inflate.write(chunk)
+    if (!this.#inflate) {
+      return
+    }
+
     if (fin) {
       this.#inflate.write(tail)
+      if (!this.#inflate) {
+        return
+      }
     }
 
     this.#inflate.flush(() => {
@@ -91,6 +115,8 @@ class PerMessageDeflate {
 
       this.#inflate[kBuffer].length = 0
       this.#inflate[kLength] = 0
+      this.#currentCallback = null
+      this.#currentPayloadSize = 0
 
       callback(null, full)
     })

--- a/test/websocket/permessage-deflate-limit.js
+++ b/test/websocket/permessage-deflate-limit.js
@@ -7,6 +7,8 @@ const { deflateRawSync } = require('node:zlib')
 const { setTimeout: sleep } = require('node:timers/promises')
 const { WebSocketServer } = require('ws')
 const { WebSocket, Agent } = require('../..')
+const { MessageSizeExceededError } = require('../../lib/core/errors')
+const { PerMessageDeflate } = require('../../lib/web/websocket/permessage-deflate')
 
 test('Compressed message under limit decompresses successfully', async (t) => {
   const server = new WebSocketServer({
@@ -298,6 +300,39 @@ test('Fragmented compressed payload over total limit is rejected', async (t) => 
 
   t.assert.strictEqual(messageReceived, false, 'Fragmented compressed message over total limit should be rejected')
   t.assert.strictEqual(client.readyState, WebSocket.CLOSED, 'Connection should be closed after exceeding limit')
+})
+
+test('PerMessageDeflate enforces maxPayloadSize against existing decompressed fragments', async (t) => {
+  const limit = 10
+  const currentPayloadSize = 5
+  const inflater = new PerMessageDeflate(new Map(), { maxPayloadSize: limit })
+  const timeout = Symbol('timeout')
+
+  // Keep the same inflater instance across calls so the limit check must use
+  // the latest currentPayloadSize argument, not values captured when the
+  // inflater was created.
+  const first = await Promise.race([
+    new Promise((resolve) => {
+      inflater.decompress(Buffer.alloc(0), false, (error, data) => resolve({ error, data }))
+    }),
+    sleep(5000, timeout)
+  ])
+
+  t.assert.notStrictEqual(first, timeout, 'Initial inflate operation should complete')
+  t.assert.ifError(first.error)
+  t.assert.strictEqual(first.data.length, 0)
+
+  const compressed = deflateRawSync(Buffer.alloc(6, 0x41))
+  const second = await Promise.race([
+    new Promise((resolve) => {
+      inflater.decompress(compressed, true, (error, data) => resolve({ error, data }), currentPayloadSize)
+    }),
+    sleep(5000, timeout)
+  ])
+
+  t.assert.notStrictEqual(second, timeout, 'Inflate should fail once the remaining message budget is exceeded')
+  t.assert.ok(second.error instanceof MessageSizeExceededError)
+  t.assert.strictEqual(second.data, undefined)
 })
 
 test('Raw uncompressed payload over immediate limit is rejected', async (t) => {


### PR DESCRIPTION
## This relates to...

WebSocket `maxPayloadSize` enforcement for fragmented permessage-deflate messages.

## Rationale

The receiver passed the current decompressed fragment total to `PerMessageDeflate.decompress()`, but the inflater ignored that argument. As a result, compressed fragmented messages were rejected only after the inflated chunk was appended, allowing inflate work beyond the remaining message budget.

## Changes

### Features

N/A

### Bug Fixes

- Teach `PerMessageDeflate.decompress()` to account for the current decompressed message size while inflating.
- Reject once `currentPayloadSize + current inflate output` exceeds `maxPayloadSize`.
- Add regression coverage for enforcing `maxPayloadSize` against existing decompressed fragments.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Validation:

- `node --test test/websocket/fragments.js test/websocket/permessage-deflate-limit.js test/websocket/permessage-deflate-config.js test/websocket/permessage-deflate-windowbits.js test/websocket/stream/too-many-fragments.js`
- `npm run lint`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
