### PR TITLE
fix(websocket): implement receive backpressure for WebSocketStream

### DIFF
--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -33,6 +33,7 @@ class WebSocketStream {
   #readableStream
   /** @type {ReadableStreamDefaultController} */
   #readableStreamController
+  #parserBackpressured = false
 
   // Each WebSocketStream object has an associated writable stream , which is a WritableStream .
   /** @type {WritableStream} */
@@ -47,9 +48,13 @@ class WebSocketStream {
     onConnectionEstablished: (response, extensions) => this.#onConnectionEstablished(response, extensions),
     onMessage: (opcode, data) => this.#onMessage(opcode, data),
     onParserError: (err) => failWebsocketConnection(this.#handler, null, err.message),
-    onParserDrain: () => this.#handler.socket.resume(),
+    onParserDrain: () => {
+      this.#parserBackpressured = false
+      this.#resumeSocketIfNeeded()
+    },
     onSocketData: (chunk) => {
       if (!this.#parser.write(chunk)) {
+        this.#parserBackpressured = true
         this.#handler.socket.pause()
       }
     },
@@ -117,7 +122,9 @@ class WebSocketStream {
     this.#closedPromise = Promise.withResolvers()
 
     // 7. Apply backpressure to the WebSocket.
-    // TODO
+    // The socket and readable stream are not available until the connection is
+    // established; backpressure is applied from the readable pull algorithm and
+    // after messages are enqueued.
 
     // 8.  If options [" signal "] exists ,
     if (options.signal != null) {
@@ -192,6 +199,11 @@ class WebSocketStream {
 
     // 2. Let reason be closeInfo [" reason "].
     const reason = closeInfo.reason
+
+    // The closing handshake needs to read the peer's Close frame off the
+    // socket to complete; a socket paused for receive backpressure (#5503)
+    // would otherwise never see it and the closed promise would hang forever.
+    this.#resumeSocketForClose()
 
     // 3. Close the WebSocket with this , code , and reason .
     closeWebSocketConnection(this.#handler, code, reason, true)
@@ -291,6 +303,7 @@ class WebSocketStream {
       start: (controller) => {
         this.#readableStreamController = controller
       },
+      pull: () => this.#resumeSocketIfNeeded(),
       cancel: (reason) => this.#cancel(reason)
     })
 
@@ -350,6 +363,35 @@ class WebSocketStream {
     this.#readableStreamController.enqueue(chunk)
 
     // 4. Apply backpressure to the WebSocket.
+    this.#applyBackpressureToWebSocket()
+  }
+
+  #applyBackpressureToWebSocket () {
+    if (this.#readableStreamController.desiredSize <= 0) {
+      this.#handler.socket.pause()
+    }
+  }
+
+  #resumeSocketIfNeeded () {
+    if (
+      !this.#parserBackpressured &&
+      this.#handler.socket != null &&
+      !this.#handler.socket.destroyed &&
+      this.#readableStreamController != null &&
+      this.#readableStreamController.desiredSize > 0
+    ) {
+      this.#handler.socket.resume()
+    }
+  }
+
+  // Once closing starts there is no more reader to protect from backpressure,
+  // and the closing handshake needs to keep reading off the socket to see the
+  // peer's Close frame - so unconditionally resume, ignoring both backpressure
+  // sources above.
+  #resumeSocketForClose () {
+    if (this.#handler.socket != null && !this.#handler.socket.destroyed) {
+      this.#handler.socket.resume()
+    }
   }
 
   /** @type {import('../websocket').Handler['onSocketClose']} */
@@ -437,6 +479,9 @@ class WebSocketStream {
       // 3.2. Set reasonString to reason ’s reason .
       reasonString = reason.reason
     }
+
+    // See close() for why this needs to happen before closeWebSocketConnection.
+    this.#resumeSocketForClose()
 
     // 4. Close the WebSocket with stream , code , and reasonString . If this throws an exception,
     //    discard code and reasonString and close the WebSocket with stream .

--- a/test/websocket/stream/issue-5503.js
+++ b/test/websocket/stream/issue-5503.js
@@ -1,0 +1,171 @@
+'use strict'
+
+const { test } = require('node:test')
+const net = require('node:net')
+const { WebSocketServer } = require('ws')
+
+const { WebSocketStream } = require('../../..')
+
+function waitFor (predicate) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now()
+
+    const check = () => {
+      if (predicate()) {
+        resolve()
+      } else if (Date.now() - started > 1000) {
+        reject(new Error('timed out waiting for condition'))
+      } else {
+        setTimeout(check, 10)
+      }
+    }
+
+    check()
+  })
+}
+
+// These tests assert that `closed` does NOT hang - if it regresses, the
+// point of the test is defeated by also hanging (up to the runner's own
+// timeout) instead of failing fast with a clear message.
+function withTimeout (promise, ms, message) {
+  let timer
+  const timeout = new Promise((resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+test('WebSocketStream applies receive backpressure to the socket', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (socket) => {
+    socket.send('one')
+  })
+
+  const { port } = server.address()
+  const originalPause = net.Socket.prototype.pause
+  const originalResume = net.Socket.prototype.resume
+  let pauseCount = 0
+  let resumeCount = 0
+
+  net.Socket.prototype.pause = function (...args) {
+    if (this.remotePort === port) {
+      pauseCount++
+    }
+
+    return originalPause.apply(this, args)
+  }
+
+  net.Socket.prototype.resume = function (...args) {
+    if (this.remotePort === port) {
+      resumeCount++
+    }
+
+    return originalResume.apply(this, args)
+  }
+
+  t.after(() => {
+    net.Socket.prototype.pause = originalPause
+    net.Socket.prototype.resume = originalResume
+
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  const stream = new WebSocketStream(`ws://127.0.0.1:${port}`)
+  const { readable } = await stream.opened
+
+  await waitFor(() => pauseCount > 0)
+
+  const resumesBeforeRead = resumeCount
+  const reader = readable.getReader()
+  const first = await reader.read()
+
+  t.assert.deepStrictEqual(first, { done: false, value: 'one' })
+
+  await waitFor(() => resumeCount > resumesBeforeRead)
+
+  await reader.cancel()
+  await stream.closed.catch(() => {})
+})
+
+test('WebSocketStream#close resolves closed even while the socket is paused for receive backpressure', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (socket) => {
+    socket.send('one')
+    socket.send('two')
+  })
+
+  const { port } = server.address()
+  const originalPause = net.Socket.prototype.pause
+  let pauseCount = 0
+
+  net.Socket.prototype.pause = function (...args) {
+    if (this.remotePort === port) {
+      pauseCount++
+    }
+
+    return originalPause.apply(this, args)
+  }
+
+  t.after(() => {
+    net.Socket.prototype.pause = originalPause
+
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  const stream = new WebSocketStream(`ws://127.0.0.1:${port}`)
+  await stream.opened
+
+  // Never read from `readable` - wait until the unread backlog has actually
+  // paused the socket (desiredSize <= 0) before closing, otherwise closing
+  // before the messages even arrive wouldn't exercise the paused-socket
+  // path at all. Closing must still complete: it needs to read the peer's
+  // own Close frame off that same paused socket.
+  await waitFor(() => pauseCount > 0)
+  stream.close()
+
+  const result = await withTimeout(stream.closed, 2000, 'stream.closed hung after close() with an unread backlog')
+  t.assert.strictEqual(result.closeCode, 1005)
+})
+
+test('WebSocketStream reader#cancel resolves closed even while the socket is paused for receive backpressure', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+
+  server.on('connection', (socket) => {
+    socket.send('one')
+    socket.send('two')
+  })
+
+  const { port } = server.address()
+
+  t.after(() => {
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
+    server.close()
+  })
+
+  const stream = new WebSocketStream(`ws://127.0.0.1:${port}`)
+  const { readable } = await stream.opened
+  const reader = readable.getReader()
+
+  // Read the first message so the reader is locked and has seen data, then
+  // leave the second one unread - the socket stays paused. Cancelling must
+  // still complete rather than hang waiting for the peer's Close frame.
+  await reader.read()
+  await reader.cancel()
+
+  const result = await withTimeout(stream.closed, 2000, 'stream.closed hung after reader.cancel() with an unread backlog')
+  t.assert.strictEqual(result.closeCode, 1005)
+})


### PR DESCRIPTION
## This relates to...

Fixes #5503

## Rationale

`WebSocketStream`'s readable side never applied backpressure. The `ReadableStream` was constructed without a `pull` algorithm, so consumer demand (`desiredSize`) was never observable, and both spec steps that say "Apply backpressure to the WebSocket" (constructor step 7, and the message-receive algorithm step 4) were `TODO`/no-op. Every parsed message was enqueued unconditionally regardless of whether the consumer was reading, so a slow (or absent) reader let the socket buffer an unbounded number of messages in memory — the issue's repro shows RSS growing from 75 MiB to 337 MiB with 200k unread 1 KiB messages, and the same amount fully flushed on the wire even though the client had read almost nothing.

The existing `onSocketData` → `parser.write() === false` → `socket.pause()` / `onParserDrain` → `socket.resume()` pair only reflects the parser's own internal buffer draining as fast as frames can be parsed — it has nothing to do with consumer demand.

## Changes

Two backpressure sources now gate the socket independently:

- **Parser buffer pressure** (pre-existing): `onSocketData` pauses when `parser.write()` returns `false`; `onParserDrain` clears that flag.
- **Consumer demand** (new): a `pull` algorithm on the `ReadableStream` re-checks on every `reader.read()`; `#onMessage` pauses the socket once `desiredSize <= 0` after enqueueing.

The socket only resumes once **both** are clear (parser not congested *and* `desiredSize > 0`) — either source alone is enough to keep it paused.

While testing this I found a second, related bug: once `close()`/`reader.cancel()` starts the closing handshake, it needs to keep reading off the socket to see the peer's own Close frame. If the socket happened to be paused for receive backpressure at that moment (a very reachable state — any unread backlog leaves it paused), the peer's Close frame was never read and `closed` hung forever. Fixed by unconditionally resuming the socket once closing starts (`#resumeSocketForClose`) — there's no more reader to protect from backpressure at that point, so ignoring both backpressure sources above is intentional, not an oversight.

### Features

N/A

### Bug Fixes

- Fixes #5503: a slow or absent `WebSocketStream` reader no longer buffers unbounded messages in memory or lets the sender flush unlimited data past what the consumer has actually read — receive backpressure now propagates down to pausing the socket, and from there to the underlying TCP connection.
- Also fixes a related hang: `close()` / `reader.cancel()` no longer wait forever on the peer's Close frame if the socket happened to be paused for receive backpressure when closing started.

### Breaking Changes and Deprecations

N/A — `WebSocketStream` is still experimental (`UNDICI-WSS` warning). Consumers that read promptly see no behavior change; slow/absent consumers now correctly experience backpressure instead of unbounded buffering.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
