### PR TITLE
fix: retry refused HTTP/2 streams

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -50,6 +50,7 @@ const kRequestStreamCleanup = Symbol('request stream cleanup')
 const kRequestStreamState = Symbol('request stream state')
 const kReceivedGoAway = Symbol('received goaway')
 const kRefusedAttempts = Symbol('refused attempts')
+const kRefusedStreamRetry = Symbol('refused stream retry')
 
 // How many times a single request may be requeued because the connection
 // refused to carry it (GOAWAY above lastStreamID). Without a budget a peer that
@@ -184,16 +185,18 @@ function completeRequest (client, request, resetPendingIdx = false) {
   }
 }
 
-function canRetryRequestAfterGoAway (request) {
+function canReplayRequest (request) {
   const { body } = request
 
-  if (body != null && !util.isBuffer(body) && !util.isBlobLike(body)) {
-    return false
-  }
+  return body == null || util.isBuffer(body) || util.isBlobLike(body)
+}
 
-  // Count this refusal against the request's budget. A peer that refuses every
-  // connection must eventually surface an error to the caller rather than
-  // being retried forever.
+// Count a GOAWAY refusal against the request's budget. A peer that refuses
+// every connection must eventually surface an error to the caller rather than
+// being retried forever. Kept separate from canReplayRequest so that the
+// REFUSED_STREAM retry, which has its own single-attempt limit, does not
+// consume this budget just by asking whether the body can be replayed.
+function registerGoAwayRefusal (request) {
   const attempts = (request[kRefusedAttempts] ?? 0) + 1
   request[kRefusedAttempts] = attempts
 
@@ -634,7 +637,7 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
     if (request != null) {
       streamsToClose.push(detachRequestStreamForClose(request))
 
-      if (canRetryRequestAfterGoAway(request)) {
+      if (canReplayRequest(request) && registerGoAwayRefusal(request)) {
         retriableRequests.push(request)
       } else {
         util.errorRequest(client, request, err)
@@ -1405,6 +1408,39 @@ function onEnd () {
   }
 }
 
+function retryRefusedStream (stream, state) {
+  const { client, request } = state
+
+  if (
+    state.responseReceived ||
+    request.aborted ||
+    request.completed ||
+    request[kRefusedStreamRetry] ||
+    !canReplayRequest(request)
+  ) {
+    return false
+  }
+
+  // RFC 9113 section 8.7 permits retrying REFUSED_STREAM, but says clients
+  // SHOULD NOT automatically retry the same request more than once.
+  request[kRefusedStreamRetry] = true
+
+  // Detach the failed attempt before moving the request back to the pending
+  // queue. The peer only reset this stream, so the HTTP/2 session remains
+  // usable for the retry.
+  releaseRequestStream(stream)
+  stream[kRequestStreamState] = null
+  state.stream = null
+  state.requestFinalized = true
+  closeStreamSession(stream)
+
+  completeRequest(client, request)
+  client[kQueue].splice(client[kPendingIdx], 0, request)
+  client[kResume]()
+
+  return true
+}
+
 function onError (err) {
   const stream = this
   const state = stream[kRequestStreamState]
@@ -1414,6 +1450,18 @@ function onError (err) {
   }
 
   stream.off('error', onError)
+
+  if (typeof stream.rstCode === 'number' && stream.rstCode !== NGHTTP2_NO_ERROR) {
+    err.http2ErrorCode = stream.rstCode
+  }
+
+  if (
+    stream.rstCode === NGHTTP2_REFUSED_STREAM &&
+    retryRefusedStream(stream, state)
+  ) {
+    return
+  }
+
   state.abort(err)
 }
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -49,14 +49,14 @@ const kRequestStream = Symbol('request stream')
 const kRequestStreamCleanup = Symbol('request stream cleanup')
 const kRequestStreamState = Symbol('request stream state')
 const kReceivedGoAway = Symbol('received goaway')
-const kRefusedAttempts = Symbol('refused attempts')
+const kGoAwayReplayAttempts = Symbol('goaway replay attempts')
 const kRefusedStreamRetry = Symbol('refused stream retry')
 
-// How many times a single request may be requeued because the connection
-// refused to carry it (GOAWAY above lastStreamID). Without a budget a peer that
-// keeps refusing turns one request into an unbounded connect/refuse/reconnect
-// loop that never settles and starves the event loop.
-const MAX_REFUSED_ATTEMPTS = 3
+// RFC 9113 section 8.7: a client SHOULD NOT automatically retry a request more
+// than once. Without a budget a peer that keeps refusing turns one request into
+// an unbounded connect/refuse/reconnect loop that never settles and starves the
+// event loop.
+const MAX_GOAWAY_REPLAY_ATTEMPTS = 1
 
 let extractBody
 
@@ -191,16 +191,16 @@ function canReplayRequest (request) {
   return body == null || util.isBuffer(body) || util.isBlobLike(body)
 }
 
-// Count a GOAWAY refusal against the request's budget. A peer that refuses
-// every connection must eventually surface an error to the caller rather than
-// being retried forever. Kept separate from canReplayRequest so that the
-// REFUSED_STREAM retry, which has its own single-attempt limit, does not
-// consume this budget just by asking whether the body can be replayed.
+// Count a GOAWAY refusal against the request's replay budget. A peer that
+// refuses every connection must eventually surface an error to the caller
+// rather than being retried forever. Kept separate from canReplayRequest so
+// that the REFUSED_STREAM retry, which has its own single-attempt limit, does
+// not consume this budget just by asking whether the body can be replayed.
 function registerGoAwayRefusal (request) {
-  const attempts = (request[kRefusedAttempts] ?? 0) + 1
-  request[kRefusedAttempts] = attempts
+  const attempts = (request[kGoAwayReplayAttempts] ?? 0) + 1
+  request[kGoAwayReplayAttempts] = attempts
 
-  return attempts <= MAX_REFUSED_ATTEMPTS
+  return attempts <= MAX_GOAWAY_REPLAY_ATTEMPTS
 }
 
 function closeStream (stream, code = NGHTTP2_REFUSED_STREAM) {
@@ -1427,12 +1427,11 @@ function retryRefusedStream (stream, state) {
 
   // Detach the failed attempt before moving the request back to the pending
   // queue. The peer only reset this stream, so the HTTP/2 session remains
-  // usable for the retry.
-  releaseRequestStream(stream)
-  stream[kRequestStreamState] = null
+  // usable for the retry. Severing also drops the 'close' listener, so the
+  // abandoned stream cannot later complete the retried request.
+  detachRequestStreamForClose(request)
   state.stream = null
   state.requestFinalized = true
-  closeStreamSession(stream)
 
   completeRequest(client, request)
   client[kQueue].splice(client[kPendingIdx], 0, request)

--- a/test/http2-goaway-refusal-storm.js
+++ b/test/http2-goaway-refusal-storm.js
@@ -130,8 +130,10 @@ async function measure (errorCode, label) {
   await pending
 
   assert.strictEqual(outcome, 'settled', `${label}: the request never settled`)
+  // RFC 9113 section 8.7 allows one automatic retry, so the first attempt plus
+  // one replay. The margin is for a pool that happens to open a spare.
   assert.ok(
-    connections <= 20,
+    connections <= 4,
     `${label}: retried the refused request over ${connections} connections`
   )
 }

--- a/test/http2-refused-stream.js
+++ b/test/http2-refused-stream.js
@@ -1,0 +1,184 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { createServer, constants } = require('node:http2')
+const { once } = require('node:events')
+const { Readable } = require('node:stream')
+const { Agent } = require('..')
+
+async function createDispatcher (t, onStream) {
+  const server = createServer()
+  server.on('stream', onStream)
+  server.listen(0)
+  await once(server, 'listening')
+
+  const dispatcher = new Agent({ connections: 1, useH2c: true })
+  t.after(async () => {
+    await dispatcher.close()
+    server.close()
+  })
+
+  return {
+    dispatcher,
+    origin: `http://localhost:${server.address().port}`
+  }
+}
+
+function refuse (stream, code = constants.NGHTTP2_REFUSED_STREAM) {
+  stream.on('error', () => {})
+  stream.close(code)
+}
+
+test('retries REFUSED_STREAM once before response headers', async (t) => {
+  let streams = 0
+  const { dispatcher, origin } = await createDispatcher(t, (stream) => {
+    streams++
+
+    if (streams === 1) {
+      refuse(stream)
+      return
+    }
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  const response = await dispatcher.request({ origin, path: '/', method: 'GET' })
+
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(await response.body.text(), 'ok')
+  assert.strictEqual(streams, 2)
+})
+
+test('retries REFUSED_STREAM while another stream is running', async (t) => {
+  let retryStreams = 0
+  const { dispatcher, origin } = await createDispatcher(t, (stream, headers) => {
+    if (headers[':path'] === '/slow') {
+      setTimeout(() => {
+        stream.respond({ ':status': 200 })
+        stream.end('slow')
+      }, 20)
+      return
+    }
+
+    retryStreams++
+    if (retryStreams === 1) {
+      refuse(stream)
+      return
+    }
+
+    stream.respond({ ':status': 200 })
+    stream.end('retried')
+  })
+
+  const slow = dispatcher
+    .request({ origin, path: '/slow', method: 'GET' })
+    .then(response => response.body.text())
+  const retried = dispatcher
+    .request({ origin, path: '/retry', method: 'GET' })
+    .then(response => response.body.text())
+
+  assert.deepStrictEqual(await Promise.all([slow, retried]), ['slow', 'retried'])
+  assert.strictEqual(retryStreams, 2)
+})
+
+test('replays a buffered POST after REFUSED_STREAM', async (t) => {
+  let streams = 0
+  const received = []
+  const { dispatcher, origin } = await createDispatcher(t, (stream) => {
+    streams++
+
+    if (streams === 1) {
+      refuse(stream)
+      return
+    }
+
+    const chunks = []
+    stream.on('data', chunk => chunks.push(chunk))
+    stream.on('end', () => {
+      received.push(Buffer.concat(chunks).toString())
+      stream.respond({ ':status': 200 })
+      stream.end('ok')
+    })
+  })
+
+  const response = await dispatcher.request({
+    origin,
+    path: '/',
+    method: 'POST',
+    body: Buffer.from('payload')
+  })
+
+  assert.strictEqual(await response.body.text(), 'ok')
+  assert.deepStrictEqual(received, ['payload'])
+  assert.strictEqual(streams, 2)
+})
+
+test('does not retry REFUSED_STREAM more than once', async (t) => {
+  let streams = 0
+  const { dispatcher, origin } = await createDispatcher(t, (stream) => {
+    streams++
+
+    if (streams <= 2) {
+      refuse(stream)
+      return
+    }
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  await assert.rejects(
+    dispatcher.request({ origin, path: '/', method: 'GET' }),
+    error => {
+      assert.strictEqual(error.code, 'ERR_HTTP2_STREAM_ERROR')
+      assert.strictEqual(error.http2ErrorCode, constants.NGHTTP2_REFUSED_STREAM)
+      return true
+    }
+  )
+  assert.strictEqual(streams, 2)
+
+  const response = await dispatcher.request({ origin, path: '/', method: 'GET' })
+  assert.strictEqual(await response.body.text(), 'ok')
+  assert.strictEqual(streams, 3)
+})
+
+test('does not retry REFUSED_STREAM with a streaming body', async (t) => {
+  let streams = 0
+  const { dispatcher, origin } = await createDispatcher(t, (stream) => {
+    streams++
+    refuse(stream)
+  })
+
+  await assert.rejects(
+    dispatcher.request({
+      origin,
+      path: '/',
+      method: 'POST',
+      body: Readable.from(['payload'])
+    }),
+    error => {
+      assert.strictEqual(error.http2ErrorCode, constants.NGHTTP2_REFUSED_STREAM)
+      return true
+    }
+  )
+  assert.strictEqual(streams, 1)
+})
+
+test('does not retry other HTTP/2 stream errors', async (t) => {
+  let streams = 0
+  const { dispatcher, origin } = await createDispatcher(t, (stream) => {
+    streams++
+    refuse(stream, constants.NGHTTP2_PROTOCOL_ERROR)
+  })
+
+  await assert.rejects(
+    dispatcher.request({ origin, path: '/', method: 'GET' }),
+    error => {
+      assert.strictEqual(error.http2ErrorCode, constants.NGHTTP2_PROTOCOL_ERROR)
+      return true
+    }
+  )
+  assert.strictEqual(streams, 1)
+})


### PR DESCRIPTION
## This relates to...

HTTP/2 peers can reject an unprocessed stream with `RST_STREAM(REFUSED_STREAM)`. Node.js surfaces this as the generic `ERR_HTTP2_STREAM_ERROR`, and Undici previously failed the request without considering the retry-safe HTTP/2 reset code.

## Rationale

[RFC 9113 section 8.7](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.7) permits clients to retry a request rejected with `REFUSED_STREAM`, including non-idempotent requests, because the peer asserts that no application processing occurred. It also says clients should not automatically retry the same request more than once.

## Changes

### Features

N/A

### Bug Fixes

- Detect `NGHTTP2_REFUSED_STREAM` using `stream.rstCode` before response headers are exposed.
- Retry the request once on the existing HTTP/2 session.
- Restrict transparent retries to replayable bodies: no body, `Buffer`, or `Blob`.
- Preserve the numeric reset code as `error.http2ErrorCode` when an error is ultimately exposed.
- Add regression coverage for concurrent streams, buffered POST bodies, the one-retry limit, streaming bodies, and other reset codes.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Validation:

- `npm run test:h2:core` — 96 passed
- `npm run test:h2:fetch` — 11 passed
- `npx eslint lib/dispatcher/client-h2.js test/http2-refused-stream.js`
- Commit hook `npm run lint`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
