### PR TITLE
chore: guard client[kUrl] in closeClientIfUnused loop

### DIFF
--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -108,7 +108,7 @@ class Agent extends DispatcherBase {
 
         let hasOrigin = false
         for (const client of this[kClients].values()) {
-          if (client[kUrl] && client[kUrl].origin === dispatcher[kUrl].origin) {
+          if (client[kUrl]?.origin === dispatcher[kUrl].origin) {
             hasOrigin = true
             break
           }

--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -108,7 +108,7 @@ class Agent extends DispatcherBase {
 
         let hasOrigin = false
         for (const client of this[kClients].values()) {
-          if (client[kUrl].origin === dispatcher[kUrl].origin) {
+          if (client[kUrl] && client[kUrl].origin === dispatcher[kUrl].origin) {
             hasOrigin = true
             break
           }

--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -108,14 +108,14 @@ class Agent extends DispatcherBase {
 
         let hasOrigin = false
         for (const client of this[kClients].values()) {
-          if (client[kUrl]?.origin === dispatcher[kUrl].origin) {
+          if (client[kUrl]?.origin === dispatcher[kUrl]?.origin) {
             hasOrigin = true
             break
           }
         }
 
         if (!hasOrigin) {
-          this[kOrigins].delete(dispatcher[kUrl].origin)
+          this[kOrigins].delete(dispatcher[kUrl]?.origin)
         }
       }
 

--- a/test/agent-connection-management.js
+++ b/test/agent-connection-management.js
@@ -1,7 +1,9 @@
 const { test, describe } = require('node:test')
 const assert = require('node:assert')
 const { createServer } = require('node:http')
+const { EventEmitter } = require('node:events')
 const { request, Agent, Pool } = require('..')
+const { kBusy, kConnected, kDispatch, kRunning, kUrl } = require('../lib/core/symbols')
 
 // https://github.com/nodejs/undici/issues/4424
 describe('Agent should close inactive clients', () => {
@@ -62,6 +64,156 @@ describe('Agent should close inactive clients', () => {
 
 // https://github.com/nodejs/undici/issues/5022
 describe('Agent should not close active clients', () => {
+  class FakeDispatcher extends EventEmitter {
+    constructor (origin, { withUrl = false } = {}) {
+      super()
+      this[kConnected] = 0
+      this[kBusy] = false
+      this[kRunning] = 0
+      this.destroyed = false
+      this.dispatchCalls = 0
+
+      if (withUrl) {
+        this[kUrl] = new URL(origin)
+      }
+    }
+
+    dispatch () {
+      this.dispatchCalls++
+      return true
+    }
+
+    close () {
+      this.destroyed = true
+      return Promise.resolve()
+    }
+
+    destroy () {
+      this.destroyed = true
+      return Promise.resolve()
+    }
+  }
+
+  test('should ignore stale disconnect from replaced client', async () => {
+    const origin = 'http://localhost:3000'
+    const created = []
+    const agent = new Agent({
+      factory: (factoryOrigin) => {
+        const dispatcher = new FakeDispatcher(String(factoryOrigin))
+        created.push(dispatcher)
+        return dispatcher
+      }
+    })
+
+    const handler = {}
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 1)
+
+    const stale = created[0]
+    stale.emit('disconnect', origin, [stale], new Error('first close'))
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 2)
+
+    // Simulate a late event from a stale dispatcher after replacement exists.
+    stale.emit('disconnect', origin, [stale], new Error('late close'))
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 2)
+    assert.equal(created[1].dispatchCalls, 2)
+
+    await agent.close()
+  })
+
+  test('should ignore stale connectionError from replaced client with kUrl', async () => {
+    const origin = 'http://localhost:3001'
+    const created = []
+    const agent = new Agent({
+      factory: (factoryOrigin) => {
+        const dispatcher = new FakeDispatcher(String(factoryOrigin), { withUrl: true })
+        created.push(dispatcher)
+        return dispatcher
+      }
+    })
+
+    const handler = {}
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 1)
+
+    const stale = created[0]
+    stale.emit('connectionError', origin, [stale], new Error('first error'))
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 2)
+
+    // Simulate a late connectionError from stale dispatcher after replacement exists.
+    stale.emit('connectionError', origin, [stale], new Error('late error'))
+
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 2)
+    assert.equal(created[1].dispatchCalls, 2)
+
+    await agent.close()
+  })
+
+  test('should handle remaining client with kUrl while cleaning replaced client', async () => {
+    const origin = 'http://localhost:3002'
+    const created = []
+    const agent = new Agent({
+      factory: (factoryOrigin) => {
+        const dispatcher = new FakeDispatcher(String(factoryOrigin), { withUrl: true })
+        created.push(dispatcher)
+        return dispatcher
+      }
+    })
+
+    const handler = {}
+
+    agent[kDispatch]({ origin }, handler)
+    agent[kDispatch]({ origin, allowH2: false }, handler)
+    assert.equal(created.length, 2)
+
+    assert.doesNotThrow(() => {
+      created[0].emit('disconnect', origin, [created[0]], new Error('disconnect'))
+    })
+
+    // A replacement for the non-http1-only key should still be creatable.
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 3)
+
+    await agent.close()
+  })
+
+  test('should handle remaining client without kUrl while cleaning replaced client', async () => {
+    const origin = 'http://localhost:3003'
+    const created = []
+    const agent = new Agent({
+      factory: (factoryOrigin) => {
+        const dispatcher = new FakeDispatcher(String(factoryOrigin))
+        created.push(dispatcher)
+        return dispatcher
+      }
+    })
+
+    const handler = {}
+
+    agent[kDispatch]({ origin }, handler)
+    agent[kDispatch]({ origin, allowH2: false }, handler)
+    assert.equal(created.length, 2)
+
+    assert.doesNotThrow(() => {
+      created[0].emit('disconnect', origin, [created[0]], new Error('disconnect'))
+    })
+
+    // A replacement for the non-http1-only key should still be creatable.
+    agent[kDispatch]({ origin }, handler)
+    assert.equal(created.length, 3)
+
+    await agent.close()
+  })
+
   test('should reuse replacement keep-alive connection after server closes the previous one', async (t) => {
     let nextSocketId = 0
     const socketIds = new Map()


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

When a custom factory (e.g `ProxyAgent`) is used with `Agent` the dispatcher registered in `kClients` may not have `kUrl` set.
`ProxyAgent` extends `DispatcherBase` directly and never assigns `this[kUrl]` so `client[kUrl]` is `undefined` for every proxied origin key


<img alt="Screenshot 2026-07-09 at 08 30 08" width="1068" height="189" src="https://private-user-images.githubusercontent.com/183694449/619146831-5ad06da1-ecf1-4205-ac6c-98dfe72ca3d7.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODM1NjEwODQsIm5iZiI6MTc4MzU2MDc4NCwicGF0aCI6Ii8xODM2OTQ0NDkvNjE5MTQ2ODMxLTVhZDA2ZGExLWVjZjEtNDIwNS1hYzZjLTk4ZGZlNzJjYTNkNy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNzA5JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDcwOVQwMTMzMDRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0xOTQ4NzQ1OGVlY2MwNDdhNjM1YjFjZjM3MzI0ODQ4NzFmOGVkYTg5MTJmMTc5ODYzMzk4NjFjNzg5NzI2Njk1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9aW1hZ2UlMkZwbmcifQ.c_IOJQ3rWueduEZDr1-z24QFDyLAKHMjevvDb-axq2o"> Used `Error.prepareStackTrace` to surface the stack trace here . it was being suppressed because the frames originate from `node:internal`.


## Testing 
<img width="893" height="286" alt="Screenshot 2026-07-14 at 11 55 31" src="https://github.com/user-attachments/assets/a69a3ef5-7bd0-483d-a972-9fa00c160897" />

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
