### PR TITLE
fix: accept a negative Set-Cookie Max-Age attribute

### DIFF
--- a/lib/web/cookies/parse.js
+++ b/lib/web/cookies/parse.js
@@ -196,7 +196,7 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
 
     // 2. If the remainder of attribute-value contains a non-DIGIT
     //    character, ignore the cookie-av.
-    if (!/^\d+$/.test(attributeValue)) {
+    if (!/^-?\d+$/.test(attributeValue)) {
       return parseUnparsedAttributes(unparsedAttributes, cookieAttributeList)
     }
 

--- a/lib/web/cookies/parse.js
+++ b/lib/web/cookies/parse.js
@@ -186,8 +186,8 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
     // If the attribute-name case-insensitively matches the string "Max-
     // Age", the user agent MUST process the cookie-av as follows.
 
-    // 1. If the first character of the attribute-value is neither a DIGIT,
-    //    nor a "-" character followed by a DIGIT, ignore the cookie-av.
+    // 1. If the first character of the attribute-value is not a DIGIT or a
+    //    "-" character, ignore the cookie-av.
     const charCode = attributeValue.charCodeAt(0)
     const startsWithDigit = charCode >= 48 && charCode <= 57
     const startsWithSignedDigit = attributeValue[0] === '-' && attributeValue.length > 1

--- a/lib/web/cookies/parse.js
+++ b/lib/web/cookies/parse.js
@@ -186,17 +186,19 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
     // If the attribute-name case-insensitively matches the string "Max-
     // Age", the user agent MUST process the cookie-av as follows.
 
-    // 1. If the first character of the attribute-value is not a DIGIT or a
-    //    "-" character, ignore the cookie-av.
+    // 1. If the first character of the attribute-value is neither a DIGIT,
+    //    nor a "-" character followed by a DIGIT, ignore the cookie-av.
     const charCode = attributeValue.charCodeAt(0)
+    const startsWithDigit = charCode >= 48 && charCode <= 57
+    const startsWithSignedDigit = attributeValue[0] === '-' && attributeValue.length > 1
 
-    if ((charCode < 48 || charCode > 57) && attributeValue[0] !== '-') {
+    if (!startsWithDigit && !startsWithSignedDigit) {
       return parseUnparsedAttributes(unparsedAttributes, cookieAttributeList)
     }
 
     // 2. If the remainder of attribute-value contains a non-DIGIT
     //    character, ignore the cookie-av.
-    if (!/^-?\d+$/.test(attributeValue)) {
+    if (/[^\d]/.test(attributeValue.slice(1))) {
       return parseUnparsedAttributes(unparsedAttributes, cookieAttributeList)
     }
 

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -449,8 +449,21 @@ test('Set-Cookie parser', () => {
     name: 'Space',
     value: 'Cat',
     secure: true,
-    httpOnly: true
+    httpOnly: true,
+    maxAge: -1
   }])
+
+  for (const maxAge of ['-', '--1', '-1a', '+1', '']) {
+    headers = new Headers({
+      'set-cookie': `Space=Cat; Secure; HttpOnly; Max-Age=${maxAge}`
+    })
+    assert.deepEqual(getSetCookies(headers), [{
+      name: 'Space',
+      value: 'Cat',
+      secure: true,
+      httpOnly: true
+    }])
+  }
 
   headers = new Headers({
     'set-cookie': 'Space=Cat; Secure; HttpOnly; Max-Age=2; Domain=deno.land'


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

`parseUnparsedAttributes` in `lib/web/cookies/parse.js` validates the `Max-Age` attribute-value with `/^\d+$/`, applied to the whole value rather than to the remainder after the sign. Any negative `Max-Age` therefore fails the check and the attribute is dropped from the parsed cookie:

```js
getSetCookies(new Headers({ 'set-cookie': 'id=a; Max-Age=-1' }))
// [{ name: 'id', value: 'a' }]
// should be: [{ name: 'id', value: 'a', maxAge: -1 }]
```

RFC 6265bis section 5.6.2 is explicit that a leading `-` is allowed:

> If the first character of the attribute-value is neither a DIGIT, nor a "-" character followed by a DIGIT, ignore the cookie-av.
>
> If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
>
> If delta-seconds is less than or equal to zero (0), let expiry-time be the earliest representable date and time.

The step-1 check at line 193 already accepts `-` as a first character, and the last step above only has meaning if negative values reach it, so the intent in the surrounding code is the spec behaviour. `Max-Age=-1` is the usual way a server expires a cookie, and today that signal is silently lost by `getSetCookies()`.

The generation side is deliberately left alone: `validateCookieMaxAge` still rejects negatives, which matches the `max-age-av = "Max-Age=" non-zero-digit *DIGIT` grammar a server must emit. Parsing is permissive, serialising stays strict.

## Changes

Relax the digit check to `/^-?\d+$/` so a single leading sign is accepted and a non-DIGIT remainder is still ignored. `Max-Age=-`, `--1`, `-1a`, `+1` and the empty value all stay ignored, and positive values are unchanged.

### Features

N/A

### Bug Fixes

- `Set-Cookie: ...; Max-Age=-1` now parses to `maxAge: -1` instead of dropping the attribute.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
