### PR TITLE
fix(readable): consume a body whose end has already been emitted

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -487,12 +487,17 @@ function consumeStart (consume) {
   }
 
   if (state.endEmitted) {
-    consumeEnd(this[kConsume], this._readableState.encoding)
-  } else {
-    consume.stream.on('end', function () {
-      consumeEnd(this[kConsume], this._readableState.encoding)
-    })
+    // No `this` to read the consume off here: consumeStart is a free function, called from
+    // the queueMicrotask above. The callback below does have one, because the emitter passes
+    // the stream as its receiver. Returning matters too - consumeEnd() clears consume.stream,
+    // which the resume() below would then dereference.
+    consumeEnd(consume, state.encoding)
+    return
   }
+
+  consume.stream.on('end', function () {
+    consumeEnd(this[kConsume], this._readableState.encoding)
+  })
 
   consume.stream.resume()
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -5,6 +5,26 @@ const { test, describe } = require('node:test')
 const { Readable } = require('../lib/api/readable')
 
 describe('Readable', () => {
+  test('consume a body whose end has already been emitted', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+
+    // An empty body, as a 204 gives, drained before anyone asks for it. No data is
+    // emitted, so the body is not disturbed and the consume is allowed to proceed -
+    // it just starts after 'end'. What must not happen is a throw out of the
+    // microtask consumeStart runs on, which no caller can catch.
+    r.push(null)
+    r.resume()
+    await new Promise(resolve => r.on('end', resolve))
+
+    t.strictEqual(await r.text(), '')
+  })
+
   test('avoid body reordering', async function (t) {
     t = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
Fixes #5614.

`consumeStart()` is a free function, called as `consumeStart(stream[kConsume])` from the `queueMicrotask()` above it, so `this` is `undefined` inside it under `'use strict'`. The `state.endEmitted` branch read `this[kConsume]` anyway:

```
TypeError: Cannot read properties of undefined (reading 'Symbol(kConsume)')
    at consumeStart (lib/api/readable.js:490:20)
    at lib/api/readable.js:450:9
    at node:internal/process/task_queues:149:7
```

The two lines are character-for-character the same as the ones in the `on('end')` callback immediately below, which is what makes it easy to read past — those work, because the emitter invokes the callback with the stream as its receiver.

The part that makes it worth fixing rather than tidying is that the caller cannot catch it. The throw happens on a microtask rather than in the promise chain, so `await`ing the consume inside `try`/`catch` still takes the process down. Draining a body and then deciding to read it after all is enough to reach it.

### On the early return

Correcting only the receiver moves the crash rather than removing it:

```
TypeError: Cannot read properties of null (reading 'resume')
    at consumeStart (lib/api/readable.js:497:18)
```

`consumeEnd()` sets `consume.stream` to `null`, and the `consume.stream.resume()` a few lines down then dereferences it — reachable only once the branch above stops throwing first. So the `return` is part of the fix.

### Tests

One case added to `test/readable.js`: an empty body, drained, then consumed. Without the change the test runner reports it as an uncaught exception rather than a failed assertion, which is the same shape as the bug:

```
Error: A resource generated asynchronous activity after the test ended. This activity created the
error "TypeError: Cannot read properties of undefined (reading 'Symbol(kConsume)')" which triggered
an uncaughtException event, caught by the test runner.
```

`test/readable.js` 11/11 and `test/client-request.js` 48/48 with the change; eslint clean.

### Possible drawbacks

The `endEmitted` path is reached by consuming a body after `'end'`, and I have only exercised it with an empty body and with a drained 204 over a real request. A body that emitted data first is disturbed and rejects with `TypeError: unusable` before reaching this code, both before and after — I checked that separately so the change is not masking it.

Node 24 on Windows only; I have not run the other matrix cells locally. I did not run `npm run test:typescript`, which fails on clean `main` in Git Bash for an unrelated reason (the script relies on shell glob expansion for `types/*.d.ts`).
