### PR TITLE
fix(h2): retire the request that completed, not the head of the queue

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -314,6 +314,36 @@ function onHttp2SessionEnd () {
  * @this {import('http2').ClientHttp2Session}
  * @param {number} errorCode
  */
+// Backport of #5410 and #5569. HTTP/2 multiplexes, so requests complete out of
+// order; advancing kRunningIdx blindly retired whichever request happened to
+// sit at the head instead of the one that actually finished, which both lost
+// requests and left phantom running slots behind.
+function completeRequest (client, request, resetPendingIdx = false) {
+  const queue = client[kQueue]
+  const runningIdx = client[kRunningIdx]
+
+  // In-order completion: clear the request and advance without splicing.
+  // The client's resume loop compacts cleared slots once the index grows.
+  if (runningIdx < client[kPendingIdx] && queue[runningIdx] === request) {
+    queue[runningIdx] = null
+    client[kRunningIdx] = runningIdx + 1
+    return
+  }
+
+  const index = queue.indexOf(request, runningIdx)
+
+  if (index === -1 || index >= client[kPendingIdx]) {
+    return
+  }
+
+  queue.splice(index, 1)
+  client[kPendingIdx]--
+
+  if (resetPendingIdx && client[kPendingIdx] < client[kRunningIdx]) {
+    client[kPendingIdx] = client[kRunningIdx]
+  }
+}
+
 function onHttp2SessionGoAway (errorCode) {
   // TODO(mcollina): Verify if GOAWAY implements the spec correctly:
   // https://datatracker.ietf.org/doc/html/rfc7540#section-6.8
@@ -335,7 +365,9 @@ function onHttp2SessionGoAway (errorCode) {
   if (client[kRunningIdx] < client[kQueue].length) {
     const request = client[kQueue][client[kRunningIdx]]
     client[kQueue][client[kRunningIdx]++] = null
-    util.errorRequest(client, request, err)
+    if (request != null) {
+      util.errorRequest(client, request, err)
+    }
     client[kPendingIdx] = client[kRunningIdx]
   }
 
@@ -368,7 +400,9 @@ function onHttp2SessionClose () {
     const requests = client[kQueue].splice(client[kRunningIdx])
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
-      util.errorRequest(client, request, err)
+      if (request != null) {
+        util.errorRequest(client, request, err)
+      }
     }
   }
 }
@@ -483,6 +517,7 @@ function writeH2 (client, request) {
 
       // We move the running index to the next request
       client[kOnError](err)
+      completeRequest(client, request)
       client[kResume]()
     }
 
@@ -537,7 +572,7 @@ function writeH2 (client, request) {
         request.onUpgrade(statusCode, parseH2Headers(realHeaders), stream)
 
         ++session[kOpenStreams]
-        client[kQueue][client[kRunningIdx]++] = null
+        completeRequest(client, request)
       })
 
       stream.on('error', () => {
@@ -570,7 +605,7 @@ function writeH2 (client, request) {
 
       request.onUpgrade(statusCode, parseH2Headers(realHeaders), stream)
       ++session[kOpenStreams]
-      client[kQueue][client[kRunningIdx]++] = null
+      completeRequest(client, request)
     })
     stream.once('close', () => {
       session[kOpenStreams] -= 1
@@ -720,14 +755,13 @@ function writeH2 (client, request) {
         request.onComplete({})
       }
 
-      client[kQueue][client[kRunningIdx]++] = null
+      completeRequest(client, request)
       client[kResume]()
     } else {
       // Stream ended without receiving a response - this is an error
       // (e.g., server destroyed the stream before sending headers)
       abort(new InformationalError('HTTP/2: stream half-closed (remote)'))
-      client[kQueue][client[kRunningIdx]++] = null
-      client[kPendingIdx] = client[kRunningIdx]
+      completeRequest(client, request, true)
       client[kResume]()
     }
   })

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -374,7 +374,9 @@ class Client extends DispatcherBase {
       const requests = this[kQueue].splice(this[kPendingIdx])
       for (let i = 0; i < requests.length; i++) {
         const request = requests[i]
-        util.errorRequest(this, request, err)
+        if (request != null) {
+          util.errorRequest(this, request, err)
+        }
       }
 
       const callback = () => {
@@ -413,7 +415,9 @@ function onError (client, err) {
 
     for (let i = 0; i < requests.length; i++) {
       const request = requests[i]
-      util.errorRequest(client, request, err)
+      if (request != null) {
+        util.errorRequest(client, request, err)
+      }
     }
     assert(client[kSize] === 0)
   }

--- a/test/issue-5404.js
+++ b/test/issue-5404.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { once } = require('node:events')
+const { createServer } = require('node:http2')
+
+const { Client } = require('..')
+const { kQueue } = require('../lib/core/symbols')
+
+// Backported from #5410.
+//
+// Regression test for https://github.com/nodejs/undici/issues/5404.
+// HTTP/2 streams can complete out of order. Completing the second stream first
+// must not clear the first request's queue slot; otherwise destroying the
+// client can lose or mis-error the still-running request.
+test('h2: out-of-order completion preserves running requests during destroy', async () => {
+  const server = createServer()
+  let firstStream
+
+  server.on('sessionError', () => {})
+  server.on('stream', (stream, headers) => {
+    switch (headers[':path']) {
+      case '/first':
+        firstStream = stream
+        break
+      case '/second':
+        stream.respond({ ':status': 200 })
+        stream.end('second')
+        break
+      case '/third':
+        stream.respond({ ':status': 200 })
+        stream.end('third')
+        break
+      default:
+        stream.respond({ ':status': 404 })
+        stream.end()
+    }
+  })
+
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`http://localhost:${server.address().port}`, {
+    allowH2: true,
+    useH2c: true,
+    maxConcurrentStreams: 2,
+    // h2 only dispatches concurrently up to `pipelining`, which defaults to 1.
+    pipelining: 2
+  })
+
+  try {
+    const first = client.request({ path: '/first', method: 'GET' })
+    const firstError = first.then(
+      () => null,
+      err => err
+    )
+
+    const second = await client.request({ path: '/second', method: 'GET' })
+    assert.strictEqual(await second.body.text(), 'second')
+
+    const third = await client.request({ path: '/third', method: 'GET' })
+    assert.strictEqual(await third.body.text(), 'third')
+
+    assert.strictEqual(firstStream.destroyed, false)
+    assert.deepStrictEqual(client[kQueue].map(request => request?.path), ['/first'])
+
+    await client.destroy(new Error('boom'))
+    assert.strictEqual((await firstError).message, 'boom')
+  } finally {
+    await client.destroy().catch(() => {})
+    server.close()
+  }
+})


### PR DESCRIPTION
Backport of #5410, with the in-order fast path from #5569. Neither is on `v7.x` — the h2 queue commits after #4881 never came across.

## The bug

HTTP/2 completes out of order, but every completion site advanced the running index blindly:

```js
client[kQueue][client[kRunningIdx]++] = null
```

That retires whichever request happens to sit at the head, not the one that actually finished. With two streams in flight (`/first` never answered, `/second` and `/third` served):

```
                 before                          after this change
after /second    queue=[null, "/second"]         queue=["/first"]
                 runningIdx=1 pendingIdx=2       runningIdx=0 pendingIdx=1
after /third     queue=[null, null, "/third"]    queue=["/first"]
                 runningIdx=2 pendingIdx=3       runningIdx=0 pendingIdx=1
```

The still-running `/first` has been dropped from the queue, and two finished requests are counted as running for good. `kRunning` never returns to zero, and since `_resume()` stops dispatching once `kRunning` reaches the concurrency limit, a client that accumulates these eventually stops sending anything at all.

## The change

`completeRequest()` ported from main: retire the request by identity, keeping the O(1) fast path when it is the head, and splice it out when it finished out of order. Cleared slots can now appear in the queue, so the paths that walk it skip them — the same `if (request != null)` guards #5410 added to `client.js`, which cherry-picked cleanly.

## Reachability on v7.x

Worth knowing for triage: v7 only dispatches h2 requests concurrently up to `pipelining`, which defaults to `1`, so the out-of-order case needs `pipelining` (or a pool where several requests share a client) to show up. main added `getMaxConcurrent()` to dispatch up to `maxConcurrentStreams` for h2, which is why this bites much harder there. The ported test therefore sets `pipelining: 2` — without it, `/second` and `/third` simply queue behind `/first` and never run.

## Tests

`test/issue-5404.js` backported from #5410, plus `pipelining: 2`. Fails on the current branch (queue is `[null, null, '/third']` instead of `['/first']`), passes with this change.

`test/+(http2|h2)*.js`: 50 pass. Full unit suite: 1304 pass, 0 fail.

A seeded chaos harness against v7 currently aborts within a round or two of starting, reporting requests left in flight with nothing outstanding. With this change it no longer drifts; stacked with #5607 it runs all 25 rounds clean (~200 requests per seed, `stuck=0`) on every seed tried.

## Relationship to the other v7 PRs

Independent of #5604, #5605 and #5607 — different bugs, no overlapping hunks. #5607 is the one that makes the harness above reach `stuck=0`; this one is what stops the queue drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49JamgF2TkZHu5h58ChUM