### PR TITLE
test: deflake invalid websocket close status test

### DIFF
--- a/test/websocket/close-invalid-status-code.js
+++ b/test/websocket/close-invalid-status-code.js
@@ -5,32 +5,33 @@ const { once } = require('node:events')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
 
-test('Client fails the connection if receiving a masked frame', async (t) => {
-  t.plan(2)
-
+test('Client fails the connection if receiving an invalid close status code', async (t) => {
+  const invalidCloseFrame = Buffer.from([0x88, 0x02, 0x03, 0xee])
   const server = new WebSocketServer({ port: 0 })
 
-  server.on('connection', (ws) => {
-    const socket = ws._socket
-
-    // 1006 status code
-    socket.write(Buffer.from([0x88, 0x02, 0x03, 0xee]), () => ws.close())
-  })
-
-  const ws = new WebSocket(`ws://localhost:${server.address().port}`)
-
-  ws.addEventListener('close', (e) => {
-    t.assert.deepStrictEqual(e.code, 1006)
-  })
-
-  ws.addEventListener('error', () => {
-    t.assert.ok(true)
-  })
-
   t.after(() => {
+    for (const client of server.clients) {
+      client.terminate()
+    }
+
     server.close()
-    ws.close()
   })
 
-  await once(ws, 'close')
+  await once(server, 'listening')
+
+  server.on('connection', (serverWs) => {
+    // 1006 status code
+    serverWs._socket.end(invalidCloseFrame)
+  })
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}`)
+  t.after(() => ws.close())
+
+  const [[errorEvent], [closeEvent]] = await Promise.all([
+    once(ws, 'error'),
+    once(ws, 'close')
+  ])
+
+  t.assert.ok(errorEvent)
+  t.assert.strictEqual(closeEvent.code, 1006)
 })


### PR DESCRIPTION
## This relates to...

Fixes #5220

## Rationale

The invalid close status-code test injected a malformed frame and then asked the `ws` server-side WebSocket to close, which can race with the server parser handling the malformed payload. Make the test deterministic by sending one raw socket close operation and awaiting the expected client events explicitly.

## Changes

### Features

N/A

### Bug Fixes

- Wait for the WebSocket server to be listening before constructing the client.
- Send the invalid close frame via the server socket with `end()` instead of racing it with `ws.close()`.
- Await both the client `error` and `close` events before asserting.
- Clean up server-side clients deterministically.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Tested with:

- `npx borp -p "test/websocket/close-invalid-status-code.js"`
- `npm run lint -- test/websocket/close-invalid-status-code.js`
- `npm run test:websocket`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
