### PR TITLE
fix(retry): handle Retry-After zero delay

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -11,7 +11,7 @@ const {
 
 function calculateRetryAfterHeader (retryAfter) {
   const retryTime = new Date(retryAfter).getTime()
-  return isNaN(retryTime) ? 0 : retryTime - Date.now()
+  return isNaN(retryTime) ? null : retryTime - Date.now()
 }
 
 // A stable controller handed to the downstream handler for the lifetime of the
@@ -211,9 +211,11 @@ class RetryHandler {
     }
 
     const retryTimeout =
-      retryAfterHeader > 0
-        ? Math.min(retryAfterHeader, maxTimeout)
-        : Math.min(minTimeout * timeoutFactor ** (counter - 1), maxTimeout)
+      retryAfterHeader === 0
+        ? 0
+        : retryAfterHeader > 0
+          ? Math.min(retryAfterHeader, maxTimeout)
+          : Math.min(minTimeout * timeoutFactor ** (counter - 1), maxTimeout)
 
     setTimeout(() => cb(null), retryTimeout)
   }

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -5,6 +5,7 @@ const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
 const { Readable } = require('node:stream')
+const FakeTimers = require('@sinonjs/fake-timers')
 
 const { RetryHandler, Client } = require('..')
 const { RequestHandler } = require('../lib/api/api-request')
@@ -344,6 +345,40 @@ test('Should use retry-after header for retries', async t => {
   })
 
   await t.completed
+})
+
+test('Should retry immediately when retry-after is zero', async t => {
+  const clock = FakeTimers.install()
+  t.after(() => clock.uninstall())
+
+  let retries = 0
+  const handler = new RetryHandler(
+    {
+      method: 'GET',
+      retryOptions: {
+        maxRetries: 1,
+        minTimeout: 500
+      }
+    },
+    {
+      dispatch () {
+        retries++
+      },
+      handler: {}
+    }
+  )
+
+  handler.onResponseError(null, {
+    statusCode: 429,
+    code: 'UND_ERR_REQ_RETRY',
+    headers: {
+      'retry-after': '0'
+    }
+  })
+
+  await clock.tickAsync(0)
+
+  t.assert.strictEqual(retries, 1)
 })
 
 test('Should use retry-after header for retries (date)', async t => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes the default retry handler so `Retry-After: 0` is treated as a valid zero-delay retry instead of falling back to `minTimeout`.

## Rationale

`Retry-After` delay-seconds can be zero. The current retry timeout selection only uses the parsed header value when it is greater than zero, so `Retry-After: 0` falls through to the exponential backoff fallback.

This change adds an explicit zero-delay branch and changes invalid HTTP-date parsing to return `null` instead of `0`, so invalid dates continue to use the fallback path.

## Changes

- Preserve `Retry-After: 0` as a zero-delay retry.
- Keep invalid `Retry-After` date values on the fallback retry path.
- Add a fake-timer regression test for the zero-delay case.

### Features

N/A

### Bug Fixes

Fixes default retry handling for `Retry-After: 0`.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
