### PR TITLE
types: fix deleteCookie attributes

### DIFF
--- a/test/types/cookies.test-d.ts
+++ b/test/types/cookies.test-d.ts
@@ -1,0 +1,11 @@
+import { expectError, expectType } from 'tsd'
+import { Headers, deleteCookie } from '../..'
+
+const headers = new Headers()
+
+expectType<void>(deleteCookie(headers, 'session'))
+expectType<void>(deleteCookie(headers, 'session', { domain: 'example.com' }))
+expectType<void>(deleteCookie(headers, 'session', { path: '/' }))
+expectType<void>(deleteCookie(headers, 'session', { domain: 'example.com', path: '/' }))
+
+expectError(deleteCookie(headers, 'session', { name: 'session' }))

--- a/types/cookies.d.ts
+++ b/types/cookies.d.ts
@@ -18,7 +18,7 @@ export interface Cookie {
 export function deleteCookie (
   headers: Headers,
   name: string,
-  attributes?: { name?: string, domain?: string }
+  attributes?: { path?: string, domain?: string }
 ): void
 
 export function getCookies (headers: Headers): Record<string, string>


### PR DESCRIPTION
## This relates to...

Fixes #5458

## Rationale

`deleteCookie(headers, name, attributes)` accepts `path` and `domain` at runtime, but the TypeScript declaration exposed `name` and `domain`.

The cookie name is already provided as the second argument, so `name` should not be accepted inside the attributes object. This updates the declaration to match the runtime behavior and existing cookie usage.

## Changes

Updates the `deleteCookie` TypeScript declaration and adds tsd coverage for the accepted/rejected attributes.

### Features

N/A

### Bug Fixes

- Allows `deleteCookie(headers, name, { path: '/' })` in TypeScript
- Rejects `deleteCookie(headers, name, { name: '...' })` in TypeScript
- Keeps `domain` supported as before

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin