### PR TITLE
fix: skip deduplication for upgrade requests

### DIFF
--- a/lib/interceptor/deduplicate.js
+++ b/lib/interceptor/deduplicate.js
@@ -59,7 +59,7 @@ module.exports = (opts = {}) => {
 
   return dispatch => {
     return (opts, handler) => {
-      if (!opts.origin || methods.includes(opts.method) === false) {
+      if (!opts.origin || opts.upgrade || methods.includes(opts.method) === false) {
         return dispatch(opts, handler)
       }
 

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -1168,6 +1168,33 @@ describe('Deduplicate Interceptor', () => {
     strictEqual(body2, 'response 2')
   })
 
+  test('does not deduplicate upgrade requests', () => {
+    let dispatchCount = 0
+    const dispatchedHandlers = []
+    const dispatch = (_opts, handler) => {
+      dispatchCount++
+      dispatchedHandlers.push(handler)
+      return true
+    }
+    const deduplicate = interceptors.deduplicate()(dispatch)
+    const opts = {
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: {}
+    }
+    const handler = {}
+
+    try {
+      deduplicate(opts, handler)
+      deduplicate({ ...opts, upgrade: 'websocket' }, handler)
+
+      strictEqual(dispatchCount, 2)
+    } finally {
+      dispatchedHandlers[0]?.onResponseEnd?.(null, {})
+    }
+  })
+
   test('does not deduplicate requests that arrive after body streaming starts', async () => {
     let requestsToOrigin = 0
     const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

The `deduplicate` interceptor currently treats upgrade-bearing requests as ordinary safe-method requests. Since `Dispatcher.upgrade()` dispatches a `GET` with an `upgrade` option, the request can enter the normal response-deduplication path.

A successful protocol upgrade completes through `onRequestUpgrade` and transfers an upgraded socket instead of following the normal `onResponseStart` → `onResponseData` → `onResponseEnd` lifecycle. As a result, the pending deduplication entry is not removed, and later matching requests can attach to stale state without being dispatched or settled.

## Rationale

Protocol upgrades are stateful operations and cannot share or replay a single upgraded transport across independent callers.

Upgrade-bearing requests should therefore bypass response deduplication before key generation and pending-request lookup. This also prevents collisions between an ordinary `GET` and an otherwise identical upgrade-bearing `GET`.

## Changes

- Skip deduplication for upgrade-bearing requests.
- Preserve existing behavior for ordinary requests where `upgrade` is absent or falsey.
- Add a deterministic regression test proving that an upgrade request is dispatched independently from a matching pending `GET`.

### Features

N/A

### Bug Fixes

- Prevent upgrade requests from entering the ordinary response-deduplication lifecycle.
- Prevent stale pending entries after a successful protocol upgrade.
- Prevent later matching requests from attaching to an already completed upgrade.
- Prevent ordinary `GET` and upgrade-bearing `GET` requests from colliding in the deduplication map.

### Breaking Changes and Deprecations

None.

## Status

<!-- KEY: S = Skipped, x = complete -->


- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
