### PR TITLE
fix: invalidate Location and Content-Location URIs on unsafe methods

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -118,6 +118,7 @@ class CacheHandler {
       } catch {
         // Fail silently
       }
+      this.#deleteLocationHeaderEntries(resHeaders)
       return downstreamOnHeaders()
     }
 
@@ -311,6 +312,58 @@ class CacheHandler {
         })
 
       downstreamOnHeaders()
+    }
+  }
+
+  /**
+   * Deletes the cache entries for the URIs in the response's Location and
+   * Content-Location headers when they share the request URI's origin
+   *  https://www.rfc-editor.org/rfc/rfc9111.html#section-4.4
+   *
+   * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
+   */
+  #deleteLocationHeaderEntries (resHeaders) {
+    let requestUrl
+    try {
+      requestUrl = new URL(this.#cacheKey.path, this.#cacheKey.origin)
+    } catch {
+      // Can't resolve the request URI, don't invalidate anything else
+      return
+    }
+
+    const invalidatedPaths = new Set([this.#cacheKey.path])
+
+    for (const headerName of ['location', 'content-location']) {
+      const header = resHeaders[headerName]
+      const value = Array.isArray(header) ? header[0] : header
+      if (typeof value !== 'string' || value === '') {
+        continue
+      }
+
+      let url
+      try {
+        url = new URL(value, requestUrl)
+      } catch {
+        continue
+      }
+
+      if (url.origin !== requestUrl.origin) {
+        // Only invalidate URIs sharing the request URI's origin, invalidating
+        //  cross-origin URIs could be used for cache poisoning
+        continue
+      }
+
+      const path = `${url.pathname}${url.search}`
+      if (invalidatedPaths.has(path)) {
+        continue
+      }
+      invalidatedPaths.add(path)
+
+      try {
+        this.#store.delete({ ...this.#cacheKey, path })?.catch?.(noop)
+      } catch {
+        // Fail silently
+      }
     }
   }
 

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -531,6 +531,83 @@ describe('Cache Interceptor', () => {
     }
   })
 
+  test('unsafe methods invalidate the URIs in Location and Content-Location response headers', async () => {
+    const requestsToOrigin = {
+      '/target': 0,
+      '/content-target': 0,
+      '/cross-origin-target': 0
+    }
+
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      if (req.method === 'GET') {
+        requestsToOrigin[req.url]++
+        res.setHeader('cache-control', 'public, s-maxage=100')
+        res.end('asd')
+        return
+      }
+
+      res.statusCode = 204
+      if (req.url === '/same-origin') {
+        // Absolute same-origin Location, relative Content-Location
+        res.setHeader('location', `http://localhost:${server.address().port}/target`)
+        res.setHeader('content-location', '/content-target')
+      } else if (req.url === '/cross-origin') {
+        // Same path as a cached entry but a different origin, must not be
+        //  invalidated
+        res.setHeader('location', 'http://other-origin.example/cross-origin-target')
+      }
+      res.end()
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const origin = `http://localhost:${server.address().port}`
+
+    // Prime the cache and make sure the responses are served from it
+    for (const path of Object.keys(requestsToOrigin)) {
+      for (let i = 0; i < 2; i++) {
+        const res = await client.request({ origin, method: 'GET', path })
+        strictEqual(await res.body.text(), 'asd')
+        equal(requestsToOrigin[path], 1, path)
+      }
+    }
+
+    // Successful unsafe request whose response points at /target and
+    //  /content-target, both must be invalidated
+    //  https://www.rfc-editor.org/rfc/rfc9111.html#section-4.4
+    {
+      const res = await client.request({ origin, method: 'POST', path: '/same-origin' })
+      await res.body.text()
+    }
+
+    for (const path of ['/target', '/content-target']) {
+      const res = await client.request({ origin, method: 'GET', path })
+      strictEqual(await res.body.text(), 'asd')
+      equal(requestsToOrigin[path], 2, path)
+    }
+
+    // Successful unsafe request whose response Location shares a path with a
+    //  cached entry but sits on another origin, the cached entry must survive
+    {
+      const res = await client.request({ origin, method: 'POST', path: '/cross-origin' })
+      await res.body.text()
+    }
+
+    {
+      const res = await client.request({ origin, method: 'GET', path: '/cross-origin-target' })
+      strictEqual(await res.body.text(), 'asd')
+      equal(requestsToOrigin['/cross-origin-target'], 1)
+    }
+  })
+
   test('unsafe methods aren\'t cached', async () => {
     const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
       res.setHeader('cache-control', 'public, s-maxage=1')


### PR DESCRIPTION
Fixes #5509

## What

`CacheHandler.onResponseStart` deleted only the request URI's entry on a 2xx/3xx response to an unsafe method. [RFC 9111 §4.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.4) also says caches SHOULD invalidate the URIs in the response's `Location` and `Content-Location` header fields when they share the request URI's origin — so the classic `POST /collection` → `201 Location: /collection/123` flow left a previously cached `GET /collection/123` stale.

This adds a `#deleteLocationHeaderEntries` step to the existing invalidation branch: it resolves each header value against the request URI (relative references included), applies the same-origin check from the RFC's security note (invalidating cross-origin URIs could be abused for cache poisoning), and deletes the matching entry from the store.

## Repro / evidence

Origin: `GET /target` served with `Cache-Control: public, s-maxage=100`; `POST /src` answers `201` with `Location: <origin>/target`.

Before (main @ cb4c2f1, Node 22):
1. `GET /target` → origin hit, cached
2. `POST /src` (response carries `Location: <origin>/target`)
3. `GET /target` → **served from cache** (1 origin hit total on `/target`)

After: step 3 goes back to the origin (2 hits), for both `Location` and `Content-Location`, absolute and relative forms. A `Location` pointing at another origin (even with a path that collides with a cached entry) does not invalidate — covered by the added test in `test/interceptors/cache.js`.

## Tests

- New node:test case `unsafe methods invalidate the URIs in Location and Content-Location response headers` in `test/interceptors/cache.js` (fails on main with `expected: 2, actual: 1` origin hits, passes with this change).
- Full cache test files (`test/interceptors/cache*.js`, `test/cache-interceptor/*`): 122 pass / 0 fail (121 baseline + 1 new).
- mnot cache-tests conformance runner (`node test/cache-interceptor/cache-tests.mjs`): the eight `invalidate-{POST,PUT,DELETE,M-SEARCH}-{location,cl}` tests move from failed-optional to passing in every environment — totals go 220 → 228 passed, 58 → 50 failed-optional, still 0 required failures. Nothing needed un-skipping in the runner's ignore list.

## Notes

- This change is agent-assisted (Claude Fable 5) working with @jeswr.
- Self-contained against `main`; independent of the sibling cache-conformance PRs #5510 (`fix/cache-request-max-age-zero`), #5511 (`fix/cache-must-revalidate-max-stale`), #5512 (`fix/cache-if-modified-since-value`) and #5513 (`fix/cache-stale-if-error-network`), which touch the interceptor/revalidation paths rather than this invalidation hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)