### PR TITLE
fix: preserve DNS origin hostname on sockets

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -105,13 +105,27 @@ function buildConnector ({ allowH2, preferH2, useH2c, maxCachedSessions, socketP
 
       port = port || 80
 
-      socket = net.connect({
+      const connectOptions = {
         highWaterMark: 64 * 1024, // Same as nodejs fs streams.
         ...options,
         localAddress,
         port,
         host: hostname
-      })
+      }
+
+      const family = net.isIP(hostname)
+      if (family !== 0 && servername && servername !== hostname) {
+        connectOptions.host = servername
+        connectOptions.lookup = (_hostname, lookupOptions, cb) => {
+          if (lookupOptions.all) {
+            cb(null, [{ address: hostname, family }])
+          } else {
+            cb(null, hostname, family)
+          }
+        }
+      }
+
+      socket = net.connect(connectOptions)
       if (useH2c === true) {
         socket.alpnProtocol = 'h2'
       }

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -672,9 +672,7 @@ function _resume (client, sync) {
     }
 
     if (!client[kHTTPContext]) {
-      if (client[kUrl].protocol === 'http:') {
-        client[kServerName] = request.servername
-      }
+      client[kServerName] = request.servername
       connect(client)
       return
     }

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -672,6 +672,9 @@ function _resume (client, sync) {
     }
 
     if (!client[kHTTPContext]) {
+      if (client[kUrl].protocol === 'http:') {
+        client[kServerName] = request.servername
+      }
       connect(client)
       return
     }

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -217,7 +217,7 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
 })
 
 test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async context => {
-  const t = tspl(context, { plan: 4 })
+  const t = tspl(context, { plan: 5 })
 
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
     res.end('hello world!')
@@ -239,13 +239,11 @@ test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async contex
   })
 
   const originalConnect = net.connect
-  let socket
   let connectOptions
 
   net.connect = function (...args) {
     connectOptions = args[0]
-    socket = originalConnect.apply(this, args)
-    return socket
+    return originalConnect.apply(this, args)
   }
   context.after(() => {
     net.connect = originalConnect
@@ -260,7 +258,19 @@ test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async contex
   t.equal(response.statusCode, 200)
   t.equal(await response.body.text(), 'hello world!')
   t.equal(connectOptions.host, 'localhost')
-  t.equal(socket.remoteAddress, '127.0.0.1')
+
+  await new Promise((resolve, reject) => {
+    connectOptions.lookup(connectOptions.host, {}, (err, address, family) => {
+      if (err) {
+        reject(err)
+        return
+      }
+
+      t.equal(address, '127.0.0.1')
+      t.equal(family, 4)
+      resolve()
+    })
+  })
 })
 
 test('Should recover on network errors (dual stack - 4)', async t => {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -2,12 +2,12 @@
 
 const FakeTimers = require('@sinonjs/fake-timers')
 const { test, after } = require('node:test')
-const { isIP } = require('node:net')
+const net = require('node:net')
+const { isIP } = net
 const { lookup } = require('node:dns')
 const { createServer } = require('node:http')
 const { createServer: createSecureServer } = require('node:https')
 const { once } = require('node:events')
-const diagnosticsChannel = require('node:diagnostics_channel')
 
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
@@ -238,18 +238,17 @@ test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async contex
     await new Promise(resolve => server.close(resolve))
   })
 
-  const socketChannel = diagnosticsChannel.channel('net.client.socket')
-  const socketDetails = new Promise(resolve => {
-    const onSocket = ({ socket }) => {
-      socket.once('connect', () => {
-        if (socket.remotePort === server.address().port) {
-          resolve({ host: socket._host, remoteAddress: socket.remoteAddress })
-        }
-      })
-    }
+  const originalConnect = net.connect
+  let socket
+  let connectOptions
 
-    socketChannel.subscribe(onSocket)
-    context.after(() => socketChannel.unsubscribe(onSocket))
+  net.connect = function (...args) {
+    connectOptions = args[0]
+    socket = originalConnect.apply(this, args)
+    return socket
+  }
+  context.after(() => {
+    net.connect = originalConnect
   })
 
   const response = await client.request({
@@ -260,10 +259,8 @@ test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async contex
 
   t.equal(response.statusCode, 200)
   t.equal(await response.body.text(), 'hello world!')
-
-  const { host, remoteAddress } = await socketDetails
-  t.equal(host, 'localhost')
-  t.equal(remoteAddress, '127.0.0.1')
+  t.equal(connectOptions.host, 'localhost')
+  t.equal(socket.remoteAddress, '127.0.0.1')
 })
 
 test('Should recover on network errors (dual stack - 4)', async t => {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -7,6 +7,7 @@ const { lookup } = require('node:dns')
 const { createServer } = require('node:http')
 const { createServer: createSecureServer } = require('node:https')
 const { once } = require('node:events')
+const diagnosticsChannel = require('node:diagnostics_channel')
 
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
@@ -213,6 +214,56 @@ test('Should respect DNS origin hostname for SNI on TLS', async t => {
 
   t.equal(response2.statusCode, 200)
   t.equal(await response2.body.text(), 'hello world!')
+})
+
+test('#5573 - Should preserve DNS origin hostname on HTTP sockets', async context => {
+  const t = tspl(context, { plan: 4 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.end('hello world!')
+  })
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const client = new Agent().compose(dns({
+    dualStack: false,
+    lookup (_origin, _opts, cb) {
+      cb(null, [{ address: '127.0.0.1', family: 4 }])
+    }
+  }))
+
+  context.after(async () => {
+    await client.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const socketChannel = diagnosticsChannel.channel('net.client.socket')
+  const socketDetails = new Promise(resolve => {
+    const onSocket = ({ socket }) => {
+      socket.once('connect', () => {
+        if (socket.remotePort === server.address().port) {
+          resolve({ host: socket._host, remoteAddress: socket.remoteAddress })
+        }
+      })
+    }
+
+    socketChannel.subscribe(onSocket)
+    context.after(() => socketChannel.unsubscribe(onSocket))
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    origin: `http://localhost:${server.address().port}`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+
+  const { host, remoteAddress } = await socketDetails
+  t.equal(host, 'localhost')
+  t.equal(remoteAddress, '127.0.0.1')
 })
 
 test('Should recover on network errors (dual stack - 4)', async t => {


### PR DESCRIPTION
## This relates to...

Fixes #5573

## Rationale

The DNS interceptor connects to a selected IP address, which causes Node's `net.client.socket` diagnostics channel to expose the IP as `socket._host`. Consumers can no longer correlate TCP connection timing with the original request hostname.

## Changes

- pass the request hostname through HTTP connection setup
- connect to the interceptor-selected IP through a fixed lookup while preserving the logical hostname on the socket
- add regression coverage for `socket._host` and `remoteAddress`

### Features

N/A

### Bug Fixes

- preserve the original DNS hostname in HTTP socket diagnostics when the DNS interceptor selects an IP

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Testing:
- `node --test --test-name-pattern='#5573' test/interceptors/dns.js`
- `npm run test:interceptors`
- `npm run lint`
- `npm run test:typescript`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
