### PR TITLE
fix(fetch): reject SharedArrayBuffer-backed body views

### DIFF
--- a/lib/web/fetch/response.js
+++ b/lib/web/fetch/response.js
@@ -577,8 +577,8 @@ webidl.converters.XMLHttpRequestBodyInit = function (V, prefix, name) {
     return V
   }
 
-  if (webidl.is.BufferSource(V)) {
-    return V
+  if (webidl.is.BufferSource(V) || ArrayBuffer.isView(V)) {
+    return webidl.converters.BufferSource(V, prefix, name)
   }
 
   if (webidl.is.FormData(V)) {

--- a/test/fetch/issue-5596.js
+++ b/test/fetch/issue-5596.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { test } = require('node:test')
+const { Request, Response } = require('../..')
+
+const sharedViews = [
+  ['Uint8Array', () => new Uint8Array(new SharedArrayBuffer(4))],
+  ['Buffer', () => Buffer.from(new SharedArrayBuffer(4))],
+  ['DataView', () => new DataView(new SharedArrayBuffer(4))]
+]
+
+for (const [name, createView] of sharedViews) {
+  test(`Request rejects a ${name} backed by a SharedArrayBuffer`, (t) => {
+    t.assert.throws(
+      () => new Request('http://localhost', {
+        method: 'POST',
+        body: createView()
+      }),
+      TypeError
+    )
+  })
+
+  test(`Response rejects a ${name} backed by a SharedArrayBuffer`, (t) => {
+    t.assert.throws(
+      () => new Response(createView()),
+      TypeError
+    )
+  })
+}
+
+test('ArrayBuffer-backed views remain valid bodies', async (t) => {
+  const bytes = Uint8Array.from([255, 216, 255, 219])
+  const request = new Request('http://localhost', {
+    method: 'POST',
+    body: bytes
+  })
+  const response = new Response(bytes)
+
+  t.assert.deepStrictEqual(
+    Buffer.from(await request.arrayBuffer()),
+    Buffer.from(bytes)
+  )
+  t.assert.deepStrictEqual(
+    Buffer.from(await response.arrayBuffer()),
+    Buffer.from(bytes)
+  )
+})


### PR DESCRIPTION
## This relates to...

Fixes #5596.

## Rationale

`XMLHttpRequestBodyInit` recognized views only when their backing buffer was an `ArrayBuffer`. A typed array or `DataView` backed by a `SharedArrayBuffer` therefore fell through to string conversion, silently changing the request or response bytes.

Routing all ArrayBuffer views through the existing Web IDL `BufferSource` converter preserves ordinary views and rejects shared-backed views with a `TypeError`, as required for a non-`[AllowShared]` buffer source.

## Changes

### Features

N/A.

### Bug Fixes

- Reject `Uint8Array`, `Buffer`, and `DataView` bodies backed by `SharedArrayBuffer` in both `Request` and `Response`.
- Preserve byte-for-byte behavior for ordinary `ArrayBuffer`-backed views.
- Add focused regression coverage for both paths.

### Breaking Changes and Deprecations

N/A.

## Validation

- `node --test test/fetch/issue-5596.js` — 7/7 passed.
- Production-hunk revert — all six shared-view rejection cases failed; restoring the patch returned 7/7 passing.
- `npm run lint` — passed.
- `npm run test:fetch` — 483 fetch, 28 Web IDL, and 47 busboy tests passed.

Implementation and validation used Codex assistance. I reviewed the final diff and test results.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (regression tests cover the behavior change; no user-facing API documentation changes)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
