### PR TITLE
[v7.x] drop: remove Node.js 26 from shared-builtin CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
       fail-fast: false
       max-parallel: 0
       matrix:
-        node-version: ['24', '26']
+        node-version: ['24']
         runs-on: ['ubuntu-latest']
     with:
       node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Node.js 26 has diverged from undici's v7.x branch, making the shared-builtin compilation and Node.js core test run unreliable. Remove v26 from the test-shared-builtin matrix while keeping it in the regular test matrix (CI and WASM SIMD tests).