### PR TITLE
fix: ignore an unparseable Set-Cookie Expires attribute

### DIFF
--- a/lib/web/cookies/parse.js
+++ b/lib/web/cookies/parse.js
@@ -178,8 +178,9 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
 
     // 2. If the attribute-value failed to parse as a cookie date, ignore
     //    the cookie-av.
-
-    cookieAttributeList.expires = expiryTime
+    if (!Number.isNaN(expiryTime.getTime())) {
+      cookieAttributeList.expires = expiryTime
+    }
   } else if (attributeNameLowercase === 'max-age') {
     // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-5.4.2
     // If the attribute-name case-insensitively matches the string "Max-

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -745,3 +745,11 @@ test('Cookie getCookie does not throw if headers is an instance of the global He
   const headers = new globalThis.Headers()
   deleteCookie(headers, 'deno')
 })
+
+test('Set-Cookie parser ignores an unparseable Expires', () => {
+  const headers = new Headers({ 'set-cookie': 'id=a3fWa; Expires=not-a-date' })
+  assert.deepEqual(getSetCookies(headers), [{
+    name: 'id',
+    value: 'a3fWa'
+  }])
+})


### PR DESCRIPTION
## Description

`parseSetCookie` assigns an `Invalid Date` to the parsed cookie's `expires` when the `Set-Cookie` `Expires` attribute fails to parse, instead of ignoring the attribute.

```js
getSetCookies(new Headers({ 'set-cookie': 'id=a3fWa; Expires=not-a-date' }))
// [{ name: 'id', value: 'a3fWa', expires: Invalid Date }]
// should be: [{ name: 'id', value: 'a3fWa' }]
```

RFC 6265bis section 5.4.1 step 2 says that if the attribute-value fails to parse as a cookie date, the user agent must ignore the cookie-av. The code comment at that spot already states this, but the assignment ran unconditionally, leaking an `Invalid Date` into the returned object.

## Fix

Only set `expires` when the parsed date is valid.

```diff
     // 2. If the attribute-value failed to parse as a cookie date, ignore
     //    the cookie-av.
-
-    cookieAttributeList.expires = expiryTime
+    if (!Number.isNaN(expiryTime.getTime())) {
+      cookieAttributeList.expires = expiryTime
+    }
```

Valid `Expires` values are unchanged.

## Test

Added a case to `test/cookie/cookies.js` for an unparseable `Expires`. It fails before the change (`expires: Invalid Date` present) and passes after (attribute omitted). Full cookie suite stays green.
