### PR TITLE
test: guard balanced-pool error port lookup

### DIFF
--- a/test/node-test/balanced-pool.js
+++ b/test/node-test/balanced-pool.js
@@ -351,6 +351,10 @@ test('getUpstream returns undefined for closed/destroyed upstream', (t) => {
   p.strictEqual(result, undefined)
 })
 
+function getErrorPort (err) {
+  return err?.socket?.remotePort ?? err?.port
+}
+
 class TestServer {
   constructor ({ config: { server, socketHangup, downOnRequests, socketHangupOnRequests }, onRequest }) {
     this.config = {
@@ -604,15 +608,21 @@ describe('weighted round robin', () => {
         try {
           await client.request({ path: '/', method: 'GET' })
         } catch (e) {
-          const serverWithError =
-          servers.find(server => server.port === e.port) ||
-          servers.find(server => {
-            if (typeof AggregateError === 'function' && e instanceof AggregateError) {
-              return e.errors.some(e => server.port === (e.socket?.remotePort ?? e.port))
+          const serverWithError = servers.find(server => {
+            if (server.port === getErrorPort(e)) {
+              return true
             }
 
-            return server.port === e.socket.remotePort
+            if (typeof AggregateError === 'function' && e instanceof AggregateError) {
+              return e.errors.some(err => server.port === getErrorPort(err))
+            }
+
+            return false
           })
+
+          if (serverWithError === undefined) {
+            throw e
+          }
 
           serverWithError.requestsCount++
 


### PR DESCRIPTION
## This relates to...

Windows flake in `test/node-test/balanced-pool.js` where an error object may not include nested socket metadata.

## Rationale

The weighted round-robin test assumed all request errors expose `error.socket.remotePort`. On Windows, some transient errors can be missing `socket`, causing the test harness to throw a masking `TypeError` instead of handling or surfacing the original error.

## Changes

### Features

N/A

### Bug Fixes

- Add a helper to safely read ports from request errors.
- Handle `AggregateError` children with the same safe lookup.
- Rethrow the original error when it cannot be mapped to a test server.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Tested with:

- `npx borp -p "test/node-test/balanced-pool.js"`
- `npm run lint -- test/node-test/balanced-pool.js`
- `git diff --check`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
