### PR TITLE
fix: send stored last-modified as if-modified-since when revalidating

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -107,9 +107,7 @@ function withinStaleWhileRevalidateWindow (result) {
 }
 
 /**
- * Returns the if-modified-since value to use when revalidating a stored
- * response: its last-modified value if available, otherwise its date value,
- * otherwise the local time the response was cached at.
+ * Returns the if-modified-since value for revalidating a stored response.
  * https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3
  * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
  * @returns {string}

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -107,6 +107,26 @@ function withinStaleWhileRevalidateWindow (result) {
 }
 
 /**
+ * Returns the if-modified-since value to use when revalidating a stored
+ * response: its last-modified value if available, otherwise its date value,
+ * otherwise the local time the response was cached at.
+ * https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3
+ * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
+ * @returns {string}
+ */
+function getIfModifiedSinceValue (result) {
+  if (typeof result.headers['last-modified'] === 'string' && result.headers['last-modified'] !== '') {
+    return result.headers['last-modified']
+  }
+
+  if (typeof result.headers.date === 'string' && result.headers.date !== '') {
+    return result.headers.date
+  }
+
+  return new Date(result.cachedAt).toUTCString()
+}
+
+/**
  * @param {DispatchFn} dispatch
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheHandlerOptions} globalOpts
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} cacheKey
@@ -307,7 +327,7 @@ function handleResult (
       queueMicrotask(() => {
         const headers = {
           ...opts.headers,
-          'if-modified-since': new Date(result.cachedAt).toUTCString()
+          'if-modified-since': getIfModifiedSinceValue(result)
         }
 
         if (result.etag) {
@@ -351,7 +371,7 @@ function handleResult (
 
     const headers = {
       ...opts.headers,
-      'if-modified-since': new Date(result.cachedAt).toUTCString()
+      'if-modified-since': getIfModifiedSinceValue(result)
     }
 
     if (result.etag) {

--- a/test/interceptors/cache-revalidate-stale.js
+++ b/test/interceptors/cache-revalidate-stale.js
@@ -157,3 +157,173 @@ describe('revalidates the request, handles 304s during stale-while-revalidate', 
   test('using if-none-match', async () => await revalidateTest(true))
   test('using if-modified-since', async () => await revalidateTest(false))
 })
+
+describe('if-modified-since value on revalidation requests (RFC 9110 §13.1.3)', () => {
+  const LAST_MODIFIED = 'Sat, 09 Oct 2010 14:28:02 GMT'
+
+  test('sends the stored last-modified value verbatim', async () => {
+    const clock = FakeTimers.install({
+      now: new Date('2028-03-15T12:00:00.000Z').getTime()
+    })
+    after(() => clock.uninstall())
+
+    const revalidationRequests = []
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      res.sendDate = false
+      res.setHeader('Date', new Date(clock.now).toUTCString())
+      res.setHeader('Cache-Control', 'public, max-age=1')
+      res.setHeader('Last-Modified', LAST_MODIFIED)
+
+      if (req.headers['if-modified-since']) {
+        revalidationRequests.push(req.headers['if-modified-since'])
+        res.statusCode = 304
+        res.end()
+      } else {
+        res.end('hello world')
+      }
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await dispatcher.close()
+    })
+
+    const url = `http://localhost:${server.address().port}`
+
+    // initial request, cache the response
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+    }
+
+    // let the response go stale, forcing a revalidation request
+    clock.tick(1500)
+
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+    }
+
+    strictEqual(revalidationRequests.length, 1)
+    strictEqual(revalidationRequests[0], LAST_MODIFIED)
+  })
+
+  test('sends the stored last-modified value verbatim during stale-while-revalidate', async () => {
+    const clock = FakeTimers.install({
+      now: new Date('2028-03-15T12:00:00.000Z').getTime()
+    })
+    after(() => clock.uninstall())
+
+    const revalidationRequests = []
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      res.sendDate = false
+      res.setHeader('Date', new Date(clock.now).toUTCString())
+      res.setHeader('Cache-Control', 'public, max-age=1, stale-while-revalidate=3600')
+      res.setHeader('Last-Modified', LAST_MODIFIED)
+
+      if (req.headers['if-modified-since']) {
+        revalidationRequests.push(req.headers['if-modified-since'])
+        res.statusCode = 304
+        res.end()
+      } else {
+        res.end('hello world')
+      }
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await dispatcher.close()
+    })
+
+    const url = `http://localhost:${server.address().port}`
+
+    // initial request, cache the response
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+    }
+
+    // within the stale-while-revalidate window, revalidated in the background
+    clock.tick(2000)
+
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+
+      // wait for the background revalidation to complete
+      await setTimeout(100)
+      clock.tick(10)
+      await setTimeout(100)
+    }
+
+    strictEqual(revalidationRequests.length, 1)
+    strictEqual(revalidationRequests[0], LAST_MODIFIED)
+  })
+
+  test('falls back to the stored date value when there is no last-modified', async () => {
+    const clock = FakeTimers.install({
+      now: new Date('2028-03-15T12:00:00.000Z').getTime()
+    })
+    after(() => clock.uninstall())
+
+    // date header trailing the local clock, as with a skewed origin clock
+    const dateHeader = new Date(clock.now - 5000).toUTCString()
+
+    const revalidationRequests = []
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      res.sendDate = false
+      res.setHeader('Date', dateHeader)
+      res.setHeader('Cache-Control', 'public, max-age=10')
+
+      if (req.headers['if-modified-since']) {
+        revalidationRequests.push(req.headers['if-modified-since'])
+        res.statusCode = 304
+        res.end()
+      } else {
+        res.end('hello world')
+      }
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await dispatcher.close()
+    })
+
+    const url = `http://localhost:${server.address().port}`
+
+    // initial request, cache the response
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+    }
+
+    // let the response go stale (staleAt is based off of the date header)
+    clock.tick(6000)
+
+    {
+      const res = await request(url, { dispatcher })
+      strictEqual(await res.body.text(), 'hello world')
+    }
+
+    strictEqual(revalidationRequests.length, 1)
+    strictEqual(revalidationRequests[0], dateHeader)
+  })
+})


### PR DESCRIPTION
Fixes #5506

## What

When revalidating a stale cached response, the cache interceptor built the conditional request with `'if-modified-since': new Date(result.cachedAt).toUTCString()` — the local wall-clock time the response was inserted into the cache — on both the synchronous revalidation path and the stale-while-revalidate background path in `lib/interceptor/cache.js`.

RFC 9110 [§13.1.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3) says a cache should generate `If-Modified-Since` from the stored response's `Last-Modified` field value, falling back to the `Date` field value, and only then the local time the response was cached.

Concrete failure modes of the old behavior:

1. **Exact-match origins never return 304.** nginx's default is `if_modified_since exact`; since the local insertion time never equals the resource's `Last-Modified`, every `Last-Modified`-only revalidation (no ETag) against such origins gets a full `200`, silently losing the 304 bandwidth saving.
2. **Clock skew can serve stale data.** If the client clock runs ahead of the origin, a resource modified between `Last-Modified` and (client-time) `cachedAt` is masked: the origin compares its mtime against a too-late date and answers `304`.

## Repro (before → after)

Origin responding `Cache-Control: max-age=1` + `Last-Modified: Sat, 09 Oct 2010 14:28:02 GMT`, two requests >1s apart through a cache-composed dispatcher, logging the revalidation request's `if-modified-since`:

- **Before (main):** `If-Modified-Since: <cache insertion wall-clock time>` (e.g. `Wed, 02 Jul 2026 ... GMT`) — does not match the stored `Last-Modified`.
- **After (this PR):** `If-Modified-Since: Sat, 09 Oct 2010 14:28:02 GMT` — the stored value, verbatim.

## Changes

- Add a `getIfModifiedSinceValue(result)` helper implementing the RFC 9110 §13.1.3 hierarchy (stored `last-modified` → stored `date` → `cachedAt`) and use it at both revalidation call sites. `If-None-Match` behavior is unchanged.
- Tests in `test/interceptors/cache-revalidate-stale.js`: verbatim `Last-Modified` on the synchronous revalidation path, on the stale-while-revalidate background path, and the `Date`-header fallback when the stored response has no `Last-Modified`. All three fail on `main` and pass with this change.

## Tests

- `node --test` over the cache interceptor test files (`test/interceptors/cache*.js`, `test/cache-interceptor/*`): 124 tests / 13 suites, 124 pass, 0 fail (baseline on main: 121/121 + the 3 new tests).
- mnot cache-tests conformance runner (`node test/cache-interceptor/cache-tests.mjs`): Total 283 — Passed 222, Failed 0, Failed-optional 57, Setup failed 4 (equal or better than the main baseline of 220 / 0 / 58 / 5; the conformance suite has no If-Modified-Since-generation test, so no skip-list entries could be un-skipped by this change).

## Notes

This change is agent-assisted (Claude Fable 5) working with @jeswr. It is part of a series of self-contained cache-interceptor conformance fixes against `main`; sibling PRs touching adjacent logic in the same interceptor: #5510 (`fix/cache-request-max-age-zero`) and #5511 (`fix/cache-must-revalidate-max-stale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
