### PR TITLE
feat(interceptors): add signal interceptor

### DIFF
--- a/docs/docs/api/Dispatcher.md
+++ b/docs/docs/api/Dispatcher.md
@@ -786,8 +786,8 @@ can make progress.
 ## Pre-built interceptors
 
 For the full reference of built-in interceptors (`dump`, `retry`, `redirect`,
-`decompress`, `responseError`, `dns`, `cache`, `deduplicate`) and their options,
-see [Interceptors](Interceptors.md).
+`decompress`, `responseError`, `dns`, `cache`, `deduplicate`, `signal`) and
+their options, see [Interceptors](Interceptors.md).
 
 [Fastify]: https://fastify.dev
 [GOAWAY frame]: https://webconcepts.info/concepts/http2-frame-type/0x7

--- a/docs/docs/api/Interceptors.md
+++ b/docs/docs/api/Interceptors.md
@@ -9,7 +9,7 @@ retries, response decompression, redirect following, DNS caching, and more.
 ```js
 import { Agent, interceptors } from 'undici'
 
-const { retry, redirect, decompress, dump, responseError, dns, cache, deduplicate } = interceptors
+const { retry, redirect, decompress, dump, responseError, dns, cache, deduplicate, signal } = interceptors
 
 const agent = new Agent().compose([
   retry({ maxRetries: 3 }),
@@ -324,6 +324,49 @@ const agent = new Agent().compose(
     excludeHeaderNames: ['x-request-id', 'x-trace-id'],
     maxBufferSize: 2 * 1024 * 1024
   })
+)
+```
+
+---
+
+## `interceptors.signal()`
+
+Aborts the request when the `signal` dispatch option is aborted. Accepts both
+[`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+and `EventEmitter`-style signals (any object emitting an `abort` event). The
+request is aborted with `signal.reason` when available, or a
+`RequestAbortedError` otherwise. If the signal is already aborted when the
+request is dispatched, the request fails immediately without reaching the
+server.
+
+The abort listener is removed as soon as the request completes, errors or is
+upgraded, so long-lived signals do not accumulate listeners across requests.
+
+This is mainly useful when calling `dispatch()` directly with a custom
+handler; the higher-level API methods (`request`, `stream`, `pipeline`, etc.)
+already handle the `signal` option themselves.
+
+**Parameters**
+
+* None.
+
+**Returns:** {Dispatcher.DispatcherComposeInterceptor}
+
+**Example**
+
+```js
+import { Client, interceptors } from 'undici'
+
+const client = new Client('https://example.com').compose(
+  interceptors.signal()
+)
+
+const ac = new AbortController()
+queueMicrotask(() => ac.abort())
+
+client.dispatch(
+  { method: 'GET', path: '/', signal: ac.signal },
+  myCustomHandler
 )
 ```
 

--- a/docs/docs/api/Interceptors.md
+++ b/docs/docs/api/Interceptors.md
@@ -339,8 +339,8 @@ request is aborted with `signal.reason` when available, or a
 request is dispatched, the request fails immediately without reaching the
 server.
 
-The abort listener is removed as soon as the request completes, errors or is
-upgraded, so long-lived signals do not accumulate listeners across requests.
+The abort listener is removed once the response has ended or errored, so
+long-lived signals do not accumulate listeners across requests.
 
 This is mainly useful when calling `dispatch()` directly with a custom
 handler; the higher-level API methods (`request`, `stream`, `pipeline`, etc.)

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ module.exports.interceptors = {
   dns: require('./lib/interceptor/dns'),
   cache: require('./lib/interceptor/cache'),
   decompress: require('./lib/interceptor/decompress'),
-  deduplicate: require('./lib/interceptor/deduplicate')
+  deduplicate: require('./lib/interceptor/deduplicate'),
+  signal: require('./lib/interceptor/signal')
 }
 
 module.exports.cacheStores = {

--- a/lib/interceptor/signal.js
+++ b/lib/interceptor/signal.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const { InvalidArgumentError, RequestAbortedError } = require('../core/errors')
+const { addAbortListener } = require('../core/util')
+const DecoratorHandler = require('../handler/decorator-handler')
+
+class SignalHandler extends DecoratorHandler {
+  /** @type {AbortSignal|import('node:events').EventEmitter} */
+  #signal
+  /** @type {import('../core/request').RequestController|null} */
+  #controller = null
+  /** @type {(() => void)|null} */
+  #removeAbortListener = null
+  /** @type {boolean} */
+  #aborted = false
+
+  constructor (signal, handler) {
+    super(handler)
+    this.#signal = signal
+  }
+
+  #abort () {
+    this.#aborted = true
+    this.#removeListener()
+    this.#controller.abort(this.#signal.reason ?? new RequestAbortedError())
+  }
+
+  #removeListener () {
+    if (this.#removeAbortListener !== null) {
+      this.#removeAbortListener()
+      this.#removeAbortListener = null
+    }
+  }
+
+  onRequestStart (controller, context) {
+    // A fresh controller is passed for every dispatch of the same request
+    // (e.g. when composed with the retry interceptor), so keep the reference
+    // up to date while registering the abort listener only once.
+    this.#controller = controller
+
+    if (this.#aborted || this.#signal.aborted) {
+      this.#abort()
+      return
+    }
+
+    if (this.#removeAbortListener === null) {
+      this.#removeAbortListener = addAbortListener(this.#signal, () => this.#abort())
+    }
+
+    super.onRequestStart(controller, context)
+  }
+
+  onRequestUpgrade (controller, statusCode, headers, socket) {
+    this.#removeListener()
+    super.onRequestUpgrade(controller, statusCode, headers, socket)
+  }
+
+  onResponseEnd (controller, trailers) {
+    this.#removeListener()
+    super.onResponseEnd(controller, trailers)
+  }
+
+  onResponseError (controller, err) {
+    this.#removeListener()
+    super.onResponseError(controller, err)
+  }
+}
+
+/**
+ * Interceptor that aborts the request when the `signal` dispatch option is
+ * aborted. Supports both `AbortSignal` and `EventEmitter`-style signals.
+ * The abort listener is removed once the request completes, errors or is
+ * upgraded.
+ *
+ * @returns {import('../../types/dispatcher').default.DispatcherComposeInterceptor}
+ */
+module.exports = () => {
+  return (dispatch) => {
+    return function signalInterceptor (opts, handler) {
+      const { signal } = opts
+
+      if (!signal) {
+        return dispatch(opts, handler)
+      }
+
+      if (typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
+        throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
+      }
+
+      return dispatch(opts, new SignalHandler(signal, handler))
+    }
+  }
+}

--- a/lib/interceptor/signal.js
+++ b/lib/interceptor/signal.js
@@ -50,11 +50,6 @@ class SignalHandler extends DecoratorHandler {
     super.onRequestStart(controller, context)
   }
 
-  onRequestUpgrade (controller, statusCode, headers, socket) {
-    this.#removeListener()
-    super.onRequestUpgrade(controller, statusCode, headers, socket)
-  }
-
   onResponseEnd (controller, trailers) {
     this.#removeListener()
     super.onResponseEnd(controller, trailers)
@@ -69,8 +64,7 @@ class SignalHandler extends DecoratorHandler {
 /**
  * Interceptor that aborts the request when the `signal` dispatch option is
  * aborted. Supports both `AbortSignal` and `EventEmitter`-style signals.
- * The abort listener is removed once the request completes, errors or is
- * upgraded.
+ * The abort listener is removed once the response has ended or errored.
  *
  * @returns {import('../../types/dispatcher').default.DispatcherComposeInterceptor}
  */

--- a/test/interceptors/signal.js
+++ b/test/interceptors/signal.js
@@ -1,0 +1,287 @@
+'use strict'
+
+const assert = require('node:assert')
+const { once, EventEmitter, getEventListeners } = require('node:events')
+const { createServer } = require('node:http')
+const { test, after } = require('node:test')
+const { interceptors, errors, Client } = require('../..')
+const { signal } = interceptors
+
+function startServer (handler) {
+  const server = createServer({ joinDuplicateHeaders: true }, handler)
+
+  server.listen(0)
+
+  return once(server, 'listening').then(() => server)
+}
+
+function createHandler (events) {
+  let resolve
+  const completed = new Promise((_resolve) => {
+    resolve = _resolve
+  })
+
+  return {
+    completed,
+    error: null,
+    onRequestStart (controller, context) {
+      events.push('onRequestStart')
+    },
+    onResponseStart (controller, statusCode, headers, statusMessage) {
+      events.push('onResponseStart')
+    },
+    onResponseData (controller, chunk) {
+      events.push('onResponseData')
+    },
+    onResponseEnd (controller, trailers) {
+      events.push('onResponseEnd')
+      resolve()
+    },
+    onResponseError (controller, err) {
+      events.push('onResponseError')
+      this.error = err
+      resolve()
+    }
+  }
+}
+
+test('aborts the request when the signal is already aborted', async () => {
+  const server = await startServer((req, res) => {
+    res.end('hello')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const reason = new Error('pre-aborted')
+  const ac = new AbortController()
+  ac.abort(reason)
+
+  const events = []
+  const handler = createHandler(events)
+
+  client.dispatch({ method: 'GET', path: '/', signal: ac.signal }, handler)
+  await handler.completed
+
+  assert.deepStrictEqual(events, ['onResponseError'])
+  assert.strictEqual(handler.error, reason)
+})
+
+test('aborts an in-flight request when the signal is aborted', async () => {
+  const server = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.write('partial')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.destroy()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const reason = new Error('custom abort reason')
+  const ac = new AbortController()
+
+  const events = []
+  const handler = createHandler(events)
+  handler.onResponseData = (controller, chunk) => {
+    events.push('onResponseData')
+    ac.abort(reason)
+  }
+
+  client.dispatch({ method: 'GET', path: '/', signal: ac.signal }, handler)
+  await handler.completed
+
+  assert.deepStrictEqual(events, [
+    'onRequestStart',
+    'onResponseStart',
+    'onResponseData',
+    'onResponseError'
+  ])
+  assert.strictEqual(handler.error, reason)
+  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0)
+})
+
+test('supports EventEmitter-style signals', async () => {
+  const server = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.write('partial')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.destroy()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const ee = new EventEmitter()
+
+  const events = []
+  const handler = createHandler(events)
+  handler.onResponseData = (controller, chunk) => {
+    events.push('onResponseData')
+    ee.emit('abort')
+  }
+
+  client.dispatch({ method: 'GET', path: '/', signal: ee }, handler)
+  await handler.completed
+
+  assert.ok(handler.error instanceof errors.RequestAbortedError)
+  assert.strictEqual(ee.listenerCount('abort'), 0)
+})
+
+test('removes the abort listener once the response completes', async () => {
+  const server = await startServer((req, res) => {
+    res.end('hello')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const ac = new AbortController()
+
+  const events = []
+  const handler = createHandler(events)
+
+  client.dispatch({ method: 'GET', path: '/', signal: ac.signal }, handler)
+  await handler.completed
+
+  assert.deepStrictEqual(events, [
+    'onRequestStart',
+    'onResponseStart',
+    'onResponseData',
+    'onResponseEnd'
+  ])
+  assert.strictEqual(handler.error, null)
+  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0)
+
+  // Aborting after completion must not affect the finished request.
+  ac.abort()
+})
+
+test('removes the abort listener when the request errors', async () => {
+  const server = await startServer((req, res) => {
+    res.destroy()
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const ac = new AbortController()
+
+  const events = []
+  const handler = createHandler(events)
+
+  client.dispatch({ method: 'GET', path: '/', signal: ac.signal }, handler)
+  await handler.completed
+
+  assert.ok(handler.error)
+  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0)
+})
+
+test('does not interfere when no signal is provided', async () => {
+  const server = await startServer((req, res) => {
+    res.end('hello')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const response = await client.request({ method: 'GET', path: '/' })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(await response.body.text(), 'hello')
+})
+
+test('throws when the signal is not an EventEmitter or EventTarget', async () => {
+  const server = await startServer((req, res) => {
+    res.end('hello')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  assert.throws(
+    () => client.dispatch(
+      { method: 'GET', path: '/', signal: 'not-a-signal' },
+      createHandler([])
+    ),
+    errors.InvalidArgumentError
+  )
+})
+
+test('works with client.request', async () => {
+  const server = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.write('partial')
+  })
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(signal())
+
+  after(async () => {
+    await client.destroy()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const reason = new Error('custom abort reason')
+  const ac = new AbortController()
+
+  const response = await client.request({ method: 'GET', path: '/', signal: ac.signal })
+  ac.abort(reason)
+
+  await assert.rejects(response.body.text(), reason)
+})

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -32,6 +32,7 @@ expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.re
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.retry())
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.decompress())
 expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.cache())
+expectAssignable<Dispatcher.DispatcherComposeInterceptor>(Undici.interceptors.signal())
 expectAssignable<CacheInterceptor.CacheStore>(new Undici.cacheStores.MemoryCacheStore())
 expectAssignable<CacheInterceptor.CacheStore>(new Undici.cacheStores.SqliteCacheStore())
 expectAssignable<CacheInterceptor.CacheStore>(new cacheStores.MemoryCacheStore())

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -77,4 +77,5 @@ declare namespace Interceptors {
   export function dns (opts?: DNSInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
   export function cache (opts?: CacheInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
   export function deduplicate (opts?: DeduplicateInterceptorOpts): Dispatcher.DispatcherComposeInterceptor
+  export function signal (): Dispatcher.DispatcherComposeInterceptor
 }


### PR DESCRIPTION
## This relates to...

Closes #3276

## Rationale

#3276 asks for `AbortSignal` handling to be available as an interceptor. Following the direction given in the issue thread, this adds a completely new `signal` interceptor shaped like `interceptors.responseError`: when the `signal` dispatch option is aborted, the request is aborted and the abort listener is cleaned up.

This is mainly useful when calling `dispatch()` directly with a custom handler, where today every caller has to wire up (and remember to remove) their own abort listener the way the API-layer handlers in `lib/api` do. The existing API-layer signal handling is intentionally left untouched.

## Changes

- Add `lib/interceptor/signal.js`, exported as `interceptors.signal`
- Supports both `AbortSignal` and `EventEmitter`-style signals (same contract as the `signal` option of the API methods, validated the same way)
- Aborts with `signal.reason` when available, `RequestAbortedError` otherwise
- A signal that is already aborted fails the dispatch before the request reaches the server, mirroring `RequestHandler`
- The abort listener is registered once per dispatched request and removed on `onResponseEnd`, `onResponseError` and `onRequestUpgrade`, so long-lived signals do not accumulate listeners
- The controller reference is refreshed on every `onRequestStart` so composing with `retry()` keeps aborting the active attempt
- Docs (`docs/docs/api/Interceptors.md`, `docs/docs/api/Dispatcher.md`), types (`types/interceptors.d.ts`) and type tests included

### Features

- New `interceptors.signal()` interceptor

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Testing

`test/interceptors/signal.js` exercises the interceptor through `client.dispatch()` with a bare handler rather than `client.request()`, since the API-layer handlers already implement their own signal handling and would mask what the interceptor does. Covered: pre-aborted signal (exact reason propagated, request never reaches the server, only `onResponseError` is delivered), mid-response abort, `EventEmitter`-style signals, listener removal after completion and after an error (asserted via `getEventListeners`/`listenerCount`), pass-through when no signal is provided, `InvalidArgumentError` for non-signal values, and compatibility with `client.request()`.

`npm run lint`, `npm run test:interceptors` and the TypeScript checks pass locally (the pre-existing zstd decompress test is skipped locally as Node 22.14 lacks `zlib.createZstdCompress`).

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
