### PR TITLE
fix(eventsource): set use-URL-credentials flag

### DIFF
--- a/lib/web/eventsource/util.js
+++ b/lib/web/eventsource/util.js
@@ -49,7 +49,7 @@ function createPotentialCORSRequest (url, destination, corsAttributeState, sameO
     destination,
     mode,
     credentials: credentialsMode,
-    useCredentials: true
+    useURLCredentials: true
   })
 }
 

--- a/test/eventsource/util.js
+++ b/test/eventsource/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
-const { isASCIINumber, isValidLastEventId } = require('../../lib/web/eventsource/util')
+const { isASCIINumber, isValidLastEventId, createPotentialCORSRequest } = require('../../lib/web/eventsource/util')
 
 test('isValidLastEventId', (t) => {
   t.assert.strictEqual(isValidLastEventId('valid'), true)
@@ -14,4 +14,42 @@ test('isASCIINumber', (t) => {
   t.assert.strictEqual(isASCIINumber('123'), true)
   t.assert.strictEqual(isASCIINumber(''), false)
   t.assert.strictEqual(isASCIINumber('123a'), false)
+})
+
+test('createPotentialCORSRequest', async (t) => {
+  const url = new URL('https://example.com/events')
+
+  const cases = [
+    {
+      name: 'anonymous',
+      state: 'anonymous',
+      mode: 'cors',
+      credentials: 'same-origin'
+    },
+    {
+      name: 'use credentials',
+      state: 'use-credentials',
+      mode: 'cors',
+      credentials: 'include'
+    }
+  ]
+
+  for (const item of cases) {
+    await t.test(item.name, (t) => {
+      const request = createPotentialCORSRequest(
+        url,
+        '',
+        item.state,
+        false
+      )
+
+      t.assert.strictEqual(request.mode, item.mode)
+      t.assert.strictEqual(request.credentials, item.credentials)
+      t.assert.strictEqual(request.useURLCredentials, true)
+      t.assert.strictEqual(request.destination, '')
+      t.assert.strictEqual(request.urlList.length, 1)
+      t.assert.strictEqual(request.urlList[0], url)
+      t.assert.strictEqual(request.url, url)
+    })
+  }
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes EventSource potential-CORS request creation so it sets the correct use-URL-credentials flag.

## Rationale

The HTML potential-CORS request algorithm requires the returned request’s use-URL-credentials flag to be set.

`createPotentialCORSRequest()` previously passed `useCredentials: true` to `makeRequest()`, but Undici stores `useCredentials` and `useURLCredentials` as separate fields. The Fetch authentication logic consumes `useURLCredentials`, so the intended flag was not being set.

WebSocket already uses `useURLCredentials: true` for the same internal request flag.

Specification: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request

## Changes

Changed `useCredentials: true` to `useURLCredentials: true` in `createPotentialCORSRequest()`.

Added unit coverage for both EventSource CORS states:

- `anonymous`: `cors` mode with `same-origin` credentials
- `use-credentials`: `cors` mode with `include` credentials

The test also verifies `useURLCredentials`, `destination`, `urlList`, and `url`.

### Features

N/A

### Bug Fixes

Fixes EventSource request creation so the use-URL-credentials flag is set on the internal Fetch request.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

## Testing

```bash
node --test test/eventsource/util.js
npm run test:eventsource
npm run lint

