### PR TITLE
fix(h2): error unfinished response on stream close

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -680,17 +680,34 @@ function completeRequestStream () {
     return
   }
 
-  // Release the stream first so request references are cleared,
-  // then complete the response with trailers if available.
-  releaseRequestStream(this)
+  this.off('close', completeRequestStream)
 
-  if (state.pendingEnd && !state.request.aborted && !state.request.completed) {
-    state.request.onResponseEnd(state.trailers || {})
-    finalizeRequest(state)
+  // A GOAWAY handler can detach a request before closing its old stream so
+  // that the request can be retried on a new session.
+  const requestOwnsStream = state.request[kRequestStream] === this
+
+  // Release the stream first so request references are cleared. Clear the
+  // state before notifying the handler so any reentrant terminal event no-ops.
+  releaseRequestStream(this)
+  this[kRequestStreamState] = null
+  closeStreamSession(this)
+
+  if (!requestOwnsStream || state.request.aborted || state.request.completed) {
+    return
   }
 
-  closeStreamSession(this)
-  this[kRequestStreamState] = null
+  if (state.pendingEnd) {
+    state.request.onResponseEnd(state.trailers || {})
+  } else {
+    // A reset stream can close without emitting 'error'. Ensure the response
+    // body still receives a terminal event instead of retaining its request.
+    const err = new InformationalError('HTTP/2: stream closed before end')
+    util.errorRequest(state.client, state.request, err)
+    state.client[kOnError](err)
+    util.destroy(state.body, err)
+  }
+
+  finalizeRequest(state)
 }
 
 // https://www.rfc-editor.org/rfc/rfc7230#section-3.3.2
@@ -1179,11 +1196,9 @@ function releaseRequestStream (stream) {
     detachRequestFromStream(request)
   }
 
-  // A closed or destroyed stream cannot emit further events; leaving the
-  // listeners in place saves the removal scans (they are collected with
-  // the stream). All handlers bail out when the stream state is gone.
+  removeRequestStreamListeners(stream)
+
   if (!stream.destroyed && !stream.closed) {
-    removeRequestStreamListeners(stream)
     stream.once('error', noop)
   }
 }

--- a/test/http2-late-data.js
+++ b/test/http2-late-data.js
@@ -327,6 +327,103 @@ test('Should complete only once when both end and a late close fire', async (t) 
   await t.completed
 })
 
+test('Should error an unfinished response when the stream closes', async (t) => {
+  t = tspl(t, { plan: 17 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  const stream = new FakeStream()
+  const session = new FakeSession(stream)
+
+  http2.connect = function connectStub () {
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  let resumeCalls = 0
+  let responseEndCalls = 0
+  const responseErrors = []
+  const clientErrors = []
+
+  const client = {
+    [kUrl]: new URL('https://localhost'),
+    [kSocket]: null,
+    [kMaxConcurrentStreams]: 100,
+    [kHTTP2InitialWindowSize]: null,
+    [kHTTP2ConnectionWindowSize]: null,
+    [kBodyTimeout]: 30_000,
+    [kStrictContentLength]: true,
+    [kQueue]: [],
+    [kRunningIdx]: 0,
+    [kPendingIdx]: 0,
+    [kRunning]: 1,
+    [kPingInterval]: 0,
+    [kOnError] (err) {
+      clientErrors.push(err)
+    },
+    [kResume] () {
+      resumeCalls++
+    },
+    emit () {},
+    destroyed: false
+  }
+
+  const context = connectH2(client, new FakeSocket())
+
+  const request = new Request('https://localhost', {
+    path: '/',
+    method: 'GET',
+    headers: {}
+  }, {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd () {
+      responseEndCalls++
+    },
+    onResponseError (_controller, err) {
+      responseErrors.push(err)
+    }
+  })
+
+  client[kQueue].push(request)
+
+  t.ok(context.write(request))
+
+  stream.emit('response', { ':status': 200 })
+  stream.emit('data', Buffer.from('partial body'))
+  const resumeCallsBeforeClose = resumeCalls
+  stream.closed = true
+  stream.emit('close')
+
+  t.strictEqual(responseErrors.length, 1)
+  t.strictEqual(responseErrors[0]?.code, 'UND_ERR_INFO')
+  t.strictEqual(responseErrors[0]?.message, 'HTTP/2: stream closed before end')
+  t.strictEqual(responseEndCalls, 0)
+  t.strictEqual(request.aborted, true)
+  t.strictEqual(clientErrors[0], responseErrors[0])
+  t.strictEqual(stream.listenerCount('close'), 0)
+  t.strictEqual(stream.listenerCount('end'), 0)
+  t.strictEqual(stream.listenerCount('error'), 0)
+  t.strictEqual(stream.listenerCount('aborted'), 0)
+  t.strictEqual(stream.listenerCount('timeout'), 0)
+  t.strictEqual(stream.listenerCount('trailers'), 0)
+  t.strictEqual(stream.listenerCount('data'), 0)
+
+  stream.emit('end')
+  stream.emit('close')
+
+  t.strictEqual(responseErrors.length, 1)
+  t.strictEqual(responseEndCalls, 0)
+  t.strictEqual(resumeCalls, resumeCallsBeforeClose + 1)
+
+  await t.completed
+})
+
 test('Should remove request-owned http2 stream listeners after completion', async (t) => {
   t = tspl(t, { plan: 7 })
 


### PR DESCRIPTION
## This relates to...

Fixes #5566.

## Rationale

An HTTP/2 stream can close without first emitting a clean `end` or a useful `error`. The request-stream cleanup path treated that close as cleanup-only when `pendingEnd` was false, leaving the response handler without a terminal event. For Fetch, the response body remained open, so end-of-body cleanup and abort-listener removal never ran and the request graph stayed retained.

## Changes

### Features

N/A.

### Bug Fixes

- Error an unfinished HTTP/2 response when its stream closes before a clean `end`.
- Clear stream state and remove request-owned listeners before notifying handlers, making later terminal events no-ops.
- Preserve GOAWAY retries by skipping request finalization when the old stream was already detached.
- Add a regression test covering terminal error delivery, listener cleanup, and exactly-once finalization.

### Breaking Changes and Deprecations

N/A.

## Testing

- `npm run test:h2:core` — 90 passed
- `npm run test:h2:fetch` — 11 passed
- `npm run lint`
- `npm run test:typescript`

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
