### PR TITLE
docs: fix broken relative links in docs site pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ Most of the directory is plain Markdown (`index.md`, `getting-started.md`,
 `api/*.md`, `best-practices/*.md`). Two JSON files control how that Markdown is
 turned into a navigable, cross-linked site:
 
-- [`site.json`](./site.json) — the sidebar / navigation structure.
-- [`type-map.json`](./type-map.json) — resolves `{Type}` annotations into links.
+- [`site.json`](./docs/site.json) — the sidebar / navigation structure.
+- [`type-map.json`](./docs/type-map.json) — resolves `{Type}` annotations into links.
 
 ## `site.json`
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -278,4 +278,4 @@ See [API Reference: Global Installation](api/GlobalInstallation.md).
 - [Undici vs. Built-in Fetch](best-practices/undici-vs-builtin-fetch.md) —
   when to install undici vs using Node.js built-in fetch
 - [API Reference](api/Dispatcher.md) — full dispatcher API documentation
-- [Examples](/examples/) — runnable code examples
+- [Examples](https://github.com/nodejs/undici/tree/main/docs/examples) — runnable code examples

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -13,7 +13,7 @@ It is also a Stranger Things reference.
 
 Have a question about using Undici? Open a [Q&A Discussion](https://github.com/nodejs/undici/discussions/new) or join our official OpenJS [Slack](https://openjs-foundation.slack.com/archives/C01QF9Q31QD) channel.
 
-Looking to contribute? Start by reading the [contributing guide](./CONTRIBUTING.md)
+Looking to contribute? Start by reading the [contributing guide](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md)
 
 ## Install
 
@@ -408,7 +408,7 @@ For more information about their behavior, please reference the body mixin from 
 
 ## Common API Methods
 
-This section documents our most commonly used API methods. Additional APIs are documented in their own files within the [docs](./docs/) folder and are accessible via the navigation list on the left side of the docs site.
+This section documents our most commonly used API methods. Additional APIs are documented in their own files within the [docs](https://github.com/nodejs/undici/tree/main/docs/docs) folder and are accessible via the navigation list on the left side of the docs site.
 
 For the top-level APIs below, the `url` argument supplies the request origin and
 path. Do not pass `origin` or `path` in the second `options` argument. The linked
@@ -418,19 +418,19 @@ lower-level APIs that do not receive a separate `url` argument.
 ### `undici.request([url, options])`
 
 * `url` {string|URL|UrlObject}
-* `options` {RequestOptions} See [`RequestOptions`](./docs/docs/api/Dispatcher.md#parameter-requestoptions).
+* `options` {RequestOptions} See [`RequestOptions`](./api/Dispatcher.md#parameter-requestoptions).
   * `dispatcher` {Dispatcher} **Default:** [getGlobalDispatcher](#undicigetglobaldispatcher).
   * `method` {string} **Default:** `PUT` if `options.body`, otherwise `GET`.
 * Returns: {Promise} A promise with the result of the `Dispatcher.request` method.
 
 Calls `options.dispatcher.request(options)`.
 
-See [Dispatcher.request](./docs/docs/api/Dispatcher.md#dispatcherrequestoptions-callback) for more details, and [request examples](./docs/examples/README.md) for examples.
+See [Dispatcher.request](./api/Dispatcher.md#dispatcherrequestoptions-callback) for more details, and [request examples](https://github.com/nodejs/undici/blob/main/docs/examples/README.md) for examples.
 
 ### `undici.stream([url, options, ]factory)`
 
 * `url` {string|URL|UrlObject}
-* `options` {StreamOptions} See [`StreamOptions`](./docs/docs/api/Dispatcher.md#parameter-streamoptions).
+* `options` {StreamOptions} See [`StreamOptions`](./api/Dispatcher.md#parameter-streamoptions).
   * `dispatcher` {Dispatcher} **Default:** [getGlobalDispatcher](#undicigetglobaldispatcher).
   * `method` {string} **Default:** `PUT` if `options.body`, otherwise `GET`.
 * `factory` {Function} `Dispatcher.stream.factory`.
@@ -438,12 +438,12 @@ See [Dispatcher.request](./docs/docs/api/Dispatcher.md#dispatcherrequestoptions-
 
 Calls `options.dispatcher.stream(options, factory)`.
 
-See [Dispatcher.stream](./docs/docs/api/Dispatcher.md#dispatcherstreamoptions-factory-callback) for more details.
+See [Dispatcher.stream](./api/Dispatcher.md#dispatcherstreamoptions-factory-callback) for more details.
 
 ### `undici.pipeline([url, options, ]handler)`
 
 * `url` {string|URL|UrlObject}
-* `options` {PipelineOptions} See [`PipelineOptions`](./docs/docs/api/Dispatcher.md#parameter-pipelineoptions).
+* `options` {PipelineOptions} See [`PipelineOptions`](./api/Dispatcher.md#parameter-pipelineoptions).
   * `dispatcher` {Dispatcher} **Default:** [getGlobalDispatcher](#undicigetglobaldispatcher).
   * `method` {string} **Default:** `PUT` if `options.body`, otherwise `GET`.
 * `handler` {Function} `Dispatcher.pipeline.handler`.
@@ -451,21 +451,21 @@ See [Dispatcher.stream](./docs/docs/api/Dispatcher.md#dispatcherstreamoptions-fa
 
 Calls `options.dispatch.pipeline(options, handler)`.
 
-See [Dispatcher.pipeline](./docs/docs/api/Dispatcher.md#dispatcherpipelineoptions-handler) for more details.
+See [Dispatcher.pipeline](./api/Dispatcher.md#dispatcherpipelineoptions-handler) for more details.
 
 ### `undici.connect([url, options])`
 
 Starts two-way communications with the requested resource using [HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT).
 
 * `url` {string|URL|UrlObject}
-* `options` {ConnectOptions} See [`ConnectOptions`](./docs/docs/api/Dispatcher.md#parameter-connectoptions).
+* `options` {ConnectOptions} See [`ConnectOptions`](./api/Dispatcher.md#parameter-connectoptions).
   * `dispatcher` {Dispatcher} **Default:** [getGlobalDispatcher](#undicigetglobaldispatcher).
 * `callback` {Function} (optional) — `(err, data) => void`.
 * Returns: {Promise} A promise with the result of the `Dispatcher.connect` method.
 
 Calls `options.dispatch.connect(options)`.
 
-See [Dispatcher.connect](./docs/docs/api/Dispatcher.md#dispatcherconnectoptions-callback) for more details.
+See [Dispatcher.connect](./api/Dispatcher.md#dispatcherconnectoptions-callback) for more details.
 
 ### `undici.fetch(input[, init])`
 
@@ -638,14 +638,14 @@ Undici limits the number of `Content-Encoding` layers in a response to **5** to 
 Upgrade to a different protocol. See [MDN - HTTP - Protocol upgrade mechanism](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) for more details.
 
 * `url` {string|URL|UrlObject}
-* `options` {UpgradeOptions} See [`UpgradeOptions`](./docs/docs/api/Dispatcher.md#parameter-upgradeoptions).
+* `options` {UpgradeOptions} See [`UpgradeOptions`](./api/Dispatcher.md#parameter-upgradeoptions).
   * `dispatcher` {Dispatcher} **Default:** [getGlobalDispatcher](#undicigetglobaldispatcher).
 * `callback` {Function} (optional) — `(error, data) => void`.
 * Returns: {Promise} A promise with the result of the `Dispatcher.upgrade` method.
 
 Calls `options.dispatcher.upgrade(options)`.
 
-See [Dispatcher.upgrade](./docs/docs/api/Dispatcher.md#dispatcherupgradeoptions-callback) for more details.
+See [Dispatcher.upgrade](./api/Dispatcher.md#dispatcherupgradeoptions-callback) for more details.
 
 ### `undici.setGlobalDispatcher(dispatcher)`
 


### PR DESCRIPTION
## What

Fixes 16 broken relative links across three docs files:

**`docs/docs/index.md`** (adapted from the root `README.md`) — several links were left written relative to the repo root, so they resolve to nonexistent paths from the file's location:
- 10× `./docs/docs/api/Dispatcher.md#…` → `./api/Dispatcher.md#…` (matches how sibling pages like `best-practices/*.md` link to API docs)
- `./CONTRIBUTING.md` and `./docs/examples/README.md` → canonical GitHub URLs, since those files live outside the docs site root
- `./docs/` → GitHub URL for the docs directory

**`docs/README.md`** — links to `./site.json` and `./type-map.json`, but both files live in `docs/docs/` → `./docs/site.json`, `./docs/type-map.json`

**`docs/docs/getting-started.md`** — `[Examples](/examples/)` → GitHub URL for `docs/examples` (the absolute path resolves nowhere on GitHub, and the examples directory is not part of the built site)

## Verification

Ran a link checker over every markdown file in the repo that resolves each relative link target against the filesystem: 16 broken before, 0 after. No prose changes — link targets only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)