### PR TITLE
fix(cache): split repeated vary headers on commas

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -4,6 +4,7 @@ const util = require('../core/util')
 const {
   parseCacheControlHeader,
   parseVaryHeader,
+  varyHeaderHasWildcard,
   isEtagUsable
 } = require('../util/cache')
 const { parseHttpDate } = require('../util/date.js')
@@ -434,7 +435,7 @@ function canCacheResponse (cacheType, statusCode, resHeaders, cacheControlDirect
   }
 
   // https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1-5
-  if (resHeaders.vary?.includes('*')) {
+  if (resHeaders.vary !== undefined && varyHeaderHasWildcard(resHeaders.vary)) {
     return false
   }
 

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -321,12 +321,27 @@ function parseCacheControlHeader (header) {
 }
 
 /**
+ * A repeated Vary header is equivalent to a single one holding the
+ *  comma-separated concatenation of the values, so each part of the list still
+ *  has to be looked at on its own.
+ * @see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3
+ *
+ * @param {string | string[]} varyHeader Vary header from the server
+ * @returns {boolean}
+ */
+function varyHeaderHasWildcard (varyHeader) {
+  return typeof varyHeader === 'string'
+    ? varyHeader.includes('*')
+    : varyHeader.some(value => value.includes('*'))
+}
+
+/**
  * @param {string | string[]} varyHeader Vary header from the server
  * @param {Record<string, string | string[]>} headers Request headers
  * @returns {Record<string, string | string[]>}
  */
 function parseVaryHeader (varyHeader, headers) {
-  if (typeof varyHeader === 'string' && varyHeader.includes('*')) {
+  if (varyHeaderHasWildcard(varyHeader)) {
     return headers
   }
 
@@ -334,7 +349,7 @@ function parseVaryHeader (varyHeader, headers) {
 
   const varyingHeaders = typeof varyHeader === 'string'
     ? varyHeader.split(',')
-    : varyHeader
+    : varyHeader.flatMap(value => value.split(','))
 
   for (const header of varyingHeaders) {
     const trimmedHeader = header.trim().toLowerCase()
@@ -449,6 +464,7 @@ module.exports = {
   assertCacheValue,
   parseCacheControlHeader,
   parseVaryHeader,
+  varyHeaderHasWildcard,
   isEtagUsable,
   assertCacheMethods,
   assertCacheStore,

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -330,9 +330,17 @@ function parseCacheControlHeader (header) {
  * @returns {boolean}
  */
 function varyHeaderHasWildcard (varyHeader) {
-  return typeof varyHeader === 'string'
-    ? varyHeader.includes('*')
-    : varyHeader.some(value => value.includes('*'))
+  if (typeof varyHeader === 'string') {
+    return varyHeader.includes('*')
+  }
+
+  for (let i = 0; i < varyHeader.length; i++) {
+    if (varyHeader[i].includes('*')) {
+      return true
+    }
+  }
+
+  return false
 }
 
 /**
@@ -347,14 +355,16 @@ function parseVaryHeader (varyHeader, headers) {
 
   const output = /** @type {Record<string, string | string[] | null>} */ ({})
 
-  const varyingHeaders = typeof varyHeader === 'string'
-    ? varyHeader.split(',')
-    : varyHeader.flatMap(value => value.split(','))
+  const varyHeaders = typeof varyHeader === 'string' ? [varyHeader] : varyHeader
 
-  for (const header of varyingHeaders) {
-    const trimmedHeader = header.trim().toLowerCase()
+  for (let i = 0; i < varyHeaders.length; i++) {
+    const fields = varyHeaders[i].split(',')
 
-    output[trimmedHeader] = headers[trimmedHeader] ?? null
+    for (let j = 0; j < fields.length; j++) {
+      const trimmedHeader = fields[j].trim().toLowerCase()
+
+      output[trimmedHeader] = headers[trimmedHeader] ?? null
+    }
   }
 
   return output

--- a/test/cache-interceptor/utils.js
+++ b/test/cache-interceptor/utils.js
@@ -274,9 +274,27 @@ describe('parseVaryHeader', () => {
     })
   })
 
+  test('splits array entries on commas', () => {
+    const result = parseVaryHeader(['Accept-Encoding, X-User-Id', 'Accept-Language'], {
+      'accept-encoding': 'gzip',
+      'x-user-id': 'alice'
+    })
+    deepStrictEqual(result, {
+      'accept-encoding': 'gzip',
+      'x-user-id': 'alice',
+      'accept-language': null
+    })
+  })
+
   test('preserves existing * behavior', () => {
     const headers = { accept: 'text/html' }
     const result = parseVaryHeader('*', headers)
+    deepStrictEqual(result, headers)
+  })
+
+  test('handles * in an array entry', () => {
+    const headers = { accept: 'text/html' }
+    const result = parseVaryHeader(['Accept-Encoding, *', 'Accept-Language'], headers)
     deepStrictEqual(result, headers)
   })
 })

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -131,6 +131,78 @@ describe('Cache Interceptor', () => {
     }
   })
 
+  test('vary directives spread over repeated headers are all honored', async () => {
+    let requestsToOrigin = 0
+    const server = createServer((req, res) => {
+      requestsToOrigin++
+      res.setHeader('cache-control', 's-maxage=10')
+      res.setHeader('vary', ['accept-encoding, a', 'accept-language'])
+      res.end(req.headers.a)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    {
+      const res = await client.request({ origin: 'localhost', method: 'GET', path: '/', headers: { a: 'asd123' } })
+      equal(requestsToOrigin, 1)
+      strictEqual(await res.body.text(), 'asd123')
+    }
+
+    {
+      const res = await client.request({ origin: 'localhost', method: 'GET', path: '/', headers: { a: 'dsa321' } })
+      equal(requestsToOrigin, 2)
+      strictEqual(await res.body.text(), 'dsa321')
+    }
+
+    {
+      const res = await client.request({ origin: 'localhost', method: 'GET', path: '/', headers: { a: 'asd123' } })
+      equal(requestsToOrigin, 2)
+      strictEqual(await res.body.text(), 'asd123')
+    }
+  })
+
+  test('does not cache a response whose repeated vary header contains *', async () => {
+    let requestsToOrigin = 0
+    const server = createServer((req, res) => {
+      requestsToOrigin++
+      res.setHeader('cache-control', 's-maxage=10')
+      res.setHeader('vary', ['accept-encoding, *', 'accept-language'])
+      res.end('asd')
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const request = { origin: 'localhost', method: 'GET', path: '/' }
+
+    {
+      const res = await client.request(request)
+      equal(requestsToOrigin, 1)
+      strictEqual(await res.body.text(), 'asd')
+    }
+
+    {
+      const res = await client.request(request)
+      equal(requestsToOrigin, 2)
+      strictEqual(await res.body.text(), 'asd')
+    }
+  })
+
   test('revalidates reponses with no-cache directive, regardless of cacheByDefault', async () => {
     let requestCount = 0
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

`parseVaryHeader` only splits on commas when the Vary header arrives as a single string. An origin is free to send the header more than once, and `parseHeaders` then hands the cache handler an array, whose entries were used verbatim as field names. A response carrying `Vary: accept-encoding, x-user-id` followed by a second `Vary: accept-language` line is therefore stored under the field name `accept-encoding, x-user-id`, so `x-user-id` never takes part in the cache match and the next request with a different value is served the first client's body. The wildcard guard in `canCacheResponse` misses the same shape, since `resHeaders.vary?.includes('*')` on an array only matches an entry that is exactly `*`. With the default shared cache type both paths hand one caller a response that was stored for another.

Repro against `interceptors.cache()`, with a server that sets `vary` to `['accept-encoding, a', 'accept-language']` and echoes the `a` request header: the request with `a: alice` reaches the origin, and the following request with `a: bob` is answered from the cache with alice's body.

## Changes

Split every element of an array-valued Vary header on commas, and share one wildcard check between the parser and `canCacheResponse` so a repeated header carrying `*` also blocks storage.

### Features

N/A

### Bug Fixes

* Vary field names spread over repeated response headers are honored when matching cached entries.
* `Vary: *` is detected when it arrives in a repeated header alongside other field names.

### Breaking Changes and Deprecations

N/A

## Status

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
