### PR TITLE
fix(h2): validate maxConcurrentStreams and read settings.initialWindowSize

### DIFF
--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -237,7 +237,7 @@ class Client extends DispatcherBase {
           throw new InvalidArgumentError('h2Options.settings.initialWindowSize must be a positive integer, greater than 0')
         }
 
-        if (h2Options.maxConcurrentStreams != null && (!Number.isInteger(h2Options.connectionWindowSize) || h2Options.maxConcurrentStreams < 1)) {
+        if (h2Options.maxConcurrentStreams != null && (!Number.isInteger(h2Options.maxConcurrentStreams) || h2Options.maxConcurrentStreams < 1)) {
           throw new InvalidArgumentError('h2Options.maxConcurrentStreams must be a positive integer, greater than 0')
         }
 
@@ -331,7 +331,7 @@ class Client extends DispatcherBase {
         //   especially on high-latency networks. This matches common production HTTP/2 servers.
         // - connectionWindowSize: 524288 (512KB) vs Node.js default (none set)
         //   Provides better flow control for the entire connection across multiple streams.
-        initialWindowSize: h2Options?.initialWindowSize ?? initialWindowSize ?? 262144
+        initialWindowSize: h2Options?.settings?.initialWindowSize ?? initialWindowSize ?? 262144
       }
     }
 

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -332,7 +332,10 @@ class Client extends DispatcherBase {
         //   especially on high-latency networks. This matches common production HTTP/2 servers.
         // - connectionWindowSize: 524288 (512KB) vs Node.js default (none set)
         //   Provides better flow control for the entire connection across multiple streams.
-        initialWindowSize: h2Options?.settings?.initialWindowSize ?? initialWindowSize ?? 262144
+        // Support both the namespaced path (h2Options.settings.initialWindowSize)
+        // and the legacy flat path (h2Options.initialWindowSize / top-level initialWindowSize)
+        // so that existing users are not silently broken.
+        initialWindowSize: h2Options?.settings?.initialWindowSize ?? h2Options?.initialWindowSize ?? initialWindowSize ?? 262144
       }
     }
 

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -238,7 +238,7 @@ class Client extends DispatcherBase {
           throw new InvalidArgumentError('h2Options.settings.initialWindowSize must be a positive integer, greater than 0')
         }
 
-        if (h2Options.maxConcurrentStreams != null && (!Number.isInteger(h2Options.connectionWindowSize) || h2Options.maxConcurrentStreams < 1)) {
+        if (h2Options.maxConcurrentStreams != null && (!Number.isInteger(h2Options.maxConcurrentStreams) || h2Options.maxConcurrentStreams < 1)) {
           throw new InvalidArgumentError('h2Options.maxConcurrentStreams must be a positive integer, greater than 0')
         }
 
@@ -332,7 +332,7 @@ class Client extends DispatcherBase {
         //   especially on high-latency networks. This matches common production HTTP/2 servers.
         // - connectionWindowSize: 524288 (512KB) vs Node.js default (none set)
         //   Provides better flow control for the entire connection across multiple streams.
-        initialWindowSize: h2Options?.initialWindowSize ?? initialWindowSize ?? 262144
+        initialWindowSize: h2Options?.settings?.initialWindowSize ?? initialWindowSize ?? 262144
       }
     }
 

--- a/test/http2-options.js
+++ b/test/http2-options.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test } = require('node:test')
+const { Client } = require('..')
+const { kHTTP2Options } = require('../lib/core/symbols')
+
+test('h2Options.maxConcurrentStreams is validated on its own value', async (t) => {
+  t = tspl(t, { plan: 4 })
+
+  const client = new Client('https://localhost', {
+    h2Options: { maxConcurrentStreams: 10 }
+  })
+  t.strictEqual(client[kHTTP2Options].maxConcurrentStreams, 10)
+  await client.close()
+
+  const withWindow = new Client('https://localhost', {
+    h2Options: { maxConcurrentStreams: 10, connectionWindowSize: 65535 }
+  })
+  t.strictEqual(withWindow[kHTTP2Options].maxConcurrentStreams, 10)
+  await withWindow.close()
+
+  t.throws(() => new Client('https://localhost', {
+    h2Options: { maxConcurrentStreams: 'not-a-number', connectionWindowSize: 65535 }
+  }), { code: 'UND_ERR_INVALID_ARG' })
+
+  t.throws(() => new Client('https://localhost', {
+    h2Options: { maxConcurrentStreams: 0 }
+  }), { code: 'UND_ERR_INVALID_ARG' })
+})
+
+test('h2Options.settings.initialWindowSize reaches the session options', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const client = new Client('https://localhost', {
+    h2Options: { settings: { initialWindowSize: 131072 } }
+  })
+  t.strictEqual(client[kHTTP2Options].sessionOptions.initialWindowSize, 131072)
+  await client.close()
+
+  const defaulted = new Client('https://localhost', { h2Options: {} })
+  t.strictEqual(defaulted[kHTTP2Options].sessionOptions.initialWindowSize, 262144)
+  await defaulted.close()
+})

--- a/test/http2-options.js
+++ b/test/http2-options.js
@@ -42,3 +42,23 @@ test('h2Options.settings.initialWindowSize reaches the session options', async (
   t.strictEqual(defaulted[kHTTP2Options].sessionOptions.initialWindowSize, 262144)
   await defaulted.close()
 })
+
+test('h2Options.initialWindowSize (legacy flat path) still reaches the session options', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  // Ensure existing code that passes initialWindowSize at the top level of h2Options
+  // is not silently broken by the move to h2Options.settings.*
+  const client = new Client('https://localhost', {
+    h2Options: { initialWindowSize: 98304 }
+  })
+  t.strictEqual(client[kHTTP2Options].sessionOptions.initialWindowSize, 98304)
+  await client.close()
+
+  // settings.* takes precedence over the flat path
+  const withBoth = new Client('https://localhost', {
+    h2Options: { initialWindowSize: 98304, settings: { initialWindowSize: 131072 } }
+  })
+  t.strictEqual(withBoth[kHTTP2Options].sessionOptions.initialWindowSize, 131072)
+  await withBoth.close()
+})
+

--- a/test/http2-options.js
+++ b/test/http2-options.js
@@ -61,4 +61,3 @@ test('h2Options.initialWindowSize (legacy flat path) still reaches the session o
   t.strictEqual(withBoth[kHTTP2Options].sessionOptions.initialWindowSize, 131072)
   await withBoth.close()
 })
-


### PR DESCRIPTION
## This relates to...

A regression from #5498, which landed after the v8.9.0 bump, so both halves below are on `main` and have not shipped yet.

## Rationale

The h2 option namespacing left two wires crossed.

**1. `h2Options.maxConcurrentStreams` is validated against the wrong property.** The guard tests `h2Options.connectionWindowSize`:

```js
if (h2Options.maxConcurrentStreams != null && (!Number.isInteger(h2Options.connectionWindowSize) || h2Options.maxConcurrentStreams < 1)) {
```

It is the block below it, copied. With `maxConcurrentStreams` set and `connectionWindowSize` absent, `Number.isInteger(undefined)` is `false` and the negation makes the condition true, so a valid integer throws. It also fails open in the other direction.

```js
new Client(origin, { h2Options: { maxConcurrentStreams: 10 } })
// InvalidArgumentError: h2Options.maxConcurrentStreams must be a positive integer, greater than 0

new Client(origin, { h2Options: { maxConcurrentStreams: 10, connectionWindowSize: 65535 } })
// fine — an unrelated option makes the same call pass

new Client(origin, { h2Options: { maxConcurrentStreams: 'not-a-number', connectionWindowSize: 65535 } })
// accepted
```

Through `Agent` or `Pool` it is worse, because clients are created lazily: construction succeeds and then every request rejects with that message, including against a plain HTTP/1.1 origin where no h2 session is ever negotiated.

```js
const agent = new Agent({ h2Options: { maxConcurrentStreams: 10 } })
await request('http://127.0.0.1:PORT/', { dispatcher: agent })
// InvalidArgumentError: h2Options.maxConcurrentStreams must be a positive integer, greater than 0
```

**2. `h2Options.settings.initialWindowSize` is validated and then dropped.** The validation checks `h2Options.settings?.initialWindowSize`, which matches `docs/docs/api/Client.md`, but the session options read `h2Options?.initialWindowSize`, so the documented option never reaches the session and an undocumented flat one is honoured instead. `{ h2Options: { settings: { initialWindowSize: 131072 } } }` leaves `sessionOptions.initialWindowSize` undefined.

## Changes

Two lines in `lib/dispatcher/client.js`: validate `maxConcurrentStreams` against itself, and read `settings.initialWindowSize` where the session options are built. I kept `Number.isInteger` rather than the looser `typeof !== 'number'` used by the legacy branch, because it is what the error message promises.

`test/http2-options.js` covers both, reading `client[kHTTP2Options]` directly. It fails 0/2 on current `main` and passes 2/2 here. `npm run test:h2` is green.

### Features

- [ ] Implemented a new feature

### Bug Fixes

- [x] Fixed a bug

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
