### PR TITLE
fix: Improve `Dispatcher.compose` when nullish values are passed as argument

### DIFF
--- a/lib/dispatcher/dispatcher.js
+++ b/lib/dispatcher/dispatcher.js
@@ -16,14 +16,16 @@ class Dispatcher extends EventEmitter {
 
   compose (...args) {
     // So we handle [interceptor1, interceptor2] or interceptor1, interceptor2, ...
-    const interceptors = Array.isArray(args[0]) ? args[0] : args
+    const maybeInterceptors = Array.isArray(args[0]) ? args[0] : args
+    const interceptors = maybeInterceptors.filter(i => i != null)
+
+    if (interceptors.length === 0) {
+      return this
+    }
+
     let dispatch = this.dispatch.bind(this)
 
     for (const interceptor of interceptors) {
-      if (interceptor == null) {
-        continue
-      }
-
       if (typeof interceptor !== 'function') {
         throw new TypeError(`invalid interceptor, expected function received ${typeof interceptor}`)
       }

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -22,7 +22,7 @@ test('dispatcher implementation', (t) => {
 })
 
 test('dispatcher.compose', (t) => {
-  t = tspl(t, { plan: 7 })
+  t = tspl(t, { plan: 8 })
 
   const dispatcher = new Dispatcher()
   const interceptor = () => (opts, handler) => {}
@@ -36,4 +36,5 @@ test('dispatcher.compose', (t) => {
   t.equal(typeof composed.dispatch, 'function', 'returns an object with a dispatch method')
   t.equal(typeof composed.close, 'function', 'returns an object with a close method')
   t.equal(typeof composed.destroy, 'function', 'returns an object with a destroy method')
+  t.equal(dispatcher.compose(), dispatcher, 'returns the same dispatcher if no interceptors are provided')
 })

--- a/test/dispatcher.js
+++ b/test/dispatcher.js
@@ -22,7 +22,7 @@ test('dispatcher implementation', (t) => {
 })
 
 test('dispatcher.compose', (t) => {
-  t = tspl(t, { plan: 8 })
+  t = tspl(t, { plan: 10 })
 
   const dispatcher = new Dispatcher()
   const interceptor = () => (opts, handler) => {}
@@ -37,4 +37,6 @@ test('dispatcher.compose', (t) => {
   t.equal(typeof composed.close, 'function', 'returns an object with a close method')
   t.equal(typeof composed.destroy, 'function', 'returns an object with a destroy method')
   t.equal(dispatcher.compose(), dispatcher, 'returns the same dispatcher if no interceptors are provided')
+  t.equal(dispatcher.compose(null), dispatcher, 'returns the same dispatcher if a null interceptor is provided')
+  t.equal(dispatcher.compose(null, null), dispatcher, 'returns the same dispatcher if multiple null interceptors are provided')
 })

--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -226,7 +226,14 @@ expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose(
     }
   }
 ))
+// @ts-expect-error cannot use both array and variadic arguments
+expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose([null], null))
+expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose(null))
+expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose(null, undefined))
+expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose([null, undefined]))
 expectAssignable<Dispatcher.ComposedDispatcher>(new Dispatcher().compose([
+  null,
+  undefined,
   (dispatcher) => {
     expectAssignable<Dispatcher['dispatch']>(dispatcher)
     return (opts, handlers) => {

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -20,8 +20,8 @@ declare class Dispatcher extends EventEmitter {
   connect<TOpaque = null>(options: Dispatcher.ConnectOptions<TOpaque>, callback: (err: Error | null, data: Dispatcher.ConnectData<TOpaque>) => void): void
   connect<TOpaque = null>(options: Dispatcher.ConnectOptions<TOpaque>): Promise<Dispatcher.ConnectData<TOpaque>>
   /** Compose a chain of dispatchers */
-  compose (dispatchers: Dispatcher.DispatcherComposeInterceptor[]): Dispatcher.ComposedDispatcher
-  compose (...dispatchers: Dispatcher.DispatcherComposeInterceptor[]): Dispatcher.ComposedDispatcher
+  compose (dispatchers: (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
+  compose (...dispatchers: (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
   /** Performs an HTTP request. */
   request<TOpaque = null>(options: Dispatcher.RequestOptions<TOpaque>, callback: (err: Error | null, data: Dispatcher.ResponseData<TOpaque>) => void): void
   request<TOpaque = null>(options: Dispatcher.RequestOptions<TOpaque>): Promise<Dispatcher.ResponseData<TOpaque>>

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -20,8 +20,8 @@ declare class Dispatcher extends EventEmitter {
   connect<TOpaque = null>(options: Dispatcher.ConnectOptions<TOpaque>, callback: (err: Error | null, data: Dispatcher.ConnectData<TOpaque>) => void): void
   connect<TOpaque = null>(options: Dispatcher.ConnectOptions<TOpaque>): Promise<Dispatcher.ConnectData<TOpaque>>
   /** Compose a chain of dispatchers */
-  compose (dispatchers: (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
-  compose (...dispatchers: (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
+  compose (dispatchers: readonly (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
+  compose (...dispatchers: readonly (null | undefined | Dispatcher.DispatcherComposeInterceptor)[]): Dispatcher.ComposedDispatcher
   /** Performs an HTTP request. */
   request<TOpaque = null>(options: Dispatcher.RequestOptions<TOpaque>, callback: (err: Error | null, data: Dispatcher.ResponseData<TOpaque>) => void): void
   request<TOpaque = null>(options: Dispatcher.RequestOptions<TOpaque>): Promise<Dispatcher.ResponseData<TOpaque>>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

The implementation of `Dispatcher.compose` allows nullish values:

https://github.com/nodejs/undici/blob/ae3efd442e9b5b76957c528ba6649e95775a3e1f/lib/dispatcher/dispatcher.js#L23-L25

This change alligns the type definitons with this to allow inline definitions:

```ts
dispatcher.compose(
  maxRedirections > 0
    ? interceptor.redirect({ maxRedirections })
    : null
)

```

## Changes

Just updated the type definition of the arguments of `Dispatcher.compose` from `Dispatcher.DispatcherComposeInterceptor[]` to `(null | undefined | Dispatcher.DispatcherComposeInterceptor)[]`

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
