### PR TITLE
fix: reject non-ascii octets in validateCookiePath

### DIFF
--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -105,7 +105,7 @@ function validateCookiePath (path) {
 
     if (
       code < 0x20 || // exclude CTLs (0-31)
-      code === 0x7F || // DEL
+      code > 0x7E || // exclude non-ascii and DEL
       code === 0x3B // ;
     ) {
       throw new Error('Invalid cookie path')

--- a/test/cookie/validate-cookie-path.js
+++ b/test/cookie/validate-cookie-path.js
@@ -48,6 +48,13 @@ describe('validateCookiePath', () => {
     throws(() => validateCookiePath(';'))
   })
 
+  test('should throw for non-ascii octets', () => {
+    throws(() => validateCookiePath('/a\xE9')) // é, 0xE9
+    throws(() => validateCookiePath('/\x80')) // first C1 control
+    throws(() => validateCookiePath('/\x9F')) // last C1 control
+    throws(() => validateCookiePath('/\xFF')) // 0xFF
+  })
+
   test('should pass for a printable character', t => {
     strictEqual(validateCookiePath('A'), undefined)
     strictEqual(validateCookiePath('Z'), undefined)


### PR DESCRIPTION
## What

`validateCookiePath` in `lib/web/cookies/util.js` accepts octets above `0x7E` (non-ascii and C1 controls), which RFC 6265 prohibits for a cookie path.

## Why

RFC 6265 §4.1.1 defines:

```
path-value = <any CHAR except CTLs or ";">
```

where `CHAR` is a US-ASCII character (`0x00`-`0x7F`). The current check rejects `code < 0x20` (CTLs), `code === 0x7F` (DEL) and `code === 0x3B` (`;`), but has no upper bound, so any code point from `0x80` to `0xFF` passes:

```js
validateCookiePath('/a\xE9') // é — currently returns undefined, should throw
```

This is inconsistent with the two sibling validators in the same file, which both reject `code > 0x7E`:

- `validateCookieName` — `code > 0x7E` present
- `validateCookieValue` — `code > 0x7E` present
- `validateCookiePath` — `code > 0x7E` missing

```js
validateCookieName('a\xE9')  // throws (correct)
validateCookieValue('a\xE9') // throws (correct)
validateCookiePath('/a\xE9') // does not throw (this PR)
```

It is reachable from the public `setCookie(headers, { path })` API. This is a conformance defect, not a security issue: CR, LF and other control octets are already rejected by the `code < 0x20` clause, so no header injection is possible.

## Fix

Replace the redundant `code === 0x7F` clause with the upper bound `code > 0x7E`, matching the sibling validators. DEL (`0x7F`) stays rejected because `0x7F > 0x7E`.

```diff
     if (
       code < 0x20 || // exclude CTLs (0-31)
-      code === 0x7F || // DEL
+      code > 0x7E || // exclude non-ascii and DEL
       code === 0x3B // ;
     ) {
```

## Tests

Added a case to `test/cookie/validate-cookie-path.js` asserting that a non-ascii path and the C1 control range throw. It fails on `main` (`Missing expected exception`) and passes with the fix. The existing DEL and printable-character cases still pass.
