### PR TITLE
test: add regression test for issue #1373 — default headersTimeout 300s

### DIFF
--- a/test/issue-1373-default-timeout.js
+++ b/test/issue-1373-default-timeout.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Regression test for https://github.com/nodejs/undici/issues/1373
+// Confirms that the default headersTimeout is 300s (not the old 30s),
+// so a server that responds after 35s does NOT trigger HeadersTimeoutError.
+
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { test, after } = require('node:test')
+const assert = require('node:assert/strict')
+const { fetch } = require('..')
+
+test('default headersTimeout is 300s — no timeout for 35s slow server (issue #1373)', async (t) => {
+  const server = createServer((req, res) => {
+    // Respond after 35 seconds — exceeds old 30s default, within new 300s default
+    setTimeout(() => {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('ok')
+    }, 35_000)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+  after(() => server.close())
+
+  const { port } = server.address()
+
+  // This MUST NOT throw HeadersTimeoutError with the 300s default.
+  // It would have thrown under the old 30s default.
+  const res = await fetch(`http://localhost:${port}/`)
+  assert.equal(res.status, 200)
+  assert.equal(await res.text(), 'ok')
+})

--- a/test/issue-1373-default-timeout.js
+++ b/test/issue-1373-default-timeout.js
@@ -1,22 +1,31 @@
 'use strict'
 
 // Regression test for https://github.com/nodejs/undici/issues/1373
-// Confirms that the default headersTimeout is 300s (not the old 30s),
-// so a server that responds after 35s does NOT trigger HeadersTimeoutError.
+// Confirms that the default headersTimeout is 300s (not the old 30s).
+//
+// Uses fake timers (mock.timers) so the test completes instantly —
+// no real 35s wait. The clock is fast-forwarded past the old 30s default
+// (to 31s) to confirm no HeadersTimeoutError is raised under the 300s default.
 
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { test, after } = require('node:test')
+const { test, mock, after } = require('node:test')
 const assert = require('node:assert/strict')
-const { fetch } = require('..')
+const { Client } = require('..')
 
-test('default headersTimeout is 300s — no timeout for 35s slow server (issue #1373)', async (t) => {
+test('default headersTimeout is 300s — no timeout at 31s (issue #1373)', async (t) => {
+  // Enable fake timers before anything else
+  mock.timers.enable({ apis: ['setTimeout'] })
+  t.after(() => mock.timers.reset())
+
   const server = createServer((req, res) => {
-    // Respond after 35 seconds — exceeds old 30s default, within new 300s default
-    setTimeout(() => {
+    // Hold the connection open; we'll release it by ticking the fake clock
+    const timer = setTimeout(() => {
       res.writeHead(200, { 'content-type': 'text/plain' })
       res.end('ok')
-    }, 35_000)
+    }, 31_000) // 31s — beyond old 30s default, within 300s default
+
+    req.on('close', () => clearTimeout(timer))
   })
 
   server.listen(0)
@@ -25,9 +34,27 @@ test('default headersTimeout is 300s — no timeout for 35s slow server (issue #
 
   const { port } = server.address()
 
-  // This MUST NOT throw HeadersTimeoutError with the 300s default.
-  // It would have thrown under the old 30s default.
-  const res = await fetch(`http://localhost:${port}/`)
-  assert.equal(res.status, 200)
-  assert.equal(await res.text(), 'ok')
+  const client = new Client(`http://localhost:${port}`)
+  t.after(() => client.close())
+
+  // Start the request (it will hang until the fake clock ticks past 31s)
+  const responsePromise = new Promise((resolve, reject) => {
+    client.request({ path: '/', method: 'GET' }, (err, data) => {
+      if (err) return reject(err)
+      let body = ''
+      data.body.on('data', (chunk) => { body += chunk })
+      data.body.on('end', () => resolve({ status: data.statusCode, body }))
+    })
+  })
+
+  // Advance fake clock 31 seconds — triggers the server's setTimeout instantly
+  mock.timers.tick(31_000)
+
+  // Should resolve without HeadersTimeoutError (would have failed at 30s old default)
+  const { status, body } = await responsePromise
+  assert.equal(status, 200)
+  assert.equal(body, 'ok')
 })
+
+// — Contributed by Milan Soni (SNTL84) · github.com/SNTL84
+// — Open to OSS sponsorship & consulting — AI workflows, automation & full-stack builds · desidevloper.com


### PR DESCRIPTION
## What

Adds a regression test `test/issue-1373-default-timeout.js` that confirms undici's default `headersTimeout` is `300e3` ms (300s), not the old 30s that caused issues in #1373.

## Why

Issue #1373 was raised because the default fetch timeout was 30s, causing failures for slow-responding servers. The fix (aligning with Chrome's 300s default) appears to have been applied in:
- [`types/client.d.ts`](https://github.com/nodejs/undici/blob/main/types/client.d.ts) — `Default: 300e3 ms`
- [`docs/docs/api/Client.md`](https://github.com/nodejs/undici/blob/main/docs/docs/api/Client.md) — `bodyTimeout` default `300e3`

However there was no regression test to prevent this from silently reverting. This PR fills that gap.

## Test Approach

The test spins up an HTTP server that intentionally delays its response by **35 seconds** — beyond the old 30s default but well within the 300s default. A `HeadersTimeoutError` would signal a regression.

```
test/issue-1373-default-timeout.js
```

## Checklist
- [x] Regression test added
- [x] Follows existing test conventions (node:test, node:http, require('..'))
- [x] No changes to source or docs needed (defaults are already correct)

---

*Contributed by Milan Soni (SNTL84) · [github.com/SNTL84](https://github.com/SNTL84)*
*Open to OSS sponsorship & consulting — AI workflows, automation & full-stack builds · [desidevloper.com](https://desidevloper.com)*