### PR TITLE
fix(redirect): remove body headers after POST-to-GET

### DIFF
--- a/lib/handler/redirect-handler.js
+++ b/lib/handler/redirect-handler.js
@@ -52,6 +52,8 @@ class RedirectHandler {
       throw new Error('max redirects')
     }
 
+    let removeContentHeaders = statusCode === 303
+
     // https://tools.ietf.org/html/rfc7231#section-6.4.2
     // https://fetch.spec.whatwg.org/#http-redirect-fetch
     // In case of HTTP 301 or 302 with POST, change the method to GET
@@ -62,6 +64,7 @@ class RedirectHandler {
         util.destroy(this.opts.body.on('error', noop))
       }
       this.opts.body = null
+      removeContentHeaders = true
     }
 
     // https://tools.ietf.org/html/rfc7231#section-6.4.4
@@ -101,9 +104,9 @@ class RedirectHandler {
     }
 
     // Remove headers referring to the original URL.
-    // By default it is Host only, unless it's a 303 (see below), which removes also all Content-* headers.
+    // By default it is Host only. A 303 or a 301/302 POST-to-GET redirect also removes all Content-* headers.
     // https://tools.ietf.org/html/rfc7231#section-6.4
-    this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin, this.stripHeadersOnRedirect, this.stripHeadersOnCrossOriginRedirect)
+    this.opts.headers = cleanRequestHeaders(this.opts.headers, removeContentHeaders, this.opts.origin !== origin, this.stripHeadersOnRedirect, this.stripHeadersOnCrossOriginRedirect)
     this.opts.path = path
     this.opts.origin = origin
     this.opts.query = null

--- a/test/redirect-request.js
+++ b/test/redirect-request.js
@@ -145,6 +145,28 @@ for (const factory of [
     t.strictEqual(body, `PUT /5 :: host@${server} connection@keep-alive content-length@7 :: REQUEST`)
   })
 
+  test('should remove request body headers when HTTP 302 changes POST to GET', async t => {
+    t = tspl(t, { plan: 3 })
+    const server = await startRedirectingServer()
+
+    const { statusCode, headers, body: bodyStream } = await request(t, server, undefined, `http://${server}/302`, {
+      method: 'POST',
+      body: 'REQUEST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Language': 'en',
+        'X-Test': 'ok'
+      },
+      maxRedirections: 10
+    })
+
+    const body = await bodyStream.text()
+
+    t.strictEqual(statusCode, 200)
+    t.ok(!headers.location)
+    t.strictEqual(body, `GET /5 :: host@${server} connection@keep-alive x-test@ok`)
+  })
+
   test('should follow redirection after a HTTP 303 changing method to GET', async t => {
     t = tspl(t, { plan: 3 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

`RedirectHandler` converts `POST` requests to `GET` for `301` and `302` redirects and removes the request body, but it currently keeps body-related `Content-*` headers on the redirected request.

For example, a redirected bodyless `GET` can still include `Content-Type: application/json` and `Content-Language: en`.

## Rationale

Headers describing the original request body should not be forwarded after the redirect changes the method to `GET` and removes the body.

This change applies the existing content-header cleanup used for `303` redirects when a `301` or `302` redirect converts `POST` to `GET`.

## Changes

### Features

N/A

### Bug Fixes

- Remove `Content-*` headers when a `301` or `302` redirect changes `POST` to `GET`.
- Preserve unrelated request headers.
- Add a regression test covering the behavior through `Client`, `Pool`, and `Agent`.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin