### PR TITLE
fix: honor request cache-control max-age=0 in cache interceptor

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -45,10 +45,8 @@ function needsRevalidation (result, age, cacheControlDirectives, { headers = {} 
     return true
   }
 
-  // Always revalidate requests whose age exceeds the max-age request
-  //  directive. Note that max-age=0 must not be ignored (it is falsy), it
-  //  forces revalidation on every request (e.g. fetch's cache: 'no-cache'
-  //  mode sends Cache-Control: max-age=0).
+  // Revalidate when age >= max-age. max-age=0 is falsy but must still
+  //  force it (e.g. fetch cache: 'no-cache' sends max-age=0).
   // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.1
   if (cacheControlDirectives?.['max-age'] !== undefined && age >= cacheControlDirectives['max-age']) {
     return true

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -34,13 +34,23 @@ const nop = () => {}
 
 /**
  * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
+ * @param {number} age
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives | undefined} cacheControlDirectives
  * @param {import('../../types/dispatcher.d.ts').default.RequestOptions} opts
  * @returns {boolean}
  */
-function needsRevalidation (result, cacheControlDirectives, { headers = {} }) {
+function needsRevalidation (result, age, cacheControlDirectives, { headers = {} }) {
   // Always revalidate requests with the no-cache request directive.
   if (cacheControlDirectives?.['no-cache']) {
+    return true
+  }
+
+  // Always revalidate requests whose age exceeds the max-age request
+  //  directive. Note that max-age=0 must not be ignored (it is falsy), it
+  //  forces revalidation on every request (e.g. fetch's cache: 'no-cache'
+  //  mode sends Cache-Control: max-age=0).
+  // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.1
+  if (cacheControlDirectives?.['max-age'] !== undefined && age >= cacheControlDirectives['max-age']) {
     return true
   }
 
@@ -297,14 +307,9 @@ function handleResult (
   }
 
   const age = Math.round((now - result.cachedAt) / 1000)
-  if (reqCacheControl?.['max-age'] && age >= reqCacheControl['max-age']) {
-    // Response is considered expired for this specific request
-    //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.1
-    return dispatch(opts, handler)
-  }
 
   const stale = isStale(result, reqCacheControl, globalOpts.type)
-  const revalidate = needsRevalidation(result, reqCacheControl, opts)
+  const revalidate = needsRevalidation(result, age, reqCacheControl, opts)
 
   // Check if the response is stale
   if (stale || revalidate) {

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -872,6 +872,188 @@ describe('Cache Interceptor', () => {
       equal(requestsToOrigin, 2)
     })
 
+    test('max-age=0 revalidates the response (RFC 9111 §5.2.1.1)', async () => {
+      let requestsToOrigin = 0
+      let revalidationRequests = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+        if (req.headers['if-none-match']) {
+          revalidationRequests++
+          res.statusCode = 304
+          res.end()
+        } else {
+          requestsToOrigin++
+          res.setHeader('cache-control', 'public, s-maxage=100')
+          res.setHeader('etag', '"asd"')
+          res.end('asd')
+        }
+      }).listen(0)
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(async () => {
+        server.close()
+        await client.close()
+      })
+
+      await once(server, 'listening')
+
+      strictEqual(requestsToOrigin, 0)
+
+      /**
+       * @type {import('../../types/dispatcher').default.RequestOptions}
+       */
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/'
+      }
+
+      // Send initial request to fill the cache
+      {
+        const response = await client.request(request)
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(revalidationRequests, 0)
+        strictEqual(await response.body.text(), 'asd')
+      }
+
+      // Send second request with max-age=0, a validation request should be
+      //  sent and the cached response served on the 304
+      {
+        const response = await client.request({
+          ...request,
+          headers: {
+            'cache-control': 'max-age=0'
+          }
+        })
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(revalidationRequests, 1)
+        strictEqual(response.statusCode, 200)
+        strictEqual(await response.body.text(), 'asd')
+      }
+
+      // Send third request w/o max-age, this should be handled by the cache
+      {
+        const response = await client.request(request)
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(revalidationRequests, 1)
+        strictEqual(await response.body.text(), 'asd')
+      }
+    })
+
+    test('response fetched due to max-age exceedance updates the cache', async () => {
+      const clock = FakeTimers.install({
+        toFake: ['Date']
+      })
+
+      let requestsToOrigin = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'public, s-maxage=100')
+        res.end(`response ${requestsToOrigin}`)
+      }).listen(0)
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(async () => {
+        clock.uninstall()
+        server.close()
+        await client.close()
+      })
+
+      await once(server, 'listening')
+
+      strictEqual(requestsToOrigin, 0)
+
+      /**
+       * @type {import('../../types/dispatcher').default.RequestOptions}
+       */
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/'
+      }
+
+      // Send first request to cache the response
+      {
+        const response = await client.request(request)
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(await response.body.text(), 'response 1')
+      }
+
+      clock.tick(6000)
+
+      // Send second request with the response's age exceeding the request's
+      //  max-age, the origin's fresh response should be served and stored
+      {
+        const response = await client.request({
+          ...request,
+          headers: {
+            'cache-control': 'max-age=5'
+          }
+        })
+        strictEqual(requestsToOrigin, 2)
+        strictEqual(await response.body.text(), 'response 2')
+      }
+
+      // Send third request w/o max-age, the fresh response stored by the
+      //  previous request should be served from the cache
+      {
+        const response = await client.request(request)
+        strictEqual(requestsToOrigin, 2)
+        strictEqual(await response.body.text(), 'response 2')
+      }
+    })
+
+    test('fetch with cache: no-cache revalidates through a composed cache dispatcher', async () => {
+      const { fetch, Agent } = require('../..')
+
+      let requestsToOrigin = 0
+      let revalidationRequests = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+        if (req.headers['if-none-match']) {
+          revalidationRequests++
+          res.statusCode = 304
+          res.end()
+        } else {
+          requestsToOrigin++
+          res.setHeader('cache-control', 'public, max-age=100')
+          res.setHeader('etag', '"asd"')
+          res.end('asd')
+        }
+      }).listen(0)
+
+      const dispatcher = new Agent().compose(interceptors.cache())
+
+      after(async () => {
+        server.close()
+        await dispatcher.close()
+      })
+
+      await once(server, 'listening')
+
+      const origin = `http://localhost:${server.address().port}`
+
+      // Send initial request to fill the cache
+      {
+        const response = await fetch(origin, { dispatcher })
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(revalidationRequests, 0)
+        strictEqual(await response.text(), 'asd')
+      }
+
+      // The no-cache fetch cache mode appends cache-control: max-age=0, which
+      //  must trigger a validation request
+      {
+        const response = await fetch(origin, { dispatcher, cache: 'no-cache' })
+        strictEqual(requestsToOrigin, 1)
+        strictEqual(revalidationRequests, 1)
+        strictEqual(response.status, 200)
+        strictEqual(await response.text(), 'asd')
+      }
+    })
+
     test('max-stale', async () => {
       const clock = FakeTimers.install({
         toFake: ['Date']


### PR DESCRIPTION
Fixes #5504

## The bug

`lib/interceptor/cache.js` checked the request `max-age` directive with

```js
if (reqCacheControl?.['max-age'] && age >= reqCacheControl['max-age']) {
```

For `max-age=0` the parsed value `0` is falsy, so the directive was ignored entirely and a cached response was served with no origin contact. RFC 9111 §5.2.1.1 requires validation in that case. This also broke `fetch(url, { cache: 'no-cache' })` through a composed cache dispatcher, since the fetch spec implements that mode by appending `Cache-Control: max-age=0` (related umbrella: #3847).

Secondary issue in the same block: when a *nonzero* request `max-age` was exceeded, the bypass dispatched without a `CacheHandler` (`return dispatch(opts, handler)`), so the fresh 200 fetched because of the bypass was never stored — the very next plain request had to contact the origin again.

## The fix

Treat request `max-age` exceedance as a revalidation trigger in `needsRevalidation()` (alongside the existing request `no-cache` handling), feeding it into the existing revalidation flow: a conditional request is sent, the cached body is served on 304, and a fresh 200 is stored via the `CacheHandler` already wrapped by `CacheRevalidationHandler`. The old falsy-guarded bypass block is removed.

## Evidence

Repro from the issue (fresh cached response, then a request with `Cache-Control: max-age=0`):

- **before:** origin hits stay at `1` — silent cache hit, no validation
- **after:** origin receives a conditional request (`If-None-Match`), hits go to `2`, cached body served on 304

Same for `fetch(url, { cache: 'no-cache' })` through `new Agent().compose(interceptors.cache(...))`: before, 1 origin hit (revalidation never sent); after, the validation request is sent.

mnot [cache-tests](https://github.com/http-tests/cache-tests) conformance runner (`node test/cache-interceptor/cache-tests.mjs`):

- `ccreq-ma0` ("Does HTTP cache honor request `Cache-Control: max-age=0` when it holds a fresh response?"): **"N no" → "Y yes"**
- Totals unchanged and green: 283 total — 220 passed, 0 failed, 58 failed-optional, 5 setup-failed (identical to `main` baseline; the `ccreq-*` checks are behavioral yes/no entries that don't count toward pass/fail totals). Nothing in the runner's skip-list relates to request `max-age`, so no un-skips were needed.

New tests in `test/interceptors/cache.js` (all fail on `main`, pass with this change):

1. `max-age=0` on a fresh cached response triggers a validation request and serves the cached body on 304
2. a fresh 200 fetched because the response's age exceeds the request's `max-age` is stored, so the next plain request is a cache hit with the new body
3. `fetch(url, { cache: 'no-cache' })` through a composed cache dispatcher sends a validation request

Full cache test files (`test/interceptors/cache*.js`, `test/cache-interceptor/*`): 124 tests / 12 suites, 124 pass, 0 fail (baseline on `main` is 121/121; the +3 are the new tests).

## Notes

- Adjacent, intentionally out of scope (each gets its own self-contained PR): the 304 that this revalidation flow receives still doesn't update the stored entry (#5505), and `must-revalidate` vs request `max-stale` (#5508).
- This change is agent-assisted (Claude Fable 5) working with @jeswr.
