### PR TITLE
fix(h2): destroy the stream on abort instead of relying on close()

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -933,8 +933,21 @@ function writeH2 (client, request) {
     if (state.stream != null) {
       clearRequestStream(request)
 
-      // On Abort, we close the stream to send RST_STREAM frame
-      state.stream.close()
+      // On Abort, we close the stream to send RST_STREAM frame.
+      const stream = state.stream
+      stream.close()
+
+      // close() alone leaves cleanup waiting on the 'close' event; on a busy,
+      // long-lived multiplexed session that event can fail to fire, leaving the
+      // native Http2Stream (and the whole request graph it pins) alive for the
+      // session's life. Destroy the stream to release the handle
+      // deterministically, but defer it by a setImmediate so the RST_STREAM
+      // frame queued by close() gets a chance to be written first.
+      setImmediate(() => {
+        if (!stream.destroyed) {
+          util.destroy(stream)
+        }
+      })
 
       // We move the running index to the next request
       client[kOnError](err)

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -772,6 +772,82 @@ test('Should clear h2 request stream references after abort before response', as
   await t.completed
 })
 
+test('Should destroy the h2 stream on abort', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  // Never respond, so the stream stays in-flight when we abort it.
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const abortReason = new Error('abort after h2 stream assigned')
+  let abortRequest = null
+
+  const waitFor = async (fn) => {
+    for (let i = 0; i < 100; i++) {
+      const value = fn()
+      if (value != null) return value
+      await sleep(10)
+    }
+    throw new Error('timed out waiting for h2 request stream')
+  }
+
+  const responseError = new Promise(resolve => {
+    client.dispatch({ path: '/', method: 'GET' }, {
+      onRequestStart (controller) {
+        abortRequest = controller.abort.bind(controller)
+      },
+      onResponseStart () {
+        t.fail('unexpected response')
+      },
+      onResponseData () {
+        return true
+      },
+      onResponseEnd () {
+        t.fail('unexpected response end')
+      },
+      onResponseError (_controller, err) {
+        resolve(err)
+      }
+    })
+  })
+
+  const requestStreamSymbol = await waitFor(() => {
+    const request = client[kQueue][client[kRunningIdx]]
+    if (request == null) return null
+    return Object.getOwnPropertySymbols(request).find(
+      (s) => s.description === 'request stream'
+    )
+  })
+  const stream = await waitFor(
+    () => client[kQueue][client[kRunningIdx]]?.[requestStreamSymbol]
+  )
+
+  abortRequest = await waitFor(() => abortRequest)
+  abortRequest(abortReason)
+
+  // The abort path must destroy the stream, not just close() it: relying on the
+  // async 'close' event leaks the native Http2Stream when that event never
+  // fires on a busy, long-lived multiplexed session. The destroy is deferred by
+  // a setImmediate so the RST_STREAM frame from close() can be written first.
+  await waitFor(() => stream.destroyed || null)
+  t.strictEqual(stream.destroyed, true)
+  t.strictEqual(await responseError, abortReason)
+
+  await t.completed
+})
+
 test('Should only accept valid ping interval values', async t => {
   const planner = tspl(t, { plan: 3 })
 


### PR DESCRIPTION
## What

On abort, the HTTP/2 client sends `RST_STREAM` via `stream.close()` and then leaves the rest of teardown to the stream's asynchronous `'close'` event (`onRequestStreamClose`, which clears the request↔stream references and lets the native `Http2Stream` be released). This adds an explicit `stream.destroy()` after `close()` so the handle is released deterministically.

```js
// lib/dispatcher/client-h2.js — abort()
stream.close()
if (!stream.destroyed) {
  util.destroy(stream)
}
```

## Why

If that `'close'` event never fires — which can happen for an aborted stream on a busy, long-lived multiplexed session — the native `Http2Stream` stays alive (pinned by a V8 global handle via `owner_symbol`), and with it the stream's `[kRequestStreamState]` and the **entire request object graph it references** (the `Request`, its `AbortController`, response buffers, and handler closures). On a connection that is intentionally kept open for a long time, one such stream leaks per aborted request, growing the heap without bound.

This was found in production on a service that routes many requests through a small, long-lived shared HTTP/2 connection pool. A heap snapshot from a leaking process showed tens of thousands of retained `ClientHttp2Stream` objects, each still holding:

- `[kHandle] = Http2Stream` (native stream **not** destroyed) ← `(Global handles)`
- `[kRequestStreamState] = { request, … }` (cleanup never ran, i.e. `'close'` never fired)
- `[kRequest] = null` (the request had already aborted)

with the abort reason overwhelmingly `TimeoutError: The operation was aborted due to timeout` (an `AbortSignal.timeout` firing mid-request). The counts scaled linearly with process uptime.

The abort path's own comment already states the intended behaviour — *"the stream gets destroyed and the session remains to create new streams"* — but `close()` alone does not guarantee it. This change makes the code match that intent. The socket/session is left untouched, so it remains available for new streams.

## Test

Adds `Should destroy the h2 stream synchronously on abort` to `test/http2-dispatcher.js`: it captures the in-flight request's stream, aborts, and asserts `stream.destroyed === true`. It **fails on the current `close()`-only path** (the stream is not destroyed synchronously) and passes with this change. Existing h2 abort tests are unaffected.

## Note on reproduction

The behavioural defect (abort leaves the stream un-destroyed, relying on an async `'close'` that may not fire) is reproduced directly by the added test. The full production leak only manifests against a real long-lived multiplexed peer where the `'close'` event is dropped; I couldn't reduce that to a minimal local server, so the test asserts the deterministic-teardown behaviour rather than the leak itself. Happy to adjust the approach (e.g. destroy on a `close()` callback/timeout instead) if maintainers prefer.

