### PR TITLE
fix(h2): guard onResponse against a 'response' event delivered after completion

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -1144,10 +1144,13 @@ function onResponse (headers) {
 
   // Due to the stream nature, it is possible we face a race condition
   // where the stream has been assigned, but the request has been aborted
-  // the request remains in-flight and headers hasn't been received yet
-  // for those scenarios, best effort is to destroy the stream immediately
-  // as there's no value to keep it open.
-  if (request.aborted) {
+  // or already completed and headers hasn't been received yet. A late
+  // 'response' delivered after completion would call request.onResponseStart
+  // post-completion, tripping its `assert(!this.completed)` (an uncatchable
+  // throw on the http2 event tick). Guard `completed` here as onEnd/onTrailers
+  // already do; best effort is to release the stream immediately as there's
+  // no value to keep it open.
+  if (request.aborted || request.completed) {
     releaseRequestStream(stream)
     return
   }

--- a/test/http2-response-after-completion.js
+++ b/test/http2-response-after-completion.js
@@ -1,0 +1,186 @@
+'use strict'
+
+// Regression test for nodejs/undici#5440.
+//
+// The HTTP/2 'response' handler (onResponse in client-h2.js) only guarded
+// request.aborted before calling request.onResponseStart, while its sibling
+// handlers onEnd/onTrailers also guard request.completed. A 'response' frame
+// delivered to a still-live stream *after* the request has completed (a
+// stream-teardown race seen under load on shared h2 sessions with GOAWAY /
+// refused-stream churn) therefore called onResponseStart post-completion,
+// tripping its assert(!this.completed). Because that throws on the http2
+// stream's event tick — outside any caller's try — it escaped as an uncaught
+// exception and crashed the process.
+//
+// This drives the real onResponse handler (registered by connectH2) against a
+// fake stream, mirroring test/http2-late-data.js, and asserts that a
+// post-completion 'response' is ignored instead of asserting.
+
+const { test, after } = require('node:test')
+const { EventEmitter } = require('node:events')
+const { tspl } = require('@matteo.collina/tspl')
+
+const connectH2 = require('../lib/dispatcher/client-h2')
+const Request = require('../lib/core/request')
+const {
+  kUrl,
+  kSocket,
+  kMaxConcurrentStreams,
+  kHTTP2InitialWindowSize,
+  kHTTP2ConnectionWindowSize,
+  kBodyTimeout,
+  kStrictContentLength,
+  kQueue,
+  kRunningIdx,
+  kPendingIdx,
+  kOnError,
+  kResume,
+  kRunning,
+  kPingInterval
+} = require('../lib/core/symbols')
+
+class FakeSocket extends EventEmitter {
+  constructor () {
+    super()
+    this.destroyed = false
+  }
+
+  destroy () {
+    this.destroyed = true
+    return this
+  }
+
+  ref () {}
+  unref () {}
+}
+
+class FakeStream extends EventEmitter {
+  setTimeout () {}
+  pause () {}
+  resume () {}
+  close () {}
+  write () { return true }
+  end () {}
+  cork () {}
+  uncork () {}
+}
+
+class FakeSession extends EventEmitter {
+  constructor (stream) {
+    super()
+    this.stream = stream
+    this.closed = false
+    this.destroyed = false
+  }
+
+  request () {
+    return this.stream
+  }
+
+  close () {
+    this.closed = true
+  }
+
+  destroy () {
+    this.destroyed = true
+  }
+
+  ref () {}
+  unref () {}
+  ping (_, cb) {
+    cb(null, 0)
+  }
+}
+
+test('Should ignore a late http2 "response" delivered after request completion', async (t) => {
+  t = tspl(t, { plan: 6 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  const stream = new FakeStream()
+  const session = new FakeSession(stream)
+
+  http2.connect = function connectStub () {
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  const client = {
+    [kUrl]: new URL('https://localhost'),
+    [kSocket]: null,
+    [kMaxConcurrentStreams]: 100,
+    [kHTTP2InitialWindowSize]: null,
+    [kHTTP2ConnectionWindowSize]: null,
+    [kBodyTimeout]: 30_000,
+    [kStrictContentLength]: true,
+    [kQueue]: [],
+    [kRunningIdx]: 0,
+    [kPendingIdx]: 0,
+    [kRunning]: 1,
+    [kPingInterval]: 0,
+    [kOnError] (err) {
+      t.ifError(err)
+    },
+    [kResume] () {},
+    emit () {},
+    destroyed: false
+  }
+
+  const context = connectH2(client, new FakeSocket())
+
+  let onResponseStartedCalls = 0
+  let onResponseStartCalls = 0
+
+  const request = new Request('https://localhost', {
+    path: '/',
+    method: 'GET',
+    headers: {}
+  }, {
+    onRequestStart () {},
+    onResponseStarted () {
+      onResponseStartedCalls++
+    },
+    onResponseStart () {
+      onResponseStartCalls++
+    },
+    onResponseData () {},
+    onResponseEnd () {},
+    onResponseError (_controller, err) {
+      t.ifError(err)
+    }
+  })
+
+  client[kQueue].push(request)
+
+  t.ok(context.write(request))
+
+  // Mark the request completed directly: the real completion path
+  // (onRequestStreamClose) also clears the stream's request state and removes
+  // its listeners, which is the opposite of the race being reproduced here —
+  // a 'response' frame buffered before teardown and delivered to the still-live
+  // stream *after* completion. aborted stays false so this exercises the
+  // completed guard specifically, not the pre-existing aborted one.
+  request.completed = true
+  t.strictEqual(request.aborted, false)
+
+  // Without the completed guard, onResponse calls request.onResponseStart,
+  // whose assert(!this.completed) throws synchronously on the stream's
+  // 'response' tick (an uncaught exception that crashes the process). With the
+  // guard, onResponse releases the stream and returns.
+  t.doesNotThrow(() => {
+    stream.emit('response', { ':status': 200 })
+  })
+
+  // onResponse ran (onResponseStarted fires before the guard)...
+  t.strictEqual(onResponseStartedCalls, 1)
+  // ...but the guard skipped the post-completion onResponseStart...
+  t.strictEqual(onResponseStartCalls, 0)
+  // ...and released the stream (releaseRequestStream removes its listeners).
+  t.strictEqual(stream.listenerCount('trailers'), 0)
+
+  await t.completed
+})


### PR DESCRIPTION
## Bug

The HTTP/2 client's `onResponse` handler in `lib/dispatcher/client-h2.js` calls `request.onResponseStart(...)` after guarding only `request.aborted` — but **not** `request.completed`:

```js
function onResponse (headers) {
  ...
  if (request.aborted) {            // ← missing `|| request.completed`
    releaseRequestStream(stream)
    return
  }
  if (request.onResponseStart(Number(statusCode), headers, stream.resume.bind(stream), '') === false) {
    stream.pause()
  }
  ...
}
```

`Request.onResponseStart` asserts both invariants:

```js
onResponseStart (statusCode, headers, resume, statusText) {
  assert(!this.aborted)
  assert(!this.completed)
  ...
}
```

So if a `'response'` event is delivered to the stream **after the request has already completed**, `onResponse` invokes `onResponseStart` post-completion and trips `assert(!this.completed)`. Because the assertion throws on the http2 stream's event tick (not inside any caller's `try`), it escapes as an uncaught exception and **crashes the process**.

The sibling handlers already treat a post-completion delivery as expected and guard against it:

```js
// onEnd
if (state.responseReceived) {
  if (!request.aborted && !request.completed) { state.pendingEnd = true }
}

// onTrailers
if (request.aborted || request.completed) { return }
```

`onResponse` is the only one of the three missing the `completed` guard — that asymmetry is the bug.

## Fix

Add the same `request.completed` guard the other handlers use:

```diff
-  if (request.aborted) {
+  if (request.aborted || request.completed) {
     releaseRequestStream(stream)
     return
   }
```

## How it shows up

We hit this in production on `undici@7.22.0` (same defect there: the v7 `'response'` handler guards only `request.aborted`, and the method was named `onHeaders`, which also `assert(!this.completed)`). The crash:

```
AssertionError [ERR_ASSERTION]: assert(!this.completed)
  at Request.onHeaders (undici/lib/core/request.js)
  at ClientHttp2Stream.<anonymous> (undici/lib/dispatcher/client-h2.js)  // the 'response' handler
  at ... node:internal/http2/core
```

It reproduces under load when many requests are multiplexed over **shared, long-lived h2 sessions** (HTTP/2 connection coalescing to a CDN edge), where server-initiated `GOAWAY` / refused-stream churn causes frequent concurrent stream teardowns — i.e. exactly the completion-vs-`'response'` race this guard handles. On the default per-origin HTTP/1.1 path the `client-h2.js` code is never exercised, so it only manifests with `allowH2: true`.

## Note on a test

This is a client-side event-ordering race; I couldn't construct a deterministic, non-flaky regression test against a real `http2` server without contriving the stream's event emission. The change mirrors the existing `onEnd`/`onTrailers` guards exactly. Happy to add a test if a maintainer can point me at the preferred way to drive a post-completion `'response'` on the request stream.

This affects `main` (v8.5.0) and `v7.x` — flagging in case a backport is wanted.