### PR TITLE
fix(eventsource): handle empty event fields

### DIFF
--- a/lib/web/eventsource/eventsource-stream.js
+++ b/lib/web/eventsource/eventsource-stream.js
@@ -309,9 +309,7 @@ class EventSourceStream extends Transform {
     if (isFieldName(line, fieldLength, EVENT)) {
       const value = line.toString('utf8', valueStart)
 
-      if (value.length > 0) {
-        event.event = value
-      }
+      event.event = value
     }
   }
 

--- a/test/eventsource/eventsource-message.js
+++ b/test/eventsource/eventsource-message.js
@@ -86,6 +86,33 @@ describe('EventSource - message', () => {
     })
   })
 
+  test('Should use the default message type when an empty event field replaces a custom type', async (t) => {
+    t.plan(3)
+
+    const server = http.createServer({ joinDuplicateHeaders: true }, (_req, res) => {
+      res.writeHead(200, 'OK', { 'Content-Type': 'text/event-stream' })
+      res.end('event: custom\nevent:\ndata: payload\n\n')
+    })
+
+    await once(server.listen(0), 'listening')
+    const port = server.address().port
+    const eventSourceInstance = new EventSource(`http://localhost:${port}`)
+
+    t.after(async () => {
+      eventSourceInstance.close()
+      await new Promise(resolve => server.close(resolve))
+    })
+
+    const received = await Promise.race([
+      once(eventSourceInstance, 'message').then(([event]) => ({ listener: 'message', event })),
+      once(eventSourceInstance, 'custom').then(([event]) => ({ listener: 'custom', event }))
+    ])
+
+    t.assert.strictEqual(received.listener, 'message')
+    t.assert.strictEqual(received.event.type, 'message')
+    t.assert.strictEqual(received.event.data, 'payload')
+  })
+
   test('Should emit a message event if data is provided', (t, done) => {
     t.plan(1)
 

--- a/test/eventsource/eventsource-stream-parse-line.js
+++ b/test/eventsource/eventsource-stream-parse-line.js
@@ -258,7 +258,7 @@ describe('EventSourceStream - parseLine', () => {
     t.assert.strictEqual(event.retry, undefined)
   })
 
-  test('empty event', (t) => {
+  test('empty event replaces previous event type', (t) => {
     const stream = new EventSourceStream({
       eventSourceSettings: {
         ...defaultEventSourceSettings
@@ -266,15 +266,11 @@ describe('EventSourceStream - parseLine', () => {
     })
 
     const event = {}
-    'event: \ndata:data'.split('\n').forEach((line) => {
-      stream.parseLine(Buffer.from(line, 'utf8'), event)
-    })
 
-    t.assert.strictEqual(typeof event, 'object')
-    t.assert.strictEqual(Object.keys(event).length, 1)
-    t.assert.strictEqual(event.data, 'data')
-    t.assert.strictEqual(event.id, undefined)
-    t.assert.strictEqual(event.event, undefined)
-    t.assert.strictEqual(event.retry, undefined)
+    stream.parseLine(Buffer.from('event: custom', 'utf8'), event)
+    t.assert.strictEqual(event.event, 'custom')
+
+    stream.parseLine(Buffer.from('event: ', 'utf8'), event)
+    t.assert.strictEqual(event.event, '')
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

This PR corrects EventSource behavior when an empty `event` field follows a previously specified custom event type in the same Server-Sent Events block.

## Rationale

The Server-Sent Events specification requires every recognized `event` field to replace the current event-type buffer, including when the field value is empty.

For example:

```text
event: custom
event:
data: payload
```

The second `event` field has an empty value, so it should clear the previous `custom` event type. The payload should then be dispatched using the default `message` event type.

Undici previously ignored empty `event` field values. As a result, the earlier `custom` value remained in the event-type buffer, and the payload was incorrectly dispatched to the `custom` listener instead of the default `message` listener.

## Changes

### Features

N/A

### Bug Fixes

* Process empty `event` field values instead of ignoring them.
* Clear a previously specified custom event type when it is followed by an empty `event` field.
* Restore dispatch to the default `message` event type when the event-type buffer is empty.
* Add a parser regression test covering a custom event type followed by an empty `event` field.
* Add a public `EventSource` regression test verifying that the payload is delivered to the `message` listener.

### Breaking Changes and Deprecations

None.

This change only corrects the previous non-conformant listener-routing behavior for valid SSE blocks containing a nonempty `event` field followed by an empty one.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
