### PR TITLE
fix(retry): skip the content-length checkpoint for HEAD and for a 206 without content-range

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -330,7 +330,7 @@ class RetryHandler {
       }
 
       // We make our best to checkpoint the body for further range headers
-      if (this.end == null) {
+      if (this.end == null && this.opts.method !== 'HEAD') {
         const contentLength = headers['content-length']
         this.end = contentLength != null ? Number(contentLength) - 1 : null
       }

--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -305,7 +305,7 @@ class RetryHandler {
         // First time we receive 206
         const range = parseRangeHeader(headers['content-range'])
 
-        if (range == null) {
+        if (range == null || range.end == null) {
           this.headersSent = true
           this.handler.onResponseStart?.(
             this.controllerProxy,

--- a/test/interceptors/retry.js
+++ b/test/interceptors/retry.js
@@ -445,6 +445,59 @@ test('Should reject initial 206 partial content with mismatched content-length',
   t.strictEqual(x, 1)
 })
 
+test('Should forward a multipart/byteranges 206 without content-range', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const body = [
+    '--THIS_STRING_SEPARATES',
+    'content-type: text/plain',
+    'content-range: bytes 0-3/25',
+    '',
+    'abcd',
+    '--THIS_STRING_SEPARATES',
+    'content-type: text/plain',
+    'content-range: bytes 10-14/25',
+    '',
+    'klmno',
+    '--THIS_STRING_SEPARATES--',
+    ''
+  ].join('\r\n')
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    t.strictEqual(req.headers.range, 'bytes=0-3,10-14')
+    res.statusCode = 206
+    res.setHeader('content-type', 'multipart/byteranges; boundary=THIS_STRING_SEPARATES')
+    res.end(body)
+  })
+
+  server.listen(0)
+
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(retry({ maxRetries: 0 }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    headers: {
+      range: 'bytes=0-3,10-14'
+    }
+  })
+
+  t.strictEqual(response.statusCode, 206)
+  t.strictEqual(response.headers['content-type'], 'multipart/byteranges; boundary=THIS_STRING_SEPARATES')
+  t.strictEqual(await response.body.text(), body)
+})
+
 test('Should handle 206 partial content - bad-etag', async t => {
   t = tspl(t, { plan: 5 })
 

--- a/test/interceptors/retry.js
+++ b/test/interceptors/retry.js
@@ -578,6 +578,35 @@ test('#4970 - Should reject resumed partial content when body exceeds Content-Ra
   })
 })
 
+test('Should not reject a HEAD response with content-length', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.setHeader('content-length', '1234')
+    res.end()
+  })
+
+  server.listen(0)
+
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(retry())
+
+  after(async () => {
+    await client.close()
+    server.close()
+
+    await once(server, 'close')
+  })
+
+  const response = await client.request({ method: 'HEAD', path: '/' })
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.headers['content-length'], '1234')
+  t.strictEqual(await response.body.text(), '')
+})
+
 test('retrying a request with a body', async t => {
   t = tspl(t, { plan: 2 })
   let counter = 0


### PR DESCRIPTION
## This relates to...

Two defects in `RetryHandler`'s byte-range checkpoint logic. No issue filed for either.

They are in one PR because they are the same three lines of logic and the same test file, and splitting them would mean two PRs touching the same block for the same reason. Each is a separate commit, so they can be taken apart if you would rather.

## Rationale

**1. A HEAD response with `Content-Length` breaks the retry interceptor.**

`onResponseStart` establishes a resume checkpoint from the response `Content-Length` without looking at the request method:

```js
if (this.end == null) {
  const contentLength = headers['content-length']
  this.end = contentLength != null ? Number(contentLength) - 1 : null
}
```

A HEAD response legitimately carries `Content-Length` describing the body a GET would return, while delivering no body at all. So the handler expects `contentLength` bytes, receives none, and the request fails with `RequestRetryError: Content-Range mismatch`. Any HEAD through `interceptors.retry()` or `RetryAgent` against a server that sets `Content-Length` on HEAD — which is normal — cannot succeed.

**2. A spec-compliant `multipart/byteranges` 206 trips an assertion.**

For a multi-range request, RFC 9110 §15.3.7.2 says the 206 carries `Content-Type: multipart/byteranges` and **no** top-level `Content-Range`; the ranges live in the part headers. The first-206 path handles that case deliberately — it forwards the response unchanged when `parseRangeHeader` returns null — but `parseRangeHeader` never returns null for an absent header, so the guard is unreachable and the request dies on `AssertionError [ERR_ASSERTION]` instead.

```js
// Range: bytes=0-3,10-14 -> 206 multipart/byteranges, no top-level Content-Range
await request(url, { headers: { range: 'bytes=0-3,10-14' }, dispatcher })
// AssertionError [ERR_ASSERTION]
```

An assertion failure is the wrong shape for "the server answered in a way this handler does not resume": it reads as an undici bug to the caller, and it is not recoverable.

## Changes

`lib/handler/retry-handler.js`, two conditions:

- skip the `Content-Length` checkpoint when the request method is HEAD;
- treat a range header that yields no usable end offset as "no checkpoint", so the existing forward-unchanged path is reachable.

`test/interceptors/retry.js` gains a case for each. Both fail on current `main`.

`npm run test:interceptors` is 294 passing / 0 failing here, and `npx eslint` is clean on both files.

### Features

- [ ] Implemented a new feature

### Bug Fixes

- [x] Fixed a bug

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
