### PR TITLE
docs: add Interceptors API reference page

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -728,6 +728,8 @@ const client = new Client('http://localhost:3000')
 await client.request({ path: '/', method: 'GET' })
 ```
 
+For the full list of built-in interceptors provided by undici, see [Interceptors](Interceptors.md).
+
 ### Event: `'connect'`
 
 <!-- YAML
@@ -783,288 +785,14 @@ can make progress.
 
 ## Pre-built interceptors
 
-undici ships a set of pre-built interceptors under the top-level `interceptors`
-namespace. Each is a factory that returns an interceptor suitable for
-[`dispatcher.compose()`][].
-
-```mjs
-import { interceptors } from 'undici'
-
-const { redirect, retry, dump, dns, responseError, decompress, cache, deduplicate } = interceptors
-```
-
-### `interceptors.redirect(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object}
-  * `maxRedirections` {number} The maximum number of redirections allowed.
-  * `throwOnMaxRedirect` {boolean} Whether to throw when the maximum number of
-    redirections is reached.
-  * `stripHeadersOnRedirect` {string[]} Header names to remove from all
-    redirected requests.
-  * `stripHeadersOnCrossOriginRedirect` {string[]} Header names to remove from
-    cross-origin redirected requests.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Customizes how the dispatcher handles redirects. The options match the
-[`RedirectHandler`][] constructor.
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.redirect({ maxRedirections: 3, throwOnMaxRedirect: true })
-)
-
-await client.request({ path: '/' })
-```
-
-### `interceptors.retry(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object} Retry options. The options match the [`RetryHandler`][]
-  constructor.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Customizes how the dispatcher handles retries. The options match the
-[`RetryHandler`][] constructor and are also configurable per request through
-`options.retryOptions`.
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.retry({
-    maxRetries: 3,
-    minTimeout: 1000,
-    maxTimeout: 10000,
-    timeoutFactor: 2,
-    retryAfter: true
-  })
-)
-```
-
-### `interceptors.dump(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object}
-  * `maxSize` {number} The maximum size, in bytes, of a response body to dump. If
-    the response body exceeds this value, the connection is closed.
-    **Default:** `1048576`.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Dumps the response body of a request up to a given limit. The per-request option
-`dumpMaxSize` can be passed to [`dispatcher.dispatch()`][] to configure the
-interceptor on a per-request basis.
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.dump({ maxSize: 1024 })
-)
-```
-
-### `interceptors.dns(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object}
-  * `maxTTL` {number} The maximum time-to-live, in milliseconds, of the DNS
-    cache. Must be a positive integer. Set to `0` to disable TTL.
-    **Default:** `10000`.
-  * `maxItems` {number} The maximum number of items to cache. Must be a positive
-    integer. **Default:** `Infinity`.
-  * `dualStack` {boolean} Whether to resolve both IPv4 and IPv6 addresses. When
-    enabled, a happy-eyeballs-like approach is used to connect to available
-    addresses on connection failure. **Default:** `true`.
-  * `affinity` {number} Whether to use IPv4 (`4`) or IPv6 (`6`) addresses. Only
-    takes effect when `dualStack` is `false`. **Default:** `4`.
-  * `lookup` {Function} A custom lookup function. **Default:** [`dns.lookup()`][].
-  * `pick` {Function} A custom function that returns a single record from the
-    resolved records. **Default:** a simplified round-robin.
-  * `storage` {Object} A custom storage for resolved DNS records.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Caches DNS lookups for a given duration, per origin. It is well suited to
-scenarios where the same domain is resolved many times.
-
-The per-request options `dns.affinity`, `dns.dualStack`, `dns.lookup`, and
-`dns.pick` can be passed to [`dispatcher.dispatch()`][] to configure the
-interceptor on a per-request basis.
-
-A custom `storage` object must implement `size` (getter), `get(origin)`,
-`set(origin, records, { ttl })`, `delete(origin)`, and `full()`. When `full()`
-returns `true`, DNS lookups are skipped and new records are not stored.
-
-```mjs
-import { Agent, interceptors } from 'undici'
-
-const client = new Agent().compose(
-  interceptors.dns({ maxTTL: 10000, maxItems: 100 })
-)
-
-const response = await client.request({ origin: 'http://localhost:3030', path: '/', method: 'GET' })
-```
-
-### `interceptors.responseError()`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Throws a [`ResponseError`][] for responses with a status code of `400` or
-greater.
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.responseError()
-)
-
-// Throws a ResponseError for status codes >= 400.
-await client.request({ method: 'GET', path: '/' })
-```
-
-### `interceptors.decompress(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-> Stability: 1 - Experimental
-
-* `options` {Object}
-  * `skipErrorResponses` {boolean} Whether to skip decompression for error
-    responses (status codes `>= 400`). **Default:** `true`.
-  * `skipStatusCodes` {number[]} Status codes for which decompression is skipped.
-    **Default:** `[204, 304]`.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Automatically decompresses response bodies compressed with gzip, deflate,
-Brotli, or Zstandard. It removes the `content-encoding` and `content-length`
-headers from decompressed responses and supports RFC 9110-compliant multiple
-encodings. The supported encodings are `gzip`/`x-gzip`, `deflate`/`x-compress`,
-`br`, and `zstd`; unsupported encodings are passed through unchanged. Encoding
-names are matched case-insensitively, and decompression is streamed without
-buffering.
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.decompress()
-)
-
-// Automatically decompresses gzip/deflate/brotli/zstd responses.
-const response = await client.request({ method: 'GET', path: '/' })
-```
-
-### `interceptors.cache(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object}
-  * `store` {CacheStore} The store used to retrieve and persist responses.
-    **Default:** a new [`MemoryCacheStore`][].
-  * `methods` {string[]} The [safe HTTP methods][] whose responses are cached.
-    **Default:** `['GET']`.
-  * `cacheByDefault` {number} The default expiration time, in seconds, for
-    responses without an explicit expiration that cannot have a heuristic expiry
-    computed. When omitted, such responses are not cached. **Default:**
-    `undefined`.
-  * `type` {string} The [type of cache][] to act as, either `'shared'` or
-    `'private'`. **Default:** `'shared'`.
-  * `origins` {Array} An array of strings or `RegExp` instances restricting which
-    origins are cached. **Default:** `undefined`.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Implements client-side response caching as described in [RFC 9111][].
-
-```mjs
-import { Agent, cacheStores, interceptors, setGlobalDispatcher } from 'undici'
-
-const client = new Agent().compose(interceptors.cache({
-  store: new cacheStores.MemoryCacheStore({
-    maxSize: 100 * 1024 * 1024, // 100 MB
-    maxCount: 1000,
-    maxEntrySize: 5 * 1024 * 1024 // 5 MB
-  })
-}))
-
-setGlobalDispatcher(client)
-
-// The first request goes to the network and is cached when cache headers allow it.
-const first = await fetch('https://example.com/data')
-
-// The second request can be served from the cache per RFC 9111 rules.
-const second = await fetch('https://example.com/data')
-```
-
-### `interceptors.deduplicate(options)`
-
-<!-- YAML
-added: v4.0.0
--->
-
-* `options` {Object}
-  * `methods` {string[]} The [safe HTTP methods][] to deduplicate.
-    **Default:** `['GET']`.
-  * `skipHeaderNames` {string[]} Header names that, when present in a request,
-    cause that request to skip deduplication entirely. Matching is
-    case-insensitive. **Default:** `[]`.
-  * `excludeHeaderNames` {string[]} Header names excluded from the deduplication
-    key, so requests that differ only in these headers are still deduplicated
-    together. Matching is case-insensitive. **Default:** `[]`.
-  * `maxBufferSize` {number} The maximum number of bytes buffered per paused
-    waiting handler. A waiting handler that exceeds this threshold is failed with
-    an abort error to prevent unbounded memory growth. **Default:** `5242880`.
-* Returns: {Function} An interceptor for [`dispatcher.compose()`][].
-
-Deduplicates concurrent identical requests. When multiple identical requests are
-made while one is already in-flight, only one request is sent to the origin and
-all waiting handlers receive the same response. Requests are considered identical
-when they share the same origin, HTTP method, path, and request headers
-(excluding any headers in `excludeHeaderNames`).
-
-Deduplication events are published to the `undici:request:pending-requests`
-[diagnostics channel][].
-
-```mjs
-import { Client, interceptors } from 'undici'
-
-const client = new Client('http://service.example').compose(
-  interceptors.deduplicate()
-)
-
-// Deduplicate together with caching.
-const clientWithCache = new Client('http://service.example').compose(
-  interceptors.deduplicate(),
-  interceptors.cache()
-)
-```
+For the full reference of built-in interceptors (`dump`, `retry`, `redirect`,
+`decompress`, `responseError`, `dns`, `cache`, `deduplicate`) and their options,
+see [Interceptors](Interceptors.md).
 
 [Fastify]: https://fastify.dev
 [GOAWAY frame]: https://webconcepts.info/concepts/http2-frame-type/0x7
 [HTTP `CONNECT`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
 [MDN: Protocol upgrade mechanism]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism
-[RFC 9111]: https://www.rfc-editor.org/rfc/rfc9111.html
 [`.arrayBuffer()`]: https://fetch.spec.whatwg.org/#dom-body-arraybuffer
 [`.blob()`]: https://fetch.spec.whatwg.org/#dom-body-blob
 [`.bytes()`]: https://fetch.spec.whatwg.org/#dom-body-bytes
@@ -1075,12 +803,8 @@ const clientWithCache = new Client('http://service.example').compose(
 [`BalancedPool`]: BalancedPool.md#class-balancedpool
 [`Client`]: Client.md#class-client
 [`EventEmitter`]: https://nodejs.org/api/events.html#class-eventemitter
-[`MemoryCacheStore`]: CacheStore.md#class-memorycachestore
 [`Pool`]: Pool.md#class-pool
 [`Readable`]: https://nodejs.org/api/stream.html#class-streamreadable
-[`RedirectHandler`]: RedirectHandler.md
-[`ResponseError`]: Errors.md#class-responseerror
-[`RetryHandler`]: RetryHandler.md
 [`Writable`]: https://nodejs.org/api/stream.html#class-streamwritable
 [`close()`]: #dispatcherclosecallback
 [`connect()`]: #dispatcherconnectoptions-callback
@@ -1089,13 +813,9 @@ const clientWithCache = new Client('http://service.example').compose(
 [`dispatcher.compose()`]: #dispatchercomposeinterceptors-interceptor
 [`dispatcher.dispatch()`]: #dispatcherdispatchoptions-handler
 [`dispatcher.request()`]: #dispatcherrequestoptions-callback
-[`dns.lookup()`]: https://nodejs.org/api/dns.html#dnslookuphostname-options-callback
 [`pipeline()`]: #dispatcherpipelineoptions-handler
 [`request()`]: #dispatcherrequestoptions-callback
 [`stream()`]: #dispatcherstreamoptions-factory-callback
 [`stream.pipeline()`]: https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options
 [`upgrade()`]: #dispatcherupgradeoptions-callback
 [body mixin]: https://fetch.spec.whatwg.org/#body-mixin
-[diagnostics channel]: DiagnosticsChannel.md#undicirequestpending-requests
-[safe HTTP methods]: https://www.rfc-editor.org/rfc/rfc9110#section-9.2.1
-[type of cache]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#types_of_caches

--- a/docs/docs/api/Interceptors.md
+++ b/docs/docs/api/Interceptors.md
@@ -1,0 +1,355 @@
+# Interceptors
+
+Undici ships with a set of built-in interceptors that can be composed via
+`dispatcher.compose()` to add cross-cutting behaviour such as automatic
+retries, response decompression, redirect following, DNS caching, and more.
+
+## Usage
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const { retry, redirect, decompress, dump, responseError, dns, cache, deduplicate } = interceptors
+
+const agent = new Agent().compose([
+  retry({ maxRetries: 3 }),
+  redirect({ maxRedirections: 5 }),
+  decompress()
+])
+
+const response = await agent.request({ origin: 'https://example.com', path: '/', method: 'GET' })
+```
+
+You can also apply interceptors to a single `Client` or `Pool`:
+
+```js
+import { Client, interceptors } from 'undici'
+
+const client = new Client('https://example.com').compose(
+  interceptors.retry({ maxRetries: 2 })
+)
+```
+
+---
+
+## `interceptors.dump([opts])`
+
+Reads and discards the response body up to a configurable size limit. Useful
+for keeping a connection alive after an error response without reading the
+body yourself.
+
+**Parameters**
+
+* `opts` {Object} (optional)
+  * `maxSize` {number} Maximum number of bytes to read and discard. Responses
+    whose `Content-Length` exceeds this value are aborted. **Default:**
+    `1_048_576` (1 MiB).
+
+Per-request override: set `dumpMaxSize` on the dispatch options to override
+the global `maxSize` for a specific request.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.dump({ maxSize: 128 * 1024 }) // discard up to 128 KiB
+)
+```
+
+---
+
+## `interceptors.retry([opts])`
+
+Automatically retries failed requests using the same options accepted by
+[`RetryHandler`](./RetryHandler.md).
+
+**Parameters**
+
+* `opts` {RetryHandler.RetryOptions} (optional) Global retry options applied
+  to every request. Individual requests can override via `opts.retryOptions`.
+  See [`RetryOptions`](./RetryHandler.md#retryoptions) for the full list of
+  accepted fields.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.retry({
+    maxRetries: 5,
+    minTimeout: 200,
+    maxTimeout: 5000,
+    timeoutFactor: 2,
+    statusCodes: [429, 502, 503, 504]
+  })
+)
+```
+
+---
+
+## `interceptors.redirect([opts])`
+
+Follows HTTP redirects (3xx responses) automatically.
+
+**Parameters**
+
+* `opts` {Object} (optional)
+  * `maxRedirections` {number} Maximum number of redirects to follow. Passing
+    `0` disables redirect following entirely. **Default:** `undefined`
+    (inherits from the per-request `maxRedirections` option).
+  * `throwOnMaxRedirect` {boolean} When `true`, throws an error once the
+    redirect limit is reached instead of returning the final redirect response.
+    **Default:** `false`.
+  * `stripHeadersOnRedirect` {string[]} List of header names to remove from
+    the request when following any redirect. **Default:** `[]`.
+  * `stripHeadersOnCrossOriginRedirect` {string[]} List of header names to
+    remove from the request when following a cross-origin redirect (i.e. the
+    redirect target has a different origin). Useful for stripping
+    `Authorization` on cross-origin hops. **Default:** `[]`.
+
+Per-request override: any of the four options above can also be set directly
+on the dispatch options to override the interceptor defaults for a specific
+request.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.redirect({
+    maxRedirections: 10,
+    throwOnMaxRedirect: true,
+    stripHeadersOnCrossOriginRedirect: ['authorization', 'cookie']
+  })
+)
+```
+
+---
+
+## `interceptors.decompress([opts])`
+
+Automatically decompresses response bodies encoded with `gzip`, `x-gzip`,
+`br` (Brotli), `deflate`, `compress`, `x-compress`, or `zstd`.
+
+> **Experimental:** This interceptor is experimental and subject to change.
+> A one-time `ExperimentalWarning` is emitted on first use.
+
+**Parameters**
+
+* `opts` {Object} (optional)
+  * `skipStatusCodes` {number[]} Status codes for which decompression is
+    skipped. **Default:** `[204, 304]`.
+  * `skipErrorResponses` {boolean} When `true`, responses with a status code
+    >= 400 are not decompressed. **Default:** `true`.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.decompress({
+    skipStatusCodes: [204, 304],
+    skipErrorResponses: false // decompress error bodies too
+  })
+)
+```
+
+---
+
+## `interceptors.responseError([opts])`
+
+Converts 4xx/5xx responses into thrown `ResponseError` instances, making it
+easy to handle HTTP errors with a standard `try/catch` block.
+
+The error body is automatically decoded for `application/json` and
+`text/plain` responses. For JSON responses the body is parsed and exposed as
+`error.body`.
+
+**Parameters**
+
+* `opts` {Object} (optional) — currently reserved for future use; may be
+  omitted.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors, errors } from 'undici'
+
+const agent = new Agent().compose(interceptors.responseError())
+
+try {
+  await agent.request({ origin: 'https://example.com', path: '/not-found', method: 'GET' })
+} catch (err) {
+  if (err instanceof errors.ResponseError) {
+    console.error(err.status, err.body)
+  }
+}
+```
+
+---
+
+## `interceptors.dns([opts])`
+
+Caches DNS lookups so that repeated requests to the same origin reuse the
+resolved IP address instead of performing a fresh lookup every time. Supports
+dual-stack (IPv4 + IPv6) and custom lookup/storage implementations.
+
+**Parameters**
+
+* `opts` {Object} (optional)
+  * `maxTTL` {number} Maximum number of milliseconds a DNS record is cached,
+    regardless of the TTL returned by the resolver. **Default:** `0`
+    (use the TTL from the DNS record).
+  * `maxItems` {number} Maximum number of origins to cache simultaneously.
+    Oldest entries are evicted when the limit is reached. **Default:**
+    `Infinity`.
+  * `dualStack` {boolean} When `true`, both IPv4 (`A`) and IPv6 (`AAAA`)
+    records are looked up and the interceptor picks between them based on
+    `affinity`. **Default:** `true`.
+  * `affinity` {4 | 6 | null} Preferred IP family when `dualStack` is
+    enabled. `null` lets the interceptor alternate between families.
+    **Default:** `null`.
+  * `lookup` {Function} (optional) Custom DNS resolution function with the
+    same signature as `node:dns`'s `lookup` callback form:
+    `(origin, options, callback) => void`.
+  * `pick` {Function} (optional) Custom record-selection function called with
+    `(origin, records, affinity)` to choose which resolved address to use.
+  * `storage` {DNSStorage} (optional) Custom storage backend. Must implement
+    `get`, `set`, `delete`, `full`, and `size`.
+
+**`DNSStorage` interface**
+
+```ts
+interface DNSStorage {
+  size: number
+  get(origin: string): DNSInterceptorOriginRecords | null
+  set(origin: string, records: DNSInterceptorOriginRecords | null, options: { ttl: number }): void
+  delete(origin: string): void
+  full(): boolean
+}
+```
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.dns({
+    maxTTL: 60_000, // cache for at most 60 seconds
+    dualStack: true,
+    affinity: 4     // prefer IPv4
+  })
+)
+```
+
+---
+
+## `interceptors.cache([opts])`
+
+Caches HTTP responses according to RFC 9111 (HTTP Caching). See
+[`CacheStore`](./CacheStore.md) for information on providing a custom
+backing store.
+
+**Parameters**
+
+* `opts` {CacheHandler.CacheOptions} (optional) See the
+  [`CacheStore`](./CacheStore.md) documentation for accepted fields.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors, cacheStores } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.cache({ store: new cacheStores.MemoryCacheStore() })
+)
+```
+
+---
+
+## `interceptors.deduplicate([opts])`
+
+Deduplicates concurrent identical requests so that only one is sent over the
+wire. All waiting callers receive the same response once the in-flight request
+completes. Only safe HTTP methods (e.g. `GET`, `HEAD`) may be deduplicated.
+
+**Parameters**
+
+* `opts` {Object} (optional)
+  * `methods` {string[]} HTTP methods to deduplicate. Must be safe HTTP
+    methods (`GET`, `HEAD`, `OPTIONS`, `TRACE`). **Default:** `['GET']`.
+  * `skipHeaderNames` {string[]} Header names whose presence in a request
+    causes it to bypass deduplication entirely. Matching is
+    case-insensitive. **Default:** `[]`.
+  * `excludeHeaderNames` {string[]} Header names to exclude from the
+    deduplication key. Requests that differ only in these headers are still
+    deduplicated together. Useful for headers like `x-request-id` that vary
+    per request but should not prevent deduplication. Matching is
+    case-insensitive. **Default:** `[]`.
+  * `maxBufferSize` {number} Maximum number of bytes buffered per paused
+    waiting handler. If a waiting handler exceeds this threshold it is failed
+    with an `AbortError` to prevent unbounded memory growth. **Default:**
+    `5_242_880` (5 MiB).
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.deduplicate({
+    methods: ['GET', 'HEAD'],
+    excludeHeaderNames: ['x-request-id', 'x-trace-id'],
+    maxBufferSize: 2 * 1024 * 1024
+  })
+)
+```
+
+---
+
+## Composing multiple interceptors
+
+Interceptors are applied in the order they appear in the `compose()` call.
+The first interceptor in the array wraps the outermost layer.
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose([
+  interceptors.dns({ maxTTL: 30_000 }),
+  interceptors.retry({ maxRetries: 3 }),
+  interceptors.redirect({ maxRedirections: 5 }),
+  interceptors.decompress(),
+  interceptors.responseError()
+])
+```
+
+In the example above the request flow is:
+
+1. **dns** — resolves and caches the target IP
+2. **retry** — retries the dispatch on transient failures
+3. **redirect** — follows any 3xx redirects
+4. **decompress** — decompresses the response body
+5. **responseError** — converts 4xx/5xx into thrown errors

--- a/docs/docs/site.json
+++ b/docs/docs/site.json
@@ -63,6 +63,12 @@
           ]
         },
         {
+          "label": "Interceptors",
+          "items": [
+            { "link": "/api/Interceptors", "label": "Interceptors" }
+          ]
+        },
+        {
           "label": "Handlers",
           "items": [
             { "link": "/api/RedirectHandler", "label": "RedirectHandler" },


### PR DESCRIPTION
## Summary

- Adds `docs/docs/api/Interceptors.md` — a comprehensive API reference for all eight built-in interceptors (`dump`, `retry`, `redirect`, `decompress`, `responseError`, `dns`, `cache`, `deduplicate`), covering constructor options, defaults, per-request overrides, and usage examples.
- Updates `docs/docs/site.json` to include the new page in the sidebar under a dedicated **Interceptors** group (between Proxy & Agents and Handlers).

Closes #886 (connect option needs more tests and docs — the `connect` option documentation gap is part of the broader missing interceptors docs).

## What changed

`docs/docs/api/Interceptors.md` — new file documenting:
- `interceptors.dump([opts])` — `maxSize`, per-request `dumpMaxSize` override
- `interceptors.retry([opts])` — links to RetryHandler options
- `interceptors.redirect([opts])` — `maxRedirections`, `throwOnMaxRedirect`, `stripHeadersOnRedirect`, `stripHeadersOnCrossOriginRedirect`
- `interceptors.decompress([opts])` — `skipStatusCodes`, `skipErrorResponses`, experimental warning note
- `interceptors.responseError([opts])` — error body decoding behaviour
- `interceptors.dns([opts])` — `maxTTL`, `maxItems`, `dualStack`, `affinity`, custom `lookup`/`pick`/`storage`
- `interceptors.cache([opts])` — links to CacheStore docs
- `interceptors.deduplicate([opts])` — `methods`, `skipHeaderNames`, `excludeHeaderNames`, `maxBufferSize`
- Composing multiple interceptors (ordering guidance + end-to-end example)

`docs/docs/site.json` — adds `{ "link": "/api/Interceptors", "label": "Interceptors" }` under a new **Interceptors** sidebar group.

## Test plan

- [ ] Verify markdown renders correctly in the docs site
- [ ] Check all option names match the TypeScript definitions in `types/interceptors.d.ts`
- [ ] Confirm sidebar link resolves to the new page
