### PR TITLE
docs: correct npm script name and JSON syntax in examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ npm i
 > This requires [docker](https://www.docker.com/) installed on your machine.
 
 ```bash
-npm run build-wasm
+npm run build:wasm
 ```
 
 #### Copy the sources to `undici`

--- a/docs/docs/best-practices/mocking-request.md
+++ b/docs/docs/best-practices/mocking-request.md
@@ -102,7 +102,7 @@ setGlobalDispatcher(mockAgent)
 // this call is made (not intercepted)
 await fetch(`http://localhost:3000/endpoint?query='hello'`, {
   method: 'POST',
-  headers: { 'content-type': 'application/json' }
+  headers: { 'content-type': 'application/json' },
   body: JSON.stringify({ data: '' })
 })
 


### PR DESCRIPTION
- `CONTRIBUTING.md` says `npm run build-wasm`; the script in package.json is `build:wasm`.
- The mock-request best-practices example is missing a comma after the `headers` property, so it throws a SyntaxError as written.

Found while running [docrot](https://github.com/getdocrot/docrot), a small checker that verifies docs examples and links against the code. Happy to adjust anything.
