### PR TITLE
feat: add generic type to `json` method

### DIFF
--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -55,7 +55,7 @@ export class BodyMixin {
    * ```
    */
   readonly formData: () => Promise<FormData>
-  readonly json: () => Promise<unknown>
+  readonly json: <T = unknown>() => Promise<T>
   readonly text: () => Promise<string>
   readonly textStream: () => ReadableStream<string>
 }

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -20,7 +20,7 @@ declare class BodyReadable extends Readable {
   /** Consumes and returns the body as a JavaScript Object
    *  https://fetch.spec.whatwg.org/#dom-body-json
    */
-  json (): Promise<unknown>
+  json<T = unknown> (): Promise<T>
 
   /** Consumes and returns the body as a Blob
    *  https://fetch.spec.whatwg.org/#dom-body-blob


### PR DESCRIPTION
### Features

Add support of generic type for `json` method of `fetch` and `request`.

### Example

```ts
import { request } from 'undici'
const response = await request('URL')
const json = await response.body.json<{ data: 'myDataType' }>()

// ---

import { fetch } from 'undici'
const response = await fetch('URL')
const json = await response.json<{ data: 'myDataType' }>()
```

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [x] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
