### PR TITLE
fix(websocket): support process.unref

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -25,6 +25,9 @@ const { SendQueue } = require('./sender')
 const { WebsocketFrameSend } = require('./frame')
 const { channels } = require('../../core/diagnostics')
 
+const kRef = Symbol.for('nodejs.ref')
+const kUnref = Symbol.for('nodejs.unref')
+
 function getSocketAddress (socket) {
   if (typeof socket?.address === 'function') {
     return socket.address()
@@ -68,6 +71,7 @@ class WebSocket extends EventTarget {
   #bufferedAmount = 0
   #protocol = ''
   #extensions = ''
+  #refed = true
 
   /** @type {SendQueue} */
   #sendQueue
@@ -192,6 +196,20 @@ class WebSocket extends EventTarget {
     // Each WebSocket object has an associated binary type, which is a
     // BinaryType. Initially it must be "blob".
     this.#binaryType = 'blob'
+  }
+
+  [kRef] () {
+    webidl.brandCheck(this, WebSocket)
+
+    this.#refed = true
+    this.#handler.socket?.ref?.()
+  }
+
+  [kUnref] () {
+    webidl.brandCheck(this, WebSocket)
+
+    this.#refed = false
+    this.#handler.socket?.unref?.()
   }
 
   /**
@@ -467,6 +485,10 @@ class WebSocket extends EventTarget {
     // processResponse is called when the "response's header list has been received and initialized."
     // once this happens, the connection is open
     this.#handler.socket = response.socket
+
+    if (!this.#refed) {
+      this.#handler.socket.unref?.()
+    }
 
     // Get options from dispatcher options
     const maxFragments = this.#handler.controller.dispatcher?.webSocketOptions?.maxFragments

--- a/test/websocket/process-ref.js
+++ b/test/websocket/process-ref.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { test } = require('node:test')
+const { spawn } = require('node:child_process')
+const { once } = require('node:events')
+const { join } = require('node:path')
+const { WebSocketServer } = require('ws')
+
+function waitForExit (child, timeout) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('Child process did not exit after WebSocket was unrefed'))
+    }, timeout)
+
+    child.once('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      resolve({ code, signal })
+    })
+  })
+}
+
+test('process.unref allows the process to exit with an open WebSocket', async (t) => {
+  const server = new WebSocketServer({ port: 0 })
+  let connected = false
+  server.once('connection', () => {
+    connected = true
+  })
+  await once(server, 'listening')
+
+  t.after(() => server.close())
+
+  const url = `ws://127.0.0.1:${server.address().port}`
+  const undici = join(__dirname, '../..')
+  const child = spawn(process.execPath, ['-e', `
+    const { WebSocket } = require(${JSON.stringify(undici)})
+    const ws = new WebSocket(${JSON.stringify(url)})
+    if (typeof ws[Symbol.for('nodejs.ref')] !== 'function' ||
+        typeof ws[Symbol.for('nodejs.unref')] !== 'function') {
+      throw new Error('WebSocket does not implement the Refable protocol')
+    }
+    ws.addEventListener('open', () => {
+      process.unref(ws)
+      process.ref(ws)
+      process.unref(ws)
+    })
+  `], { stdio: 'ignore' })
+
+  t.after(() => child.kill())
+
+  const { code, signal } = await waitForExit(child, 5000)
+
+  t.assert.strictEqual(connected, true)
+  t.assert.strictEqual(code, 0)
+  t.assert.strictEqual(signal, null)
+})


### PR DESCRIPTION
Fixes #5570.

Adds Refable protocol support to `WebSocket`.

Tests: `npm run test:websocket`
