### PR TITLE
fix(decompress): skip HEAD responses

### DIFF
--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -276,6 +276,10 @@ function createDecompressInterceptor (options = {}) {
 
   return (dispatch) => {
     return (opts, handler) => {
+      if (opts.method === 'HEAD') {
+        return dispatch(opts, handler)
+      }
+
       const decompressHandler = new DecompressHandler(handler, options)
       return dispatch(opts, decompressHandler)
     }

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -3,10 +3,10 @@
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { createGzip, createDeflate, createBrotliCompress, createZstdCompress } = require('node:zlib')
+const { createGzip, createDeflate, createBrotliCompress, createZstdCompress, gzipSync } = require('node:zlib')
 const { tspl } = require('@matteo.collina/tspl')
 
-const { Client, getGlobalDispatcher, setGlobalDispatcher, request } = require('../..')
+const { Client, getGlobalDispatcher, setGlobalDispatcher, request, interceptors } = require('../..')
 const createDecompressInterceptor = require('../../lib/interceptor/decompress')
 
 test('should decompress gzip response', async t => {
@@ -47,6 +47,46 @@ test('should decompress gzip response', async t => {
   t.equal(response.statusCode, 200)
   t.equal(response.headers['content-encoding'], undefined)
   t.equal(body, data)
+
+  await t.completed
+})
+
+test('should preserve representation headers and empty body for HEAD responses', async t => {
+  const compressedRepresentation = gzipSync('HEAD response representation')
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Content-Encoding': 'gzip',
+      'Content-Length': compressedRepresentation.length
+    })
+    res.end()
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(interceptors.decompress())
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  t = tspl(t, { plan: 4 })
+
+  const response = await client.request({
+    method: 'HEAD',
+    path: '/'
+  })
+  const body = await response.body.text()
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-encoding'], 'gzip')
+  t.equal(response.headers['content-length'], `${compressedRepresentation.length}`)
+  t.equal(body, '')
 
   await t.completed
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->
## This relates to...

`interceptors.decompress()` currently attempts to initialize a decoder for `HEAD` responses when the server includes a supported `Content-Encoding`.

Because a valid `HEAD` response contains no response body, the decoder receives no compressed data and `response.body.text()` rejects with:

```text
Z_BUF_ERROR: unexpected end of file
```

The interceptor also removes `Content-Encoding` and `Content-Length`, even though those headers describe the corresponding `GET` representation and are valid metadata on a `HEAD` response.

## Rationale

HTTP `HEAD` responses must not include response content, but their representation headers describe the response that would have been returned for a corresponding `GET`.

Undici’s Fetch implementation already skips response decoding for `HEAD`. The decompression interceptor should do the same rather than creating an empty decoder and removing representation metadata.

## Changes

### Features

N/A

### Bug Fixes

- Bypass the decompression interceptor for `HEAD` requests.
- Preserve `Content-Encoding` and `Content-Length` on encoded `HEAD` responses.
- Ensure the response body resolves to an empty string instead of rejecting with `Z_BUF_ERROR`.
- Add a public API regression test using `Client.compose(interceptors.decompress())`.

### Breaking Changes and Deprecations

None.

## Testing

```bash
node --test test/interceptors/decompress.js
npm run test:interceptors
npm run lint
```


## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
