### PR TITLE
fix: enforce must-revalidate and proxy-revalidate over max-stale and stale-if-error

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -58,15 +58,33 @@ function needsRevalidation (result, cacheControlDirectives, { headers = {} }) {
 }
 
 /**
+ * A response with the must-revalidate directive (or proxy-revalidate for
+ * shared caches) can't be used once stale without successful validation,
+ * taking precedence over max-stale and stale-if-error
+ * https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.2
+ * https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.8
  * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
- * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives | undefined} cacheControlDirectives
+ * @param {'shared' | 'private'} cacheType
  * @returns {boolean}
  */
-function isStale (result, cacheControlDirectives) {
+function forbidsServingStale (result, cacheType) {
+  return Boolean(
+    result.cacheControlDirectives?.['must-revalidate'] ||
+    (cacheType === 'shared' && result.cacheControlDirectives?.['proxy-revalidate'])
+  )
+}
+
+/**
+ * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
+ * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives | undefined} cacheControlDirectives
+ * @param {'shared' | 'private'} cacheType
+ * @returns {boolean}
+ */
+function isStale (result, cacheControlDirectives, cacheType) {
   const now = Date.now()
   if (now > result.staleAt) {
     // Response is stale
-    if (cacheControlDirectives?.['max-stale']) {
+    if (cacheControlDirectives?.['max-stale'] && !forbidsServingStale(result, cacheType)) {
       // There's a threshold where we can serve stale responses, let's see if
       //  we're in it
       // https://www.rfc-editor.org/rfc/rfc9111.html#name-max-stale
@@ -286,7 +304,7 @@ function handleResult (
     return dispatch(opts, handler)
   }
 
-  const stale = isStale(result, reqCacheControl)
+  const stale = isStale(result, reqCacheControl, globalOpts.type)
   const revalidate = needsRevalidation(result, reqCacheControl, opts)
 
   // Check if the response is stale
@@ -345,7 +363,7 @@ function handleResult (
 
     let withinStaleIfErrorThreshold = false
     const staleIfErrorExpiry = result.cacheControlDirectives['stale-if-error'] ?? reqCacheControl?.['stale-if-error']
-    if (staleIfErrorExpiry) {
+    if (staleIfErrorExpiry && !forbidsServingStale(result, globalOpts.type)) {
       withinStaleIfErrorThreshold = now < (result.staleAt + (staleIfErrorExpiry * 1000))
     }
 

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -58,9 +58,8 @@ function needsRevalidation (result, cacheControlDirectives, { headers = {} }) {
 }
 
 /**
- * A response with the must-revalidate directive (or proxy-revalidate for
- * shared caches) can't be used once stale without successful validation,
- * taking precedence over max-stale and stale-if-error
+ * must-revalidate (proxy-revalidate for shared caches) forbids serving a stale
+ * response without successful validation, overriding max-stale and stale-if-error.
  * https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.2
  * https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.8
  * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -749,6 +749,67 @@ describe('Cache Interceptor', () => {
     }
   })
 
+  test('must-revalidate excludes the response from stale-if-error', async () => {
+    const clock = FakeTimers.install({
+      toFake: ['Date']
+    })
+
+    let requestsToOrigin = 0
+    const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+      res.setHeader('date', 0)
+
+      requestsToOrigin++
+      if (requestsToOrigin === 1) {
+        // First request
+        res.setHeader('cache-control', 'public, s-maxage=10, stale-if-error=20, must-revalidate')
+        res.end('asd')
+      } else {
+        res.statusCode = 500
+        res.end('')
+      }
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      clock.uninstall()
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    /**
+     * @type {import('../../types/dispatcher').default.RequestOptions}
+     */
+    const request = {
+      origin: 'localhost',
+      method: 'GET',
+      path: '/'
+    }
+
+    // Send first request. This will hit the origin and succeed
+    {
+      const response = await client.request(request)
+      equal(requestsToOrigin, 1)
+      equal(response.statusCode, 200)
+      equal(await response.body.text(), 'asd')
+    }
+
+    clock.tick(15000)
+
+    // Send second request. The response is stale and revalidation fails.
+    //  Despite being within the stale-if-error threshold, must-revalidate
+    //  forbids serving it without successful validation (RFC 5861 §4,
+    //  RFC 9111 §5.2.2.2), so we should see the error.
+    {
+      const response = await client.request(request)
+      equal(requestsToOrigin, 2)
+      equal(response.statusCode, 500)
+    }
+  })
+
   describe('Client-side directives', () => {
     test('max-age', async () => {
       const clock = FakeTimers.install({
@@ -882,6 +943,174 @@ describe('Cache Interceptor', () => {
       // Wait for background revalidation to complete
       await sleep(100)
       equal(revalidationRequests, 1)
+    })
+
+    test('max-stale doesn\'t allow serving a stale response with must-revalidate', async () => {
+      const clock = FakeTimers.install({
+        toFake: ['Date']
+      })
+
+      let requestsToOrigin = 0
+      let revalidationRequests = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+        res.setHeader('date', 0)
+
+        if (req.headers['if-none-match']) {
+          revalidationRequests++
+          if (req.headers['if-none-match'] !== '"asd123"') {
+            res.statusCode = 500
+            res.end('received incorrect etag')
+            return
+          }
+
+          res.statusCode = 304
+          res.end()
+        } else {
+          requestsToOrigin++
+          res.setHeader('cache-control', 'public, s-maxage=1, must-revalidate')
+          res.setHeader('etag', '"asd123"')
+          res.end('asd')
+        }
+      }).listen(0)
+
+      const client = new Client(`http://localhost:${server.address().port}`)
+        .compose(interceptors.cache())
+
+      after(async () => {
+        server.close()
+        await client.close()
+        clock.uninstall()
+      })
+
+      await once(server, 'listening')
+
+      /**
+       * @type {import('../../types/dispatcher').default.RequestOptions}
+       */
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/'
+      }
+
+      // Prime the cache
+      {
+        const response = await client.request(request)
+        strictEqual(await response.body.text(), 'asd')
+        equal(requestsToOrigin, 1)
+        equal(revalidationRequests, 0)
+      }
+
+      clock.tick(1500)
+
+      // The response is now stale. max-stale would normally allow serving it
+      //  as-is, but must-revalidate forbids using a stale response without
+      //  successful validation (RFC 9111 §5.2.2.2)
+      {
+        const response = await client.request({
+          ...request,
+          headers: {
+            'cache-control': 'max-stale=600'
+          }
+        })
+        strictEqual(response.statusCode, 200)
+        strictEqual(await response.body.text(), 'asd')
+        equal(requestsToOrigin, 1)
+        equal(revalidationRequests, 1)
+      }
+    })
+
+    test('max-stale doesn\'t allow a shared cache to serve a stale response with proxy-revalidate', async () => {
+      const clock = FakeTimers.install({
+        toFake: ['Date']
+      })
+
+      let revalidationRequests = 0
+      const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+        res.setHeader('date', 0)
+
+        if (req.headers['if-none-match']) {
+          revalidationRequests++
+          if (req.headers['if-none-match'] !== '"asd123"') {
+            res.statusCode = 500
+            res.end('received incorrect etag')
+            return
+          }
+
+          res.statusCode = 304
+          res.end()
+        } else {
+          res.setHeader('cache-control', 'public, max-age=1, proxy-revalidate')
+          res.setHeader('etag', '"asd123"')
+          res.end('asd')
+        }
+      }).listen(0)
+
+      const origin = `http://localhost:${server.address().port}`
+      const sharedClient = new Client(origin)
+        .compose(interceptors.cache({ type: 'shared' }))
+      const privateClient = new Client(origin)
+        .compose(interceptors.cache({ type: 'private' }))
+
+      after(async () => {
+        server.close()
+        await sharedClient.close()
+        await privateClient.close()
+        clock.uninstall()
+      })
+
+      await once(server, 'listening')
+
+      /**
+       * @type {import('../../types/dispatcher').default.RequestOptions}
+       */
+      const request = {
+        origin: 'localhost',
+        method: 'GET',
+        path: '/'
+      }
+
+      // Prime both caches
+      {
+        const response = await sharedClient.request(request)
+        strictEqual(await response.body.text(), 'asd')
+      }
+      {
+        const response = await privateClient.request(request)
+        strictEqual(await response.body.text(), 'asd')
+      }
+      equal(revalidationRequests, 0)
+
+      clock.tick(1500)
+
+      // proxy-revalidate has the same semantics as must-revalidate for shared
+      //  caches (RFC 9111 §5.2.2.8), so the shared cache needs to revalidate
+      //  despite the request's max-stale
+      {
+        const response = await sharedClient.request({
+          ...request,
+          headers: {
+            'cache-control': 'max-stale=600'
+          }
+        })
+        strictEqual(response.statusCode, 200)
+        strictEqual(await response.body.text(), 'asd')
+        equal(revalidationRequests, 1)
+      }
+
+      // proxy-revalidate doesn't apply to private caches, so max-stale allows
+      //  serving the stale response without validation
+      {
+        const response = await privateClient.request({
+          ...request,
+          headers: {
+            'cache-control': 'max-stale=600'
+          }
+        })
+        strictEqual(response.statusCode, 200)
+        strictEqual(await response.body.text(), 'asd')
+        equal(revalidationRequests, 1)
+      }
     })
 
     test('min-fresh', async () => {


### PR DESCRIPTION
## What

The cache interceptor's `isStale()` granted the request `max-stale` grace window without consulting the stored response's directives, and `handleResult()` applied the `stale-if-error` threshold unconditionally.

RFC 9111 [§5.2.2.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.2): a cache **MUST NOT** use a stale response with `must-revalidate` to satisfy any request without successful validation — this overrides the request's `max-stale` (see the note in §5.2.1.2) and also excludes the response from `stale-if-error` (RFC 5861 §4). [`proxy-revalidate`](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.8) has the same semantics for shared caches — the interceptor's default `type` — and was parsed but never enforced anywhere.

Fixes #5508

## Repro

Store `200 Cache-Control: max-age=1, must-revalidate` (+ ETag), wait past staleness, then request with `Cache-Control: max-stale=600`:

- **Before** (undici 8.7.0 / current main, Node 22): served straight from cache, zero origin contact.
- **After**: conditional request (`if-none-match`/`if-modified-since`) sent to the origin; the cached response is only reused after successful validation.

Same for `stale-if-error`: a stale `must-revalidate` response was previously served when revalidation returned a 5xx within the `stale-if-error` window; now the error is propagated.

## Changes

- `lib/interceptor/cache.js`: new `forbidsServingStale(result, cacheType)` helper; `isStale()` skips the `max-stale` grace window and `handleResult()` skips the `stale-if-error` threshold when the stored response has `must-revalidate` (or `proxy-revalidate` on a shared cache). `proxy-revalidate` correctly remains inert for `type: 'private'` caches.
- `test/interceptors/cache.js`: three new tests (must-revalidate vs max-stale, proxy-revalidate shared vs private, must-revalidate excluded from stale-if-error), all failing before the fix and passing after.

## Testing

- New tests fail on main (stale served with 0 revalidation requests / 200 instead of 500) and pass with the fix.
- Full cache interceptor suite (`test/interceptors/cache*.js`, `test/cache-interceptor/*.js`): 124 tests, 124 pass, 0 fail (121 baseline + 3 new).
- mnot cache-tests conformance runner (`node test/cache-interceptor/cache-tests.mjs`): identical to main's baseline — 283 total, 220 passed, 0 failed, 58 failed-optional, 5 setup-failed. (The suite has no test for the max-stale + must-revalidate combination, so no skip-list entries could be un-skipped; the skipped `stale-close-must-revalidate` test depends on the connection-close revalidation path, which is out of scope here.)

## Notes

- This change is agent-assisted (Claude Fable 5) working with @jeswr.
- Touches the same `handleResult()` region as the sibling PR #5510 (`fix/cache-request-max-age-zero`), but both are self-contained against main and merge-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
