### PR TITLE
fix: track origins by client map key in Agent teardown

### DIFF
--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -107,15 +107,15 @@ class Agent extends DispatcherBase {
         }
 
         let hasOrigin = false
-        for (const client of this[kClients].values()) {
-          if (client[kUrl].origin === dispatcher[kUrl].origin) {
+        for (const k of this[kClients].keys()) {
+          if (k === origin || k === `${origin}#http1-only`) {
             hasOrigin = true
             break
           }
         }
 
         if (!hasOrigin) {
-          this[kOrigins].delete(dispatcher[kUrl].origin)
+          this[kOrigins].delete(origin)
         }
       }
 

--- a/test/agent-connection-management.js
+++ b/test/agent-connection-management.js
@@ -1,7 +1,9 @@
 const { test, describe } = require('node:test')
 const assert = require('node:assert')
 const { createServer } = require('node:http')
-const { request, Agent, Pool } = require('..')
+const { once } = require('node:events')
+const { request, Agent, Pool, ProxyAgent } = require('..')
+const { kClients } = require('../lib/core/symbols')
 
 // https://github.com/nodejs/undici/issues/4424
 describe('Agent should close inactive clients', () => {
@@ -152,5 +154,49 @@ describe('Agent should not close active clients', () => {
 
     assert.deepEqual(socketSequence.slice(0, 3), ['1', '1', '1'])
     assert.deepEqual(socketSequence.slice(3), ['2', '2'])
+  })
+})
+
+// https://github.com/nodejs/undici/issues/5529
+describe('Agent teardown of factory dispatchers without an internal url', () => {
+  test('ProxyAgent forwarding plain http does not crash on teardown', async (t) => {
+    // A minimal forward proxy: answers any absolute-form request itself.
+    const proxy = createServer((req, res) => {
+      res.setHeader('connection', 'close')
+      res.end('ok')
+    }).listen(0)
+
+    t.after(() => {
+      proxy.closeAllConnections?.()
+      proxy.close()
+    })
+    await once(proxy, 'listening')
+
+    const proxyAgent = new ProxyAgent(`http://localhost:${proxy.address().port}`)
+    t.after(() => proxyAgent.close())
+
+    // A plain-http request registers an Http1ProxyWrapper, which has no kUrl,
+    // in the inner Agent's client map.
+    const { statusCode, body } = await request('http://target.example/', { dispatcher: proxyAgent })
+    assert.equal(statusCode, 200)
+    await body.text()
+
+    let innerAgent
+    for (const sym of Object.getOwnPropertySymbols(proxyAgent)) {
+      const value = proxyAgent[sym]
+      if (value && value[kClients] instanceof Map && value[kClients].size > 0) {
+        innerAgent = value
+        break
+      }
+    }
+    assert.ok(innerAgent, 'expected to find the inner Agent')
+    const [wrapper] = innerAgent[kClients].values()
+
+    // The Agent subscribes to this event on every dispatcher its factory
+    // returns. Before the fix this threw
+    // "Cannot read properties of undefined (reading 'origin')".
+    wrapper.emit('disconnect', 'http://target.example', [wrapper], new Error('closed'))
+
+    assert.equal(innerAgent[kClients].size, 0, 'expected the unused wrapper to be removed')
   })
 })


### PR DESCRIPTION
## This relates to...

Fixes #5529

## Rationale

`Agent#closeClientIfUnused` reads `client[kUrl].origin` for every dispatcher in the client map, but the factory option is public API and nothing guarantees a factory-built dispatcher sets `kUrl`. `ProxyAgent`'s own factory registers `Http1ProxyWrapper` (and `Socks5ProxyAgent`), neither of which does, so since 8.7.0 a plain-http request through a proxy crashes with `Cannot read properties of undefined (reading 'origin')` on the disconnect / connectionError teardown path.

## Changes

The teardown closure already holds the `origin` string that was added to `kOrigins` and the map `key` derived from it, so the bookkeeping doesn't need `kUrl` at all: check the remaining map keys for the origin (including the `#http1-only` variant) and delete the captured `origin` string. This is the third option suggested in the issue.

A side effect worth noting: `kOrigins.delete` is now symmetric with the `add`. Previously `add` used `String(opts.origin)` while `delete` used `kUrl.origin`, which diverge when `opts.origin` is a `URL` instance (trailing slash), so those origins were never removed and counted against `maxOrigins` forever.

The `stats` getter still reads `dispatcher[kUrl].origin` and has the same fragility with kUrl-less dispatchers; left alone here since changing its keys is a visible behavior change. Can follow up if there's interest.

### Features

N/A

### Bug Fixes

- `ProxyAgent` no longer crashes the inner `Agent` on connection teardown for plain-http (non-tunneled) targets.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Documentation is not needed
- [x] Lint passed

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11