### PR TITLE
fix(h2): allow stream-bodied requests to multiplex on a busy session

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -322,16 +322,6 @@ function connectH2 (client, socket) {
           // Don't dispatch an upgrade until all preceding requests have completed.
           // Possibly, we do not have remote settings confirmed yet.
           if ((request.upgrade === 'websocket' || request.method === 'CONNECT') && session[kRemoteSettings] === false) return true
-          // Request with stream or iterator body can error while other requests
-          // are inflight and indirectly error those as well.
-          // Ensure this doesn't happen by waiting for inflight
-          // to complete before dispatching.
-
-          // Request with stream or iterator body cannot be retried.
-          // Ensure that no other requests are inflight and
-          // could cause failure.
-          if (util.bodyLength(request.body) !== 0 &&
-            (util.isStream(request.body) || util.isAsyncIterable(request.body) || util.isFormDataLike(request.body))) return true
         } else {
           return (request.upgrade === 'websocket' || request.method === 'CONNECT') && session[kRemoteSettings] === false
         }

--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -147,8 +147,19 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
 
   const dispatcher = new Agent({ useH2c: true })
   const sse = new AbortController()
+
+  // Track the SSE fetch and its response so teardown can wait for the abort
+  // to actually settle -- and explicitly cancel the never-read response
+  // body -- before closing the dispatcher. Without this, an abort that's
+  // still propagating when the dispatcher closes can surface a late,
+  // listener-less socket error (e.g. ECONNRESET) as an uncaughtException
+  // after the test has already completed.
+  let sseResponse
+  let ssePromise = Promise.resolve()
   after(async () => {
     sse.abort()
+    await ssePromise
+    await sseResponse?.body?.cancel().catch(() => {})
     await dispatcher.close()
   })
 
@@ -161,9 +172,11 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
   })
   await warmup.text()
 
-  fetch(`${origin}/events`, {
+  ssePromise = fetch(`${origin}/events`, {
     dispatcher,
     signal: sse.signal
+  }).then(res => {
+    sseResponse = res
   }).catch(() => {})
   await eventsOpenedPromise
 

--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const { test, after } = require('node:test')
-const { createSecureServer } = require('node:http2')
+const { createSecureServer, createServer } = require('node:http2')
 const { once } = require('node:events')
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
-const { Client, Pool } = require('..')
+const { Agent, Client, Pool, fetch } = require('..')
 
 test('h2 client multiplexes concurrent requests by default (#4143)', async t => {
   const N = 5
@@ -109,6 +109,75 @@ test('Pool with connections=1 multiplexes h2 streams on the single session (#414
 
   t.strictEqual(sessions.size, 1, `expected 1 h2 session, got ${sessions.size}`)
   t.strictEqual(sockets.size, 1, `expected 1 TCP socket, got ${sockets.size}`)
+
+  await t.completed
+})
+
+test('fetch POST multiplexes while an SSE stream is open on the same h2 session (#5524)', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const server = createServer()
+  const paths = []
+  const sessions = new Set()
+  let eventsOpened
+  const eventsOpenedPromise = new Promise(resolve => {
+    eventsOpened = resolve
+  })
+
+  server.on('session', session => {
+    sessions.add(session)
+  })
+
+  server.on('stream', (stream, headers) => {
+    paths.push(headers[':path'])
+
+    if (headers[':path'] === '/events') {
+      stream.respond({ ':status': 200, 'content-type': 'text/event-stream' })
+      stream.write(': ping\n\n')
+      eventsOpened()
+      return
+    }
+
+    stream.respond({ ':status': 200, 'content-type': 'application/json' })
+    stream.end('{"ok":true}')
+  })
+
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+  after(() => server.close())
+
+  const dispatcher = new Agent({ useH2c: true })
+  const sse = new AbortController()
+  after(async () => {
+    sse.abort()
+    await dispatcher.close()
+  })
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  const warmup = await fetch(`${origin}/warmup`, {
+    method: 'POST',
+    body: '{"warmup":true}',
+    dispatcher
+  })
+  await warmup.text()
+
+  fetch(`${origin}/events`, {
+    dispatcher,
+    signal: sse.signal
+  }).catch(() => {})
+  await eventsOpenedPromise
+
+  const response = await fetch(`${origin}/rpc`, {
+    method: 'POST',
+    body: '{"ok":true}',
+    dispatcher,
+    signal: AbortSignal.timeout(5000)
+  })
+
+  t.strictEqual(response.status, 200)
+  t.strictEqual(await response.text(), '{"ok":true}')
+  t.deepStrictEqual(paths, ['/warmup', '/events', '/rpc'])
+  t.strictEqual(sessions.size, 1)
 
   await t.completed
 })

--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -182,6 +182,68 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
   await t.completed
 })
 
+test('fetch POST bodies dispatch concurrently on the same h2 session instead of serializing (#5494)', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createServer()
+  const sessions = new Set()
+  const streams = []
+  let resolveSecondArrived
+  const secondArrived = new Promise(resolve => {
+    resolveSecondArrived = resolve
+  })
+
+  server.on('session', session => {
+    sessions.add(session)
+  })
+
+  server.on('stream', stream => {
+    // Hold every stream open instead of responding immediately, so a
+    // serialized client would never let the second request's headers
+    // reach the server until the first one's stream is released.
+    streams.push(stream)
+    if (streams.length === 2) {
+      resolveSecondArrived()
+    }
+  })
+
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+  after(() => server.close())
+
+  const dispatcher = new Agent({ useH2c: true })
+  after(async () => {
+    await dispatcher.close()
+  })
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+
+  const first = fetch(origin, { method: 'POST', body: '{"first":1}', dispatcher })
+  // Wait for the first request's stream to actually open before dispatching
+  // the second -- this reproduces the exact ordering #5494 reported
+  // (one bodied request already in flight when the next one is dispatched).
+  while (streams.length < 1) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  const second = fetch(origin, { method: 'POST', body: '{"second":1}', dispatcher, signal: AbortSignal.timeout(5000) })
+
+  // If the second request is stuck behind the first (the bug), its stream
+  // never opens and this hangs until the timeout signal aborts it.
+  await secondArrived
+
+  for (const stream of streams) {
+    stream.respond({ ':status': 200 })
+    stream.end('{"ok":true}')
+  }
+
+  const [firstRes, secondRes] = await Promise.all([first, second])
+  t.strictEqual(firstRes.status, 200)
+  t.strictEqual(secondRes.status, 200)
+  t.strictEqual(sessions.size, 1)
+
+  await t.completed
+})
+
 test('Client#pipelining keeps its h1 (RFC7230) semantic on an h2 client', async t => {
   t = tspl(t, { plan: 2 })
 

--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -120,6 +120,7 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
   const paths = []
   const sessions = new Set()
   let eventsOpened
+  let eventsStream
   const eventsOpenedPromise = new Promise(resolve => {
     eventsOpened = resolve
   })
@@ -132,6 +133,7 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
     paths.push(headers[':path'])
 
     if (headers[':path'] === '/events') {
+      eventsStream = stream
       stream.respond({ ':status': 200, 'content-type': 'text/event-stream' })
       stream.write(': ping\n\n')
       eventsOpened()
@@ -150,13 +152,14 @@ test('fetch POST multiplexes while an SSE stream is open on the same h2 session 
 
   // Track the SSE fetch and its response so teardown can wait for the abort
   // to actually settle -- and explicitly cancel the never-read response
-  // body -- before closing the dispatcher. Without this, an abort that's
-  // still propagating when the dispatcher closes can surface a late,
-  // listener-less socket error (e.g. ECONNRESET) as an uncaughtException
-  // after the test has already completed.
+  // body -- before closing the dispatcher. Ending the still-open SSE stream
+  // from the server side first lets the client see a normal stream close
+  // instead of an abrupt reset, avoiding a trailing ECONNRESET on the
+  // socket once the dispatcher is closed.
   let sseResponse
   let ssePromise = Promise.resolve()
   after(async () => {
+    eventsStream?.end()
     sse.abort()
     await ssePromise
     await sseResponse?.body?.cancel().catch(() => {})


### PR DESCRIPTION
## This relates to...

Fixes #5524
Fixes #5494

Same root cause for both -- #5494 already has an open fix in #5497 (same core change to `busy()`, currently blocked on a requested unit test) -- see "Relationship to #5497" below before reviewing.

## Rationale

`busy()` in `lib/dispatcher/client-h2.js` deferred any request with a stream/async-iterable/FormData body until every other in-flight request on the h2 session completed. If one of those in-flight requests is a long-lived stream (e.g. an open `text/event-stream` GET), every bodied request queued behind it parks indefinitely. The client also stops reporting `kBusy` while an h2 context is attached (so the pool keeps multiplexing instead of opening a second connection), so there's no escape route -- for an SSE stream, the hang is permanent.

The two hazards the guard's comments cited are already handled more precisely elsewhere in this file:
- "can error while other requests are inflight and indirectly error those as well" -- a stream erroring mid-request now only aborts that one stream via the `abort()` closure (explicit comment there: "We do not destroy the socket as we can continue using the session"); it doesn't touch sibling streams.
- "cannot be retried... could cause failure" -- `canRetryRequestAfterGoAway()` already excludes stream/iterable/FormData bodies from the requests it resurrects after a GOAWAY (`body == null || isBuffer || isBlobLike` only), erroring the rest instead of replaying a partially-consumed body.

Both of those were already in place before this change, so the blanket pre-dispatch guard was redundant.

## Relationship to #5497

#5497 removes the same 9 lines for the same reason, opened against #5494 (concurrent POSTs on h2 not running concurrently -- a throughput complaint). #5524 is a more severe symptom of the identical guard: not just serialized, but a permanent deadlock when one of the concurrent requests is a long-lived stream like SSE. I only found #5497 after finishing this fix independently.

This PR adds what #5497 doesn't currently have:
- The unit test `mcollina` requested on #5497 (still outstanding as of this PR) -- covering #5494's own scenario directly: a second stream-bodied POST now dispatches while the first is still in flight instead of waiting for it to complete.
- A separate regression test for the more severe #5524 deadlock scenario (SSE held open + bodied POST hangs forever, not just serializes).

Happy to close this in favor of #5497 if the maintainers would rather continue there -- opening it mainly so the missing test and both scenarios' coverage aren't lost. No preference on which one lands.

## Changes

### Features

N/A

### Bug Fixes

- Fixes #5524: a bodied `fetch()`/`request()` call on an h2 session no longer waits forever behind an open long-lived stream (e.g. SSE) on the same session.
- Fixes #5494: concurrent bodied `fetch()`/`request()` calls on the same h2 session now dispatch concurrently instead of serializing.

### Breaking Changes and Deprecations

N/A -- this only removes a guard that prevented dispatch; nothing that previously worked changes behavior, only what could not previously proceed now can.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

