### PR TITLE
fix: preserve original hostname on HTTP socket when using DNS interceptor

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -115,6 +115,10 @@ function buildConnector ({ allowH2, preferH2, useH2c, maxCachedSessions, socketP
       if (useH2c === true) {
         socket.alpnProtocol = 'h2'
       }
+
+      if (servername) {
+        socket._host = servername
+      }
     }
 
     // Set TCP keep alive options on the socket here instead of in connect() for the case of assigning the socket

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -665,6 +665,8 @@ function _resume (client, sync) {
         client[kHTTPContext] = null
         resume(client)
       })
+    } else if (client[kUrl].protocol !== 'https:' && client[kServerName] !== request.servername) {
+      client[kServerName] = request.servername
     }
 
     if (client[kConnecting]) {

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -11,7 +11,7 @@ const { once } = require('node:events')
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
-const { interceptors, Agent, Client, Pool, request } = require('../..')
+const { interceptors, Agent, Client, Pool, request, fetch } = require('../..')
 const { dns } = interceptors
 
 // Helper to check if IPv6 is available for localhost
@@ -2251,4 +2251,65 @@ test('#4234 - Should pass Pool requests without origin through', async t => {
   t.equal(response.statusCode, 200)
   t.equal(await response.body.text(), 'hello world!')
   t.equal(lookupCount, 0)
+})
+
+test('Should preserve original hostname on HTTP socket when using DNS interceptor', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createServer()
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  let hostFromSocket = null
+  const RESOLVED_ADDRESS = '127.0.0.1'
+  const diagnosticsChannel = require('node:diagnostics_channel')
+  const netClientSocketChannel = diagnosticsChannel.channel('net.client.socket')
+
+  after(async () => {
+    await dispatcher.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  // Subscribe to the net.client.socket channel BEFORE creating the socket
+  const connectPromise = new Promise((resolve) => {
+    netClientSocketChannel.subscribe(({ socket }) => {
+      socket.once('connect', () => {
+        hostFromSocket = socket._host
+        resolve()
+      })
+    })
+  })
+
+  const dispatcher = new Agent().compose(
+    dns({
+      maxTTL: 60_000,
+      lookup (_origin, _opts, cb) {
+        cb(null, [
+          {
+            address: RESOLVED_ADDRESS,
+            family: 4,
+            ttl: 60_000
+          }
+        ])
+      }
+    })
+  )
+
+  const url = `http://localhost:${server.address().port}`
+
+  // Perform a request with the DNS interceptor
+  const response = await fetch(url, { dispatcher })
+  t.equal(response.status, 200)
+
+  // Wait for the connect event to fire
+  await connectPromise
+
+  // The socket._host should be the original hostname, not the resolved IP
+  t.equal(hostFromSocket, 'localhost')
 })


### PR DESCRIPTION
### Fixes

https://github.com/nodejs/undici/issues/5573

### Problem

When the DNS interceptor resolves a hostname and replaces the connection origin with the resolved IP address, the original hostname is lost for HTTP connections. For HTTPS, the hostname remains accessible through TLS SNI (servername), but for plain HTTP it is nowhere available on the socket.

This breaks diagnostics channel instrumentation that relies on the original hostname for metrics attribution.

### Changes

1. **lib/dispatcher/client.js**: Sets `client[kServerName]` for HTTP connections when `request.servername` differs (the DNS interceptor already sets `servername` in dispatch opts)

2. **lib/core/connect.js**: Overrides `socket._host` with the original hostname for HTTP connections when `servername` is provided

3. **test/interceptors/dns.js**: Adds test verifying `socket._host` is the original hostname when using the DNS interceptor with HTTP

### Verification

```bash
$ node -e "...
const { Agent, fetch, interceptors } = require('.');
const { dns } = interceptors;
...
const dispatcher = new Agent().compose(dns({
  lookup: (_origin, _opts, cb) => {
    cb(null, [{ address: '127.0.0.1', family: 4, ttl: 60_000 }]);
  }
}));
const response = await fetch('http://localhost:PORT', { dispatcher });
// socket._host is 'localhost', not '127.0.0.1'
```

All existing DNS interceptor tests pass.