### PR TITLE
test: add unexpected disconnect guards to http2 tests

### DIFF
--- a/test/http2-connection.js
+++ b/test/http2-connection.js
@@ -44,6 +44,12 @@ test('Should support H2 connection', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     path: '/',
     method: 'GET',
@@ -97,6 +103,12 @@ test('Should support H2 connection(multiple requests)', async t => {
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   for (let i = 0; i < 3; i++) {
     const sendBody = `seq ${i}`
@@ -156,6 +168,12 @@ test('Should support H2 connection (headers as array)', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     path: '/',
     method: 'GET',
@@ -214,6 +232,12 @@ test('Should support multiple header values with semicolon separator', async t =
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const response = await client.request({
     path: '/',
@@ -297,6 +321,12 @@ test('Should support H2 connection(POST Buffer)', async t => {
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const sendBody = 'hello!'
   const body = []

--- a/test/http2-continue.js
+++ b/test/http2-continue.js
@@ -43,6 +43,12 @@ test('Should handle h2 continue', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     path: '/',
     method: 'POST',
@@ -91,6 +97,12 @@ test('Should deliver an early final response to an Expect: 100-continue request 
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const response = await client.request({
     path: '/',

--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -36,6 +36,12 @@ test('h2 client multiplexes concurrent requests by default (#4143)', async t => 
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const results = await Promise.all(
     Array.from({ length: N }, () =>
       client.request({ path: '/', method: 'GET' })
@@ -96,6 +102,12 @@ test('Pool with connections=1 multiplexes h2 streams on the single session (#414
   })
   after(() => pool.close())
 
+  pool.on('disconnect', () => {
+    if (!pool.closed && !pool.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const results = await Promise.all(
     Array.from({ length: N }, () =>
       pool.request({ path: '/', method: 'GET' })
@@ -129,6 +141,12 @@ test('Client#pipelining keeps its h1 (RFC7230) semantic on an h2 client', async 
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   // Even after negotiating h2, client.pipelining reflects only the user-set
   // h1 pipelining factor — the h2 dispatch limit is maxConcurrentStreams.

--- a/test/http2-pseudo-headers.js
+++ b/test/http2-pseudo-headers.js
@@ -44,6 +44,12 @@ test('Should provide pseudo-headers in proper order', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     path: '/',
     method: 'GET'
@@ -78,6 +84,12 @@ test('The h2 pseudo-headers is not included in the headers', async t => {
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const response = await client.request({
     path: '/',


### PR DESCRIPTION
Adds the disconnect guard pattern from `docs/docs/best-practices/writing-tests.md`
to the happy-path HTTP/2 test files, so silent disconnect/reconnect cycles fail
the tests instead of passing unnoticed.

Files covered (12 guards): http2-pseudo-headers.js, http2-continue.js,
http2-connection.js, http2-pipelining-default.js (incl. one Pool guard).

Intentionally skipped: http2-instantiation.js (ALPN-mismatch test where
disconnect is expected) and http2-invalid-connection-headers.js (reconnection
is the behavior under test). Happy to cover http2-body.js and the connect-*
group in follow-ups.

Refs: #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)