### PR TITLE
fix(h2): destroy aborted stream synchronously instead of via setImmediate

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -933,14 +933,14 @@ function writeH2 (client, request) {
       // close() alone leaves cleanup waiting on the 'close' event; on a busy,
       // long-lived multiplexed session that event can fail to fire, leaving the
       // native Http2Stream (and the whole request graph it pins) alive for the
-      // session's life. Destroy the stream to release the handle
-      // deterministically, but defer it by a setImmediate so the RST_STREAM
-      // frame queued by close() gets a chance to be written first.
-      setImmediate(() => {
-        if (!stream.destroyed) {
-          util.destroy(stream)
-        }
-      })
+      // session's life. Destroy the stream synchronously to release the handle
+      // deterministically. Deferring the destroy (e.g. via setImmediate) leaks
+      // the same way when the event loop is stalled and the callback never runs
+      // under abort churn (#5558); close() has already queued the RST_STREAM
+      // frame on the native session, so a synchronous destroy still sends it.
+      if (!stream.destroyed) {
+        util.destroy(stream)
+      }
 
       // We move the running index to the next request
       client[kOnError](err)

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -837,11 +837,10 @@ test('Should destroy the h2 stream on abort', async t => {
   abortRequest = await waitFor(() => abortRequest)
   abortRequest(abortReason)
 
-  // The abort path must destroy the stream, not just close() it: relying on the
-  // async 'close' event leaks the native Http2Stream when that event never
-  // fires on a busy, long-lived multiplexed session. The destroy is deferred by
-  // a setImmediate so the RST_STREAM frame from close() can be written first.
-  await waitFor(() => stream.destroyed || null)
+  // The abort path must destroy the stream synchronously, not just close() it
+  // or defer the destroy: relying on the async 'close' event (or a setImmediate
+  // that never runs while the event loop is stalled) leaks the native
+  // Http2Stream on a busy, long-lived multiplexed session (#5558).
   t.strictEqual(stream.destroyed, true)
   t.strictEqual(await responseError, abortReason)
 


### PR DESCRIPTION
Follow-up to #5462.

#5462 fixed a leak where an aborted HTTP/2 request left teardown to the stream's async `'close'` event, which can fail to fire on a busy, long-lived multiplexed session — pinning the native `Http2Stream` and the request graph it references. It did so by destroying the stream after `close()`, but **deferred the destroy behind a `setImmediate`** so the `RST_STREAM` frame queued by `close()` is written first.

That deferral reintroduces the same leak under a different trigger. `setImmediate` callbacks only run once the loop reaches the check phase, so while the event loop is stalled by a long synchronous task the deferred destroy never runs. Every stream aborted during the stall stays alive (plus the request graph each one pins), and abort churn — timeouts, cancellations — tends to spike precisely when the loop is busy. The result is an unbounded, positive-feedback leak until the process OOMs.

This was not hypothetical for us: a high-throughput fetch service (~100K req/s across the fleet) that periodically stalls its loop under bursty work saw memory roughly triple and the fleet enter a sustained `OOMKilled` crashloop immediately after taking stock 8.7.0 (which carries the `setImmediate` defer) in place of a local patch that destroyed synchronously. Details in #5558.

## Change

- Destroy the stream **synchronously** after `close()` in the `writeH2` abort path. `close()` has already queued the `RST_STREAM` frame on the native session, so it is still sent; teardown no longer depends on the event loop advancing.
- Tighten the `'Should destroy the h2 stream on abort'` regression test to assert the stream is destroyed **synchronously** on abort (drops the `waitFor` poll), so a future re-deferral fails in CI instead of in production.

## Testing

`test/http2-dispatcher.js` (all 18) plus `http2-abort`, `http2-goaway`, `http2-destroy-after-failed-stream`, `http2-response-after-completion`, `http2-timeout`, and `http2-stream` pass locally. `eslint` clean.

If there is a concrete `RST_STREAM`-ordering scenario the `setImmediate` was guarding against that isn't covered by the current tests, I'm happy to add a case for it — but in practice `close(code)` submits the frame to the native handle synchronously, so a subsequent `destroy()` still delivers it.
