### PR TITLE
fix(h2): settle a request whose stream is cancelled

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -738,6 +738,14 @@ function writeH2 (client, request) {
     if (session[kOpenStreams] === 0) {
       session.unref()
     }
+
+    // A stream can close without ever emitting 'end' or 'error': a peer's
+    // RST_STREAM(CANCEL) received before the response is reported by Node as a
+    // bare 'close', and destroying the stream unenrolls its timeout, so no
+    // 'timeout' follows either. Nothing else would ever settle this request.
+    if (!request.aborted && !request.completed) {
+      abort(new InformationalError('HTTP/2: stream closed before the response was complete'))
+    }
   })
 
   stream.once('error', function (err) {

--- a/test/http2-stream-cancel.js
+++ b/test/http2-stream-cancel.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { constants, createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client } = require('..')
+
+// RST_STREAM(CANCEL) received before the response is the one reset code Node
+// reports as a bare 'close' on the client stream: no 'end' (unlike NO_ERROR)
+// and no 'error' (unlike PROTOCOL_ERROR / INTERNAL_ERROR / REFUSED_STREAM).
+// Destroying the stream also unenrolls its timeout, so no 'timeout' follows.
+//
+// The client completed a request only from 'end', 'error' or 'timeout', so a
+// cancelled stream left the request in the running window forever and its
+// caller never heard back. Proxies send this upstream whenever their own
+// downstream client goes away.
+test('a stream cancelled before the response settles the request', async t => {
+  t = tspl(t, { plan: 1 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+    setTimeout(() => {
+      try {
+        stream.close(constants.NGHTTP2_CANCEL)
+      } catch {}
+    }, 30)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    // Long enough that only a real completion can settle this in time.
+    headersTimeout: 30000,
+    bodyTimeout: 30000
+  })
+  after(() => client.destroy())
+
+  await t.rejects(client.request({ path: '/', method: 'GET' }), {
+    code: 'UND_ERR_INFO'
+  })
+
+  await t.completed
+})
+
+test('a stream cancelled after the response headers still completes', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+    stream.respond({ ':status': 200 })
+    setTimeout(() => {
+      try {
+        stream.close(constants.NGHTTP2_CANCEL)
+      } catch {}
+    }, 30)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    headersTimeout: 30000,
+    bodyTimeout: 30000
+  })
+  after(() => client.destroy())
+
+  const res = await client.request({ path: '/', method: 'GET' })
+  t.strictEqual(res.statusCode, 200)
+  t.strictEqual(await res.body.text(), '')
+
+  await t.completed
+})


### PR DESCRIPTION
A request over HTTP/2 was only ever completed from the stream's `'end'`, `'error'` or `'timeout'`. There is one case that produces none of them, and it strands the request forever.

## What Node reports per reset code

Client sends a GET, server RSTs the stream before responding (pure `node:http2`, no undici):

```
RST NO_ERROR        events=[end, close]
RST PROTOCOL_ERROR  events=[error, close]
RST INTERNAL_ERROR  events=[error, close]
RST REFUSED_STREAM  events=[error, close]
RST CANCEL          events=[close]          ← nothing to act on
```

`CANCEL` is the code Node itself uses when a stream is destroyed locally, so an incoming `RST_STREAM(CANCEL)` is treated as a plain teardown rather than an error. Destroying the stream also **unenrolls its timeout**, so no `'timeout'` follows either — `stream.setTimeout()` is silently cancelled.

The result, with `headersTimeout` and `bodyTimeout` both set to 500ms:

```
undici 7.29.0: never settled — no error, no timeout after 5008ms
with this fix: UND_ERR_INFO: HTTP/2: stream closed before the response was complete after 48ms
```

No response, no error, no timeout, regardless of the configured timeouts — the caller's promise simply never settles and the request stays in the running window for the life of the client.

This is reachable against ordinary infrastructure: a proxy cancels its upstream stream whenever its own downstream client goes away.

## Change

Settle the request from `'close'` when nothing else has, mirroring what the `'error'` handler already does. The guard is `!request.aborted && !request.completed`, so normal completions and existing error paths are untouched.

## Tests

`test/http2-stream-cancel.js` covers both directions: cancelled before the response (must reject) and cancelled after the headers arrive (must still complete normally). Note the first test **hangs** rather than failing on the current branch — that is the bug.

`test/+(http2|h2)*.js`: 53 pass. Full unit suite: 1306 pass, 0 fail.

A seeded chaos harness over the same code goes from requests that never settle to `stuck=0` across every seed tried (7, 1, 42, 99).

## Still outstanding

That harness still reports queue drift on this branch — `running` stays above zero with nothing in flight — because the abort path settles the caller without advancing `kRunningIdx`, and the queue is head-of-line only (`client[kQueue][client[kRunningIdx]++] = null`) while h2 completes out of order. That predates this change and is not affected by it, but it means a long-lived client can still accumulate phantom running slots. Happy to look at it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49JamgF2TkZHu5h58ChUM