### PR TITLE
fix(decompress): preserve response trailers

### DIFF
--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -32,6 +32,8 @@ let warningEmitted = /** @type {boolean} */ (false)
 class DecompressHandler extends DecoratorHandler {
   /** @type {Transform[]} */
   #decompressors = []
+  /** @type {Record<string, string | string[]> | undefined} */
+  #trailers
   /** @type {Readonly<number[]>} */
   #skipStatusCodes
   /** @type {boolean} */
@@ -123,7 +125,7 @@ class DecompressHandler extends DecoratorHandler {
     this.#setupDecompressorEvents(decompressor, controller)
 
     decompressor.on('end', () => {
-      super.onResponseEnd(controller, {})
+      super.onResponseEnd(controller, this.#trailers)
     })
   }
 
@@ -141,7 +143,7 @@ class DecompressHandler extends DecoratorHandler {
         super.onResponseError(controller, err)
         return
       }
-      super.onResponseEnd(controller, {})
+      super.onResponseEnd(controller, this.#trailers)
     })
   }
 
@@ -236,6 +238,7 @@ class DecompressHandler extends DecoratorHandler {
    */
   onResponseEnd (controller, trailers) {
     if (this.#decompressors.length > 0) {
+      this.#trailers = trailers
       this.#decompressors[0].end()
       this.#cleanupDecompressors()
       return

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -51,6 +51,46 @@ test('should decompress gzip response', async t => {
   await t.completed
 })
 
+test('should preserve trailers when decompressing response', async t => {
+  const data = 'Response with trailers'
+  const compressed = gzipSync(data)
+  const server = createServer({ joinDuplicateHeaders: true }, (_req, res) => {
+    res.writeHead(200, {
+      'Content-Encoding': 'gzip',
+      Trailer: 'X-Checksum'
+    })
+    res.addTrailers({ 'X-Checksum': 'verified' })
+    res.end(compressed)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(interceptors.decompress())
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  t = tspl(t, { plan: 2 })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    headers: { TE: 'trailers' }
+  })
+  const body = await response.body.text()
+
+  t.equal(body, data)
+  t.deepEqual(response.trailers, { 'x-checksum': 'verified' })
+
+  await t.completed
+})
+
 test('should preserve representation headers and empty body for HEAD responses', async t => {
   const compressedRepresentation = gzipSync('HEAD response representation')
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
@@ -614,7 +654,7 @@ test('should allow custom skipStatusCodes', async t => {
 })
 
 test('should decompress multiple encodings in correct order', async t => {
-  t = tspl(t, { plan: 3 })
+  t = tspl(t, { plan: 4 })
 
   const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {
     // First compress with gzip, then with deflate (gzip, deflate)
@@ -623,7 +663,8 @@ test('should decompress multiple encodings in correct order', async t => {
 
     res.writeHead(200, {
       'Content-Type': 'text/plain',
-      'Content-Encoding': 'gzip, deflate' // Applied in this order
+      'Content-Encoding': 'gzip, deflate', // Applied in this order
+      Trailer: 'X-Checksum'
     })
 
     const data = 'Multiple encoding test message'
@@ -631,6 +672,7 @@ test('should decompress multiple encodings in correct order', async t => {
     // Pipe: data → gzip → deflate → response
     gzip.pipe(deflate)
     deflate.pipe(res)
+    res.addTrailers({ 'X-Checksum': 'verified' })
     gzip.end(data)
   })
 
@@ -649,7 +691,8 @@ test('should decompress multiple encodings in correct order', async t => {
 
   const response = await client.request({
     method: 'GET',
-    path: '/'
+    path: '/',
+    headers: { TE: 'trailers' }
   })
 
   const body = await response.body.text()
@@ -657,6 +700,7 @@ test('should decompress multiple encodings in correct order', async t => {
   t.equal(response.statusCode, 200)
   t.equal(response.headers['content-encoding'], undefined) // Should be removed
   t.equal(body, 'Multiple encoding test message') // Should be fully decompressed
+  t.deepEqual(response.trailers, { 'x-checksum': 'verified' })
 
   await t.completed
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

No existing issue. This fixes response trailers being discarded by `interceptors.decompress()` after successful decompression.

## Rationale

`interceptors.decompress()` delays response completion until the decompression stream finishes. Its completion callbacks previously forwarded an empty trailers object, causing valid HTTP response trailers to be lost.

The trailers received by `onResponseEnd()` must be retained across the asynchronous decompression boundary and forwarded when decompression completes.

## Changes

- Store normalized response trailers while decompression is finishing.
- Forward trailers through both the single-decoder and chained-decoder completion paths.
- Add regression coverage for gzip responses with trailers.
- Extend the multiple-content-encoding test to verify trailer preservation.

### Features

N/A

### Bug Fixes

- Preserve HTTP response trailers when using `interceptors.decompress()`.
- Preserve trailers for responses with multiple content encodings.

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

### Tests

```console
node --test test/interceptors/decompress.js
npm run test:interceptors
npm run lint
```