### PR TITLE
fix: collapse identical repeated content-length in legacy dispatcher bridge

### DIFF
--- a/lib/dispatcher/dispatcher1-wrapper.js
+++ b/lib/dispatcher/dispatcher1-wrapper.js
@@ -60,13 +60,10 @@ class LegacyHandlerWrapper {
   }
 }
 
-// Legacy (v1) consumers such as Node's bundled fetch (undici v6/v7) append
-// their computed content-length even when the request already carries one,
-// producing an identical comma-repeated value (e.g. "58, 58") that the v1
-// core tolerated but the current core rejects. RFC 9110 permits treating
-// identical repeated values as one, so collapse them; conflicting values
-// are left untouched and still rejected downstream.
-// See https://github.com/nodejs/undici/issues/5500
+// Legacy consumers (e.g. Node's bundled fetch) may send an identical
+// comma-repeated content-length ("58, 58") that the current core rejects.
+// RFC 9110 allows collapsing identical repeats; conflicting values still
+// fail downstream. See https://github.com/nodejs/undici/issues/5500
 function collapseRepeatedContentLength (value) {
   if (typeof value !== 'string' || !value.includes(',')) {
     return value

--- a/lib/dispatcher/dispatcher1-wrapper.js
+++ b/lib/dispatcher/dispatcher1-wrapper.js
@@ -60,6 +60,59 @@ class LegacyHandlerWrapper {
   }
 }
 
+// Legacy (v1) consumers such as Node's bundled fetch (undici v6/v7) append
+// their computed content-length even when the request already carries one,
+// producing an identical comma-repeated value (e.g. "58, 58") that the v1
+// core tolerated but the current core rejects. RFC 9110 permits treating
+// identical repeated values as one, so collapse them; conflicting values
+// are left untouched and still rejected downstream.
+// See https://github.com/nodejs/undici/issues/5500
+function collapseRepeatedContentLength (value) {
+  if (typeof value !== 'string' || !value.includes(',')) {
+    return value
+  }
+
+  const parts = value.split(',')
+  const first = parts[0].trim()
+
+  if (first === '') {
+    return value
+  }
+
+  for (let i = 1; i < parts.length; i++) {
+    if (parts[i].trim() !== first) {
+      return value
+    }
+  }
+
+  return first
+}
+
+function normalizeLegacyHeaders (headers) {
+  if (Array.isArray(headers)) {
+    for (let i = 0; i + 1 < headers.length; i += 2) {
+      if (typeof headers[i] === 'string' && headers[i].toLowerCase() === 'content-length') {
+        const collapsed = collapseRepeatedContentLength(headers[i + 1])
+        if (collapsed !== headers[i + 1]) {
+          headers = headers.slice()
+          headers[i + 1] = collapsed
+        }
+      }
+    }
+  } else if (headers && typeof headers === 'object') {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'content-length') {
+        const collapsed = collapseRepeatedContentLength(headers[key])
+        if (collapsed !== headers[key]) {
+          headers = { ...headers, [key]: collapsed }
+        }
+      }
+    }
+  }
+
+  return headers
+}
+
 class Dispatcher1Wrapper extends Dispatcher {
   #dispatcher
 
@@ -90,6 +143,11 @@ class Dispatcher1Wrapper extends Dispatcher {
     // See https://github.com/nodejs/undici/issues/4989
     if (opts.allowH2 !== false) {
       opts = { ...opts, allowH2: false }
+    }
+
+    const headers = normalizeLegacyHeaders(opts.headers)
+    if (headers !== opts.headers) {
+      opts = { ...opts, headers }
     }
 
     return this.#dispatcher.dispatch(opts, Dispatcher1Wrapper.wrapHandler(handler))

--- a/test/dispatcher1-wrapper-content-length.js
+++ b/test/dispatcher1-wrapper-content-length.js
@@ -6,9 +6,6 @@ const { createServer } = require('node:http')
 const { once } = require('node:events')
 const { Agent, Dispatcher1Wrapper } = require('..')
 
-// Legacy consumers such as Node's bundled fetch (undici v6/v7) can hand the
-// dispatcher an identical comma-repeated content-length (e.g. "13, 13").
-// The wrapper must collapse it; conflicting values must still be rejected.
 // See https://github.com/nodejs/undici/issues/5500
 
 function legacyDispatch (wrapper, opts) {

--- a/test/dispatcher1-wrapper-content-length.js
+++ b/test/dispatcher1-wrapper-content-length.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, after } = require('node:test')
+const { test } = require('node:test')
 const assert = require('node:assert')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
@@ -31,7 +31,7 @@ function legacyDispatch (wrapper, opts) {
   })
 }
 
-async function startServer (t) {
+async function startServer () {
   const server = createServer((req, res) => {
     let length = 0
     req.on('data', (chunk) => { length += chunk.length })
@@ -45,10 +45,10 @@ async function startServer (t) {
 }
 
 test('collapses identical repeated content-length from a legacy consumer', async (t) => {
-  const server = await startServer(t)
+  const server = await startServer()
   const agent = new Agent()
   const wrapper = new Dispatcher1Wrapper(agent)
-  after(() => { server.close(); return agent.close() })
+  t.after(() => { server.close(); return agent.close() })
 
   const { statusCode, body } = await legacyDispatch(wrapper, {
     origin: `http://127.0.0.1:${server.address().port}`,
@@ -63,10 +63,10 @@ test('collapses identical repeated content-length from a legacy consumer', async
 })
 
 test('collapses identical repeated content-length in flat array headers', async (t) => {
-  const server = await startServer(t)
+  const server = await startServer()
   const agent = new Agent()
   const wrapper = new Dispatcher1Wrapper(agent)
-  after(() => { server.close(); return agent.close() })
+  t.after(() => { server.close(); return agent.close() })
 
   const { statusCode, body } = await legacyDispatch(wrapper, {
     origin: `http://127.0.0.1:${server.address().port}`,
@@ -80,29 +80,49 @@ test('collapses identical repeated content-length in flat array headers', async 
   assert.strictEqual(body, '13:13')
 })
 
-test('still rejects conflicting repeated content-length', async (t) => {
-  const server = await startServer(t)
+test('leaves a single content-length untouched', async (t) => {
+  const server = await startServer()
   const agent = new Agent()
   const wrapper = new Dispatcher1Wrapper(agent)
-  after(() => { server.close(); return agent.close() })
+  t.after(() => { server.close(); return agent.close() })
 
-  await assert.rejects(
-    legacyDispatch(wrapper, {
-      origin: `http://127.0.0.1:${server.address().port}`,
-      path: '/',
-      method: 'POST',
-      headers: { 'content-length': '10, 13' },
-      body: 'update=INSERT'
-    }),
-    { code: 'UND_ERR_INVALID_ARG', message: 'invalid content-length header' }
-  )
+  const { statusCode, body } = await legacyDispatch(wrapper, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: { 'content-length': '13' },
+    body: 'update=INSERT'
+  })
+
+  assert.strictEqual(statusCode, 200)
+  assert.strictEqual(body, '13:13')
+})
+
+test('still rejects conflicting or malformed repeated content-length', async (t) => {
+  const server = await startServer()
+  const agent = new Agent()
+  const wrapper = new Dispatcher1Wrapper(agent)
+  t.after(() => { server.close(); return agent.close() })
+
+  for (const value of ['10, 13', ', 13']) {
+    await assert.rejects(
+      legacyDispatch(wrapper, {
+        origin: `http://127.0.0.1:${server.address().port}`,
+        path: '/',
+        method: 'POST',
+        headers: { 'content-length': value },
+        body: 'update=INSERT'
+      }),
+      { code: 'UND_ERR_INVALID_ARG', message: 'invalid content-length header' }
+    )
+  }
 })
 
 test('does not mutate the caller-provided headers object', async (t) => {
-  const server = await startServer(t)
+  const server = await startServer()
   const agent = new Agent()
   const wrapper = new Dispatcher1Wrapper(agent)
-  after(() => { server.close(); return agent.close() })
+  t.after(() => { server.close(); return agent.close() })
 
   const headers = { 'content-length': '13, 13' }
   await legacyDispatch(wrapper, {

--- a/test/dispatcher1-wrapper-content-length.js
+++ b/test/dispatcher1-wrapper-content-length.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const { test, after } = require('node:test')
+const assert = require('node:assert')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { Agent, Dispatcher1Wrapper } = require('..')
+
+// Legacy consumers such as Node's bundled fetch (undici v6/v7) can hand the
+// dispatcher an identical comma-repeated content-length (e.g. "13, 13").
+// The wrapper must collapse it; conflicting values must still be rejected.
+// See https://github.com/nodejs/undici/issues/5500
+
+function legacyDispatch (wrapper, opts) {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    wrapper.dispatch(opts, {
+      onConnect () {},
+      onHeaders (statusCode) {
+        this.statusCode = statusCode
+        return true
+      },
+      onData (chunk) {
+        body += chunk
+        return true
+      },
+      onComplete () {
+        resolve({ statusCode: this.statusCode, body })
+      },
+      onError (err) {
+        reject(err)
+      }
+    })
+  })
+}
+
+async function startServer (t) {
+  const server = createServer((req, res) => {
+    let length = 0
+    req.on('data', (chunk) => { length += chunk.length })
+    req.on('end', () => {
+      res.end(`${length}:${req.headers['content-length']}`)
+    })
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  return server
+}
+
+test('collapses identical repeated content-length from a legacy consumer', async (t) => {
+  const server = await startServer(t)
+  const agent = new Agent()
+  const wrapper = new Dispatcher1Wrapper(agent)
+  after(() => { server.close(); return agent.close() })
+
+  const { statusCode, body } = await legacyDispatch(wrapper, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: { 'Content-Length': '13, 13', 'content-type': 'text/plain' },
+    body: 'update=INSERT'
+  })
+
+  assert.strictEqual(statusCode, 200)
+  assert.strictEqual(body, '13:13')
+})
+
+test('collapses identical repeated content-length in flat array headers', async (t) => {
+  const server = await startServer(t)
+  const agent = new Agent()
+  const wrapper = new Dispatcher1Wrapper(agent)
+  after(() => { server.close(); return agent.close() })
+
+  const { statusCode, body } = await legacyDispatch(wrapper, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers: ['content-length', '13 , 13', 'content-type', 'text/plain'],
+    body: 'update=INSERT'
+  })
+
+  assert.strictEqual(statusCode, 200)
+  assert.strictEqual(body, '13:13')
+})
+
+test('still rejects conflicting repeated content-length', async (t) => {
+  const server = await startServer(t)
+  const agent = new Agent()
+  const wrapper = new Dispatcher1Wrapper(agent)
+  after(() => { server.close(); return agent.close() })
+
+  await assert.rejects(
+    legacyDispatch(wrapper, {
+      origin: `http://127.0.0.1:${server.address().port}`,
+      path: '/',
+      method: 'POST',
+      headers: { 'content-length': '10, 13' },
+      body: 'update=INSERT'
+    }),
+    { code: 'UND_ERR_INVALID_ARG', message: 'invalid content-length header' }
+  )
+})
+
+test('does not mutate the caller-provided headers object', async (t) => {
+  const server = await startServer(t)
+  const agent = new Agent()
+  const wrapper = new Dispatcher1Wrapper(agent)
+  after(() => { server.close(); return agent.close() })
+
+  const headers = { 'content-length': '13, 13' }
+  await legacyDispatch(wrapper, {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    path: '/',
+    method: 'POST',
+    headers,
+    body: 'update=INSERT'
+  })
+
+  assert.strictEqual(headers['content-length'], '13, 13')
+})

--- a/test/fixtures/global-fetch-content-length.js
+++ b/test/fixtures/global-fetch-content-length.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// This fixture must use Node's *global* fetch and Headers — exercising the
+// bundled fetch against the installed undici's dispatcher bridge is the point.
+/* eslint-disable no-restricted-globals */
+
+// Regression fixture for https://github.com/nodejs/undici/issues/5500.
+// Requiring undici installs the legacy global-dispatcher bridge; Node's
+// bundled fetch (undici v6/v7) then dispatches through it and produces an
+// identical comma-repeated content-length (e.g. "13, 13") when the request
+// sets its own Content-Length header.
+require('../..')
+
+const http = require('node:http')
+const { once } = require('node:events')
+
+async function main () {
+  const server = http.createServer((req, res) => {
+    let length = 0
+    req.on('data', (chunk) => { length += chunk.length })
+    req.on('end', () => res.end(String(length)))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+
+  try {
+    const body = 'update=INSERT'
+    const headers = new Headers()
+    headers.append('Content-Type', 'application/x-www-form-urlencoded')
+    headers.append('Content-Length', String(body.length))
+
+    const url = 'http://127.0.0.1:' + server.address().port
+    const res = await fetch(url, { method: 'POST', headers, body })
+    process.stdout.write(await res.text())
+  } finally {
+    server.close()
+  }
+}
+
+main().catch((err) => {
+  console.error(err?.cause?.stack || err?.stack || err)
+  process.exitCode = 1
+})

--- a/test/fixtures/global-fetch-content-length.js
+++ b/test/fixtures/global-fetch-content-length.js
@@ -1,14 +1,9 @@
 'use strict'
 
-// This fixture must use Node's *global* fetch and Headers — exercising the
-// bundled fetch against the installed undici's dispatcher bridge is the point.
+// Exercising Node's *global* fetch/Headers against the dispatcher bridge
+// is the point. See https://github.com/nodejs/undici/issues/5500
 /* eslint-disable no-restricted-globals */
 
-// Regression fixture for https://github.com/nodejs/undici/issues/5500.
-// Requiring undici installs the legacy global-dispatcher bridge; Node's
-// bundled fetch (undici v6/v7) then dispatches through it and produces an
-// identical comma-repeated content-length (e.g. "13, 13") when the request
-// sets its own Content-Length header.
 require('../..')
 
 const http = require('node:http')

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -102,37 +102,12 @@ test('requiring undici does not break Node.js global fetch with a request-set Co
   // Node's bundled fetch (undici v6/v7) appends its computed content-length
   // even when the request already carries one, producing "13, 13".
   // See https://github.com/nodejs/undici/issues/5500
-  const script = `
-    require('./index.js')
-    const http = require('node:http')
-    const { once } = require('node:events')
+  const result = spawnSync(
+    process.execPath,
+    [join(__dirname, '../fixtures/global-fetch-content-length.js')],
+    { cwd, encoding: 'utf8' }
+  )
 
-    ;(async () => {
-      const server = http.createServer((req, res) => {
-        let length = 0
-        req.on('data', (chunk) => { length += chunk.length })
-        req.on('end', () => res.end(String(length)))
-      })
-      server.listen(0)
-      await once(server, 'listening')
-
-      const body = 'update=INSERT'
-      const headers = new Headers()
-      headers.append('Content-Type', 'application/x-www-form-urlencoded')
-      headers.append('Content-Length', String(body.length))
-
-      const url = 'http://127.0.0.1:' + server.address().port
-      const res = await fetch(url, { method: 'POST', headers, body })
-      process.stdout.write(await res.text())
-
-      server.close()
-    })().catch((err) => {
-      console.error(err?.cause?.stack || err?.stack || err)
-      process.exit(1)
-    })
-  `
-
-  const result = runNode(script)
   assert.strictEqual(result.status, 0, result.stderr)
   assert.strictEqual(result.stdout, '13')
 })

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -98,6 +98,45 @@ test('setGlobalDispatcher mirrors a v1-compatible dispatcher that Node.js global
   assert.strictEqual(payload.mirroredV2, true)
 })
 
+test('requiring undici does not break Node.js global fetch with a request-set Content-Length', () => {
+  // Node's bundled fetch (undici v6/v7) appends its computed content-length
+  // even when the request already carries one, producing "13, 13".
+  // See https://github.com/nodejs/undici/issues/5500
+  const script = `
+    require('./index.js')
+    const http = require('node:http')
+    const { once } = require('node:events')
+
+    ;(async () => {
+      const server = http.createServer((req, res) => {
+        let length = 0
+        req.on('data', (chunk) => { length += chunk.length })
+        req.on('end', () => res.end(String(length)))
+      })
+      server.listen(0)
+      await once(server, 'listening')
+
+      const body = 'update=INSERT'
+      const headers = new Headers()
+      headers.append('Content-Type', 'application/x-www-form-urlencoded')
+      headers.append('Content-Length', String(body.length))
+
+      const url = 'http://127.0.0.1:' + server.address().port
+      const res = await fetch(url, { method: 'POST', headers, body })
+      process.stdout.write(await res.text())
+
+      server.close()
+    })().catch((err) => {
+      console.error(err?.cause?.stack || err?.stack || err)
+      process.exit(1)
+    })
+  `
+
+  const result = runNode(script)
+  assert.strictEqual(result.status, 0, result.stderr)
+  assert.strictEqual(result.stdout, '13')
+})
+
 test('Dispatcher1Wrapper bridges legacy handlers to a new Agent', () => {
   const script = `
     const { Agent, Dispatcher1Wrapper } = require('./index.js')

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -99,8 +99,6 @@ test('setGlobalDispatcher mirrors a v1-compatible dispatcher that Node.js global
 })
 
 test('requiring undici does not break Node.js global fetch with a request-set Content-Length', () => {
-  // Node's bundled fetch (undici v6/v7) appends its computed content-length
-  // even when the request already carries one, producing "13, 13".
   // See https://github.com/nodejs/undici/issues/5500
   const result = spawnSync(
     process.execPath,


### PR DESCRIPTION
## Summary

A bare `require('undici')` (v8) on Node 22/24 silently breaks Node's **bundled** `fetch` for any request that sets its own `Content-Length` header, failing with `TypeError: fetch failed` → `InvalidArgumentError: invalid content-length header`.

Fixes #5500

## Root cause

- `lib/global.js` eagerly claims the legacy `Symbol.for('undici.globalDispatcher.1')` at import time, so the bundled fetch (undici v6 on Node 22, v7 on Node 24) starts dispatching through `Dispatcher1Wrapper` into the v8 core.
- The bundled v6/v7 fetch appends its computed content-length even when the request already carries one, producing an identical comma-repeated value (e.g. `"58, 58"`).
- #5060 both added the strict digit-only content-length validator **and** changed v8's fetch to skip the append when the header is already present — so v8's own fetch never trips the validator, but the bundled v6/v7 fetch got neither half and is rejected.

This is the same class of bridge-semantics divergence as #4990 (`allowH2`) and #5345 (`rawHeaders`), this time on request-header validation. Note the issue reports Node 22, but Node 24 (bundled undici 7.x) is affected as well; Node 26 (bundled v8) is not.

## Fix

`Dispatcher1Wrapper.dispatch()` now collapses an identical comma-repeated `content-length` value to the single value before forwarding, for both plain-object and flat-array header shapes. RFC 9110 §8.6 explicitly permits treating identical repeated field values as one, so this does not reopen the request-smuggling hardening from #5060 — genuinely conflicting values (e.g. `"10, 13"`) are left untouched and still rejected by the core. `opts.headers` is cloned rather than mutated, and the fast path (no collapse needed) allocates nothing.

## Tests

- `test/node-test/global-dispatcher-version.js`: end-to-end regression — `require('./index.js')`, then a POST through the bundled global fetch with a request-set `Content-Length`. Fails without the fix on Node 22/24, passes with it.
- `test/dispatcher1-wrapper-content-length.js` (new): direct wrapper tests — collapse for object and flat-array headers, conflicting values still rejected with `UND_ERR_INVALID_ARG`, caller headers not mutated.

Verified the issue's own repro script passes against this branch on Node 22.22.1, 24.14.1, and 26.3.0. Full `test:unit` suite: 1417 pass, 0 fail.