### PR TITLE
refactor: replace tspl with node:test t.plan in connect-timeout tests

### DIFF
--- a/test/connect-timeout.js
+++ b/test/connect-timeout.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { tspl } = require('@matteo.collina/tspl')
 const { test, describe } = require('node:test')
 const { Client, Pool, errors } = require('..')
 const net = require('node:net')
@@ -10,21 +9,25 @@ const skip = !!process.env.CITGM
 
 // Using describe instead of test to avoid the timeout
 describe('prioritize socket errors over timeouts', { skip }, async () => {
-  const t = tspl({ ...assert, after: () => {} }, { plan: 2 })
   const client = new Pool('http://foorbar.invalid:1234', { connectTimeout: 1 })
+  const { promise, resolve } = Promise.withResolvers()
 
   client.request({ method: 'GET', path: '/foobar' })
-    .then(() => t.fail())
+    .then(() => {
+      assert.fail('should have errored')
+      resolve()
+    })
     .catch((err) => {
-      t.strictEqual(err.code, 'ENOTFOUND')
-      t.strictEqual(err.code !== 'UND_ERR_CONNECT_TIMEOUT', true)
+      assert.strictEqual(err.code, 'ENOTFOUND')
+      assert.strictEqual(err.code !== 'UND_ERR_CONNECT_TIMEOUT', true)
+      resolve()
     })
 
   // block for 1s which is enough for the dns lookup to complete and the
   // Timeout to fire
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(1000))
 
-  await t.completed
+  await promise
 })
 
 // mock net.connect to avoid the dns lookup
@@ -33,7 +36,7 @@ net.connect = function (options) {
 }
 
 async function assertConnectTimeout (dispatcher, t) {
-  const tt = tspl(t, { plan: 3 })
+  t.plan(3)
 
   await new Promise((resolve, reject) => {
     // Connection timeouts use FastTimers, which have a deliberately low
@@ -48,9 +51,9 @@ async function assertConnectTimeout (dispatcher, t) {
       method: 'GET'
     }, (err) => {
       try {
-        tt.ok(err instanceof errors.ConnectTimeoutError)
-        tt.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-        tt.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
+        t.assert.ok(err instanceof errors.ConnectTimeoutError)
+        t.assert.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+        t.assert.strictEqual(err.message, 'Connect Timeout Error (attempted address: localhost:9000, timeout: 1000ms)')
         resolve()
       } catch (error) {
         reject(error)
@@ -59,8 +62,6 @@ async function assertConnectTimeout (dispatcher, t) {
       }
     })
   })
-
-  await tt.completed
 }
 
 test('connect-timeout (Client)', { skip }, async t => {
@@ -82,8 +83,7 @@ test('connect-timeout (Pool)', { skip }, async t => {
 })
 
 test('autoSelectFamily AggregateError with ETIMEDOUT is normalized to ConnectTimeoutError', { skip }, async t => {
-  const _t = t
-  t = tspl(t, { plan: 5 })
+  t.plan(5)
 
   const aggregate = new AggregateError([
     Object.assign(new Error('connect ETIMEDOUT 127.0.0.1:9000'), { code: 'ETIMEDOUT' }),
@@ -103,18 +103,29 @@ test('autoSelectFamily AggregateError with ETIMEDOUT is normalized to ConnectTim
   const client = new Client('http://localhost:9000', {
     connectTimeout: 1e3
   })
-  _t.after(() => client.close().catch(() => {}))
+  t.after(() => client.close().catch(() => {}))
 
-  client.request({
-    path: '/',
-    method: 'GET'
-  }, (err) => {
-    t.ok(err instanceof errors.ConnectTimeoutError)
-    t.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
-    t.strictEqual(err.message, 'Connect Timeout Error (attempted addresses: 127.0.0.1:9000, ::1:9000, timeout: 1000ms)')
-    t.ok(err.cause instanceof AggregateError)
-    t.strictEqual(err.cause, aggregate)
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('timeout waiting for callback'))
+    }, 5e3)
+
+    client.request({
+      path: '/',
+      method: 'GET'
+    }, (err) => {
+      try {
+        t.assert.ok(err instanceof errors.ConnectTimeoutError)
+        t.assert.strictEqual(err.code, 'UND_ERR_CONNECT_TIMEOUT')
+        t.assert.strictEqual(err.message, 'Connect Timeout Error (attempted addresses: 127.0.0.1:9000, ::1:9000, timeout: 1000ms)')
+        t.assert.ok(err.cause instanceof AggregateError)
+        t.assert.strictEqual(err.cause, aggregate)
+        resolve()
+      } catch (error) {
+        reject(error)
+      } finally {
+        clearTimeout(timeout)
+      }
+    })
   })
-
-  await t.completed
 })


### PR DESCRIPTION
## Summary
Replace `@matteo.collina/tspl` with Node.js core `t.plan()` in `test/connect-timeout.js`.

### Changes
- Removed `tspl` import and all `tspl(...)` calls
- `describe` block: uses `Promise.withResolvers()` + raw `assert.*` (since `describe` has no test context)
- `assertConnectTimeout` helper: `t.plan(3)` + `t.assert.*` instead of `tspl(t, {plan:3})`
- `autoSelectFamily` test: `t.plan(5)` + wrapped in `await new Promise(...)` to keep the test function alive for async callback assertions

### Testing
- npx borp -p "test/connect-timeout.js"
- npx eslint test/connect-timeout.js