### PR TITLE
fix: store revalidation-only responses so etag revalidation can engage

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -26,6 +26,12 @@ const NOT_UNDERSTOOD_STATUS_CODES = [
 
 const MAX_RESPONSE_AGE = 2147483647000
 
+// How long revalidation-only entries (zero freshness lifetime but a validator
+//  present, e.g. `cache-control: no-cache` or `max-age=0` with an etag) are
+//  retained so there is something to revalidate against. Every successful
+//  revalidation re-stores the entry, sliding this window.
+const REVALIDATION_ONLY_RETENTION = 86400000 // 24 hours
+
 /**
  * @typedef {import('../../types/dispatcher.d.ts').default.DispatchHandler} DispatchHandler
  *
@@ -150,8 +156,12 @@ class CacheHandler {
       ? parseHttpDate(resHeaders.date)
       : undefined
 
+    const hasValidator =
+      (typeof resHeaders.etag === 'string' && isEtagUsable(resHeaders.etag)) ||
+      typeof resHeaders['last-modified'] === 'string'
+
     const staleAt =
-      determineStaleAt(this.#cacheType, now, resAge, resHeaders, resDate, cacheControlDirectives) ??
+      determineStaleAt(this.#cacheType, now, resAge, resHeaders, resDate, cacheControlDirectives, hasValidator) ??
       this.#cacheByDefault
     if (staleAt === undefined || (resAge && resAge > staleAt)) {
       return downstreamOnHeaders()
@@ -159,7 +169,13 @@ class CacheHandler {
 
     const baseTime = resDate ? resDate.getTime() : now
     const absoluteStaleAt = staleAt + baseTime
-    if (now >= absoluteStaleAt) {
+    // Responses with a zero freshness lifetime but a validator (e.g.
+    //  `cache-control: no-cache` or `max-age=0` with an etag) are stale from
+    //  the start, but they're still storable - each reuse is preceded by a
+    //  revalidation request.
+    //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4
+    const revalidationOnly = staleAt === 0 && hasValidator
+    if (now >= absoluteStaleAt && !revalidationOnly) {
       // Response is already stale
       return downstreamOnHeaders()
     }
@@ -422,23 +438,37 @@ function getAge (ageHeader) {
  * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
  * @param {Date | undefined} responseDate
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives} cacheControlDirectives
+ * @param {boolean} hasValidator whether the response has a validator (etag or
+ *  last-modified) that revalidation requests can be made with
  *
  * @returns {number | undefined} time that the value is stale at in seconds or undefined if it shouldn't be cached
  */
-function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheControlDirectives) {
+function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheControlDirectives, hasValidator) {
   if (cacheType === 'shared') {
     // Prioritize s-maxage since we're a shared cache
     //  s-maxage > max-age > Expire
     //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.10-3
     const sMaxAge = cacheControlDirectives['s-maxage']
     if (sMaxAge !== undefined) {
-      return sMaxAge > 0 ? sMaxAge * 1000 : undefined
+      if (sMaxAge > 0) {
+        return sMaxAge * 1000
+      }
+
+      // An immediately stale response can still be stored if we can
+      //  revalidate it before reuse
+      return sMaxAge === 0 && hasValidator ? 0 : undefined
     }
   }
 
   const maxAge = cacheControlDirectives['max-age']
   if (maxAge !== undefined) {
-    return maxAge > 0 ? maxAge * 1000 : undefined
+    if (maxAge > 0) {
+      return maxAge * 1000
+    }
+
+    // An immediately stale response can still be stored if we can revalidate
+    //  it before reuse
+    return maxAge === 0 && hasValidator ? 0 : undefined
   }
 
   if (typeof resHeaders.expires === 'string') {
@@ -482,6 +512,13 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
     return 31536000000
   }
 
+  if (cacheControlDirectives['no-cache'] === true && hasValidator) {
+    // The response has no freshness source, but, since it has a validator,
+    //  it can still be stored and revalidated before each reuse
+    //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4
+    return 0
+  }
+
   return undefined
 }
 
@@ -518,6 +555,14 @@ function determineDeleteAt (baseTime, cachedAt, cacheControlDirectives, staleAt)
   // revalidated.
   if (staleWhileRevalidate === -Infinity && staleIfError === -Infinity && immutable === -Infinity) {
     const freshnessLifetime = staleAt - baseTime
+    if (freshnessLifetime <= 0) {
+      // Revalidation-only entry (zero freshness lifetime, stored solely so
+      //  reuses can be revalidated with a conditional request): there's no
+      //  freshness lifetime to base the buffer on, so retain it for a bounded
+      //  window instead. Every successful revalidation re-stores the entry,
+      //  sliding the window.
+      return cachedAt + REVALIDATION_ONLY_RETENTION
+    }
     const datePrecisionPadding = Math.min(Math.max(cachedAt - baseTime, 0), 1000)
     return staleAt + freshnessLifetime + datePrecisionPadding
   }

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -26,10 +26,8 @@ const NOT_UNDERSTOOD_STATUS_CODES = [
 
 const MAX_RESPONSE_AGE = 2147483647000
 
-// How long revalidation-only entries (zero freshness lifetime but a validator
-//  present, e.g. `cache-control: no-cache` or `max-age=0` with an etag) are
-//  retained so there is something to revalidate against. Every successful
-//  revalidation re-stores the entry, sliding this window.
+// Retention for revalidation-only entries (zero freshness lifetime but a
+//  validator present); each successful revalidation re-stores the entry.
 const REVALIDATION_ONLY_RETENTION = 86400000 // 24 hours
 
 /**
@@ -169,10 +167,8 @@ class CacheHandler {
 
     const baseTime = resDate ? resDate.getTime() : now
     const absoluteStaleAt = staleAt + baseTime
-    // Responses with a zero freshness lifetime but a validator (e.g.
-    //  `cache-control: no-cache` or `max-age=0` with an etag) are stale from
-    //  the start, but they're still storable - each reuse is preceded by a
-    //  revalidation request.
+    // Zero freshness lifetime but a validator: stale from the start, yet still
+    //  storable since each reuse is preceded by a revalidation request.
     //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4
     const revalidationOnly = staleAt === 0 && hasValidator
     if (now >= absoluteStaleAt && !revalidationOnly) {
@@ -454,8 +450,7 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
         return sMaxAge * 1000
       }
 
-      // An immediately stale response can still be stored if we can
-      //  revalidate it before reuse
+      // Immediately stale, but storable if we can revalidate it before reuse.
       return sMaxAge === 0 && hasValidator ? 0 : undefined
     }
   }
@@ -466,8 +461,7 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
       return maxAge * 1000
     }
 
-    // An immediately stale response can still be stored if we can revalidate
-    //  it before reuse
+    // Immediately stale, but storable if we can revalidate it before reuse.
     return maxAge === 0 && hasValidator ? 0 : undefined
   }
 
@@ -513,8 +507,7 @@ function determineStaleAt (cacheType, now, age, resHeaders, responseDate, cacheC
   }
 
   if (cacheControlDirectives['no-cache'] === true && hasValidator) {
-    // The response has no freshness source, but, since it has a validator,
-    //  it can still be stored and revalidated before each reuse
+    // No freshness source, but a validator lets us revalidate before reuse.
     //  https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4
     return 0
   }
@@ -556,11 +549,8 @@ function determineDeleteAt (baseTime, cachedAt, cacheControlDirectives, staleAt)
   if (staleWhileRevalidate === -Infinity && staleIfError === -Infinity && immutable === -Infinity) {
     const freshnessLifetime = staleAt - baseTime
     if (freshnessLifetime <= 0) {
-      // Revalidation-only entry (zero freshness lifetime, stored solely so
-      //  reuses can be revalidated with a conditional request): there's no
-      //  freshness lifetime to base the buffer on, so retain it for a bounded
-      //  window instead. Every successful revalidation re-stores the entry,
-      //  sliding the window.
+      // Revalidation-only entry: no freshness lifetime to size the buffer on,
+      //  so retain it for a bounded window instead.
       return cachedAt + REVALIDATION_ONLY_RETENTION
     }
     const datePrecisionPadding = Math.min(Math.max(cachedAt - baseTime, 0), 1000)

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -170,6 +170,167 @@ describe('Cache Interceptor', () => {
     strictEqual(requestCount, 2)
   })
 
+  test('stores response with no-cache directive and etag, revalidates it on reuse', async () => {
+    let requestsToOrigin = 0
+    let revalidationRequests = 0
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      if (req.headers['if-none-match'] === '"asd123"') {
+        revalidationRequests++
+        res.statusCode = 304
+        res.end()
+      } else {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'no-cache')
+        res.setHeader('etag', '"asd123"')
+        res.end('asd')
+      }
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    /**
+     * @type {import('../../types/dispatcher').default.RequestOptions}
+     */
+    const request = {
+      origin: 'localhost',
+      method: 'GET',
+      path: '/'
+    }
+
+    // Send initial request. This should reach the origin
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 0)
+    }
+
+    // Send second request. The response was stored, so this should be a
+    //  revalidation request answered with a 304 and served from the cache
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 1)
+    }
+  })
+
+  test('stores response with max-age=0 and etag, revalidates it on reuse', async () => {
+    let requestsToOrigin = 0
+    let revalidationRequests = 0
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      if (req.headers['if-none-match'] === '"asd123"') {
+        revalidationRequests++
+        res.statusCode = 304
+        res.end()
+      } else {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'max-age=0')
+        res.setHeader('etag', '"asd123"')
+        res.end('asd')
+      }
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    /**
+     * @type {import('../../types/dispatcher').default.RequestOptions}
+     */
+    const request = {
+      origin: 'localhost',
+      method: 'GET',
+      path: '/'
+    }
+
+    // Send initial request. This should reach the origin
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 0)
+    }
+
+    // Send second request. The response was stored but is already stale, so
+    //  this should be a revalidation request answered with a 304 and served
+    //  from the cache
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 1)
+    }
+  })
+
+  test('stores response with no-cache directive, etag and last-modified, revalidates it on reuse', async () => {
+    let requestsToOrigin = 0
+    let revalidationRequests = 0
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      if (req.headers['if-none-match'] === '"asd123"') {
+        revalidationRequests++
+        res.statusCode = 304
+        res.end()
+      } else {
+        requestsToOrigin++
+        res.setHeader('cache-control', 'no-cache')
+        res.setHeader('etag', '"asd123"')
+        res.setHeader('last-modified', new Date(Date.now() - 60000).toUTCString())
+        res.end('asd')
+      }
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    /**
+     * @type {import('../../types/dispatcher').default.RequestOptions}
+     */
+    const request = {
+      origin: 'localhost',
+      method: 'GET',
+      path: '/'
+    }
+
+    // Send initial request. This should reach the origin
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 0)
+    }
+
+    // Send second request. The response was stored, so this should be a
+    //  revalidation request answered with a 304 and served from the cache
+    {
+      const res = await client.request(request)
+      strictEqual(await res.body.text(), 'asd')
+      strictEqual(requestsToOrigin, 1)
+      strictEqual(revalidationRequests, 1)
+    }
+  })
+
   test('expires caching', async () => {
     const clock = FakeTimers.install({
       toFake: ['Date']


### PR DESCRIPTION
## This relates to...

Discussion #4620 and PR #4624 by @steunix (this PR supersedes #4624 — full credit to @steunix for identifying the problem and taking the first pass at it; see "Relationship to #4624" below for why a fresh approach was needed).

## Rationale

Responses with a validator (`ETag` or `Last-Modified`) but zero freshness lifetime — `Cache-Control: no-cache` or `max-age=0` with no other freshness source — are never stored by the cache interceptor: `determineStaleAt()` returns `undefined`, so no entry is created, no `If-None-Match` is ever sent, and every request gets a full 200 from the origin. `ETag` + `no-cache` is the canonical "cache, but always validate" pattern for API servers, and RFC 9111 [§3](https://www.rfc-editor.org/rfc/rfc9111.html#section-3) / [§5.2.2.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4) explicitly allows storing these responses as long as each reuse is revalidated — undici currently gets zero 304 benefit from them.

Repro against `main` (Node 22), origin serving `cache-control: no-cache` + `etag "..."` (no `Last-Modified`):

- **before**: 2 requests → 2 full 200s at the origin, no conditional headers sent
- **after**: 2 requests → 1 full 200 + 1 conditional request answered with a 304, cached body reused

Same for `cache-control: max-age=0` + `etag`. The already-working `no-cache` + `Last-Modified` case (stored via the heuristic-freshness branch) is unchanged, and now covered by a regression test.

## Changes

Store such responses with immediate-stale semantics (three coordinated pieces in `lib/handler/cache-handler.js`):

1. `determineStaleAt()` returns `0` instead of `undefined` for `max-age=0` / `s-maxage=0` / unqualified `no-cache` when the response has a usable validator (`isEtagUsable` etag or a `Last-Modified` header). The new `no-cache` branch sits *below* the `Last-Modified` heuristic branch so it cannot shadow the existing behavior.
2. The "response is already stale" rejection in `onResponseStart()` is relaxed for these revalidation-only entries (zero freshness lifetime + validator) so they can actually be written to the store.
3. `determineDeleteAt()` retains them for a bounded 24h window: the usual revalidation buffer is proportional to the freshness lifetime, which is zero here, so the entry would otherwise be evicted immediately and never be available to revalidate. Every successful revalidation re-stores the entry, sliding the window; store-level limits (LRU / maxCount / maxSize) still apply.

The read side needs no changes: stored unqualified-`no-cache` entries are already forced through revalidation on every use by `needsRevalidation()`, and `max-age=0` entries are always stale, so `isStale()` triggers the same conditional-request flow.

### Relationship to #4624

#4624 identified exactly this problem and made `determineStaleAt()` return `0` for `no-cache`/`max-age=0`. Testing that diff against `main` showed two issues (which is why this is a fresh PR rather than a review comment):

- the entry is still rejected downstream: with `staleAt = 0`, `now >= absoluteStaleAt` is true, so `onResponseStart()` bails with "response is already stale" before anything is written — and even past that, `determineDeleteAt()` computes a delete time of `staleAt + freshnessLifetime (= 0) + ≤1s padding`, evicting the entry immediately (pieces 2 and 3 above address these);
- because the new `no-cache → 0` branch sat *above* the `Last-Modified` heuristic branch, the currently-working `no-cache` + `Last-Modified` case stopped being cached (request pattern went from `full, conditional` to `full, full`).

### Features

N/A

### Bug Fixes

- Responses with `Cache-Control: no-cache` (unqualified) and a validator are now stored and revalidated with a conditional request on each reuse.
- Responses with `Cache-Control: max-age=0` (or `s-maxage=0` for shared caches) and a validator are now stored and revalidated before reuse.

### Breaking Changes and Deprecations

N/A

## Tests

- 3 new tests in `test/interceptors/cache.js` (no-cache + etag, max-age=0 + etag, and the no-cache + etag + last-modified regression guard). The first two fail on `main`, all three pass with this change.
- Full cache test files (`test/interceptors/cache*.js`, `test/cache-interceptor/*`): 124/124 pass.
- mnot cache-tests conformance runner (`node test/cache-interceptor/cache-tests.mjs`): 0 required failures before and after; the previously failing optional test `cc-resp-no-cache-revalidate` ("An optimal HTTP cache stores a response with `Cache-Control: no-cache`, but revalidates it upon use") now passes in all 4 environments (221 passed / 57 failed-optional, vs 220 / 58 on `main`). No test regressed.
- (Observation while verifying, left out of this PR to keep it self-contained: the `cc-resp-no-cache` / `cc-resp-no-cache-case-insensitive` skip-list entries in `test/cache-interceptor/cache-tests.mjs` appear stale — both pass on unmodified `main` when un-skipped.)

Sibling PRs from the same RFC 9111 review (each self-contained against `main`): #5510 (`fix/cache-request-max-age-zero`, the request-side `max-age=0` falsy check) and #5512 (`fix/cache-if-modified-since-value`, validator sent on revalidation) touch the adjacent request-directive/revalidation logic; also #5511, #5513, #5514.

This change is agent-assisted (Claude Fable 5) working with @jeswr.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
