### PR TITLE
fix: update stored cache entry on synchronous 304 revalidation

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -121,6 +121,12 @@ class CacheHandler {
       return downstreamOnHeaders()
     }
 
+    // Not modified, freshen the stored response and re-use its body
+    // https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses
+    if (statusCode === 304) {
+      return this.#handle304(controller, resHeaders, downstreamOnHeaders)
+    }
+
     const cacheControlHeader = resHeaders['cache-control']
     const heuristicallyCacheable = resHeaders['last-modified'] && HEURISTICALLY_CACHEABLE_STATUS_CODES.includes(statusCode)
     if (
@@ -191,126 +197,206 @@ class CacheHandler {
       deleteAt
     }
 
-    // Not modified, re-use the cached value
-    // https://www.rfc-editor.org/rfc/rfc9111.html#name-handling-304-not-modified
-    if (statusCode === 304) {
-      const handle304 = (cachedValue) => {
-        if (!cachedValue) {
-          // Do not create a new cache entry, as a 304 won't have a body - so cannot be cached.
+    if (typeof resHeaders.etag === 'string' && isEtagUsable(resHeaders.etag)) {
+      value.etag = resHeaders.etag
+    }
+
+    this.#writeStream = this.#store.createWriteStream(this.#cacheKey, value)
+
+    if (!this.#writeStream) {
+      return downstreamOnHeaders()
+    }
+
+    this.#writeStream
+      .on('drain', () => controller.resume())
+      .on('error', function () {
+        // TODO (fix): Make error somehow observable?
+        handler.#writeStream = undefined
+
+        // Delete the value in case the cache store is holding onto state from
+        //  the call to createWriteStream
+        handler.#store.delete(handler.#cacheKey)
+      })
+      .on('close', function () {
+        if (handler.#writeStream === this) {
+          handler.#writeStream = undefined
+        }
+
+        // TODO (fix): Should we resume even if was paused downstream?
+        controller.resume()
+      })
+
+    downstreamOnHeaders()
+  }
+
+  /**
+   * Handles a 304 Not Modified validation response by updating the stored
+   *  response with the validation response's header fields and recomputing
+   *  its freshness from the merged headers, per RFC 9111 §4.3.4.
+   *
+   * https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses
+   *
+   * @param {import('../../types/dispatcher.d.ts').default.DispatchController} controller
+   * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
+   * @param {() => void} downstreamOnHeaders
+   */
+  #handle304 (controller, resHeaders, downstreamOnHeaders) {
+    const handler = this
+
+    const handle304 = (cachedValue) => {
+      if (!cachedValue) {
+        // We have nothing stored to freshen. Do not create a new cache entry,
+        //  as a 304 won't have a body - so it cannot be cached.
+        return downstreamOnHeaders()
+      }
+
+      // https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4-4
+      const headers = mergeValidationHeaders(cachedValue.headers, resHeaders)
+      const cacheControlDirectives = headers['cache-control']
+        ? parseCacheControlHeader(headers['cache-control'])
+        : {}
+
+      if (!canCacheResponse(this.#cacheType, cachedValue.statusCode, headers, cacheControlDirectives, this.#cacheKey.headers)) {
+        // The freshened response is no longer storable, leave the stored
+        //  entry as it is
+        return downstreamOnHeaders()
+      }
+
+      const now = Date.now()
+      const resAge = resHeaders.age ? getAge(resHeaders.age) : undefined
+      if (resAge && resAge >= MAX_RESPONSE_AGE) {
+        return downstreamOnHeaders()
+      }
+
+      const resDate = typeof resHeaders.date === 'string'
+        ? parseHttpDate(resHeaders.date)
+        : undefined
+
+      // Recompute the freshness lifetime from the merged headers, not just
+      //  the ones present on the 304 itself
+      const staleAt =
+        determineStaleAt(this.#cacheType, now, resAge, headers, resDate, cacheControlDirectives) ??
+        this.#cacheByDefault
+      if (staleAt === undefined || (resAge && resAge > staleAt)) {
+        return downstreamOnHeaders()
+      }
+
+      const baseTime = resDate ? resDate.getTime() : now
+      const absoluteStaleAt = staleAt + baseTime
+      if (now >= absoluteStaleAt) {
+        // Still stale after freshening, leave the stored entry as it is
+        return downstreamOnHeaders()
+      }
+
+      let varyDirectives
+      if (this.#cacheKey.headers && headers.vary) {
+        varyDirectives = parseVaryHeader(headers.vary, this.#cacheKey.headers)
+        if (!varyDirectives) {
+          // Parse error
           return downstreamOnHeaders()
         }
-
-        // Re-use the cached value: statuscode, statusmessage, headers and body
-        value.statusCode = cachedValue.statusCode
-        value.statusMessage = cachedValue.statusMessage
-        value.etag = cachedValue.etag
-        value.headers = { ...cachedValue.headers, ...strippedHeaders }
-
-        downstreamOnHeaders()
-
-        this.#writeStream = this.#store.createWriteStream(this.#cacheKey, value)
-
-        if (!this.#writeStream || !cachedValue?.body) {
-          return
-        }
-
-        if (typeof cachedValue.body.values === 'function') {
-          const bodyIterator = cachedValue.body.values()
-
-          const streamCachedBody = () => {
-            for (const chunk of bodyIterator) {
-              const full = this.#writeStream.write(chunk) === false
-              this.#handler.onResponseData?.(controller, chunk)
-              // when stream is full stop writing until we get a 'drain' event
-              if (full) {
-                break
-              }
-            }
-          }
-
-          this.#writeStream
-            .on('error', function () {
-              handler.#writeStream = undefined
-              handler.#store.delete(handler.#cacheKey)
-            })
-            .on('drain', () => {
-              streamCachedBody()
-            })
-            .on('close', function () {
-              if (handler.#writeStream === this) {
-                handler.#writeStream = undefined
-              }
-            })
-
-          streamCachedBody()
-        } else if (typeof cachedValue.body.on === 'function') {
-          // Readable stream body (e.g. from async/remote cache stores)
-          cachedValue.body
-            .on('data', (chunk) => {
-              this.#writeStream.write(chunk)
-              this.#handler.onResponseData?.(controller, chunk)
-            })
-            .on('end', () => {
-              this.#writeStream.end()
-            })
-            .on('error', () => {
-              this.#writeStream = undefined
-              this.#store.delete(this.#cacheKey)
-            })
-
-          this.#writeStream
-            .on('error', function () {
-              handler.#writeStream = undefined
-              handler.#store.delete(handler.#cacheKey)
-            })
-            .on('close', function () {
-              if (handler.#writeStream === this) {
-                handler.#writeStream = undefined
-              }
-            })
-        }
       }
+
+      const cachedAt = resAge ? now - resAge : now
 
       /**
        * @type {import('../../types/cache-interceptor.d.ts').default.CacheValue}
        */
-      const result = this.#store.get(this.#cacheKey)
-      if (result && typeof result.then === 'function') {
-        result.then(handle304)
-      } else {
-        handle304(result)
+      const value = {
+        statusCode: cachedValue.statusCode,
+        statusMessage: cachedValue.statusMessage,
+        headers,
+        vary: varyDirectives,
+        cacheControlDirectives,
+        cachedAt,
+        staleAt: absoluteStaleAt,
+        deleteAt: determineDeleteAt(baseTime, cachedAt, cacheControlDirectives, absoluteStaleAt)
       }
-    } else {
+
       if (typeof resHeaders.etag === 'string' && isEtagUsable(resHeaders.etag)) {
         value.etag = resHeaders.etag
+      } else {
+        value.etag = cachedValue.etag
       }
+
+      downstreamOnHeaders()
 
       this.#writeStream = this.#store.createWriteStream(this.#cacheKey, value)
 
-      if (!this.#writeStream) {
-        return downstreamOnHeaders()
+      if (!this.#writeStream || !cachedValue.body) {
+        return
       }
 
-      this.#writeStream
-        .on('drain', () => controller.resume())
-        .on('error', function () {
-          // TODO (fix): Make error somehow observable?
-          handler.#writeStream = undefined
+      if (typeof cachedValue.body.on === 'function') {
+        // Readable stream body (e.g. from async/remote cache stores)
+        cachedValue.body
+          .on('data', (chunk) => {
+            this.#writeStream.write(chunk)
+            this.#handler.onResponseData?.(controller, chunk)
+          })
+          .on('end', () => {
+            this.#writeStream.end()
+          })
+          .on('error', () => {
+            this.#writeStream = undefined
+            this.#store.delete(this.#cacheKey)
+          })
 
-          // Delete the value in case the cache store is holding onto state from
-          //  the call to createWriteStream
-          handler.#store.delete(handler.#cacheKey)
-        })
-        .on('close', function () {
-          if (handler.#writeStream === this) {
+        this.#writeStream
+          .on('error', function () {
             handler.#writeStream = undefined
+            handler.#store.delete(handler.#cacheKey)
+          })
+          .on('close', function () {
+            if (handler.#writeStream === this) {
+              handler.#writeStream = undefined
+            }
+          })
+      } else {
+        // Iterable of chunks (e.g. MemoryCacheStore) or a single contiguous
+        //  body (e.g. SqliteCacheStore returns a Buffer, whose values()
+        //  would iterate single bytes)
+        const bodyIterator = typeof cachedValue.body.values === 'function' && !ArrayBuffer.isView(cachedValue.body)
+          ? cachedValue.body.values()
+          : [cachedValue.body].values()
+
+        const streamCachedBody = () => {
+          for (const chunk of bodyIterator) {
+            const full = this.#writeStream.write(chunk) === false
+            this.#handler.onResponseData?.(controller, chunk)
+            // when stream is full stop writing until we get a 'drain' event
+            if (full) {
+              break
+            }
           }
+        }
 
-          // TODO (fix): Should we resume even if was paused downstream?
-          controller.resume()
-        })
+        this.#writeStream
+          .on('error', function () {
+            handler.#writeStream = undefined
+            handler.#store.delete(handler.#cacheKey)
+          })
+          .on('drain', () => {
+            streamCachedBody()
+          })
+          .on('close', function () {
+            if (handler.#writeStream === this) {
+              handler.#writeStream = undefined
+            }
+          })
 
-      downstreamOnHeaders()
+        streamCachedBody()
+      }
+    }
+
+    /**
+     * @type {import('../../types/cache-interceptor.d.ts').default.CacheValue}
+     */
+    const result = this.#store.get(this.#cacheKey)
+    if (result && typeof result.then === 'function') {
+      result.then(handle304)
+    } else {
+      handle304(result)
     }
   }
 
@@ -526,6 +612,27 @@ function determineDeleteAt (baseTime, cachedAt, cacheControlDirectives, staleAt)
 }
 
 /**
+ * Updates stored response headers with the ones of a validation response,
+ *  per RFC 9111 §4.3.4. Content-Length is not carried over since it
+ *  describes the validation response, not the stored body.
+ *
+ * https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4-4
+ *
+ * @param {Record<string, string | string[]>} cachedHeaders headers of the stored response
+ * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders headers of the validation response
+ * @returns {Record<string, string | string[]>}
+ */
+function mergeValidationHeaders (cachedHeaders, resHeaders) {
+  const cacheControlDirectives = resHeaders['cache-control']
+    ? parseCacheControlHeader(resHeaders['cache-control'])
+    : {}
+  const validationHeaders = { ...stripNecessaryHeaders(resHeaders, cacheControlDirectives) }
+  delete validationHeaders['content-length']
+
+  return { ...cachedHeaders, ...validationHeaders }
+}
+
+/**
  * Strips headers required to be removed in cached responses
  * @param {import('../../types/header.d.ts').IncomingHttpHeaders} resHeaders
  * @param {import('../../types/cache-interceptor.d.ts').default.CacheControlDirectives} cacheControlDirectives
@@ -584,3 +691,4 @@ function isValidDate (date) {
 }
 
 module.exports = CacheHandler
+module.exports.mergeValidationHeaders = mergeValidationHeaders

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -245,8 +245,7 @@ class CacheHandler {
 
     const handle304 = (cachedValue) => {
       if (!cachedValue) {
-        // We have nothing stored to freshen. Do not create a new cache entry,
-        //  as a 304 won't have a body - so it cannot be cached.
+        // Do not create a new cache entry, as a 304 won't have a body - so cannot be cached.
         return downstreamOnHeaders()
       }
 
@@ -257,8 +256,7 @@ class CacheHandler {
         : {}
 
       if (!canCacheResponse(this.#cacheType, cachedValue.statusCode, headers, cacheControlDirectives, this.#cacheKey.headers)) {
-        // The freshened response is no longer storable, leave the stored
-        //  entry as it is
+        // The freshened response is no longer storable, leave the stored entry as-is
         return downstreamOnHeaders()
       }
 
@@ -272,8 +270,7 @@ class CacheHandler {
         ? parseHttpDate(resHeaders.date)
         : undefined
 
-      // Recompute the freshness lifetime from the merged headers, not just
-      //  the ones present on the 304 itself
+      // Recompute freshness from the merged headers, not just those on the 304
       const staleAt =
         determineStaleAt(this.#cacheType, now, resAge, headers, resDate, cacheControlDirectives) ??
         this.#cacheByDefault
@@ -353,9 +350,8 @@ class CacheHandler {
             }
           })
       } else {
-        // Iterable of chunks (e.g. MemoryCacheStore) or a single contiguous
-        //  body (e.g. SqliteCacheStore returns a Buffer, whose values()
-        //  would iterate single bytes)
+        // Iterable of chunks (e.g. MemoryCacheStore), or a single Buffer
+        //  (e.g. SqliteCacheStore) whose values() would iterate single bytes
         const bodyIterator = typeof cachedValue.body.values === 'function' && !ArrayBuffer.isView(cachedValue.body)
           ? cachedValue.body.values()
           : [cachedValue.body].values()

--- a/lib/handler/cache-revalidation-handler.js
+++ b/lib/handler/cache-revalidation-handler.js
@@ -19,7 +19,13 @@ class CacheRevalidationHandler {
   #successful = false
 
   /**
-   * @type {((boolean, any) => void) | null}
+   * Whether we're forwarding a 304 response to the cache update handler
+   * @type {boolean}
+   */
+  #updatingCache = false
+
+  /**
+   * @type {((success: boolean, context: any, statusCode?: number, headers?: Record<string, string | string[]>) => void) | null}
    */
   #callback
 
@@ -27,6 +33,13 @@ class CacheRevalidationHandler {
    * @type {(import('../../types/dispatcher.d.ts').default.DispatchHandler)}
    */
   #handler
+
+  /**
+   * Handler that updates the stored response with a 304's headers
+   *  (https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses)
+   * @type {import('../../types/dispatcher.d.ts').default.DispatchHandler | null}
+   */
+  #cacheUpdateHandler
 
   #context
 
@@ -36,11 +49,12 @@ class CacheRevalidationHandler {
   #allowErrorStatusCodes
 
   /**
-   * @param {(boolean) => void} callback Function to call if the cached value is valid
+   * @param {(success: boolean, context: any, statusCode?: number, headers?: Record<string, string | string[]>) => void} callback Function to call if the cached value is valid
    * @param {import('../../types/dispatcher.d.ts').default.DispatchHandlers} handler
    * @param {boolean} allowErrorStatusCodes
+   * @param {import('../../types/dispatcher.d.ts').default.DispatchHandler} [cacheUpdateHandler]
    */
-  constructor (callback, handler, allowErrorStatusCodes) {
+  constructor (callback, handler, allowErrorStatusCodes, cacheUpdateHandler = null) {
     if (typeof callback !== 'function') {
       throw new TypeError('callback must be a function')
     }
@@ -48,10 +62,12 @@ class CacheRevalidationHandler {
     this.#callback = callback
     this.#handler = handler
     this.#allowErrorStatusCodes = allowErrorStatusCodes
+    this.#cacheUpdateHandler = cacheUpdateHandler
   }
 
   onRequestStart (_, context) {
     this.#successful = false
+    this.#updatingCache = false
     this.#context = context
   }
 
@@ -71,10 +87,24 @@ class CacheRevalidationHandler {
     // https://datatracker.ietf.org/doc/html/rfc5861#section-4
     this.#successful = statusCode === 304 ||
       (this.#allowErrorStatusCodes && statusCode >= 500 && statusCode <= 504)
-    this.#callback(this.#successful, this.#context)
+    this.#callback(this.#successful, this.#context, statusCode, headers)
     this.#callback = null
 
     if (this.#successful) {
+      if (statusCode === 304 && this.#cacheUpdateHandler) {
+        // Let the cache update handler freshen the stored response with the
+        //  headers of the validation response
+        //  https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses
+        this.#updatingCache = true
+        this.#cacheUpdateHandler.onRequestStart?.(controller, this.#context)
+        this.#cacheUpdateHandler.onResponseStart?.(
+          controller,
+          statusCode,
+          headers,
+          statusMessage
+        )
+      }
+
       return true
     }
 
@@ -89,6 +119,9 @@ class CacheRevalidationHandler {
 
   onResponseData (controller, chunk) {
     if (this.#successful) {
+      if (this.#updatingCache) {
+        this.#cacheUpdateHandler.onResponseData?.(controller, chunk)
+      }
       return
     }
 
@@ -97,6 +130,9 @@ class CacheRevalidationHandler {
 
   onResponseEnd (controller, trailers) {
     if (this.#successful) {
+      if (this.#updatingCache) {
+        this.#cacheUpdateHandler.onResponseEnd?.(controller, trailers)
+      }
       return
     }
 
@@ -105,6 +141,9 @@ class CacheRevalidationHandler {
 
   onResponseError (controller, err) {
     if (this.#successful) {
+      if (this.#updatingCache) {
+        this.#cacheUpdateHandler.onResponseError?.(controller, err)
+      }
       return
     }
 

--- a/lib/handler/cache-revalidation-handler.js
+++ b/lib/handler/cache-revalidation-handler.js
@@ -92,9 +92,8 @@ class CacheRevalidationHandler {
 
     if (this.#successful) {
       if (statusCode === 304 && this.#cacheUpdateHandler) {
-        // Let the cache update handler freshen the stored response with the
-        //  headers of the validation response
-        //  https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses
+        // Let the cache update handler freshen the stored response with the 304's headers
+        // https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses
         this.#updatingCache = true
         this.#cacheUpdateHandler.onRequestStart?.(controller, this.#context)
         this.#cacheUpdateHandler.onResponseStart?.(

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -381,9 +381,8 @@ function handleResult (
         (success, context, statusCode, resHeaders) => {
           if (success) {
             if (statusCode === 304) {
-              // The response was successfully validated, serve it freshened
-              //  with the validation response's headers (RFC 9111 §4.3.4).
-              //  It is not stale anymore and its age resets.
+              // Validated: serve it freshened with the 304's headers, no longer
+              //  stale and with age reset (RFC 9111 §4.3.4)
               const headers = resHeaders
                 ? CacheHandler.mergeValidationHeaders(result.headers, resHeaders)
                 : result.headers
@@ -398,8 +397,7 @@ function handleResult (
         },
         new CacheHandler(globalOpts, cacheKey, handler),
         withinStaleIfErrorThreshold,
-        // Updates the stored response with the 304's headers while the
-        //  cached value is served to the handler
+        // Updates the stored response with the 304's headers as the cached value is served
         new CacheHandler(globalOpts, cacheKey, noopHandler)
       )
     )

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -29,6 +29,19 @@ function assertCacheOrigins (origins, name) {
 const nop = () => {}
 
 /**
+ * Silent handler for responses that only update the cache
+ * @type {import('../../types/dispatcher.d.ts').default.DispatchHandler}
+ */
+const noopHandler = {
+  onRequestStart () {},
+  onRequestUpgrade () {},
+  onResponseStart () {},
+  onResponseData () {},
+  onResponseEnd () {},
+  onResponseError () {}
+}
+
+/**
  * @typedef {(options: import('../../types/dispatcher.d.ts').default.DispatchOptions, handler: import('../../types/dispatcher.d.ts').default.DispatchHandler) => void} DispatchFn
  */
 
@@ -328,15 +341,7 @@ function handleResult (
             ...opts,
             headers
           },
-          new CacheHandler(globalOpts, cacheKey, {
-            // Silent handler that just updates the cache
-            onRequestStart () {},
-            onRequestUpgrade () {},
-            onResponseStart () {},
-            onResponseData () {},
-            onResponseEnd () {},
-            onResponseError () {}
-          })
+          new CacheHandler(globalOpts, cacheKey, noopHandler)
         )
       })
 
@@ -373,16 +378,29 @@ function handleResult (
         headers
       },
       new CacheRevalidationHandler(
-        (success, context) => {
+        (success, context, statusCode, resHeaders) => {
           if (success) {
-            // TODO: successful revalidation should be considered fresh (not give stale warning).
-            sendCachedValue(handler, opts, result, age, context, stale)
+            if (statusCode === 304) {
+              // The response was successfully validated, serve it freshened
+              //  with the validation response's headers (RFC 9111 §4.3.4).
+              //  It is not stale anymore and its age resets.
+              const headers = resHeaders
+                ? CacheHandler.mergeValidationHeaders(result.headers, resHeaders)
+                : result.headers
+              sendCachedValue(handler, opts, { ...result, headers }, 0, context, false)
+            } else {
+              // stale-if-error, the response is still stale
+              sendCachedValue(handler, opts, result, age, context, stale)
+            }
           } else if (util.isStream(result.body)) {
             result.body.on('error', nop).destroy()
           }
         },
         new CacheHandler(globalOpts, cacheKey, handler),
-        withinStaleIfErrorThreshold
+        withinStaleIfErrorThreshold,
+        // Updates the stored response with the 304's headers while the
+        //  cached value is served to the handler
+        new CacheHandler(globalOpts, cacheKey, noopHandler)
       )
     )
   }

--- a/test/cache-interceptor/cache-tests.mjs
+++ b/test/cache-interceptor/cache-tests.mjs
@@ -73,12 +73,10 @@ const BASE_TEST_ENVIRONMENT = {
     'cc-resp-no-cache',
     'cc-resp-no-cache-case-insensitive',
 
-    // We're not caching 304s currently
+    // Needs an entry-retention floor: the entry (max-age=1) is deleted at
+    //  ~2x its freshness lifetime, before the test's 3s pause elapses, so
+    //  there is nothing left to revalidate (see nodejs/undici#4624)
     '304-etag-update-response-Cache-Control',
-    '304-etag-update-response-Content-Foo',
-    '304-etag-update-response-Test-Header',
-    '304-etag-update-response-X-Content-Foo',
-    '304-etag-update-response-X-Test-Header',
 
     // We just trim whatever's in the decimal place off (i.e. 7200.0 -> 7200)
     'age-parse-float',

--- a/test/interceptors/cache-revalidate-stale.js
+++ b/test/interceptors/cache-revalidate-stale.js
@@ -69,6 +69,165 @@ test('revalidates the request when the response is stale', async () => {
   }
 })
 
+test('304 revalidation response updates the stored entry (RFC 9111 §4.3.4)', async () => {
+  const clock = FakeTimers.install({
+    now: 1000
+  })
+  after(() => clock.uninstall())
+
+  let requestsToOrigin = 0
+  let revalidationRequests = 0
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.sendDate = false
+    res.setHeader('Date', new Date(clock.now).toUTCString())
+
+    if (req.headers['if-none-match'] === '"asd"') {
+      revalidationRequests++
+      // Extend the response's freshness & update a header (RFC 9111 §4.3.4)
+      res.statusCode = 304
+      res.setHeader('Cache-Control', 'public, max-age=60')
+      res.setHeader('X-Test-Header', 'updated')
+      res.end()
+    } else {
+      requestsToOrigin++
+      res.setHeader('Cache-Control', 'public, max-age=1')
+      res.setHeader('ETag', '"asd"')
+      res.setHeader('X-Test-Header', 'original')
+      res.end('hello world')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    .compose(interceptors.cache())
+
+  after(async () => {
+    server.close()
+    await dispatcher.close()
+  })
+
+  const url = `http://localhost:${server.address().port}`
+
+  // Initial request, populates the cache
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 0)
+  }
+
+  clock.tick(1500)
+
+  // Response is stale, revalidation gets a 304 carrying new headers. The
+  //  served response was just validated: no stale warning, updated headers
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(res.statusCode, 200)
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 1)
+    strictEqual(res.headers.warning, undefined)
+    strictEqual(res.headers['x-test-header'], 'updated')
+    strictEqual(res.headers['cache-control'], 'public, max-age=60')
+  }
+
+  // Well past the original freshness lifetime but within the extended one,
+  //  the updated entry must be served from cache without revalidating again
+  clock.tick(30000)
+
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(res.statusCode, 200)
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 1)
+    strictEqual(res.headers.warning, undefined)
+    strictEqual(res.headers['x-test-header'], 'updated')
+  }
+})
+
+test('bare 304 revalidation response refreshes the stored entry', async () => {
+  const clock = FakeTimers.install({
+    now: 1000
+  })
+  after(() => clock.uninstall())
+
+  let requestsToOrigin = 0
+  let revalidationRequests = 0
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.sendDate = false
+    res.setHeader('Date', new Date(clock.now).toUTCString())
+
+    if (req.headers['if-none-match'] === '"asd"') {
+      revalidationRequests++
+      // 304 without any headers to merge, freshness is recomputed from the
+      //  stored headers
+      res.statusCode = 304
+      res.end()
+    } else {
+      requestsToOrigin++
+      res.setHeader('Cache-Control', 'public, max-age=1')
+      res.setHeader('ETag', '"asd"')
+      res.end('hello world')
+    }
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const dispatcher = new Client(`http://localhost:${server.address().port}`)
+    .compose(interceptors.cache())
+
+  after(async () => {
+    server.close()
+    await dispatcher.close()
+  })
+
+  const url = `http://localhost:${server.address().port}`
+
+  // Initial request, populates the cache
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 0)
+  }
+
+  clock.tick(1500)
+
+  // Response is stale, revalidation gets a bare 304
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 1)
+    strictEqual(res.headers.warning, undefined)
+  }
+
+  // The entry got a new freshness window from the stored max-age, this is
+  //  served from cache instead of revalidating on every request
+  clock.tick(400)
+
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 1)
+  }
+
+  // Stale again, revalidates again
+  clock.tick(1500)
+
+  {
+    const res = await request(url, { dispatcher })
+    strictEqual(await res.body.text(), 'hello world')
+    strictEqual(requestsToOrigin, 1)
+    strictEqual(revalidationRequests, 2)
+  }
+})
+
 describe('revalidates the request, handles 304s during stale-while-revalidate', async () => {
   function isStale (res) {
     return res.headers.warning === '110 - "response is stale"'


### PR DESCRIPTION
Fixes #5505

## Problem

#4617 (fixing #4596) taught `CacheHandler` to merge 304 responses into the stored entry, but that code path was only reachable from the stale-while-revalidate background refresh. On the *synchronous* revalidation path, `CacheRevalidationHandler` short-circuited on `statusCode === 304` and never forwarded anything to the wrapped `CacheHandler`, so:

1. Headers carried by the 304 (notably a new `Cache-Control`) were discarded. RFC 9111 [§4.3.4](https://www.rfc-editor.org/rfc/rfc9111.html#name-freshening-stored-responses) says the cache MUST update the stored response with the 304's header fields and recompute freshness. An origin extending freshness via `304 + Cache-Control: max-age=60` got zero benefit: undici revalidated again on the very next request, every time, forever.
2. Even a bare 304 left the entry stale, producing per-request conditional traffic instead of a fresh window.
3. The revalidated response was served with `Warning: 110 - "response is stale"` although it had just been successfully validated (TODO in `lib/interceptor/cache.js`; the `Warning` header is also obsolete per RFC 9111 §5.5).

Additionally, `CacheHandler`'s cacheability pre-checks ran against the 304's *own* headers, so bare 304s bypassed the merge branch even on the background path, and the merged entry lost its stored `Vary`.

## Repro

```js
const { Agent, interceptors, cacheStores, request } = require('undici')
const http = require('node:http')
const { setTimeout: sleep } = require('node:timers/promises')

let hits = 0
const server = http.createServer((req, res) => {
  hits++
  if (req.headers['if-none-match'] === '"v1"') {
    res.writeHead(304, { 'cache-control': 'max-age=60', etag: '"v1"' })
    return res.end()
  }
  res.writeHead(200, { 'cache-control': 'max-age=1', etag: '"v1"' })
  res.end('hello')
}).listen(0, async () => {
  const origin = `http://localhost:${server.address().port}`
  const d = new Agent().compose(interceptors.cache({ store: new cacheStores.MemoryCacheStore() }))
  const get = () => request(origin, { dispatcher: d }).then(r => r.body.text())
  await get()            // hits=1 (stored, fresh 1s)
  await sleep(1400)
  await get()            // hits=2 (revalidate -> 304 max-age=60)
  await get()            // expected: served fresh from the updated entry
  await get()
  console.log(hits)
  server.close()
})
```

**Before** (main @ cb4c2f1): `hits = 4` and keeps growing on every request; validated response served with `warning: 110 - "response is stale"` and the old `cache-control: max-age=1`.
**After**: `hits = 2`; validated response served with no `warning`, the merged `cache-control: max-age=60`, and `age: 0`; subsequent requests are cache hits.

## Changes

- `lib/handler/cache-handler.js`: 304 handling moved in front of the cacheability gates into a `#handle304` method. Freshness (`staleAt`/`deleteAt`/`cachedAt`) is recomputed from the **merged** (stored + 304) headers per §4.3.4, so bare 304s also refresh the entry; the stored `Vary` and `ETag` are preserved (an ETag on the 304 wins if usable); `Content-Length` from the 304 is not merged. New exported helper `mergeValidationHeaders`.
- `lib/handler/cache-revalidation-handler.js`: on a 304 the response events are forwarded to a dedicated cache-update `CacheHandler` (silent downstream), and the validation response's status/headers are passed to the callback.
- `lib/interceptor/cache.js`: on successful validation the cached body is served with the freshened headers, `age: 0`, and **without** the `Warning: 110` header (still emitted for stale-if-error 5xx fallbacks and stale-while-revalidate serves, which really are stale).
- Fixed the 304 body-reuse path byte-iterating `Buffer` bodies returned by `SqliteCacheStore` (`Buffer.prototype.values()` yields single bytes, corrupting the re-written entry).

## Tests

- New: `test/interceptors/cache-revalidate-stale.js` — "304 revalidation response updates the stored entry (RFC 9111 §4.3.4)" and "bare 304 revalidation response refreshes the stored entry". Both fail on main, pass with this change.
- Cache unit suites (`test/interceptors/cache*.js`, `test/cache-interceptor/*.js`): 123/123 pass (121 baseline + 2 new).
- mnot cache-tests conformance (`node test/cache-interceptor/cache-tests.mjs`): un-skipped four `304-etag-update-response-*` tests ("We're not caching 304s currently"); they now pass in all 4 environments (shared/private × MemoryCacheStore/SqliteCacheStore). Totals: Passed 220 → 238, Failed 0 → 0, Failed-optional 58 → 44 (14 optional `update304` checks flipped to yes), Setup-failed 5 → 5. A per-test diff against main shows every status change is within the `update304` family; nothing else moved.
- `304-etag-update-response-Cache-Control` stays skipped with an updated comment: its stored entry (`max-age=1`) is deleted at ~2x its freshness lifetime, before the test's 3s pause, so there is nothing left to revalidate — that needs the entry-retention floor discussed in #4624 (`fix/cache-store-etag-no-cache` territory), not 304 merging.

## Related

Self-contained against `main`; sibling PRs from the same review touch adjacent logic: `jeswr:fix/cache-if-modified-since-value` (revalidation request headers), `jeswr:fix/cache-request-max-age-zero` (request-directive revalidation path), `jeswr:fix/cache-store-etag-no-cache` (entry retention for revalidation-only responses).

This change is agent-assisted (Claude Fable 5) working with @jeswr.
