### PR TITLE
perf(h1): deliver fixed-length response bodies without copying into wasm

### DIFF
--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -9,8 +9,9 @@ const cluster = require('node:cluster')
 const socketPath = path.join(os.tmpdir(), 'undici.sock')
 
 const port = process.env.PORT || socketPath
-const timeout = parseInt(process.env.TIMEOUT, 10) || 1
+const timeout = Number.isNaN(parseInt(process.env.TIMEOUT, 10)) ? 1 : parseInt(process.env.TIMEOUT, 10)
 const workers = parseInt(process.env.WORKERS) || os.cpus().length
+const bodySize = parseInt(process.env.BODY_SIZE, 10) || 64 * 1024
 
 if (cluster.isPrimary) {
   try {
@@ -23,7 +24,7 @@ if (cluster.isPrimary) {
     cluster.fork()
   }
 } else {
-  const buf = Buffer.alloc(64 * 1024, '_')
+  const buf = Buffer.alloc(bodySize, '_')
 
   const headers = {
     'Content-Length': `${buf.byteLength}`,
@@ -32,6 +33,11 @@ if (cluster.isPrimary) {
   let i = 0
   const server = createServer((_req, res) => {
     i++
+    if (timeout === 0) {
+      res.writeHead(200, headers)
+      res.end(buf)
+      return
+    }
     setTimeout(() => {
       res.writeHead(200, headers)
       res.end(buf)

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -56,6 +56,11 @@ const {
 const constants = require('../llhttp/constants.js')
 const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
+// Size of the slices fed to llhttp while parsing the status line and
+// headers. Bounds how many body bytes of a fixed-length message are
+// copied into wasm memory before onHeadersComplete pauses the parser
+// and executeFastBody() takes over. Must be a multiple of 4096.
+const HEADER_SLICE_SIZE = 4096
 const removeAllListeners = util.removeAllListeners
 const kIdleSocketValidation = Symbol('kIdleSocketValidation')
 const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout')
@@ -238,6 +243,9 @@ class Parser {
     this.keepAlive = ''
     this.contentLength = -1
     this.connectionKeepAlive = false
+    this.transferEncoding = false
+    this.fastBody = false
+    this.executing = false
     this.maxResponseSize = client[kMaxResponseSize]
   }
 
@@ -283,8 +291,6 @@ class Parser {
     assert(this.ptr != null)
     assert(currentParser === null)
 
-    this.llhttp.llhttp_resume(this.ptr)
-
     assert(this.timeoutType === TIMEOUT_BODY)
     if (this.timeout) {
       if (this.timeout.refresh) {
@@ -292,13 +298,32 @@ class Parser {
       }
     }
 
+    if (this.fastBody) {
+      // llhttp is not paused while the fast path owns the body; there
+      // is no parser state to flush.
+      this.paused = false
+      if (this.bytesRead === this.contentLength) {
+        // Paused on the final body chunk; complete the message before
+        // reading more data.
+        this.completeFastBody()
+      }
+      this.readMore()
+      return
+    }
+
+    this.llhttp.llhttp_resume(this.ptr)
+
     this.paused = false
     this.execute(this.socket.read() || EMPTY_BUF) // Flush parser.
     this.readMore()
   }
 
   readMore () {
-    while (!this.paused && this.ptr) {
+    // A re-entrant call (e.g. from a resume triggered inside
+    // onMessageComplete) must not consume socket data out from under
+    // the frame that is currently executing; that frame continues
+    // reading once it regains control.
+    while (!this.paused && !this.executing && this.ptr) {
       const chunk = this.socket.read()
       if (chunk === null) {
         break
@@ -314,60 +339,190 @@ class Parser {
     assert(currentParser === null)
     assert(this.ptr != null)
     assert(!this.paused)
+    assert(!this.executing)
 
+    this.executing = true
+
+    try {
+      if (this.fastBody) {
+        this.executeFastBody(chunk)
+      } else {
+        this.executeParser(chunk)
+      }
+    } finally {
+      this.executing = false
+    }
+  }
+
+  /**
+   * @param {Buffer} chunk
+   */
+  executeParser (chunk) {
     const { socket, llhttp } = this
 
-    // Allocate a new buffer if the current buffer is too small.
-    if (chunk.length > currentBufferSize) {
-      if (currentBufferPtr) {
-        llhttp.free(currentBufferPtr)
-      }
-      // Allocate a buffer that is a multiple of 4096 bytes.
-      currentBufferSize = Math.ceil(chunk.length / 4096) * 4096
-      currentBufferPtr = llhttp.malloc(currentBufferSize)
-    }
-
-    if (
-      currentBuffer === null ||
-      currentBuffer.buffer !== llhttp.memory.buffer ||
-      currentBuffer.byteOffset !== currentBufferPtr ||
-      currentBuffer.byteLength !== currentBufferSize
-    ) {
-      currentBuffer = new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize)
-    }
-
-    currentBuffer.set(chunk)
-
-    // Call `execute` on the wasm parser.
-    // We pass the `llhttp_parser` pointer address, the pointer address of buffer view data,
-    // and finally the length of bytes to parse.
-    // The return value is an error code or `constants.ERROR.OK`.
     try {
-      let ret
+      // While waiting for the status line and headers of the next
+      // message, feed llhttp bounded slices so that the body bytes of a
+      // fixed-length message are not copied into wasm memory; once
+      // onHeadersComplete pauses the parser they are delivered directly
+      // by executeFastBody(). Past the headers (chunked or EOF-framed
+      // bodies) the rest of the chunk is parsed in a single call.
+      let offset = 0
 
-      try {
-        currentBufferRef = chunk
-        currentParser = this
-        ret = llhttp.llhttp_execute(this.ptr, currentBufferPtr, chunk.length)
-      } finally {
-        currentParser = null
-        currentBufferRef = null
-      }
+      do {
+        const end = this.statusCode === 0
+          ? Math.min(chunk.length, offset + HEADER_SLICE_SIZE)
+          : chunk.length
+        const slice = offset === 0 && end === chunk.length
+          ? chunk
+          : new FastBuffer(chunk.buffer, chunk.byteOffset + offset, end - offset)
 
-      if (ret !== constants.ERROR.OK) {
-        const data = chunk.subarray(llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr)
-
-        if (ret === constants.ERROR.PAUSED_UPGRADE) {
-          this.onUpgrade(data)
-        } else if (ret === constants.ERROR.PAUSED) {
-          this.paused = true
-          socket.unshift(data)
-        } else {
-          throw this.createError(ret, data)
+        // Allocate a new buffer if the current buffer is too small.
+        if (slice.length > currentBufferSize) {
+          if (currentBufferPtr) {
+            llhttp.free(currentBufferPtr)
+          }
+          // Allocate a buffer that is a multiple of 4096 bytes.
+          currentBufferSize = Math.ceil(slice.length / 4096) * 4096
+          currentBufferPtr = llhttp.malloc(currentBufferSize)
         }
-      }
+
+        if (
+          currentBuffer === null ||
+          currentBuffer.buffer !== llhttp.memory.buffer ||
+          currentBuffer.byteOffset !== currentBufferPtr ||
+          currentBuffer.byteLength !== currentBufferSize
+        ) {
+          currentBuffer = new Uint8Array(llhttp.memory.buffer, currentBufferPtr, currentBufferSize)
+        }
+
+        currentBuffer.set(slice)
+
+        // Call `execute` on the wasm parser.
+        // We pass the `llhttp_parser` pointer address, the pointer address of buffer view data,
+        // and finally the length of bytes to parse.
+        // The return value is an error code or `constants.ERROR.OK`.
+        let ret
+
+        try {
+          currentBufferRef = slice
+          currentParser = this
+          ret = llhttp.llhttp_execute(this.ptr, currentBufferPtr, slice.length)
+        } finally {
+          currentParser = null
+          currentBufferRef = null
+        }
+
+        if (ret !== constants.ERROR.OK) {
+          const at = offset + llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr
+          const data = chunk.subarray(at)
+
+          if (ret === constants.ERROR.PAUSED_UPGRADE) {
+            this.onUpgrade(data)
+          } else if (ret === constants.ERROR.PAUSED) {
+            if (this.fastBody) {
+              // llhttp paused right after the headers of a fixed-length
+              // message; deliver the body bytes directly.
+              this.executeFastBody(data)
+            } else {
+              this.paused = true
+              socket.unshift(data)
+            }
+          } else {
+            throw this.createError(ret, data)
+          }
+
+          return
+        }
+
+        offset = end
+      } while (offset < chunk.length)
     } catch (err) {
       util.destroy(socket, err)
+    }
+  }
+
+  /**
+   * Fast path for fixed content-length bodies. The chunk is delivered
+   * to the request without copying it into wasm memory. llhttp is
+   * paused right after the headers while this mode is active and is
+   * re-synchronized at the message boundary by completeFastBody().
+   *
+   * @param {Buffer} chunk
+   */
+  executeFastBody (chunk) {
+    const { client, socket, maxResponseSize } = this
+
+    if (socket.destroyed || chunk.length === 0) {
+      return
+    }
+
+    assert(this.timeoutType === TIMEOUT_BODY)
+    if (this.timeout) {
+      if (this.timeout.refresh) {
+        this.timeout.refresh()
+      }
+    }
+
+    const remaining = this.contentLength - this.bytesRead
+    assert(remaining > 0)
+
+    const request = client[kQueue][client[kRunningIdx]]
+    assert(request)
+
+    let body = chunk
+    if (chunk.length > remaining) {
+      body = new FastBuffer(chunk.buffer, chunk.byteOffset, remaining)
+      // Data past the message boundary belongs to the next response.
+      // Unshift it before completing the message so that a re-entrant
+      // read triggered by onMessageComplete parses it in order.
+      socket.unshift(new FastBuffer(chunk.buffer, chunk.byteOffset + remaining, chunk.length - remaining))
+    }
+
+    if (maxResponseSize > -1 && this.bytesRead + body.length > maxResponseSize) {
+      util.destroy(socket, new ResponseExceededMaxSizeError())
+      return
+    }
+
+    this.bytesRead += body.length
+
+    const paused = request.onResponseData(body) === false
+
+    if (this.bytesRead === this.contentLength) {
+      if (paused) {
+        // Mirror llhttp pausing before on_message_complete: the
+        // message is completed when the parser is resumed.
+        this.paused = true
+        return
+      }
+
+      this.completeFastBody()
+    } else if (paused) {
+      this.paused = true
+    }
+  }
+
+  completeFastBody () {
+    assert(this.fastBody)
+    assert(this.bytesRead === this.contentLength)
+
+    this.fastBody = false
+
+    // llhttp was paused after the headers when the fast path took
+    // over. Reset it to the start-of-message state; type, settings and
+    // lenient flags are preserved by llhttp_reset.
+    this.llhttp.llhttp_reset(this.ptr)
+
+    // Data past the message boundary was unshifted onto the socket.
+    // Guard against a re-entrant readMore (e.g. from a resume triggered
+    // inside onMessageComplete) consuming it before the pipeline state
+    // has settled; the calling frame reads it once this returns.
+    const wasExecuting = this.executing
+    this.executing = true
+    try {
+      this.onMessageComplete()
+    } finally {
+      this.executing = wasExecuting
     }
   }
 
@@ -386,18 +541,37 @@ class Parser {
     // body reaches on_message_complete during execute(); an EOF-delimited body
     // stays paused (its length is unknown) and is completed by llhttp_finish().
     if (this.paused) {
-      let data
-      do {
-        llhttp.llhttp_resume(this.ptr)
+      if (this.fastBody && this.bytesRead === this.contentLength) {
+        // Paused on the final body chunk; the message is complete.
         this.paused = false
-        data = this.socket.read() || EMPTY_BUF
-        this.execute(data)
-      } while (this.paused && data.length > 0)
+        this.completeFastBody()
+      } else {
+        let data
+        do {
+          if (!this.fastBody) {
+            llhttp.llhttp_resume(this.ptr)
+          }
+          this.paused = false
+          data = this.socket.read() || EMPTY_BUF
+          this.execute(data)
+        } while (this.paused && data.length > 0)
 
-      if (this.paused) {
-        llhttp.llhttp_resume(this.ptr)
-        this.paused = false
+        if (this.paused) {
+          if (this.fastBody && this.bytesRead === this.contentLength) {
+            this.completeFastBody()
+          } else if (!this.fastBody) {
+            llhttp.llhttp_resume(this.ptr)
+          }
+          this.paused = false
+        }
       }
+    }
+
+    if (this.fastBody) {
+      // The peer closed the connection before the fixed-length body
+      // completed. llhttp was left mid-body when the fast path took
+      // over, so llhttp_finish() cannot detect the truncation.
+      return new ResponseContentLengthMismatchError()
     }
 
     let ret
@@ -454,6 +628,7 @@ class Parser {
     this.timeoutType = null
 
     this.paused = false
+    this.fastBody = false
   }
 
   /**
@@ -538,6 +713,8 @@ class Parser {
       for (let i = 0; i < buf.length; i++) {
         this.contentLength = (this.contentLength * 10) + (buf[i] - 0x30)
       }
+    } else if (key.length === 17 && util.bufferToLowerCasedHeaderName(key) === 'transfer-encoding') {
+      this.transferEncoding = true
     }
 
     this.trackHeader(buf.length)
@@ -716,7 +893,26 @@ class Parser {
       client[kResume]()
     }
 
-    return pause ? constants.ERROR.PAUSED : 0
+    if (pause) {
+      return constants.ERROR.PAUSED
+    }
+
+    if (
+      this.contentLength > 0 &&
+      !this.transferEncoding &&
+      // llhttp skips the body of 204/304 responses even when a
+      // content-length header is present; see llhttp/src/http.c.
+      statusCode !== 204 &&
+      statusCode !== 304
+    ) {
+      // Fixed-length body: pause llhttp right after the headers so that
+      // execute() hands the body bytes to executeFastBody() without
+      // copying them into wasm memory.
+      this.fastBody = true
+      return constants.ERROR.PAUSED
+    }
+
+    return 0
   }
 
   /**
@@ -782,6 +978,7 @@ class Parser {
     this.contentLength = -1
     this.keepAlive = ''
     this.connectionKeepAlive = false
+    this.transferEncoding = false
 
     this.headers = []
     this.headersSize = 0

--- a/test/client-content-length-fastpath.js
+++ b/test/client-content-length-fastpath.js
@@ -1,0 +1,393 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after, describe } = require('node:test')
+const net = require('node:net')
+const { Client, errors } = require('..')
+const { createServer } = require('node:http')
+
+// Exercises the content-length body fast path in lib/dispatcher/client-h1.js:
+// once the headers of a fixed-length response are parsed, body bytes are
+// delivered without going through llhttp. These tests pin down the framing
+// edge cases the fast path owns: message boundaries shared with pipelined
+// responses, backpressure pauses, truncation and keep-alive reuse.
+
+describe('content-length body fast path', () => {
+  test('large fixed-length body split across many packets', async (t) => {
+    t = tspl(t, { plan: 3 })
+
+    const body = Buffer.alloc(256 * 1024, 'x')
+    const server = createServer((req, res) => {
+      res.writeHead(200, { 'content-length': `${body.length}` })
+      res.end(body)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.close())
+
+      const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+      const buf = Buffer.from(await stream.arrayBuffer())
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(buf.length, body.length)
+      t.strictEqual(buf.equals(body), true)
+    })
+
+    await t.completed
+  })
+
+  test('keep-alive reuse after fast path completion', async (t) => {
+    t = tspl(t, { plan: 10 })
+
+    const body = Buffer.alloc(128 * 1024, 'y')
+    const server = createServer((req, res) => {
+      res.writeHead(200, { 'content-length': `${body.length}` })
+      res.end(body)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.close())
+
+      client.on('disconnect', () => {
+        if (!client.closed && !client.destroyed) {
+          t.fail('connection must be reused')
+        }
+      })
+
+      for (let i = 0; i < 5; i++) {
+        const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+        const buf = Buffer.from(await stream.arrayBuffer())
+        t.strictEqual(statusCode, 200)
+        t.strictEqual(buf.equals(body), true)
+      }
+    })
+
+    await t.completed
+  })
+
+  test('pipelined responses sharing packets, boundaries mid-chunk', async (t) => {
+    t = tspl(t, { plan: 2 })
+
+    const body1 = 'A'.repeat(64 * 1024)
+    const body2 = 'B'.repeat(32 * 1024)
+    const h1 = `HTTP/1.1 200 OK\r\ncontent-length: ${body1.length}\r\n\r\n`
+    const h2 = `HTTP/1.1 200 OK\r\ncontent-length: ${body2.length}\r\n\r\n`
+
+    const server = net.createServer((sock) => {
+      sock.setNoDelay(true)
+      let reqs = 0
+      let sent1 = false
+      let sent2 = false
+      sock.on('data', (d) => {
+        reqs += (d.toString().match(/GET/g) || []).length
+        if (reqs >= 1 && !sent1) {
+          sent1 = true
+          // Headers and only the first slice of body1; the fast path
+          // takes over for the rest.
+          sock.write(h1 + body1.slice(0, 1000))
+        }
+        if (reqs >= 2 && !sent2) {
+          sent2 = true
+          // One glued packet: rest of body1, response 2 headers, first
+          // slice of body2. The fast path must complete message 1 and
+          // re-enter llhttp for message 2 headers.
+          sock.write(body1.slice(1000) + h2 + body2.slice(0, 1000))
+          setTimeout(() => sock.write(body2.slice(1000)), 20)
+        }
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`, { pipelining: 2 })
+      after(() => client.destroy())
+
+      const [ta, tb] = await Promise.all([
+        client.request({ path: '/1', method: 'GET' }).then(r => r.body.text()),
+        client.request({ path: '/2', method: 'GET' }).then(r => r.body.text())
+      ])
+      t.strictEqual(ta === body1, true)
+      t.strictEqual(tb === body2, true)
+    })
+
+    await t.completed
+  })
+
+  test('exact message boundary at end of packet', async (t) => {
+    t = tspl(t, { plan: 2 })
+
+    const body = 'Z'.repeat(16 * 1024)
+    const header = `HTTP/1.1 200 OK\r\ncontent-length: ${body.length}\r\n\r\n`
+
+    const server = net.createServer((sock) => {
+      sock.setNoDelay(true)
+      sock.once('data', () => {
+        // Headers in one packet, body in a second packet ending exactly
+        // at the message boundary.
+        sock.write(header)
+        setTimeout(() => sock.write(body), 10)
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.destroy())
+
+      const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(await stream.text(), body)
+    })
+
+    await t.completed
+  })
+
+  test('truncated fixed-length body errors on connection close', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    const body = 'T'.repeat(32 * 1024)
+
+    const server = net.createServer((sock) => {
+      sock.once('data', () => {
+        sock.write(`HTTP/1.1 200 OK\r\ncontent-length: ${body.length}\r\nconnection: close\r\n\r\n`)
+        // Send only part of the body, then close.
+        sock.write(body.slice(0, 10000))
+        setTimeout(() => sock.end(), 20)
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.destroy())
+
+      try {
+        const { body: stream } = await client.request({ path: '/', method: 'GET' })
+        await stream.text()
+        t.fail('must not resolve')
+      } catch (err) {
+        t.strictEqual(err.code, 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH')
+      }
+    })
+
+    await t.completed
+  })
+
+  test('truncated keep-alive fixed-length body errors on connection close', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    const body = 'K'.repeat(32 * 1024)
+
+    const server = net.createServer((sock) => {
+      sock.once('data', () => {
+        sock.write(`HTTP/1.1 200 OK\r\ncontent-length: ${body.length}\r\n\r\n`)
+        sock.write(body.slice(0, 10000))
+        setTimeout(() => sock.end(), 20)
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.destroy())
+
+      try {
+        const { body: stream } = await client.request({ path: '/', method: 'GET' })
+        await stream.text()
+        t.fail('must not resolve')
+      } catch (err) {
+        t.ok(err)
+      }
+    })
+
+    await t.completed
+  })
+
+  test('backpressure pause and resume mid-body', async (t) => {
+    t = tspl(t, { plan: 2 })
+
+    // Body larger than the default 64KB highWaterMark so that push()
+    // returns false and the parser pauses while the fast path is active.
+    const body = Buffer.alloc(512 * 1024, 'p')
+    const server = createServer((req, res) => {
+      res.writeHead(200, { 'content-length': `${body.length}` })
+      res.end(body)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.close())
+
+      const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+      t.strictEqual(statusCode, 200)
+
+      // Consume slowly to force pauses.
+      const chunks = []
+      for await (const chunk of stream) {
+        chunks.push(chunk)
+        await new Promise(resolve => setImmediate(resolve))
+      }
+      t.strictEqual(Buffer.concat(chunks).equals(body), true)
+    })
+
+    await t.completed
+  })
+
+  test('maxResponseSize enforced on fast path body', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    const body = Buffer.alloc(256 * 1024, 'm')
+    const server = createServer((req, res) => {
+      res.writeHead(200, { 'content-length': `${body.length}` })
+      res.end(body)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`, { maxResponseSize: 100 * 1024 })
+      after(() => client.destroy())
+
+      try {
+        const { body: stream } = await client.request({ path: '/', method: 'GET' })
+        await stream.text()
+        t.fail('must not resolve')
+      } catch (err) {
+        t.strictEqual(err instanceof errors.ResponseExceededMaxSizeError, true)
+      }
+    })
+
+    await t.completed
+  })
+
+  test('chunked transfer-encoding is not affected', async (t) => {
+    t = tspl(t, { plan: 2 })
+
+    const body = 'c'.repeat(128 * 1024)
+    const server = createServer((req, res) => {
+      // No content-length: Node uses chunked encoding.
+      res.writeHead(200)
+      res.write(body.slice(0, 60000))
+      setTimeout(() => res.end(body.slice(60000)), 10)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.close())
+
+      const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(await stream.text(), body)
+    })
+
+    await t.completed
+  })
+
+  test('fast path does not activate for bodyless 304 with content-length', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    const server = net.createServer((sock) => {
+      sock.once('data', () => {
+        // llhttp treats 304 as bodyless even with content-length set, and
+        // undici then rejects the length mismatch. If the fast path
+        // activated here the client would hang waiting for body bytes
+        // instead of erroring right away.
+        sock.write('HTTP/1.1 304 Not Modified\r\ncontent-length: 1234\r\n\r\n')
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.destroy())
+
+      try {
+        const { body } = await client.request({ path: '/', method: 'GET' })
+        await body.text()
+        t.fail('must not resolve')
+      } catch (err) {
+        t.strictEqual(err.code, 'UND_ERR_RES_CONTENT_LENGTH_MISMATCH')
+      }
+    })
+
+    await t.completed
+  })
+
+  test('headers larger than the slice size parse correctly', async (t) => {
+    t = tspl(t, { plan: 3 })
+
+    // Header block larger than HEADER_SLICE_SIZE (4096) to cover header
+    // parsing spanning multiple slices.
+    const bigValue = 'v'.repeat(3000)
+    const body = 'H'.repeat(64 * 1024)
+    const server = createServer((req, res) => {
+      res.writeHead(200, {
+        'content-length': `${body.length}`,
+        'x-big-one': bigValue,
+        'x-big-two': bigValue
+      })
+      res.end(body)
+    })
+    after(() => {
+      server.closeAllConnections?.()
+      server.close()
+    })
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.close())
+
+      const { statusCode, headers, body: stream } = await client.request({ path: '/', method: 'GET' })
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['x-big-two'], bigValue)
+      t.strictEqual(await stream.text(), body)
+    })
+
+    await t.completed
+  })
+
+  test('bodies interleaved with 100-continue-free informational responses', async (t) => {
+    t = tspl(t, { plan: 2 })
+
+    const body = 'i'.repeat(20000)
+    const server = net.createServer((sock) => {
+      sock.once('data', () => {
+        // 103 Early Hints, then the real fixed-length response.
+        sock.write('HTTP/1.1 103 Early Hints\r\nlink: </style.css>; rel=preload\r\n\r\n')
+        sock.write(`HTTP/1.1 200 OK\r\ncontent-length: ${body.length}\r\n\r\n`)
+        setTimeout(() => sock.write(body), 10)
+      })
+    })
+    after(() => server.close())
+
+    server.listen(0, async () => {
+      const client = new Client(`http://localhost:${server.address().port}`)
+      after(() => client.destroy())
+
+      const { statusCode, body: stream } = await client.request({ path: '/', method: 'GET' })
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(await stream.text(), body)
+    })
+
+    await t.completed
+  })
+})


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

Reduce CPU and memory-copy overhead when receiving HTTP/1.1 responses with a known fixed content length by delivering body bytes directly to the request instead of copying them through the wasm llhttp parser.

## Changes

- Add a fixed-length HTTP/1 response body fast path that pauses llhttp after headers and streams the known body bytes directly.
- Preserve existing parsing behavior for transfer-encoding, HEAD, CONNECT/upgrade, informational/bodyless responses, and user-paused responses.
- Detect truncated fixed-length bodies explicitly and guard `readMore()` against re-entrant reads while completing a response.
- Add regression coverage for pipelining, keep-alive reuse, truncation, backpressure, max response size, chunked responses, bodyless responses, large headers, and informational responses.
- Make `benchmarks/server.js` configurable for response body size and synchronous responses.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Validation

- `git diff --check origin/main..HEAD`
- `npx eslint lib/dispatcher/client-h1.js test/client-content-length-fastpath.js benchmarks/server.js`
- `node --test test/client-content-length-fastpath.js`

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
