### PR TITLE
fix(eventsource): set use-URL-credentials flag

### DIFF
--- a/lib/web/eventsource/util.js
+++ b/lib/web/eventsource/util.js
@@ -49,7 +49,7 @@ function createPotentialCORSRequest (url, destination, corsAttributeState, sameO
     destination,
     mode,
     credentials: credentialsMode,
-    useCredentials: true
+    useURLCredentials: true
   })
 }
 

--- a/test/eventsource/eventsource-connect.js
+++ b/test/eventsource/eventsource-connect.js
@@ -6,6 +6,7 @@ const { test, describe, after } = require('node:test')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { EventSource, defaultReconnectionTime } = require('../../lib/web/eventsource/eventsource')
 const { randomInt } = require('node:crypto')
+const { closeServerAsPromise } = require('../utils/node-http')
 
 describe('EventSource - sending correct request headers', () => {
   test('should send request with connection keep-alive', async (t) => {
@@ -91,6 +92,53 @@ describe('EventSource - sending correct request headers', () => {
     eventSourceInstance.onerror = (t) => {
       t.assert.fail('Should not have errored')
     }
+  })
+
+  test('should use URL credentials after an authentication challenge', async (t) => {
+    const authorizations = []
+    const expectedAuthorization = `Basic ${Buffer.from('user:pass').toString('base64')}`
+
+    const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      authorizations.push(req.headers.authorization)
+
+      if (req.headers.authorization == null) {
+        res.writeHead(401, {
+          'WWW-Authenticate': 'Basic realm="test"'
+        })
+        res.end()
+        return
+      }
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream'
+      })
+      res.write('data: authenticated\n\n')
+    })
+
+    await once(server.listen(0, '127.0.0.1'), 'listening')
+    const port = server.address().port
+
+    const eventSourceInstance = new EventSource(
+      `http://user:pass@127.0.0.1:${port}/events`
+    )
+
+    t.after(async () => {
+      eventSourceInstance.close()
+      await closeServerAsPromise(server)()
+    })
+
+    const event = await new Promise((resolve, reject) => {
+      eventSourceInstance.onmessage = resolve
+      eventSourceInstance.onerror = () => {
+        reject(new Error('EventSource authentication failed'))
+      }
+    })
+
+    t.assert.strictEqual(event.data, 'authenticated')
+    t.assert.deepStrictEqual(authorizations, [
+      undefined,
+      expectedAuthorization
+    ])
   })
 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes EventSource potential-CORS request creation so it sets the correct use-URL-credentials flag.

## Rationale

The HTML potential-CORS request algorithm requires the returned request’s use-URL-credentials flag to be set.

`createPotentialCORSRequest()` previously passed `useCredentials`, but Undici represents the use-URL-credentials flag using the separate `useURLCredentials` field. The Fetch authentication path reads `useURLCredentials`, so an EventSource URL containing credentials did not retry after a `401` authentication challenge.

Specification:
https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request

## Changes

Changed EventSource’s potential-CORS request creation to pass `useURLCredentials: true` instead of `useCredentials: true`.

Added a behavioral regression test that verifies:

- the initial EventSource request does not send `Authorization`;
- the server returns a Basic authentication challenge;
- EventSource retries using credentials from the URL; and
- the authenticated event stream is received.

### Features

N/A

### Bug Fixes

Fixes EventSource authentication with URL credentials after a `401 WWW-Authenticate` Basic challenge.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
