### PR TITLE
fix(h2): deliver an early final response to an Expect: 100-continue request

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -1037,6 +1037,7 @@ function writeH2 (client, request) {
     headersTimeout,
     bodyTimeout,
     responseReceived: false,
+    bodySent: false,
     session,
     stream: null
   }
@@ -1136,6 +1137,13 @@ function onResponse (headers) {
 
   stream.off('response', onResponse)
 
+  // Final response received while still awaiting 100 (Continue): the body won't
+  // be sent, so close our half or the stream stays open and never completes.
+  if (state.body != null && !state.bodySent && !stream.writableEnded) {
+    stream.removeListener('continue', writeBodyH2)
+    stream.end()
+  }
+
   const statusCode = headers[HTTP2_HEADER_STATUS]
   delete headers[HTTP2_HEADER_STATUS]
   request.onResponseStarted()
@@ -1233,6 +1241,7 @@ function onTrailers (trailers) {
 function writeBodyH2 () {
   const stream = this
   const state = stream[kRequestStreamState]
+  state.bodySent = true
   const { abort, body, client, contentLength, expectsPayload, request } = state
 
   if (!body || contentLength === 0) {

--- a/test/http2-continue.js
+++ b/test/http2-continue.js
@@ -65,3 +65,46 @@ test('Should handle h2 continue', async t => {
 
   await t.completed
 })
+
+test('Should deliver an early final response to an Expect: 100-continue request without sending the body', async t => {
+  t = tspl(t, { plan: 4 })
+
+  let requestBodyBytes = 0
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }), () => {})
+
+  server.on('checkContinue', (request, response) => {
+    t.strictEqual(request.headers.expect, '100-continue')
+    request.on('data', chunk => { requestBodyBytes += chunk.length })
+
+    // Answer from the header fields alone; do not send 100 (Continue).
+    response.writeHead(401, { 'content-type': 'text/plain' })
+    response.end('denied')
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  const response = await client.request({
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-type': 'text/plain'
+    },
+    body: 'x'.repeat(1024),
+    expectContinue: true
+  })
+
+  t.strictEqual(response.statusCode, 401)
+  t.strictEqual(await response.body.text(), 'denied')
+  t.strictEqual(requestBodyBytes, 0)
+
+  await t.completed
+})


### PR DESCRIPTION
Fixes #5465.

## Problem

Over HTTP/2, when a server answers a request carrying `Expect: 100-continue` with a final response (e.g. `401`) instead of `100 (Continue)`, undici withholds the request body correctly but never delivers the response — the request hangs.

The body write is bound to the stream's `'continue'` event; on an early final response that never fires, so the client never sends `END_STREAM`. The h2 stream stays half-open, its `'close'` never fires, and `onRequestStreamClose` (which finalizes the response) never runs. RFC 9110 [§10.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1) permits a server to answer with a final status determinable from the header fields in place of `100 (Continue)`, so this is a client conformance bug. HTTP/2 only — HTTP/1.x already handles it.

## Fix

In `onResponse` (`lib/dispatcher/client-h2.js`): when a final response arrives and the body was never sent, remove the `continue` listener and `stream.end()` the writable half, so the stream completes and the response is delivered without sending the body. "Body not sent" is tracked with a new `state.bodySent`, set when `writeBodyH2` runs.

## Tests

New case in `test/http2-continue.js`: an early `401` to an `Expect: 100-continue` `POST` is delivered, and the server receives 0 body bytes. The existing h2 suite passes.

Minimal reproduction: https://github.com/jeswr/undici-h2-expect-continue-bug
