### PR TITLE
fix: do not reject open-ended Range values in simpleRangeHeaderValue

### DIFF
--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -1195,7 +1195,10 @@ function simpleRangeHeaderValue (value, allowWhitespace) {
   // 18. If rangeStartValue and rangeEndValue are numbers, and rangeStartValue is
   //     greater than rangeEndValue, then return failure.
   // Note: ... when can they not be numbers?
-  if (rangeStartValue > rangeEndValue) {
+  // Note: rangeStartValue or rangeEndValue may be null for open-ended ranges
+  //     such as `bytes=5-` or `bytes=-5`. A null value must not be coerced to 0
+  //     in the comparison, so this check only applies when both are numbers.
+  if (rangeStartValue !== null && rangeEndValue !== null && rangeStartValue > rangeEndValue) {
     return 'failure'
   }
 

--- a/test/fetch/range-open-ended.js
+++ b/test/fetch/range-open-ended.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { fetch } = require('../..')
+
+// https://fetch.spec.whatwg.org/#simple-range-header-value
+// Step 18: "If rangeStartValue and rangeEndValue are numbers, and
+// rangeStartValue is greater than rangeEndValue, then return failure."
+// An open-ended range such as `bytes=5-` has a null rangeEndValue and must
+// not be rejected.
+test('blob: fetch with an open-ended Range (bytes=N-) returns 206', async () => {
+  const blob = new Blob(['hello world']) // 11 bytes
+  const url = URL.createObjectURL(blob)
+
+  const res = await fetch(url, { headers: { Range: 'bytes=5-' } })
+
+  assert.strictEqual(res.status, 206)
+  assert.strictEqual(await res.text(), 'hello world'.slice(5))
+  assert.strictEqual(res.headers.get('Content-Range'), `bytes 5-10/${blob.size}`)
+})


### PR DESCRIPTION
The "simple range header value" parser rejected valid open-ended ranges such
as `bytes=5-`.

Per https://fetch.spec.whatwg.org/#simple-range-header-value step 18, the
"start greater than end" failure only applies when rangeStartValue and
rangeEndValue are both numbers. For an open-ended range like `bytes=5-`,
rangeEndValue is null. The code compared `rangeStartValue > rangeEndValue`
directly, and JavaScript coerces null to 0 in that comparison, so `5 > null`
becomes `5 > 0`, which is true, and the parser returned failure.

The effect is that `fetch()` of a `blob:` URL with `Range: bytes=5-` returned a
network error and the promise rejected, instead of returning a 206 Partial
Content. `bytes=0-` worked only by accident because 0 does not exceed 0.

This change guards the comparison so it runs only when both values are numbers,
matching the spec. A genuinely inverted range such as `bytes=5-3` still returns
failure, and the null-null case is already handled by step 17.

Added a test that fetches a blob URL with `Range: bytes=5-` and asserts a 206
response with the correct body and Content-Range.
