### PR TITLE
fix(h2): requeue request on GOAWAY'd session instead of crashing

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -862,7 +862,10 @@ function openStream (client, request, session, abort, headers, options) {
   try {
     return session.request(headers, options)
   } catch (err) {
-    if (err?.code === 'ERR_HTTP2_INVALID_SESSION') {
+    // A GOAWAY'd session rejects new streams, same as an invalid session:
+    // reset and requeue on a fresh connection rather than the destroy + abort
+    // below, whose destroy(socket, err) can crash via an unhandled 'error'.
+    if (err?.code === 'ERR_HTTP2_INVALID_SESSION' || err?.code === 'ERR_HTTP2_GOAWAY_SESSION') {
       const wrappedErr = new SocketError(err.message, util.getSocketInfo(session[kSocket]))
       wrappedErr.cause = err
       session[kError] = wrappedErr

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -3,7 +3,7 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { constants, createSecureServer } = require('node:http2')
-const { once } = require('node:events')
+const { once, EventEmitter } = require('node:events')
 
 const pem = require('@metcoder95/https-pem')
 
@@ -287,6 +287,75 @@ test('#5089 - Handle GOAWAY Gracefully', async (t) => {
   t.deepStrictEqual([...sessionCounts.values()], [2, 4])
   t.deepStrictEqual(results.map((result) => result.statusCode), Array(6).fill(200))
   t.deepStrictEqual(results.map((result) => result.body), Array(6).fill('hello world'))
+
+  await t.completed
+})
+
+test('#5453 - request onto a GOAWAY-rejected session is requeued on a fresh session', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  // A session that has received GOAWAY rejects new streams synchronously.
+  class FakeSession extends EventEmitter {
+    constructor () {
+      super()
+      this.closed = false
+      this.destroyed = false
+    }
+
+    request () {
+      const err = new Error('New streams cannot be created after receiving a GOAWAY')
+      err.code = 'ERR_HTTP2_GOAWAY_SESSION'
+      throw err
+    }
+
+    destroy () {
+      if (this.destroyed) return
+      this.destroyed = true
+      this.emit('close')
+    }
+
+    ref () {}
+    unref () {}
+  }
+
+  const session = new FakeSession()
+  let connectCalls = 0
+  let streams = 0
+
+  http2.connect = function connectStub (...args) {
+    connectCalls++
+    return connectCalls === 1 ? session : originalConnect.apply(this, args)
+  }
+  after(() => { http2.connect = originalConnect })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  server.on('stream', (stream) => {
+    streams++
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    allowH2: true,
+    connect: { rejectUnauthorized: false }
+  })
+  after(() => client.close())
+
+  const response = await client.request({ path: '/', method: 'GET' })
+  const chunks = []
+  response.body.on('data', chunk => chunks.push(chunk))
+  await once(response.body, 'end')
+
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(Buffer.concat(chunks).toString(), 'ok')
+  t.strictEqual(streams, 1)
+  t.strictEqual(connectCalls, 2)
+  t.strictEqual(session.destroyed, true)
 
   await t.completed
 })


### PR DESCRIPTION
## Issue

When a request is dispatched onto an HTTP/2 session that has **already received a `GOAWAY` frame**, `ClientHttp2Session.request()` throws `ERR_HTTP2_GOAWAY_SESSION` ("New streams cannot be created after receiving a GOAWAY"). In `writeH2`'s `requestStream`, only `ERR_HTTP2_INVALID_SESSION` is handled gracefully; `GOAWAY` falls through to:

```js
session.destroy(wrappedErr)
util.destroy(session[kSocket], wrappedErr)   // <-
abort(wrappedErr)
```

The `util.destroy(socket, wrappedErr)` re-emits `'error'` on a socket whose `'error'` listener can already be detached during teardown, which surfaces as an **`uncaughtException` and crashes the process**:

```
Uncaught exception
  InformationalError: New streams cannot be created after receiving a GOAWAY
  code: UND_ERR_INFO, cause.code: ERR_HTTP2_GOAWAY_SESSION
    at requestStream (lib/dispatcher/client-h2.js)
    at writeH2 → _resume → resume → [dispatch] → Pool.dispatch
```

Observed in production on a high-volume `allowH2: true` client talking to servers that routinely send `GOAWAY` to rotate connections: under load a queued request is dispatched onto a session in the window after the `GOAWAY` frame is received but before `onHttp2SessionGoAway` retires the session, and the process crashes. Same family as the recently-hardened h2 teardown crashes (#5440, #4564).

## Fix

A `GOAWAY`'d session is the same situation as `ERR_HTTP2_INVALID_SESSION` — the peer won't accept new streams — so route it through the existing graceful branch (`resetHttp2Session` + `requeueUnsentRequest`). The request is **reset and requeued on a fresh connection** instead of failing and risking the unhandled socket `'error'`.

```diff
-      if (err?.code === 'ERR_HTTP2_INVALID_SESSION') {
+      if (err?.code === 'ERR_HTTP2_INVALID_SESSION' || err?.code === 'ERR_HTTP2_GOAWAY_SESSION') {
```

## Test

Added a regression test in `test/http2-goaway.js`, modeled on the existing `http2-invalid-session.js` pattern: it stubs `http2.connect` to return a fake session whose `request()` throws `ERR_HTTP2_GOAWAY_SESSION`, then asserts the request is requeued onto a fresh real session and succeeds (`connectCalls === 2`, `200`, `'ok'`). It **fails on `main`** (the throw escapes via the destroy+abort fallthrough) and **passes with this change**.
