### PR TITLE
fix: add static buildDispatch method to RedirectHandler type definition

### DIFF
--- a/test/types/handlers.test-d.ts
+++ b/test/types/handlers.test-d.ts
@@ -1,0 +1,6 @@
+import { expectAssignable } from 'tsd'
+import { Agent, Dispatcher, RedirectHandler } from '../..'
+
+const dispatcher = new Agent()
+
+expectAssignable<Dispatcher.Dispatch>(RedirectHandler.buildDispatch(dispatcher, 3))

--- a/types/handlers.d.ts
+++ b/types/handlers.d.ts
@@ -1,6 +1,8 @@
 import Dispatcher from './dispatcher'
 
 export declare class RedirectHandler implements Dispatcher.DispatchHandler {
+  static buildDispatch(dispatcher: Dispatcher, maxRedirections: number): Dispatcher.Dispatch
+
   constructor (
     dispatch: Dispatcher.Dispatch,
     maxRedirections: number,

--- a/types/handlers.d.ts
+++ b/types/handlers.d.ts
@@ -1,7 +1,7 @@
 import Dispatcher from './dispatcher'
 
 export declare class RedirectHandler implements Dispatcher.DispatchHandler {
-  static buildDispatch(dispatcher: Dispatcher, maxRedirections: number): Dispatcher.Dispatch
+  static buildDispatch (dispatcher: Dispatcher, maxRedirections: number): Dispatcher.Dispatch
 
   constructor (
     dispatch: Dispatcher.Dispatch,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Add a missing `static` method from the type definitions

## Changes

Declare `buildDispatch` as a static method of the `RedirectHandler` type definition


### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
