### PR TITLE
fix(h2): keep the connection ref'd while requests are outstanding

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -219,7 +219,11 @@ function resumeH2 (client) {
   const socket = client[kSocket]
 
   if (socket?.destroyed === false) {
-    if (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0) {
+    // Only let the process exit when there is genuinely nothing outstanding.
+    // Unreffing because the peer advertised MAX_CONCURRENT_STREAMS = 0 left
+    // queued requests with nothing holding the event loop open, so the process
+    // could exit with status 0 while an awaited request never settled.
+    if (client[kSize] === 0) {
       socket.unref()
       client[kHTTP2Session].unref()
     } else {

--- a/test/fixtures/h2-no-streams-client.js
+++ b/test/fixtures/h2-no-streams-client.js
@@ -1,0 +1,33 @@
+'use strict'
+
+// Child process for test/http2-max-concurrent-streams-zero-unref.js.
+//
+// Nothing in this process holds the event loop open except the outstanding
+// request, so if the client unrefs its connection while that request is still
+// queued, the process exits with status 0 and the await never returns.
+const { Client } = require('../..')
+
+async function main () {
+  const client = new Client(`https://localhost:${process.argv[2]}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    headersTimeout: 30000,
+    bodyTimeout: 30000
+  })
+
+  const warm = await client.request({ path: '/', method: 'GET' })
+  await warm.body.dump()
+  // Let the peer's drain SETTINGS land before asking for another stream.
+  await new Promise(resolve => setTimeout(resolve, 300))
+  process.send('warmed')
+
+  // The peer now advertises maxConcurrentStreams: 0, so this cannot start.
+  await client.request({ path: '/queued', method: 'GET' })
+
+  console.log('UNREACHABLE')
+}
+
+main().then(
+  () => { process.exitCode = 4 },
+  () => { process.exitCode = 5 } // settling with an error is fine; a silent exit 0 is not
+)

--- a/test/http2-max-concurrent-streams-zero-unref.js
+++ b/test/http2-max-concurrent-streams-zero-unref.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+const { fork } = require('node:child_process')
+const { join } = require('node:path')
+
+const pem = require('@metcoder95/https-pem')
+
+// resumeH2() unreffed the socket and session whenever the peer advertised
+// SETTINGS_MAX_CONCURRENT_STREAMS = 0 -- which a peer may legitimately do to
+// refuse new streams (RFC 9113 6.5.2) -- including while requests were still
+// queued. A queued request owns no handle and arms no timer of its own, so
+// nothing was left holding the event loop open: the process exited with status
+// 0 while an awaited request never settled, and the line after the await never
+// ran.
+test('a queued request keeps the process alive when the peer allows no streams', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  // Serve one request, then refuse any further streams.
+  server.on('session', (session) => {
+    session.once('stream', () => {
+      setTimeout(() => {
+        try {
+          session.settings({ maxConcurrentStreams: 0 })
+        } catch {}
+      }, 50)
+    })
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const child = fork(
+    join(__dirname, 'fixtures', 'h2-no-streams-client.js'),
+    [String(server.address().port)],
+    { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] }
+  )
+  after(() => child.kill('SIGKILL'))
+
+  let stdout = ''
+  child.stdout.on('data', (c) => { stdout += c })
+  child.stderr.on('data', () => {})
+
+  await once(child, 'message') // warm-up done, the drain SETTINGS have landed
+
+  // Still being alive is the pass condition: the request is outstanding, so the
+  // process must not have concluded it had nothing left to do.
+  let timer
+  const code = await Promise.race([
+    once(child, 'exit').then(([code]) => code),
+    new Promise((resolve) => { timer = setTimeout(() => resolve('still running'), 5000) })
+  ]).finally(() => clearTimeout(timer))
+
+  t.notStrictEqual(code, 0, 'the process exited cleanly with a request still outstanding')
+  t.ok(!stdout.includes('UNREACHABLE'), 'the queued request must not appear to succeed')
+
+  await t.completed
+})


### PR DESCRIPTION
`resumeH2()` unreffed the socket and the session whenever the peer advertised `SETTINGS_MAX_CONCURRENT_STREAMS = 0`, regardless of whether anything was still queued:

```js
if (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0) {
  socket.unref()
  client[kHTTP2Session].unref()
}
```

A peer may legitimately advertise `0` to refuse new streams for a while (RFC 9113 §6.5.2) — graceful drain, overload shedding, a load balancer draining a backend. A request queued behind that owns no handle and arms no timer of its own, so once the connection was unreffed there was nothing left holding the event loop open.

The result is a process that exits **with status 0** while an awaited request never settles:

```
warm-up request OK; server now advertises maxConcurrentStreams: 0
issuing the second request … (this await never returns)
>>> process exiting with code 0 — reached line: warm-up done
```

No error, no warning, no non-zero exit code — the code after the `await` simply never runs. For a job or a CLI that means silently skipped work reported as success.

Unref only when there is genuinely nothing outstanding.

## Test

`test/http2-max-concurrent-streams-zero-unref.js` drives a child process whose only live work is the queued request, against a server that drains to `maxConcurrentStreams: 0`. Staying alive is the pass condition; exiting 0 is the bug. Verified to fail before this change (`the process exited cleanly with a request still outstanding`) and pass after.

`test/+(http2|h2)*.js`: 51 pass. Full unit suite: 1304 pass, 0 fail.

## Note

This makes the failure visible rather than silent — the request itself is still stuck until a stream timeout fires. #5604 (`fix(h2): honour headersTimeout`) is what bounds that wait properly; the two are independent but complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49JamgF2TkZHu5h58ChUM