### PR TITLE
fix(types): export MockAgent pending interceptor type

### DIFF
--- a/test/types/mock-agent.test-d.ts
+++ b/test/types/mock-agent.test-d.ts
@@ -5,8 +5,6 @@ import ProxyAgent from '../../types/proxy-agent'
 import EnvHttpProxyAgent from '../../types/env-http-proxy-agent'
 import RetryAgent from '../../types/retry-agent'
 
-import MockDispatch = MockInterceptor.MockDispatch
-
 expectAssignable<MockAgent>(new MockAgent())
 expectAssignable<MockAgent>(new MockAgent({}))
 
@@ -67,15 +65,11 @@ expectAssignable<MockAgent>(new MockAgent({}))
 }
 
 {
-  interface PendingInterceptor extends MockDispatch {
-    origin: string;
-  }
-
   const agent = new MockAgent({ agent: new Agent() })
-  expectType<() => PendingInterceptor[]>(agent.pendingInterceptors)
+  expectType<() => MockAgent.PendingInterceptor[]>(agent.pendingInterceptors)
   expectType<(options?: {
     pendingInterceptorsFormatter?: {
-      format(pendingInterceptors: readonly PendingInterceptor[]): string;
+      format(pendingInterceptors: readonly MockAgent.PendingInterceptor[]): string;
     }
   }) => void>(agent.assertNoPendingInterceptors)
 }

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -6,10 +6,6 @@ import { MockCallHistory } from './mock-call-history'
 
 export default MockAgent
 
-interface PendingInterceptor extends MockDispatch {
-  origin: string;
-}
-
 /** A mocked Agent class that implements the Agent API. It allows one to intercept HTTP requests made through undici and return mocked responses instead. */
 declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.Options> extends Dispatcher {
   constructor (options?: TMockAgentOptions)
@@ -40,17 +36,21 @@ declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.
   enableCallHistory (): this
   /** Disable call history. Any subsequence calls will then not be registered. */
   disableCallHistory (): this
-  pendingInterceptors (): PendingInterceptor[]
+  pendingInterceptors (): MockAgent.PendingInterceptor[]
   assertNoPendingInterceptors (options?: {
-    pendingInterceptorsFormatter?: PendingInterceptorsFormatter;
+    pendingInterceptorsFormatter?: MockAgent.PendingInterceptorsFormatter;
   }): void
 }
 
-interface PendingInterceptorsFormatter {
-  format(pendingInterceptors: readonly PendingInterceptor[]): string;
-}
-
 declare namespace MockAgent {
+  export interface PendingInterceptor extends MockDispatch {
+    origin: string;
+  }
+
+  export interface PendingInterceptorsFormatter {
+    format(pendingInterceptors: readonly PendingInterceptor[]): string;
+  }
+
   /** MockAgent options. */
   export interface Options extends Agent.Options {
     /** A custom agent to be encapsulated by the MockAgent. */


### PR DESCRIPTION
## Summary
- expose `PendingInterceptor` through the `MockAgent` namespace
- make `pendingInterceptors()` and its formatter reference the public namespaced types
- verify the public annotation in the TypeScript declaration tests

## Why
`MockAgent#pendingInterceptors()` returned a declaration-private interface, so consumers could inspect the values but could not name the return element type in their own TypeScript APIs. The existing mock-agent type test had to duplicate that interface locally.

## Validation
- `npx tsd`
- `npx tsc test/imports/undici-import.ts --typeRoots ./types --noEmit`
- `npx tsc <all types/*.d.ts files> --noEmit --typeRoots ./types`
- `npm run lint -- --no-cache`

Fixes #5563