### PR TITLE
fix(fetch): convert null init in Response.json

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -45,9 +45,7 @@ class Response {
   static json (data, init = undefined) {
     webidl.argumentLengthCheck(arguments, 1, 'Response.json')
 
-    if (init !== null) {
-      init = webidl.converters.ResponseInit(init)
-    }
+    init = webidl.converters.ResponseInit(init)
 
     // 1. Let bytes the result of running serialize a JavaScript value to JSON bytes on data.
     const bytes = textEncoder.encode(

--- a/test/fetch/response-json.js
+++ b/test/fetch/response-json.js
@@ -10,6 +10,7 @@ const FOO_BAR = 'foo/bar'
 
 const INIT_TESTS = [
   [undefined, 200, '', APPLICATION_JSON, {}],
+  [null, 200, '', APPLICATION_JSON, {}],
   [{ status: 400 }, 400, '', APPLICATION_JSON, {}],
   [{ statusText: 'foo' }, 200, 'foo', APPLICATION_JSON, {}],
   [{ headers: {} }, 200, '', APPLICATION_JSON, {}],


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

Fixes `Response.json(data, null)` so `null` is handled through `ResponseInit` conversion instead of being passed directly to response initialization.

## Rationale

`Response.json()` takes an optional `ResponseInit` dictionary. Web IDL dictionary conversion allows `null`, treating dictionary members as absent so defaults apply.

`Response.json()` was skipping `ResponseInit` conversion when `init` was `null`, which caused raw `null` to reach `initializeResponse()` and throw when reading `init.status`.

This change routes `null` through the existing `ResponseInit` converter, matching the behavior already used by the `Response` constructor.

## Changes

- Always convert `init` with `webidl.converters.ResponseInit()` in `Response.json()`.
- Add regression coverage for `Response.json(data, null)` in the existing `INIT_TESTS` table.

### Features

N/A

### Bug Fixes

Fixes `Response.json(data, null)` throwing `TypeError`.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
