### PR TITLE
docs: clarify top-level request option url fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,11 @@ For more information about their behavior, please reference the body mixin from 
 
 This section documents our most commonly used API methods. Additional APIs are documented in their own files within the [docs](./docs/) folder and are accessible via the navigation list on the left side of the docs site.
 
+For the top-level APIs below, the `url` argument supplies the request origin and
+path. Do not pass `origin` or `path` in the second `options` argument. The linked
+`Dispatcher` option types include those fields because dispatcher methods are
+lower-level APIs that do not receive a separate `url` argument.
+
 ### `undici.request([url, options]): Promise`
 
 Arguments:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -410,6 +410,11 @@ For more information about their behavior, please reference the body mixin from 
 
 This section documents our most commonly used API methods. Additional APIs are documented in their own files within the [docs](./docs/) folder and are accessible via the navigation list on the left side of the docs site.
 
+For the top-level APIs below, the `url` argument supplies the request origin and
+path. Do not pass `origin` or `path` in the second `options` argument. The linked
+`Dispatcher` option types include those fields because dispatcher methods are
+lower-level APIs that do not receive a separate `url` argument.
+
 ### `undici.request([url, options])`
 
 * `url` {string|URL|UrlObject}


### PR DESCRIPTION
## Summary

Refs #1011.

Clarifies the distinction between top-level Undici API options and lower-level dispatcher options. Top-level calls like `undici.request(url, options)` get `origin` and `path` from the separate `url` argument, so those fields should not be supplied in the second `options` argument even though the linked dispatcher option docs include them.

## Verification

- `git diff --check`
- `npm run lint`
- `npm run test:typescript`