### PR TITLE
split wpt out of npm test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,13 @@ jobs:
           cd ${{ github.workspace }}/test/web-platform-tests/wpt
           python3 wpt make-hosts-file | sudo tee -a /etc/hosts
 
-      - name: Run tests
+      - name: Run tests (excluding WPT)
         run: npm run test:javascript:without-intl
+
+      - name: Test WPT
+        run: npm run test:wpt
+        env:
+          CI: true
 
   test-without-ssl:
     name: Test with Node.js ${{ matrix.node-version }} compiled --without-ssl

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint:fix": "eslint --fix --cache",
     "test": "npm run test:javascript && cross-env NODE_V8_COVERAGE= npm run test:typescript",
     "test:javascript": "npm run test:javascript:no-jest && npm run test:jest",
-    "test:javascript:no-jest": "npm run generate-pem && npm run test:unit && npm run test:fetch && npm run test:node-fetch && npm run test:infra && npm run test:cache && npm run test:cache-interceptor && npm run test:interceptors && npm run test:cookies && npm run test:eventsource && npm run test:subresource-integrity && npm run test:wpt && npm run test:websocket && npm run test:node-test && npm run test:cache-tests",
+    "test:javascript:no-jest": "npm run generate-pem && npm run test:unit && npm run test:fetch && npm run test:node-fetch && npm run test:infra && npm run test:cache && npm run test:cache-interceptor && npm run test:interceptors && npm run test:cookies && npm run test:eventsource && npm run test:subresource-integrity && npm run test:websocket && npm run test:node-test && npm run test:cache-tests",
     "test:javascript:without-intl": "npm run test:javascript:no-jest",
     "test:busboy": "borp --timeout 180000 -p \"test/busboy/*.js\"",
     "test:cache": "borp --timeout 180000 -p \"test/cache/*.js\"",


### PR DESCRIPTION
Remove `test:wpt` from the `test:javascript:no-jest` script chain so that local `npm test` no longer runs the slow WPT tests. The `test:wpt` script remains available for explicit invocation.

In CI, add a separate WPT step to the `test-without-intl` job so WPT still always runs in CI. The reusable `nodejs.yml` workflow already had WPT as a separate step, so no change is needed there.