### PR TITLE
fix(sri): split integrity metadata on ascii whitespace

### DIFF
--- a/lib/web/subresource-integrity/subresource-integrity.js
+++ b/lib/web/subresource-integrity/subresource-integrity.js
@@ -187,6 +187,8 @@ function getStrongestMetadata (metadataList) {
   return result
 }
 
+const ASCII_WHITESPACE_SPLIT_REGEX = /[\u0009\u000A\u000C\u000D\u0020]+/ // eslint-disable-line no-control-regex
+
 /**
  * @param {string} metadata
  * @returns {MetadataList}
@@ -199,7 +201,7 @@ function parseMetadata (metadata) {
   const result = []
 
   // 2. For each item returned by splitting metadata on spaces:
-  for (const item of metadata.split(' ')) {
+  for (const item of metadata.split(ASCII_WHITESPACE_SPLIT_REGEX)) {
     // 1. Let expression-and-options be the result of splitting item on U+003F (?).
     const expressionAndOptions = item.split('?', 1)
 

--- a/test/subresource-integrity/parse-metadata.js
+++ b/test/subresource-integrity/parse-metadata.js
@@ -46,6 +46,17 @@ describe('parseMetadata', () => {
     ])
   })
 
+  test('should split on ASCII whitespace, not only on spaces', { skip }, (t) => {
+    const validMetadata = `\nsha256-${hash256}\tsha384-${hash384}\r\nsha512-${hash512}\n`
+    const result = parseMetadata(validMetadata)
+
+    t.assert.deepEqual(result, [
+      { alg: 'sha256', val: hash256 },
+      { alg: 'sha384', val: hash384 },
+      { alg: 'sha512', val: hash512 }
+    ])
+  })
+
   test('should not set hash as undefined when invalid base64 chars are provided', { skip }, (t) => {
     const invalidHash384 = 'zifp5hE1Xl5LQQqQz[]Bq/iaq9Wb6jVb//T7EfTmbXD2aEP5c2ZdJr9YTDfcTE1ZH+'
 


### PR DESCRIPTION
## This relates to...

Subresource integrity checking in `fetch()`.

## Rationale

`parseMetadata` splits the integrity string on U+0020 only, but [parse metadata](https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata) step 2 splits on ASCII whitespace (tab, LF, FF, CR, space). An integrity value carrying any of the other four separators, such as `"\nsha256-<hash>"` or hashes separated by a tab, yields no parsed items, and `bytesMatch` returns `true` for an empty metadata list per step 2 of [does response match metadataList](https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist). The check then passes for any response bytes rather than enforcing the hash, so integrity fails open exactly where the spec says it should fail closed. Multi-line integrity values are easy to end up with when hashes are pasted from an HTML `integrity` attribute or built from a template.

Splitting on the whitespace set the spec names keeps the fix in the parser, where the metadata list is produced, so `bytesMatch` continues to treat "empty list" as "nothing to check" as specified.

## Changes

Split the metadata string on ASCII whitespace instead of U+0020 in `parseMetadata`.

### Features

N/A

### Bug Fixes

- integrity metadata separated by tab, LF, FF or CR is parsed and enforced instead of being silently dropped, which previously let the check pass for any bytes.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
