### PR TITLE
fix(h1): stop unref'ing the idle socket validation immediate

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1068,8 +1068,7 @@ function scheduleIdleSocketValidation (client, socket) {
     if (client[kSocket] === socket && !socket.destroyed) {
       client[kResume]()
     }
-  }, 0)
-  socket[kIdleSocketValidationTimeout].unref?.()
+  })
 }
 
 /**

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1069,7 +1069,6 @@ function scheduleIdleSocketValidation (client, socket) {
       client[kResume]()
     }
   })
-  socket[kIdleSocketValidationTimeout].unref?.()
 }
 
 /**

--- a/test/issue-5600.js
+++ b/test/issue-5600.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { Pool } = require('..')
+
+test('https://github.com/nodejs/undici/issues/5600', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const requests = 6
+  const serverDelay = 10
+
+  const server = createServer((req, res) => {
+    setTimeout(() => {
+      res.writeHead(200, { 'content-length': 2 })
+      res.end('ok')
+    }, serverDelay)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const pool = new Pool(`http://127.0.0.1:${server.address().port}`, { connections: 1 })
+
+  after(async () => {
+    await pool.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  let slowest = 0
+  for (let i = 0; i < requests; i++) {
+    const start = process.hrtime.bigint()
+    const { statusCode, body } = await pool.request({ path: '/', method: 'GET' })
+    await body.text()
+    const elapsed = Number(process.hrtime.bigint() - start) / 1e6
+
+    if (statusCode !== 200) {
+      t.fail(`request ${i} returned ${statusCode}`)
+      return
+    }
+    if (elapsed > slowest) {
+      slowest = elapsed
+    }
+  }
+
+  t.ok(true, 'every request completed')
+  // An idle keep-alive socket is revalidated on a setImmediate. While that
+  // immediate was unref'd it could be skipped on an otherwise idle event loop,
+  // and the queued request only progressed on the next fast-timers tick, so a
+  // reuse cost roughly 500ms instead of the server's 10ms.
+  t.ok(slowest < 250, `slowest request took ${slowest.toFixed(1)}ms, expected well under a fast-timers tick`)
+})


### PR DESCRIPTION
## This relates to...

Fixes #5600.

## Rationale

Reusing an idle keep-alive socket stalls for up to a fast-timers tick before the request reaches the wire. With a pool of one connection against a 10 ms server, six sequential requests take over a second instead of the ~60 ms the server accounts for.

`scheduleIdleSocketValidation` moved from an unref'd `setTimeout(..., 0)` to `setImmediate` in #5499, and the `unref?.()` came along with it. An unref'd immediate does not hold the loop open, so on an otherwise idle loop the check phase is reached only once the next fast-timers tick wakes things up, and the queued request waits for that.

By the time the validation is scheduled, the request it exists for is already queued, so there is nothing to keep alive artificially. The immediate is a one-shot that runs on the very next check phase, and `clearIdleSocketValidation` cancels it when the socket goes away, so leaving it ref'd cannot delay process exit by more than that one turn — unlike the `setTimeout` this was inherited from.

Measured on Windows with Node 24, six sequential requests through a single-connection pool:

```
before   1095 ms, 1565 ms, 2045 ms   (per-request: 34, 41, 447, 66, 438, 50)
after     122 ms,  137 ms,  219 ms   (per-request: 38, 23, 15, 15, 16, 15)
server-side floor: 60 ms
```

## Changes

- `lib/dispatcher/client-h1.js`: drop the `unref?.()` on the idle socket validation immediate.
- `test/issue-5600.js`: the reproduction from the issue, asserting the slowest of six sequential requests on a single-connection pool stays well under a fast-timers tick. It fails on current `main` with a slowest request around 425 ms.

`npx borp --timeout 180000 --expose-gc -p "test/*.js"` is 1439 passing here. The one failure in that run is `test/http2-dispatcher.js` "Should send http2 PING frames", which fails about two runs in three on unpatched `main` on this machine as well — unrelated to HTTP/1, and I have a separate branch for it if that is wanted.

### Features

- [ ] Implemented a new feature

### Bug Fixes

- [x] Fixed a bug

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
