### PR TITLE
fix(readable): keep body bytes that arrive after setEncoding()

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -15,6 +15,7 @@ const kContentType = Symbol('kContentType')
 const kContentLength = Symbol('kContentLength')
 const kUsed = Symbol('kUsed')
 const kBytesRead = Symbol('kBytesRead')
+const kPreservedBuffer = Symbol('kPreservedBuffer')
 
 const noop = () => {}
 
@@ -68,6 +69,13 @@ class BodyReadable extends Readable {
     this[kContentLength] = Number.isFinite(contentLength) ? contentLength : null
 
     /**
+     * Raw chunks kept aside while an encoding is set, see setEncoding().
+     *
+     * @type {Buffer[]|null}
+     */
+    this[kPreservedBuffer] = null
+
+    /**
      * Is stream being consumed through Readable API?
      * This is an optimization so that we avoid checking
      * for 'data' and 'readable' listeners in the hot path
@@ -84,6 +92,10 @@ class BodyReadable extends Readable {
    * @returns {void}
    */
   _destroy (err, callback) {
+    // A consume can no longer start, and one that did start has already
+    // taken these over in consumeStart().
+    this[kPreservedBuffer] = null
+
     if (!err && !this._readableState.endEmitted) {
       err = new RequestAbortedError()
     }
@@ -160,6 +172,18 @@ class BodyReadable extends Readable {
       if (this[kConsume]) {
         consumePush(this[kConsume], chunk)
         return this[kReading] ? super.push(chunk) : true
+      }
+      if (this[kPreservedBuffer] !== null) {
+        // An encoding is set and no consume has started yet, so super.push()
+        // will hand this chunk to state.decoder and buffer a decoded string
+        // instead. Keep the raw bytes for a consume that may still start.
+        if (this._readableState.dataEmitted) {
+          // Data has already left the stream, which makes the body disturbed
+          // and a consume impossible, so stop retaining raw chunks.
+          this[kPreservedBuffer] = null
+        } else {
+          this[kPreservedBuffer].push(chunk)
+        }
       }
     }
 
@@ -325,14 +349,48 @@ class BodyReadable extends Readable {
    */
   setEncoding (encoding) {
     if (Buffer.isEncoding(encoding)) {
+      // Preserve raw Buffer chunks for the consume path (body.text(),
+      // body.json(), etc.) before super.setEncoding() replaces them
+      // with decoded strings. Without this, the consume path would
+      // lose access to the original bytes — some of which may be held
+      // by the decoder for incomplete multi-byte sequences, and the
+      // rest converted to strings that can't be safely concatenated
+      // byte-wise.
+      //
+      // From here on push() keeps appending raw chunks, so that the array
+      // stays a complete byte-level record of the body and not just of the
+      // part that happened to be buffered at this point in time.
+      //
+      // This retains no more than the stream itself already does. The array is
+      // dropped when a consume starts, when the stream is destroyed, and on the
+      // first push() after data has been emitted — and a consume can only start
+      // while no data has been emitted, because a body that has been read is
+      // disturbed (see isUnusable). That window is exactly the one in which
+      // state.buffer holds on to every pushed chunk as well, so the two are
+      // bounded by the same highWaterMark.
+      const state = this._readableState
+      if (this[kConsume] === null && state.dataEmitted === false) {
+        const preserved = this[kPreservedBuffer] ?? []
+        if (state.decoder == null) {
+          // No encoding was set before, so everything still buffered is raw.
+          // With an encoding already set, state.buffer only holds decoded
+          // strings of chunks that are preserved here already.
+          const buffer = state.buffer
+          const source = typeof buffer.slice === 'function'
+            ? buffer.slice(state.bufferIndex ?? 0)
+            : buffer
+          for (const data of source) {
+            preserved.push(data)
+          }
+        }
+        this[kPreservedBuffer] = preserved
+      }
+
       // Delegate to Node.js Readable.setEncoding() which initializes a
       // StringDecoder and re-encodes already-buffered chunks. This properly
       // handles multi-byte sequences split at chunk boundaries for the
       // for-await / on('data') paths. Without this, Node.js uses
       // buf.toString(encoding) on each chunk, producing U+FFFD for split chars.
-      //
-      // The consume path (body.text(), body.json(), ...) copes with the
-      // decoded strings this leaves in state.buffer, see consumeStart().
       super.setEncoding(encoding)
     }
     return this
@@ -441,7 +499,20 @@ function consumeStart (consume) {
 
   const { _readableState: state } = consume.stream
 
-  if (state.bufferIndex) {
+  // If setEncoding() was called, state.buffer holds decoded strings (which
+  // would break Buffer.concat in chunksDecode) and the trailing bytes of an
+  // incomplete multi-byte sequence are held inside state.decoder, so they are
+  // missing from those strings altogether. kPreservedBuffer holds every raw
+  // chunk pushed since setEncoding() — including the ones buffered before it —
+  // and is therefore the complete, byte-exact source. state.buffer is skipped
+  // in that case because everything in it is covered here already.
+  const preserved = consume.stream[kPreservedBuffer]
+  if (preserved !== null) {
+    for (const chunk of preserved) {
+      consumePush(consume, chunk)
+    }
+    consume.stream[kPreservedBuffer] = null
+  } else if (state.bufferIndex) {
     const start = state.bufferIndex
     const end = state.buffer.length
     for (let n = start; n < end; n++) {
@@ -451,16 +522,6 @@ function consumeStart (consume) {
     for (const chunk of state.buffer) {
       consumePush(consume, chunk)
     }
-  }
-
-  // If setEncoding() was called, state.buffer holds decoded strings, which
-  // consumePush() turns back into bytes. The trailing bytes of a multi-byte
-  // sequence split across a chunk boundary are not part of any of those
-  // strings, they are held inside the decoder until the rest arrives, so
-  // take them from there.
-  const decoder = state.decoder
-  if (decoder != null && decoder.lastNeed > 0) {
-    consumePush(consume, Buffer.from(decoder.lastChar.subarray(0, decoder.lastTotal - decoder.lastNeed)))
   }
 
   if (state.endEmitted) {
@@ -574,11 +635,10 @@ function consumePush (consume, chunk) {
   }
 
   if (typeof chunk === 'string') {
-    // Buffered before the consume started, while an encoding was set.
     // consume.length has to stay a byte count and chunksDecode()/chunksConcat()
     // only work on bytes, so re-encode. A string's own length is in UTF-16 code
     // units and Uint8Array.prototype.set() ignores a string argument entirely.
-    chunk = Buffer.from(chunk, consume.stream._readableState.encoding)
+    chunk = Buffer.from(chunk, consume.stream._readableState.encoding || 'utf8')
   }
 
   consume.length += chunk.length

--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -117,6 +117,19 @@ class BodyReadable extends Readable {
 
   /**
    * @param {string|symbol} event
+   * @param {any[]} args
+   * @returns {boolean}
+   */
+  emit (event, ...args) {
+    const ret = super.emit(event, ...args)
+    if (event === 'data') {
+      this[kPreservedBuffer] = null
+    }
+    return ret
+  }
+
+  /**
+   * @param {string|symbol} event
    * @param {(...args: any[]) => void} listener
    * @returns {this}
    */
@@ -177,9 +190,14 @@ class BodyReadable extends Readable {
         // An encoding is set and no consume has started yet, so super.push()
         // will hand this chunk to state.decoder and buffer a decoded string
         // instead. Keep the raw bytes for a consume that may still start.
-        if (this._readableState.dataEmitted) {
-          // Data has already left the stream, which makes the body disturbed
-          // and a consume impossible, so stop retaining raw chunks.
+        //
+        // Drop the raw-bytes copy as soon as the stream enters flowing mode
+        // (a 'data' listener or .resume() call), because at that point the
+        // body is being read externally and .text()/.json() will throw anyway.
+        // This avoids holding both decoded strings (state.buffer) and raw bytes
+        // (kPreservedBuffer) simultaneously, which would double peak memory.
+        if (this._readableState.dataEmitted || this._readableState.flowing === true) {
+          // Body is flowing or has already emitted data — consume is impossible.
           this[kPreservedBuffer] = null
         } else {
           this[kPreservedBuffer].push(chunk)


### PR DESCRIPTION
Fixes #5611.

A response body is silently truncated when `setEncoding()` is used and the body arrives in more than one chunk. `.text()`, `.json()`, `.bytes()`, `.arrayBuffer()` and `.blob()` all return short data and nothing is raised. It reproduces on v8.6.0 through v8.9.0 and on `main`, and not on `74a2299e^`.

```js
const { body } = await client.request({ path: '/', method: 'GET' })
body.setEncoding('utf8')
await new Promise(r => setTimeout(r, 150))   // let the body arrive
await body.text()                            // "abc�" instead of "abc傳def"
```

### Why not just read both sources in `consumeStart()`

That was my first idea in the issue, and it does not hold up. `super.setEncoding()` collapses `state.buffer` into a single decoded string covering exactly the bytes `kPreservedBuffer` already holds, and a second `setEncoding()` call folds later chunks into that same entry — so "which entry of `state.buffer` is the duplicate" has no general answer, and any de-duplication rule I could write would be wrong for some interleaving.

Instead `push()` keeps appending the raw chunk while an encoding is set and no consume has started. That makes `kPreservedBuffer` a complete byte record, so `consumeStart()` can ignore `state.buffer` altogether and double counting is structurally impossible rather than avoided by arithmetic.

It also fixes the decoder straddle for free: the tail of an incomplete multi-byte sequence lives inside `state.decoder` and is absent from the decoded string, so anything rebuilding bytes from that string would turn today's loud `ERR_INVALID_ARG_TYPE` into silent corruption. Here the raw bytes are never reconstructed, so that trade never arises.

`consumePush()` also re-encodes a string chunk with the stream's encoding, which keeps `consume.length` a byte count. Without that, `.arrayBuffer()`/`.bytes()` return a zero-filled buffer of the wrong length, because `consume.length` sums UTF-16 code units while `Uint8Array.prototype.set(string)` writes nothing.

### Memory

Retention is bounded by one copy of the not-yet-delivered body, which is the same thing `state.buffer` is already holding, and the array is never allocated unless `setEncoding()` is called. It is dropped on the first `push()` after data has been emitted — once data leaves the stream the body is disturbed and a consume can no longer start — and in `_destroy()`, which `autoDestroy: true` guarantees for a clean end, for `dump()` and for an abort.

I measured this rather than assuming it. With a `'data'` listener and 400 chunks pushed in one tick the array holds all 400 until the loop turns, then goes to `null` on the next `push()`; after `dump()`, after `.text()` and after `destroy()` it is `null`. The drop on the data path is lazy by one push, since there is no hook at the moment of emission — worth knowing, though the ceiling is unchanged.

Note it deliberately survives `push(null)`: a consume can start after the body has fully arrived, which is exactly the case above, so releasing at EOF would reintroduce the bug.

### Tests

`test/readable.js` gains 7 cases — chunks pushed after `setEncoding()`, a partial character buffered, `utf8`/`hex`/`base64`/`latin1` before any chunk arrives, and `.json()`. Each was checked to fail against the current `lib/api/readable.js` and pass with this change; the failures are the truncation, `ERR_INVALID_ARG_TYPE`, and a 13-byte zero-filled `Uint8Array` where 15 real bytes were expected.

`test/readable.js` 17/17, `test/client-request.js` 48/48, and the body-consuming suites I could identify pass individually: `get-head-body.js`, `response-queue-poisoning.js` (uses `setEncoding('latin1')`), `issue-4691.js`, `client.js`, `promises.js`, `retry-agent.js`, `fetch/client-fetch.js`, `fetch/response-json.js`, `fetch/readable-stream-from.js`, `interceptors/redirect.js`, `interceptors/retry.js`. eslint clean.

#5003 is not undone — `setEncoding` followed by `for await` and by `on('data')` both still decode a split multi-byte character correctly, which is covered by the existing `client-request.js` test.

### Possible drawbacks

The retention is new behaviour on a hot path, and while I measured the four exit paths above I have not profiled a large streaming download that calls `setEncoding()` and never consumes. Everything here was run on Node 24 on Windows; I have not exercised the other matrix cells locally, and the straddle and zero-fill behaviours depend on `StringDecoder` internals that could differ by Node major. I also did not run `npm run test:typescript`, which fails on clean `main` in Git Bash for an unrelated reason — the script relies on shell glob expansion for `types/*.d.ts`.
