### PR TITLE
fix: handle frozen globalThis in setGlobalDispatcher

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -8,6 +8,9 @@ const { InvalidArgumentError } = require('./core/errors')
 const Agent = require('./dispatcher/agent')
 const Dispatcher1Wrapper = require('./dispatcher/dispatcher1-wrapper')
 
+// Fallback storage for when globalThis is not extensible (e.g. frozen)
+let fallbackDispatcher
+
 if (getGlobalDispatcher() === undefined) {
   setGlobalDispatcher(new Agent())
 }
@@ -17,25 +20,42 @@ function setGlobalDispatcher (agent) {
     throw new InvalidArgumentError('Argument agent must implement Agent')
   }
 
-  Object.defineProperty(globalThis, globalDispatcher, {
-    value: agent,
-    writable: true,
-    enumerable: false,
-    configurable: false
-  })
+  try {
+    Object.defineProperty(globalThis, globalDispatcher, {
+      value: agent,
+      writable: true,
+      enumerable: false,
+      configurable: false
+    })
+  } catch (err) {
+    // globalThis is not extensible (e.g. Object.freeze(globalThis))
+    // Use fallback storage instead
+    if (err instanceof TypeError) {
+      fallbackDispatcher = agent
+      return
+    }
+    throw err
+  }
 
-  const legacyAgent = agent instanceof Dispatcher1Wrapper ? agent : new Dispatcher1Wrapper(agent)
+  try {
+    const legacyAgent = agent instanceof Dispatcher1Wrapper ? agent : new Dispatcher1Wrapper(agent)
 
-  Object.defineProperty(globalThis, legacyGlobalDispatcher, {
-    value: legacyAgent,
-    writable: true,
-    enumerable: false,
-    configurable: false
-  })
+    Object.defineProperty(globalThis, legacyGlobalDispatcher, {
+      value: legacyAgent,
+      writable: true,
+      enumerable: false,
+      configurable: false
+    })
+  } catch (err) {
+    // globalThis is not extensible; fallback storage is already set
+    if (!(err instanceof TypeError)) {
+      throw err
+    }
+  }
 }
 
 function getGlobalDispatcher () {
-  return globalThis[globalDispatcher]
+  return globalThis[globalDispatcher] ?? fallbackDispatcher
 }
 
 // These are the globals that can be installed by undici.install().

--- a/test/global-frozen.js
+++ b/test/global-frozen.js
@@ -3,52 +3,60 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
 
-test('frozen globalThis - setGlobalDispatcher succeeds', async (t) => {
+test('frozen globalThis - setGlobalDispatcher succeeds', (t) => {
   t = tspl(t, { plan: 2 })
 
   // Freeze globalThis
   Object.freeze(globalThis)
 
+  // Dynamically require inside test to get fresh module state
+  // in a frozen globalThis context
+  const { setGlobalDispatcher, getGlobalDispatcher } = require('../lib/global')
+  const Agent = require('../lib/dispatcher/agent')
+
+  // Create a new dispatcher and set it - should not throw
+  const newAgent = new Agent()
+  let setError = null
   try {
-    // Dynamically require inside test to get fresh module state
-    // in a frozen globalThis context
-    const { setGlobalDispatcher, getGlobalDispatcher } = require('../lib/global')
-    const Agent = require('../lib/dispatcher/agent')
-
-    // Create a new dispatcher and set it - should not throw
-    const newAgent = new Agent()
-    let setError = null
-    try {
-      setGlobalDispatcher(newAgent)
-    } catch (err) {
-      setError = err
-    }
-
-    t.ifError(setError, 'setGlobalDispatcher should not throw with frozen globalThis')
-
-    // Verify we can retrieve a dispatcher
-    const retrieved = getGlobalDispatcher()
-    t.ok(retrieved, 'getGlobalDispatcher should return a dispatcher')
-  } finally {
-    // globalThis remains frozen for remainder of process
+    setGlobalDispatcher(newAgent)
+  } catch (err) {
+    setError = err
   }
 
-  await t.completed
+  t.ifError(setError, 'setGlobalDispatcher should not throw with frozen globalThis')
+
+  // Verify we can retrieve a dispatcher
+  const retrieved = getGlobalDispatcher()
+  t.ok(retrieved, 'getGlobalDispatcher should return a dispatcher')
 })
 
-test('frozen globalThis - graceful degradation', async (t) => {
+test('frozen globalThis - graceful degradation', (t) => {
   t = tspl(t, { plan: 1 })
 
   // globalThis is already frozen from previous test
-  try {
-    const { getGlobalDispatcher } = require('../lib/global')
+  const { getGlobalDispatcher } = require('../lib/global')
 
-    // Should still be able to get a dispatcher without errors
-    const dispatcher = getGlobalDispatcher()
-    t.ok(dispatcher !== null && dispatcher !== undefined, 'getGlobalDispatcher should return a valid dispatcher even with frozen globalThis')
-  } catch (err) {
-    t.fail(`should not throw: ${err.message}`)
-  }
+  // Should still be able to get a dispatcher without errors
+  const dispatcher = getGlobalDispatcher()
+  t.ok(dispatcher !== null && dispatcher !== undefined, 'getGlobalDispatcher should return a valid dispatcher even with frozen globalThis')
+})
 
-  await t.completed
+test('frozen globalThis - fallback dispatcher persists', (t) => {
+  t = tspl(t, { plan: 2 })
+
+  // globalThis is already frozen from previous tests
+  const { getGlobalDispatcher, setGlobalDispatcher } = require('../lib/global')
+  const Agent = require('../lib/dispatcher/agent')
+
+  // Get current dispatcher
+  const dispatcher1 = getGlobalDispatcher()
+  t.ok(dispatcher1, 'First call to getGlobalDispatcher returns dispatcher')
+
+  // Set a new one
+  const newAgent = new Agent()
+  setGlobalDispatcher(newAgent)
+
+  // Get again - should return the one we just set (from fallback)
+  const dispatcher2 = getGlobalDispatcher()
+  t.equal(dispatcher2, newAgent, 'getGlobalDispatcher returns dispatcher set in frozen globalThis')
 })

--- a/test/global-frozen.js
+++ b/test/global-frozen.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test } = require('node:test')
+
+test('frozen globalThis - setGlobalDispatcher succeeds', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  // Freeze globalThis
+  Object.freeze(globalThis)
+
+  try {
+    // Dynamically require inside test to get fresh module state
+    // in a frozen globalThis context
+    const { setGlobalDispatcher, getGlobalDispatcher } = require('../lib/global')
+    const Agent = require('../lib/dispatcher/agent')
+
+    // Create a new dispatcher and set it - should not throw
+    const newAgent = new Agent()
+    let setError = null
+    try {
+      setGlobalDispatcher(newAgent)
+    } catch (err) {
+      setError = err
+    }
+
+    t.ifError(setError, 'setGlobalDispatcher should not throw with frozen globalThis')
+
+    // Verify we can retrieve a dispatcher
+    const retrieved = getGlobalDispatcher()
+    t.ok(retrieved, 'getGlobalDispatcher should return a dispatcher')
+  } finally {
+    // globalThis remains frozen for remainder of process
+  }
+
+  await t.completed
+})
+
+test('frozen globalThis - graceful degradation', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  // globalThis is already frozen from previous test
+  try {
+    const { getGlobalDispatcher } = require('../lib/global')
+
+    // Should still be able to get a dispatcher without errors
+    const dispatcher = getGlobalDispatcher()
+    t.ok(dispatcher !== null && dispatcher !== undefined, 'getGlobalDispatcher should return a valid dispatcher even with frozen globalThis')
+  } catch (err) {
+    t.fail(`should not throw: ${err.message}`)
+  }
+
+  await t.completed
+})


### PR DESCRIPTION
## Problem
When `Object.freeze(globalThis)` is called before undici globals are accessed for the first time, the lazy initialisation inside `setGlobalDispatcher` throws:

```
TypeError: Cannot define property Symbol(undici.globalDispatcher.2),
           object is not extensible
```

This is particularly problematic because the Node.js security best practices guide explicitly recommends `Object.freeze(globalThis)` as a defence against monkey-patching (CWE-349).

## Root Cause
`setGlobalDispatcher` unconditionally calls `Object.defineProperty(globalThis, ...)`. When globalThis is not extensible, the call throws instead of degrading gracefully.

## Solution
Wrap the `Object.defineProperty` calls in `setGlobalDispatcher` with a try/catch. When globalThis is not extensible the dispatcher is stored in a module-level fallback variable. `getGlobalDispatcher` is updated to return `globalThis[symbol] ?? fallbackDispatcher` so the normal (extensible) path is unchanged.

## Testing
A test verifies that:
1. `setGlobalDispatcher` succeeds even with frozen globalThis
2. `getGlobalDispatcher` returns the correct dispatcher
3. The fallback mechanism works correctly