### PR TITLE
fix: narrow DispatchOptions.upgrade type to string | null

### DIFF
--- a/test/types/dispatcher.test-d.ts
+++ b/test/types/dispatcher.test-d.ts
@@ -1,6 +1,6 @@
 import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'node:http'
 import { Duplex, Readable, Writable } from 'node:stream'
-import { expectAssignable, expectType } from 'tsd'
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 import { Dispatcher, Headers } from '../..'
 import { URL } from 'node:url'
 import { Blob } from 'node:buffer'
@@ -52,6 +52,11 @@ expectAssignable<Dispatcher>(new Dispatcher())
   expectAssignable<boolean>(dispatcher.dispatch({ origin: '', path: '', method: 'GET', headers: iteratorHeaders, reset: true }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ origin: new URL('http://localhost'), path: '', method: 'GET' }, {}))
   expectAssignable<boolean>(dispatcher.dispatch({ path: '', method: 'CUSTOM' }, {}))
+
+  // upgrade must be string or null, not boolean
+  expectNotAssignable<Dispatcher.DispatchOptions>({ path: '/', method: 'GET', upgrade: true })
+  expectAssignable<Dispatcher.DispatchOptions>({ path: '/', method: 'GET', upgrade: 'websocket' })
+  expectAssignable<Dispatcher.DispatchOptions>({ path: '/', method: 'GET', upgrade: null })
 
   // connect
   expectAssignable<Promise<Dispatcher.ConnectData>>(dispatcher.connect({ origin: '', path: '' }))

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -114,7 +114,7 @@ declare namespace Dispatcher {
     /** The IP Type of Service (ToS) value for the request socket. Must be an integer between 0 and 255. Default: `0` */
     typeOfService?: number | null;
     /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
-    upgrade?: boolean | string | null;
+    upgrade?: string | null;
     /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers. Defaults to 300 seconds. */
     headersTimeout?: number | null;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use 0 to disable it entirely. Defaults to 300 seconds. */


### PR DESCRIPTION
## Summary

Fixes #5466

`DispatchOptions.upgrade` accepted `boolean` in the TypeScript type, but the runtime validator in `lib/core/request.js` rejects any truthy non-string value with `InvalidArgumentError: upgrade must be a string`. A TypeScript-valid call like `client.dispatch({ path: '/', method: 'GET', upgrade: true }, handler)` therefore fails at runtime.

## Changes

- **`types/dispatcher.d.ts`**: Narrowed `upgrade` from `boolean | string | null` to `string | null`
- **`test/types/dispatcher.test-d.ts`**: Added type-level assertion that `upgrade: true` is rejected via `expectNotAssignable`, plus positive assertions for `upgrade: 'websocket'` and `upgrade: null`

## Testing

- `expectNotAssignable<Dispatcher.DispatchOptions>({ ..., upgrade: true })` — fails at type-check time
- Existing valid usage (`upgrade: 'websocket'`, `upgrade: null`) remains accepted