### PR TITLE
fix: revert idle socket validation to setTimeout(0) to prevent stall on idle event loop

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1052,7 +1052,7 @@ function onSocketClose () {
 
 function clearIdleSocketValidation (socket) {
   if (socket[kIdleSocketValidationTimeout]) {
-    clearImmediate(socket[kIdleSocketValidationTimeout])
+    clearTimeout(socket[kIdleSocketValidationTimeout])
     socket[kIdleSocketValidationTimeout] = null
   }
 
@@ -1061,14 +1061,14 @@ function clearIdleSocketValidation (socket) {
 
 function scheduleIdleSocketValidation (client, socket) {
   socket[kIdleSocketValidation] = 1
-  socket[kIdleSocketValidationTimeout] = setImmediate(() => {
+  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
     socket[kIdleSocketValidationTimeout] = null
     socket[kIdleSocketValidation] = 2
 
     if (client[kSocket] === socket && !socket.destroyed) {
       client[kResume]()
     }
-  })
+  }, 0)
   socket[kIdleSocketValidationTimeout].unref?.()
 }
 

--- a/test/node-test/keep-alive-reuse.js
+++ b/test/node-test/keep-alive-reuse.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const http = require('node:http')
+const { Pool } = require('../..')
+
+const REQUESTS = 6
+const SERVER_DELAY_MS = 50
+const MAX_TIME_PER_REQUEST = 200
+
+test('reusing an idle keep-alive socket must not stall', async (t) => {
+  const server = http.createServer((req, res) => {
+    setTimeout(() => {
+      res.writeHead(200, { 'content-length': 2 })
+      res.end('ok')
+    }, SERVER_DELAY_MS)
+  })
+
+  await new Promise((resolve) => server.listen(0, resolve))
+  t.after(() => { server.close() })
+
+  const pool = new Pool(`http://127.0.0.1:${server.address().port}`, { connections: 1 })
+  t.after(async () => { await pool.close() })
+
+  for (let i = 0; i < REQUESTS; i++) {
+    const requestStart = Date.now()
+    const res = await pool.request({ path: '/', method: 'GET' })
+    await res.body.text()
+    const elapsed = Date.now() - requestStart
+    assert.ok(elapsed < MAX_TIME_PER_REQUEST,
+      `Request #${i + 1} took ${elapsed}ms (max allowed: ${MAX_TIME_PER_REQUEST}ms)`)
+  }
+})

--- a/test/node-test/keep-alive-reuse.js
+++ b/test/node-test/keep-alive-reuse.js
@@ -2,33 +2,67 @@
 
 const { test } = require('node:test')
 const assert = require('node:assert')
-const http = require('node:http')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
 const { Pool } = require('../..')
 
-const REQUESTS = 6
-const SERVER_DELAY_MS = 50
-const MAX_TIME_PER_REQUEST = 200
+// Regression for #5600 / #5606:
+// Reusing an idle keep-alive socket must not stall behind the poll phase.
+// Progress is asserted via logical I/O events (server 'connection' / 'request'),
+// not wall-clock thresholds. If idle-socket validation is deferred with an
+// unref'd setImmediate, the poll phase blocks on the re-ref'd socket and this
+// test hits the timeout instead of completing.
+//
+// The buggy setImmediate path stalls ~TICK_MS (~499ms) per reuse when the
+// event loop is idle (woken only by undici's fast-timer tick). Five reuses
+// therefore take well over 1s when regressed, and a few dozen ms when fixed.
 
-test('reusing an idle keep-alive socket must not stall', async (t) => {
-  const server = http.createServer((req, res) => {
-    setTimeout(() => {
-      res.writeHead(200, { 'content-length': 2 })
-      res.end('ok')
-    }, SERVER_DELAY_MS)
+const REUSES = 5
+
+test('reusing an idle keep-alive socket must not stall', { timeout: 1000 }, async (t) => {
+  let connections = 0
+
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'content-length': 2 })
+    res.end('ok')
   })
 
-  await new Promise((resolve) => server.listen(0, resolve))
-  t.after(() => { server.close() })
+  server.on('connection', () => {
+    connections++
+  })
 
-  const pool = new Pool(`http://127.0.0.1:${server.address().port}`, { connections: 1 })
-  t.after(async () => { await pool.close() })
+  server.listen(0)
+  await once(server, 'listening')
 
-  for (let i = 0; i < REQUESTS; i++) {
-    const requestStart = Date.now()
-    const res = await pool.request({ path: '/', method: 'GET' })
-    await res.body.text()
-    const elapsed = Date.now() - requestStart
-    assert.ok(elapsed < MAX_TIME_PER_REQUEST,
-      `Request #${i + 1} took ${elapsed}ms (max allowed: ${MAX_TIME_PER_REQUEST}ms)`)
+  const pool = new Pool(`http://127.0.0.1:${server.address().port}`, {
+    connections: 1
+  })
+
+  t.after(async () => {
+    await pool.close()
+    server.close()
+  })
+
+  // Establish the keep-alive connection.
+  {
+    const res = await pool.request({ path: '/0', method: 'GET' })
+    assert.strictEqual(await res.body.text(), 'ok')
+  }
+  assert.strictEqual(connections, 1)
+
+  // Each reuse is gated on the server observing the request. Between
+  // iterations the client socket is idle/unref'd, which is the state that
+  // triggers idle-socket validation on the next dispatch.
+  for (let i = 1; i <= REUSES; i++) {
+    const requested = once(server, 'request')
+    const resPromise = pool.request({ path: `/${i}`, method: 'GET' })
+    // Suppress unhandled rejection if the test times out mid-request.
+    resPromise.catch(() => {})
+
+    await requested
+
+    const res = await resPromise
+    assert.strictEqual(await res.body.text(), 'ok')
+    assert.strictEqual(connections, 1, 'keep-alive socket must be reused')
   }
 })


### PR DESCRIPTION
## Summary

Reverts `scheduleIdleSocketValidation` in `client-h1.js` from `setImmediate()` back to `setTimeout(0)`, along with the corresponding `clearImmediate` → `clearTimeout`.

## Background

PR #5499 changed `setTimeout(0)` → `setImmediate()` to remove the ~1ms timer floor on idle socket validation. While that change performed well under sustained load (where the event loop is continuously busy), it causes up to **~500ms stalls** when reusing an idle keep-alive socket on an otherwise idle event loop.

## Root Cause

When a keep-alive socket is reused and the event loop is otherwise idle:

1. The previous request completes → `resumeH1()` unrefs the socket (`socket.unref()`)
2. The next request is queued → `scheduleIdleSocketValidation` sets an `unref()`'d `setImmediate`
3. The socket is re-ref'd but the setImmediate fires in the **check phase** (after poll)
4. Since the socket was just ref'd but has no pending I/O, the poll phase waits for its default timeout before proceeding to the check phase — this can be up to 500ms on some platforms

`setTimeout(0)` fires in the **timers phase** (before poll), so the callback runs promptly regardless of poll timeout, at the cost of ~1ms timer resolution.

## Reproduction

Script in the issue shows sequential requests on a 1-connection pool taking 20ms, 458ms, 34ms, 51ms, 450ms, 464ms instead of ~13ms each.

## Fix

This PR reverts the approach from #5499. The original motivation (removing the timer floor) is worthwhile, but it introduces an order-of-magnitude worse regression on idle event loops. A hybrid approach (check-phase scheduling with poll-timeout prevention) could be explored separately.

Fixes #5600