### PR TITLE
fix(fetch): parse multipart body up to the full boundary delimiter

### DIFF
--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -76,10 +76,6 @@ function multipartFormDataParser (input, mimeType) {
 
   const boundary = Buffer.from(`--${boundaryString}`, 'utf8')
 
-  // The delimiter that terminates a part's body is the CRLF that precedes the
-  // next boundary delimiter line, i.e. "\r\n--boundary". Matching the full
-  // delimiter (not a bare boundary token) is required so boundary-like bytes
-  // inside a body are not mistaken for a delimiter.
   const crlfDashBoundary = Buffer.from(`\r\n--${boundaryString}`, 'utf8')
 
   // 3. Let entry list be an empty entry list.

--- a/lib/web/fetch/formdata-parser.js
+++ b/lib/web/fetch/formdata-parser.js
@@ -76,6 +76,12 @@ function multipartFormDataParser (input, mimeType) {
 
   const boundary = Buffer.from(`--${boundaryString}`, 'utf8')
 
+  // The delimiter that terminates a part's body is the CRLF that precedes the
+  // next boundary delimiter line, i.e. "\r\n--boundary". Matching the full
+  // delimiter (not a bare boundary token) is required so boundary-like bytes
+  // inside a body are not mistaken for a delimiter.
+  const crlfDashBoundary = Buffer.from(`\r\n--${boundaryString}`, 'utf8')
+
   // 3. Let entry list be an empty entry list.
   const entryList = []
 
@@ -140,15 +146,14 @@ function multipartFormDataParser (input, mimeType) {
     let body
 
     // 5.8. Body loop: While position is not past the end of input:
-    // TODO: the steps here are completely wrong
     {
-      const boundaryIndex = input.indexOf(boundary.subarray(2), position.position)
+      const boundaryIndex = input.indexOf(crlfDashBoundary, position.position)
 
       if (boundaryIndex === -1) {
         throw parsingError('expected boundary after body')
       }
 
-      body = input.subarray(position.position, boundaryIndex - 4)
+      body = input.subarray(position.position, boundaryIndex)
 
       position.position += body.length
 

--- a/test/busboy/formdata-boundary-token.js
+++ b/test/busboy/formdata-boundary-token.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { test } = require('node:test')
+const { Request } = require('../..')
+
+test('multipart formdata body containing the boundary token', async (t) => {
+  t.plan(2)
+
+  const boundary = '----formdata-undici-0.6204674738279623'
+  // Both values embed the bare boundary token. It only marks a real delimiter
+  // when it forms a "\r\n--boundary" line, so these bytes must stay in the body.
+  const field = `a${boundary}b`
+  const file = `--${boundary}--`
+
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`
+    },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="field"\r\n' +
+      '\r\n' +
+      `${field}\r\n` +
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="file"; filename="f.txt"\r\n' +
+      'Content-Type: text/plain\r\n' +
+      '\r\n' +
+      `${file}\r\n` +
+      `--${boundary}--`
+  })
+
+  const form = await request.formData()
+  t.assert.strictEqual(form.get('field'), field)
+  t.assert.strictEqual(await form.get('file').text(), file)
+})

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -268,38 +268,6 @@ test('multipart fromdata non-ascii filed names', async (t) => {
   t.assert.strictEqual(form.get('fiŝo'), 'value1')
 })
 
-test('multipart formdata body containing the boundary token', async (t) => {
-  t.plan(2)
-
-  const boundary = '----formdata-undici-0.6204674738279623'
-  // Both values embed the bare boundary token. It only marks a real delimiter
-  // when it forms a "\r\n--boundary" line, so these bytes must stay in the body.
-  const field = `a${boundary}b`
-  const file = `--${boundary}--`
-
-  const request = new Request('http://localhost', {
-    method: 'POST',
-    headers: {
-      'Content-Type': `multipart/form-data; boundary=${boundary}`
-    },
-    body:
-      `--${boundary}\r\n` +
-      'Content-Disposition: form-data; name="field"\r\n' +
-      '\r\n' +
-      `${field}\r\n` +
-      `--${boundary}\r\n` +
-      'Content-Disposition: form-data; name="file"; filename="f.txt"\r\n' +
-      'Content-Type: text/plain\r\n' +
-      '\r\n' +
-      `${file}\r\n` +
-      `--${boundary}--`
-  })
-
-  const form = await request.formData()
-  t.assert.strictEqual(form.get('field'), field)
-  t.assert.strictEqual(await form.get('file').text(), file)
-})
-
 test('busboy emit error', async (t) => {
   t.plan(1)
   const formData = new FormData()

--- a/test/fetch/client-fetch.js
+++ b/test/fetch/client-fetch.js
@@ -268,6 +268,38 @@ test('multipart fromdata non-ascii filed names', async (t) => {
   t.assert.strictEqual(form.get('fiŝo'), 'value1')
 })
 
+test('multipart formdata body containing the boundary token', async (t) => {
+  t.plan(2)
+
+  const boundary = '----formdata-undici-0.6204674738279623'
+  // Both values embed the bare boundary token. It only marks a real delimiter
+  // when it forms a "\r\n--boundary" line, so these bytes must stay in the body.
+  const field = `a${boundary}b`
+  const file = `--${boundary}--`
+
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`
+    },
+    body:
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="field"\r\n' +
+      '\r\n' +
+      `${field}\r\n` +
+      `--${boundary}\r\n` +
+      'Content-Disposition: form-data; name="file"; filename="f.txt"\r\n' +
+      'Content-Type: text/plain\r\n' +
+      '\r\n' +
+      `${file}\r\n` +
+      `--${boundary}--`
+  })
+
+  const form = await request.formData()
+  t.assert.strictEqual(form.get('field'), field)
+  t.assert.strictEqual(await form.get('file').text(), file)
+})
+
 test('busboy emit error', async (t) => {
   t.plan(1)
   const formData = new FormData()


### PR DESCRIPTION
## This relates to...

Multipart parsing in `response.formData()` / `request.formData()`.

## Rationale

The body loop in `multipartFormDataParser` looked for a bare boundary token (`boundary.subarray(2)`) rather than the `\r\n--boundary` delimiter line, then blindly subtracted 4 from the match index. A part whose body legitimately contains the boundary token gets truncated at the wrong offset, and in most cases the whole body is rejected with `expected CRLF` even though it is well framed. This block carried a `// TODO: the steps here are completely wrong` note. The fix matches the full delimiter so boundary-like bytes inside a body are no longer mistaken for a delimiter, which also removes an ambiguity where such bytes could be read as an extra part.

## Changes

Search for `\r\n--boundary` when terminating a part body and slice up to that index, instead of finding the bare boundary token and offsetting by 4.

### Features

N/A

### Bug Fixes

- multipart body loop now terminates a part at the full boundary delimiter, so bodies containing the boundary token parse correctly instead of being truncated or rejected.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin