### PR TITLE
fix(h2): honour headersTimeout

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -8,7 +8,9 @@ const {
   RequestAbortedError,
   SocketError,
   InformationalError,
-  InvalidArgumentError
+  InvalidArgumentError,
+  HeadersTimeoutError,
+  BodyTimeoutError
 } = require('../core/errors.js')
 const {
   kUrl,
@@ -33,6 +35,7 @@ const {
   kHTTPContext,
   kClosed,
   kBodyTimeout,
+  kHeadersTimeout,
   kEnableConnectProtocol,
   kRemoteSettings,
   kHTTP2Stream,
@@ -416,7 +419,10 @@ function shouldSendContentLength (method) {
 }
 
 function writeH2 (client, request) {
-  const requestTimeout = request.bodyTimeout ?? client[kBodyTimeout]
+  // Time to the response headers, then time between body chunks. Using
+  // bodyTimeout for both made headersTimeout a no-op over HTTP/2.
+  const headersTimeout = request.headersTimeout ?? client[kHeadersTimeout]
+  const bodyTimeout = request.bodyTimeout ?? client[kBodyTimeout]
   const session = client[kHTTP2Session]
   const { method, path, host, upgrade, expectContinue, signal, protocol, headers: reqHeaders } = request
   let { body } = request
@@ -554,7 +560,7 @@ function writeH2 (client, request) {
         if (session[kOpenStreams] === 0) session.unref()
       })
 
-      stream.setTimeout(requestTimeout)
+      stream.setTimeout(headersTimeout)
       return true
     }
 
@@ -576,7 +582,7 @@ function writeH2 (client, request) {
       session[kOpenStreams] -= 1
       if (session[kOpenStreams] === 0) session.unref()
     })
-    stream.setTimeout(requestTimeout)
+    stream.setTimeout(headersTimeout)
 
     return true
   }
@@ -677,7 +683,7 @@ function writeH2 (client, request) {
 
   // Increment counter as we have new streams open
   ++session[kOpenStreams]
-  stream.setTimeout(requestTimeout)
+  stream.setTimeout(headersTimeout)
 
   // Track whether we received a response (headers)
   let responseReceived = false
@@ -686,6 +692,7 @@ function writeH2 (client, request) {
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
     request.onResponseStarted()
     responseReceived = true
+    stream.setTimeout(bodyTimeout)
 
     // Due to the stream nature, it is possible we face a race condition
     // where the stream has been assigned, but the request has been aborted
@@ -755,7 +762,9 @@ function writeH2 (client, request) {
   })
 
   stream.on('timeout', () => {
-    const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
+    const err = responseReceived
+      ? new BodyTimeoutError(`HTTP/2: "body timeout after ${bodyTimeout}"`)
+      : new HeadersTimeoutError(`HTTP/2: "headers timeout after ${headersTimeout}"`)
     stream.removeAllListeners('data')
     session[kOpenStreams] -= 1
 

--- a/test/http2-headers-timeout.js
+++ b/test/http2-headers-timeout.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client } = require('..')
+
+// writeH2() armed the stream timer from bodyTimeout for the whole request, so
+// headersTimeout had no effect at all over HTTP/2: a server that accepted the
+// stream and never sent headers was only cut off after bodyTimeout.
+
+test('headersTimeout is honoured over HTTP/2', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  // Accept the stream and never respond.
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    headersTimeout: 200,
+    // Much larger, so a failure here means bodyTimeout was used instead.
+    bodyTimeout: 5000
+  })
+  after(() => client.close())
+
+  const start = Date.now()
+
+  await t.rejects(client.request({ path: '/', method: 'GET' }), {
+    message: 'HTTP/2: "headers timeout after 200"',
+    code: 'UND_ERR_HEADERS_TIMEOUT'
+  })
+
+  t.ok(Date.now() - start < 2000, 'must not wait for bodyTimeout')
+
+  await t.completed
+})
+
+test('bodyTimeout applies once the response headers arrive', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  // Answer immediately, then stall the body.
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+    stream.respond({ ':status': 200 })
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    // Small enough that a request still waiting on headersTimeout would fail
+    // the wrong way.
+    headersTimeout: 5000,
+    bodyTimeout: 200
+  })
+  after(() => client.close())
+
+  const res = await client.request({ path: '/', method: 'GET' })
+  t.strictEqual(res.statusCode, 200)
+
+  await t.rejects(res.body.text(), {
+    message: 'HTTP/2: "body timeout after 200"',
+    code: 'UND_ERR_BODY_TIMEOUT'
+  })
+
+  await t.completed
+})

--- a/test/http2-timeout.js
+++ b/test/http2-timeout.js
@@ -50,7 +50,8 @@ test('Should handle http2 stream timeout', async t => {
   })
 
   await t.rejects(res.body.text(), {
-    message: 'HTTP/2: "stream timeout after 50"'
+    message: 'HTTP/2: "body timeout after 50"',
+    code: 'UND_ERR_BODY_TIMEOUT'
   })
 
   await t.completed


### PR DESCRIPTION
`writeH2()` armed the stream timer from `bodyTimeout` for the whole request:

```js
const requestTimeout = request.bodyTimeout ?? client[kBodyTimeout]
```

so **`headersTimeout` had no effect at all over HTTP/2**. A server that accepted the stream and never sent headers was only cut off after `bodyTimeout`.

With `headersTimeout: 200, bodyTimeout: 5000` against a server that accepts the stream and never responds:

| | before | after |
|---|---|---|
| fails after | 5131ms | ~200ms |
| error | `InformationalError: HTTP/2: "stream timeout after 5000"` | `HeadersTimeoutError: HTTP/2: "headers timeout after 200"` |

## Change

- arm the stream timer with `headersTimeout`
- switch it to `bodyTimeout` once the response headers arrive
- report whichever deadline actually elapsed as `HeadersTimeoutError` (`UND_ERR_HEADERS_TIMEOUT`) or `BodyTimeoutError` (`UND_ERR_BODY_TIMEOUT`), matching the HTTP/1.1 path and `main`

The upgrade / CONNECT paths also use `headersTimeout`, since those streams are waiting for a response.

## Behaviour changes worth a look

Two, both on the h2 path only:

1. **Requests now time out earlier** when `headersTimeout < bodyTimeout` — that is the point of the fix, but anyone who had (unknowingly) been relying on `bodyTimeout` covering the headers phase will see requests fail sooner. The defaults are equal (300s), so only users who set the two differently are affected.
2. **The error type and message changed** for h2 timeouts: `UND_ERR_INFO` / `"stream timeout after N"` becomes `UND_ERR_HEADERS_TIMEOUT` / `UND_ERR_BODY_TIMEOUT` with `"headers timeout after N"` / `"body timeout after N"`. This aligns v7 with h1 and with `main`, so it removes a surprise on upgrade, but it is a visible change for anyone matching on the old code or string. `test/http2-timeout.js` is updated accordingly.

Happy to drop (2) and keep the `InformationalError` shape if you would rather not change error codes on a maintenance branch — the timing fix stands on its own.

## Tests

`test/http2-headers-timeout.js` covers both directions: `headersTimeout` firing while `bodyTimeout` is much larger, and `bodyTimeout` applying once headers have arrived. Both were verified to fail before this change (the first waiting 5131ms and reporting the wrong error).

`test/+(http2|h2)*.js`: 52 pass. Full unit suite: 1305 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49JamgF2TkZHu5h58ChUM