### PR TITLE
fix: reject cross-realm FormData request bodies

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -47,9 +47,6 @@ const kHandler = Symbol('handler')
 const kController = Symbol('controller')
 const kResume = Symbol('resume')
 
-// Lazily loaded brand check for undici's own FormData class; only needed
-// when a FormData-like body is passed, so the fetch machinery is not
-// loaded upfront.
 let isUndiciFormData
 
 class RequestController {
@@ -212,11 +209,6 @@ class Request {
     } else if (typeof body === 'string') {
       this.body = body.length ? Buffer.from(body) : null
     } else if (isFormDataLike(body)) {
-      // Only undici's own FormData can be encoded. Instances from other
-      // realms (Node.js' builtin, another undici copy, a polyfill) would
-      // otherwise fall through to the iterable handling and produce a
-      // broken body, historically hanging the request.
-      // https://github.com/nodejs/undici/issues/5520
       isUndiciFormData ??= require('../web/webidl').webidl.is.FormData
       if (!isUndiciFormData(body)) {
         throw new InvalidArgumentError('FormData body must be an instance of undici\'s FormData class. FormData objects from other realms (e.g. Node.js\' global FormData) are not supported.')

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -47,6 +47,11 @@ const kHandler = Symbol('handler')
 const kController = Symbol('controller')
 const kResume = Symbol('resume')
 
+// Lazily loaded brand check for undici's own FormData class; only needed
+// when a FormData-like body is passed, so the fetch machinery is not
+// loaded upfront.
+let isUndiciFormData
+
 class RequestController {
   #paused = false
   #reason = null
@@ -206,7 +211,18 @@ class Request {
       this.body = body.byteLength ? Buffer.from(body) : null
     } else if (typeof body === 'string') {
       this.body = body.length ? Buffer.from(body) : null
-    } else if (isFormDataLike(body) || isIterable(body) || isBlobLike(body)) {
+    } else if (isFormDataLike(body)) {
+      // Only undici's own FormData can be encoded. Instances from other
+      // realms (Node.js' builtin, another undici copy, a polyfill) would
+      // otherwise fall through to the iterable handling and produce a
+      // broken body, historically hanging the request.
+      // https://github.com/nodejs/undici/issues/5520
+      isUndiciFormData ??= require('../web/webidl').webidl.is.FormData
+      if (!isUndiciFormData(body)) {
+        throw new InvalidArgumentError('FormData body must be an instance of undici\'s FormData class. FormData objects from other realms (e.g. Node.js\' global FormData) are not supported.')
+      }
+      this.body = body
+    } else if (isIterable(body) || isBlobLike(body)) {
       this.body = body
     } else {
       throw new InvalidArgumentError('body must be a string, a Buffer, a Readable stream, an iterable, or an async iterable')

--- a/test/issue-5520.js
+++ b/test/issue-5520.js
@@ -4,61 +4,26 @@ const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { createServer: createH2Server } = require('node:http2')
 const { once } = require('node:events')
-const { request, FormData: UndiciFormData, H2CClient, errors } = require('..')
+const { request, H2CClient, errors } = require('..')
 
 // https://github.com/nodejs/undici/issues/5520
-// request() accepts FormData bodies via a duck-typed check
-// (util.isFormDataLike), but only undici's own FormData can be encoded.
-// Instances from other realms (e.g. Node.js' builtin globalThis.FormData)
-// used to fall through the brand-checked extraction and were dispatched as
-// a body that never produced any bytes, hanging the request until an
-// external timeout. They are now rejected upfront with InvalidArgumentError.
 
-function createEchoServer (t) {
+test('request() rejects a cross-realm (Node builtin) FormData body', { timeout: 60000 }, async (t) => {
   const server = createServer((req, res) => {
-    const chunks = []
-    req.on('data', (chunk) => chunks.push(chunk))
-    req.on('end', () => {
-      res.setHeader('content-type', 'application/json')
-      res.end(JSON.stringify({
-        contentType: req.headers['content-type'] ?? null,
-        contentLength: req.headers['content-length'] ?? null,
-        body: Buffer.concat(chunks).toString('utf8')
-      }))
-    })
+    req.on('data', () => {})
+    req.on('end', () => res.end('{}'))
   })
   t.after(() => {
     server.closeAllConnections?.()
     server.close()
   })
-  return server
-}
 
-test('request() rejects a cross-realm (Node builtin) FormData body', { timeout: 60000 }, async (t) => {
-  // The premise of the test: the global FormData is not undici's own class.
-  t.assert.notStrictEqual(globalThis.FormData, UndiciFormData)
-
-  const server = createEchoServer(t)
   server.listen(0)
   await once(server, 'listening')
 
   const form = new globalThis.FormData()
   form.append('field', 'value')
   form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
-
-  await t.assert.rejects(
-    request(`http://localhost:${server.address().port}/`, { method: 'POST', body: form }),
-    errors.InvalidArgumentError
-  )
-})
-
-test('request() rejects a string-only cross-realm FormData body', { timeout: 60000 }, async (t) => {
-  const server = createEchoServer(t)
-  server.listen(0)
-  await once(server, 'listening')
-
-  const form = new globalThis.FormData()
-  form.append('a', '1')
 
   await t.assert.rejects(
     request(`http://localhost:${server.address().port}/`, { method: 'POST', body: form }),
@@ -86,60 +51,4 @@ test('HTTP/2 client rejects a cross-realm (Node builtin) FormData body', { timeo
     client.request({ path: '/', method: 'POST', body: form }),
     errors.InvalidArgumentError
   )
-})
-
-test('request() still encodes undici\'s own FormData body', { timeout: 60000 }, async (t) => {
-  const server = createEchoServer(t)
-  server.listen(0)
-  await once(server, 'listening')
-
-  const form = new UndiciFormData()
-  form.append('field', 'value with spaces')
-  form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
-
-  const res = await request(`http://localhost:${server.address().port}/`, {
-    method: 'POST',
-    body: form
-  })
-  const echo = await res.body.json()
-
-  t.assert.strictEqual(res.statusCode, 200)
-  const boundary = /^multipart\/form-data; boundary=(\S+)$/.exec(echo.contentType)?.[1]
-  t.assert.ok(boundary, `expected multipart content-type, got ${echo.contentType}`)
-  t.assert.strictEqual(echo.contentLength, String(Buffer.byteLength(echo.body)))
-  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="field"\r\n\r\nvalue with spaces\r\n'))
-  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="file"; filename="hello.txt"'))
-  t.assert.ok(echo.body.includes('file contents'))
-  t.assert.ok(echo.body.endsWith(`--${boundary}--\r\n`))
-})
-
-test('HTTP/2 client still encodes undici\'s own FormData body', { timeout: 60000 }, async (t) => {
-  const server = createH2Server((req, res) => {
-    const chunks = []
-    req.on('data', (chunk) => chunks.push(chunk))
-    req.on('end', () => {
-      res.setHeader('content-type', 'application/json')
-      res.end(JSON.stringify({
-        contentType: req.headers['content-type'] ?? null,
-        body: Buffer.concat(chunks).toString('utf8')
-      }))
-    })
-  })
-  t.after(() => server.close())
-
-  server.listen(0)
-  await once(server, 'listening')
-
-  const client = new H2CClient(`http://localhost:${server.address().port}`)
-  t.after(() => client.close())
-
-  const form = new UndiciFormData()
-  form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
-
-  const res = await client.request({ path: '/', method: 'POST', body: form })
-  const echo = await res.body.json()
-
-  t.assert.strictEqual(res.statusCode, 200)
-  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="file"; filename="hello.txt"'))
-  t.assert.ok(echo.body.includes('file contents'))
 })

--- a/test/issue-5520.js
+++ b/test/issue-5520.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { createServer: createH2Server } = require('node:http2')
+const { once } = require('node:events')
+const { request, FormData: UndiciFormData, H2CClient, errors } = require('..')
+
+// https://github.com/nodejs/undici/issues/5520
+// request() accepts FormData bodies via a duck-typed check
+// (util.isFormDataLike), but only undici's own FormData can be encoded.
+// Instances from other realms (e.g. Node.js' builtin globalThis.FormData)
+// used to fall through the brand-checked extraction and were dispatched as
+// a body that never produced any bytes, hanging the request until an
+// external timeout. They are now rejected upfront with InvalidArgumentError.
+
+function createEchoServer (t) {
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({
+        contentType: req.headers['content-type'] ?? null,
+        contentLength: req.headers['content-length'] ?? null,
+        body: Buffer.concat(chunks).toString('utf8')
+      }))
+    })
+  })
+  t.after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+  return server
+}
+
+test('request() rejects a cross-realm (Node builtin) FormData body', { timeout: 60000 }, async (t) => {
+  // The premise of the test: the global FormData is not undici's own class.
+  t.assert.notStrictEqual(globalThis.FormData, UndiciFormData)
+
+  const server = createEchoServer(t)
+  server.listen(0)
+  await once(server, 'listening')
+
+  const form = new globalThis.FormData()
+  form.append('field', 'value')
+  form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
+
+  await t.assert.rejects(
+    request(`http://localhost:${server.address().port}/`, { method: 'POST', body: form }),
+    errors.InvalidArgumentError
+  )
+})
+
+test('request() rejects a string-only cross-realm FormData body', { timeout: 60000 }, async (t) => {
+  const server = createEchoServer(t)
+  server.listen(0)
+  await once(server, 'listening')
+
+  const form = new globalThis.FormData()
+  form.append('a', '1')
+
+  await t.assert.rejects(
+    request(`http://localhost:${server.address().port}/`, { method: 'POST', body: form }),
+    errors.InvalidArgumentError
+  )
+})
+
+test('HTTP/2 client rejects a cross-realm (Node builtin) FormData body', { timeout: 60000 }, async (t) => {
+  const server = createH2Server((req, res) => {
+    req.on('data', () => {})
+    req.on('end', () => res.end('{}'))
+  })
+  t.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new H2CClient(`http://localhost:${server.address().port}`)
+  t.after(() => client.close())
+
+  const form = new globalThis.FormData()
+  form.append('field', 'value')
+
+  await t.assert.rejects(
+    client.request({ path: '/', method: 'POST', body: form }),
+    errors.InvalidArgumentError
+  )
+})
+
+test('request() still encodes undici\'s own FormData body', { timeout: 60000 }, async (t) => {
+  const server = createEchoServer(t)
+  server.listen(0)
+  await once(server, 'listening')
+
+  const form = new UndiciFormData()
+  form.append('field', 'value with spaces')
+  form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
+
+  const res = await request(`http://localhost:${server.address().port}/`, {
+    method: 'POST',
+    body: form
+  })
+  const echo = await res.body.json()
+
+  t.assert.strictEqual(res.statusCode, 200)
+  const boundary = /^multipart\/form-data; boundary=(\S+)$/.exec(echo.contentType)?.[1]
+  t.assert.ok(boundary, `expected multipart content-type, got ${echo.contentType}`)
+  t.assert.strictEqual(echo.contentLength, String(Buffer.byteLength(echo.body)))
+  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="field"\r\n\r\nvalue with spaces\r\n'))
+  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="file"; filename="hello.txt"'))
+  t.assert.ok(echo.body.includes('file contents'))
+  t.assert.ok(echo.body.endsWith(`--${boundary}--\r\n`))
+})
+
+test('HTTP/2 client still encodes undici\'s own FormData body', { timeout: 60000 }, async (t) => {
+  const server = createH2Server((req, res) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json')
+      res.end(JSON.stringify({
+        contentType: req.headers['content-type'] ?? null,
+        body: Buffer.concat(chunks).toString('utf8')
+      }))
+    })
+  })
+  t.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new H2CClient(`http://localhost:${server.address().port}`)
+  t.after(() => client.close())
+
+  const form = new UndiciFormData()
+  form.append('file', new Blob(['file contents'], { type: 'text/plain' }), 'hello.txt')
+
+  const res = await client.request({ path: '/', method: 'POST', body: form })
+  const echo = await res.body.json()
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.ok(echo.body.includes('Content-Disposition: form-data; name="file"; filename="hello.txt"'))
+  t.assert.ok(echo.body.includes('file contents'))
+})


### PR DESCRIPTION
## This relates to...

Fixes #5520. Related context: #5500 / #5502 (legacy dispatcher bridge), #5016 and #4285 (fetch-side cross-realm FormData behavior, unchanged here).

## Rationale

`request()` accepts FormData bodies through the duck-typed `util.isFormDataLike()` check, but only undici's own `FormData` can be encoded: the multipart extraction is gated on the `webidl.is.FormData` brand check. A FormData from another realm (Node.js' builtin `globalThis.FormData`, another undici copy, a polyfill) passed the gate, fell through the extraction, and was dispatched as a body that never produced any bytes: the request hung silently until an external timeout, with zero bytes written to the socket (full version matrix and reproductions in #5520).

Per review direction (encode vs reject, maintainers chose reject): such bodies now fail fast with `InvalidArgumentError`. The check lives in the `Request` constructor, where other invalid body types are already rejected, so both the HTTP/1 and HTTP/2 clients reject cleanly at dispatch time and the fetch code is untouched. The FormData brand check is loaded lazily so the fetch machinery is not pulled in upfront.

Note for changelog purposes: this is a behavior change relative to v6, which encoded cross-realm FormData successfully (v7.0.0 through 7.19.x failed these bodies with an unrelated TypeError; 7.20.0+ hung).

## Changes

- `lib/core/request.js`: FormData-like bodies that are not instances of undici's `FormData` now throw `InvalidArgumentError` instead of falling through to iterable handling.
- `test/issue-5520.js`: cross-realm FormData rejection over HTTP/1 and HTTP/2 (own-FormData encoding is already covered by `test/client-request.js` and `test/http2-body.js`).

### Features

N/A

### Bug Fixes

- `request()` with a FormData from another realm now rejects immediately with a clear error instead of hanging forever.

### Breaking Changes and Deprecations

N/A (the affected input previously hung or produced a broken body; it never worked on v7/v8)

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested (`test/issue-5520.js` plus unit, fetch, client-request, http2-body and h2 core suites; lint clean)
- [ ] Benchmarked (**optional**)
- [x] Documented (behavior fix; error message self-describes)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
