### PR TITLE
chore(benchmarks): require(esm) on ESM-only packages

### DIFF
--- a/benchmarks/benchmark-http2.js
+++ b/benchmarks/benchmark-http2.js
@@ -9,6 +9,8 @@ const { isMainThread } = require('node:worker_threads')
 
 const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
+const { cronometro } = require('cronometro')
+
 const ca = readFileSync(path.join(__dirname, '..', 'test', 'fixtures', 'ca.pem'), 'utf8')
 const servername = 'agent1'
 
@@ -258,9 +260,7 @@ if (process.env.PORT) {
   }
 }
 
-async function main () {
-  const { cronometro } = await import('cronometro')
-
+function main () {
   cronometro(
     experiments,
     {

--- a/benchmarks/benchmark-https.js
+++ b/benchmarks/benchmark-https.js
@@ -9,6 +9,8 @@ const { isMainThread } = require('node:worker_threads')
 
 const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
+const { cronometro } = require('cronometro')
+
 const ca = readFileSync(path.join(__dirname, '..', 'test', 'fixtures', 'ca.pem'), 'utf8')
 const servername = 'agent1'
 
@@ -267,9 +269,7 @@ if (process.env.PORT) {
   }
 }
 
-async function main () {
-  const { cronometro } = await import('cronometro')
-
+function main () {
   cronometro(
     experiments,
     {

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -10,10 +10,11 @@ const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
 const { makeParallelRequests, printResults } = require('./_util')
 
-let nodeFetch
+const { cronometro } = require('cronometro')
+const { default: nodeFetch } = require('node-fetch')
 const axios = require('axios')
-let superagent
-let got
+const _superagent = require('superagent')
+const { default: got } = require('got')
 
 const { promisify } = require('node:util')
 const request = promisify(require('request'))
@@ -85,6 +86,9 @@ const superagentAgent = new http.Agent({
   keepAlive: true,
   maxSockets: connections
 })
+
+// https://github.com/ladjs/superagent/issues/1540#issue-561464561
+const superagent = _superagent.agent().use((req) => req.agent(superagentAgent))
 
 const undiciOptions = {
   path: '/',
@@ -328,16 +332,7 @@ if (process.env.PORT) {
   }
 }
 
-async function main () {
-  const { cronometro } = await import('cronometro')
-  const _nodeFetch = await import('node-fetch')
-  nodeFetch = _nodeFetch.default
-  const _got = await import('got')
-  got = _got.default
-  const _superagent = await import('superagent')
-  // https://github.com/ladjs/superagent/issues/1540#issue-561464561
-  superagent = _superagent.agent().use((req) => req.agent(superagentAgent))
-
+function main () {
   // cronometro runs each benchmark in a worker, so attach cleanup to every
   // test before the worker exits.
   const tests = Object.fromEntries(

--- a/benchmarks/post-benchmark.js
+++ b/benchmarks/post-benchmark.js
@@ -10,10 +10,11 @@ const { Pool, Client, fetch, Agent, setGlobalDispatcher } = require('..')
 
 const { makeParallelRequests, printResults } = require('./_util')
 
-let nodeFetch
+const { cronometro } = require('cronometro')
+const { default: nodeFetch } = require('node-fetch')
 const axios = require('axios')
-let superagent
-let got
+const _superagent = require('superagent')
+const { default: got } = require('got')
 
 const { promisify } = require('node:util')
 const request = promisify(require('request'))
@@ -94,6 +95,9 @@ const superagentAgent = new http.Agent({
   keepAlive: true,
   maxSockets: connections
 })
+
+// https://github.com/ladjs/superagent/issues/1540#issue-561464561
+const superagent = _superagent.agent().use((req) => req.agent(superagentAgent))
 
 /** @type {import("..").Dispatcher.DispatchOptions} */
 const undiciOptions = {
@@ -353,16 +357,7 @@ if (process.env.PORT) {
   }
 }
 
-async function main () {
-  const { cronometro } = await import('cronometro')
-  const _nodeFetch = await import('node-fetch')
-  nodeFetch = _nodeFetch.default
-  const _got = await import('got')
-  got = _got.default
-  const _superagent = await import('superagent')
-  // https://github.com/ladjs/superagent/issues/1540#issue-561464561
-  superagent = _superagent.agent().use((req) => req.agent(superagentAgent))
-
+function main () {
   cronometro(
     experiments,
     {


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...
N/A
<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale
Since v8 requires node >= 22.19 and some of the bench dependencies also moved past node v20 (e.g. cronometro), we can use `require(esm)` and remove the special handling previosuly required for these packages.
<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
