### PR TITLE
fix(types): correct deleteCookie attributes

### DIFF
--- a/test/types/cookies.test-d.ts
+++ b/test/types/cookies.test-d.ts
@@ -1,0 +1,19 @@
+import { expectError, expectType } from 'tsd'
+import { Headers, deleteCookie } from '../..'
+
+const headers = new Headers()
+
+// `path` and `domain` should be accepted as deleteCookie attributes.
+expectType<void>(deleteCookie(headers, 'session', {
+  domain: 'example.com',
+  path: '/'
+}))
+
+expectType<void>(deleteCookie(headers, 'session', { path: '/' }))
+expectType<void>(deleteCookie(headers, 'session', { domain: 'example.com' }))
+
+// `name` should not be accepted because the cookie name is the second positional argument.
+expectError(deleteCookie(headers, 'session', {
+  domain: 'example.com',
+  name: 'session'
+}))

--- a/types/cookies.d.ts
+++ b/types/cookies.d.ts
@@ -18,7 +18,7 @@ export interface Cookie {
 export function deleteCookie (
   headers: Headers,
   name: string,
-  attributes?: { name?: string, domain?: string }
+  attributes?: { path?: string, domain?: string }
 ): void
 
 export function getCookies (headers: Headers): Record<string, string>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes #5458 

## Rationale

deleteCookie(headers, name, attributes) supports path and domain at runtime for deleting path-scoped cookies, but the TypeScript declaration currently exposes the attributes object as { name?: string, domain?: string }.

This causes TypeScript to reject valid usage with path, while accepting name even though the cookie name is already provided as the second positional argument.

## Changes

Updates the deleteCookie TypeScript declaration from:

{ name?: string, domain?: string }

to:

{ path?: string, domain?: string }


Adds tsd coverage to verify that:
- path and domain are accepted as delete-cookie attributes
- name is rejected inside the attributes object

### Features

N/A

### Bug Fixes

Fixes the deleteCookie TypeScript declaration so it matches runtime behavior and documentation.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [X] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [X] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [X] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
