### PR TITLE
fix(mock): native fetch bypasses MockAgent due to allowH2

### DIFF
--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -87,9 +87,7 @@ class MockAgent extends Dispatcher {
       dispatchOpts.path = `${path}?${normalizedSearchParams}`
     }
 
-    if (dispatchOpts.allowH2 === false) {
-      delete dispatchOpts.allowH2
-    }
+    delete dispatchOpts.allowH2
 
     return this[kAgent].dispatch(dispatchOpts, handler)
   }

--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -87,6 +87,10 @@ class MockAgent extends Dispatcher {
       dispatchOpts.path = `${path}?${normalizedSearchParams}`
     }
 
+    if (dispatchOpts.allowH2 === false) {
+      delete dispatchOpts.allowH2
+    }
+
     return this[kAgent].dispatch(dispatchOpts, handler)
   }
 

--- a/test/issue-5036.js
+++ b/test/issue-5036.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { MockAgent, setGlobalDispatcher } = require('../index.js')
+
+test('MockAgent works with native Node.js fetch', async (t) => {
+  // Only run if native fetch is available
+  if (typeof globalThis.fetch !== 'function') {
+    return
+  }
+
+  const agent = new MockAgent()
+  agent.disableNetConnect()
+
+  setGlobalDispatcher(agent)
+
+  agent.get('https://example.com')
+    .intercept({
+      method: 'GET',
+      path: '/v1/test'
+    })
+    .reply(200, { test: 123 })
+
+  const req = await globalThis.fetch('https://example.com/v1/test')
+  assert.strictEqual(req.status, 200)
+
+  const data = await req.json()
+  assert.deepStrictEqual(data, { test: 123 })
+})


### PR DESCRIPTION
Fixes #5036

### Description

This PR fixes an issue where native Node.js `fetch` queries would bypass the `MockAgent` globally registered using `setGlobalDispatcher`.

#### Root Cause
In version 8.0.3, a change was introduced to wrap the legacy global dispatcher with a `Dispatcher1Wrapper` (`fix: mirror the legacy global dispatcher for built-in fetch`). To support legacy consumers, `Dispatcher1Wrapper.dispatch` modifies `opts` to forcefully add `allowH2: false`.

Because of this, `native node fetch` passes `allowH2: false` when delegating to the `MockAgent`. When `MockAgent` proxies the request to its internal encapsulated `Agent` instance:
1. `MockAgent.get(origin)` pre-registers and creates a `MockClient` for the `origin` exactly as-is.
2. The encapsulated `Agent.dispatch` checks `allowH2: false` and modifies the lookup key to be `${origin}#http1-only`.
3. Because the `MockClient` registered is under `${origin}`, the cache miss causes the underlying `Agent` to instantiate a brand new real `Client` under `${origin}#http1-only`.
4. As a result, the request completely bypasses the mock interceptors and is fired over the real network!

#### Fix
The mock interceptor system shouldn't be concerned about whether `HTTP/2` or `HTTP/1.1` is being explicitly requested by the wrapper. To solve this, `MockAgent.dispatch` now safely deletes the `allowH2` flag from `dispatchOpts` if it is set to `false`. This ensures the underlying encapsulated `Agent` retains the standard origin as the lookup key and successfully resolves to the pre-registered `MockClient`.

A regression test using native `globalThis.fetch` has also been added in `test/issue-5036.js`.
