### PR TITLE
fix: validate coerced header values for CRLF

### DIFF
--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -472,7 +472,13 @@ function processHeader (request, key, val) {
       } else if (typeof val[i] === 'object') {
         throw new InvalidArgumentError(`invalid ${key} header`)
       } else {
-        arr.push(`${val[i]}`)
+        // Coerce primitives (and reject unsafe coercions such as functions
+        // with a crafted toString/Symbol.toPrimitive).
+        const str = `${val[i]}`
+        if (!isValidHeaderValue(str)) {
+          throw new InvalidArgumentError(`invalid ${key} header`)
+        }
+        arr.push(str)
       }
     }
     val = arr
@@ -483,7 +489,12 @@ function processHeader (request, key, val) {
   } else if (val === null) {
     val = ''
   } else {
+    // Coerce primitives (and reject unsafe coercions such as functions
+    // with a crafted toString/Symbol.toPrimitive).
     val = `${val}`
+    if (!isValidHeaderValue(val)) {
+      throw new InvalidArgumentError(`invalid ${key} header`)
+    }
   }
 
   if (headerName === 'host') {

--- a/test/header-function-crlf.js
+++ b/test/header-function-crlf.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { Client, errors } = require('..')
+
+function makeInjectingFn (payload) {
+  const fn = function () {}
+  fn.toString = () => payload
+  return fn
+}
+
+function makeToPrimitiveFn (payload) {
+  const fn = function () {}
+  fn[Symbol.toPrimitive] = () => payload
+  return fn
+}
+
+test('rejects function header value with CRLF via toString', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const client = new Client('http://localhost:8080')
+  after(() => client.destroy())
+
+  t.rejects(client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-safe': makeInjectingFn('legit\r\ntransfer-encoding: chunked')
+    }
+  }), new errors.InvalidArgumentError('invalid x-safe header'))
+
+  await t.completed
+})
+
+test('rejects function header value with CRLF via Symbol.toPrimitive', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const client = new Client('http://localhost:8080')
+  after(() => client.destroy())
+
+  t.rejects(client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-safe': makeToPrimitiveFn('legit\r\nx-injected: yes')
+    }
+  }), new errors.InvalidArgumentError('invalid x-safe header'))
+
+  await t.completed
+})
+
+test('rejects function header value in array element with CRLF via toString', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const client = new Client('http://localhost:8080')
+  after(() => client.destroy())
+
+  t.rejects(client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-safe': [makeInjectingFn('legit\r\nx-injected: via-array')]
+    }
+  }), new errors.InvalidArgumentError('invalid x-safe header'))
+
+  await t.completed
+})
+
+test('rejects function header value in array element with CRLF via Symbol.toPrimitive', async (t) => {
+  t = tspl(t, { plan: 1 })
+
+  const client = new Client('http://localhost:8080')
+  after(() => client.destroy())
+
+  t.rejects(client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-safe': [makeToPrimitiveFn('legit\r\nx-injected: via-array-primitive')]
+    }
+  }), new errors.InvalidArgumentError('invalid x-safe header'))
+
+  await t.completed
+})
+
+test('still accepts number and boolean header values', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.strictEqual(req.headers['x-num'], '123')
+    t.strictEqual(req.headers['x-bool'], 'true')
+    res.end('ok')
+  })
+  after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+  after(() => client.close())
+
+  const { body } = await client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-num': 123,
+      'x-bool': true
+    }
+  })
+  await body.dump()
+
+  await t.completed
+})


### PR DESCRIPTION
## Why

`processHeader()` rejected objects but not functions (`typeof fn === 'function'`). Non-string values were coerced with `` `${val}` `` and written to the HTTP/1.1 wire without `isValidHeaderValue()`, so a function with a crafted `toString()` / `Symbol.toPrimitive` could inject CRLF sequences into request headers.

This is defense-in-depth / hardening, not a security advisory under our threat model: exploitation requires the application to pass a function as a header value (trusted application input). String CRLF was already rejected.

## Changes

- After coercing non-string scalar header values, run `isValidHeaderValue()`
- Same validation for non-string array elements after coercion
- Regression tests for `toString` and `Symbol.toPrimitive` on scalar and array paths
- Confirm numbers/booleans still work

## Test plan

- [x] `node --test test/header-function-crlf.js test/request-crlf.js test/headers-crlf.js test/invalid-headers.js`
- [x] `npm run lint`