### PR TITLE
fix(mock): non-string path matchers under ignoreTrailingSlash, and DataView reply bodies

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -158,7 +158,7 @@ function getResponseData (data) {
     // rather than a plain object. Buffer.from() cannot read one directly, so
     // expose the bytes it covers instead of letting it reach JSON.stringify.
     return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-  } else if (typeof data === 'object') {
+  } else if (data && typeof data === 'object') {
     return JSON.stringify(data)
   } else if (data) {
     return data.toString()

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -225,9 +225,15 @@ function deleteMockDispatch (mockDispatches, key) {
 }
 
 /**
- * @param {string} path Path to remove trailing slash from
+ * @param {string|RegExp|Function} path Path, or path matcher, to remove trailing slash from
  */
 function removeTrailingSlash (path) {
+  // Registered path matchers may be a RegExp or a function, which have no
+  // trailing slash to strip; hand those back for matchValue to apply.
+  if (typeof path !== 'string') {
+    return path
+  }
+
   while (path.endsWith('/')) {
     path = path.slice(0, -1)
   }

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -153,6 +153,11 @@ function getResponseData (data) {
     return data
   } else if (data instanceof ArrayBuffer) {
     return data
+  } else if (ArrayBuffer.isView(data)) {
+    // A DataView, or any non-Uint8Array typed array, is a byte container
+    // rather than a plain object. Buffer.from() cannot read one directly, so
+    // expose the bytes it covers instead of letting it reach JSON.stringify.
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
   } else if (typeof data === 'object') {
     return JSON.stringify(data)
   } else if (data) {

--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -158,7 +158,7 @@ function getResponseData (data) {
     // rather than a plain object. Buffer.from() cannot read one directly, so
     // expose the bytes it covers instead of letting it reach JSON.stringify.
     return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-  } else if (data && typeof data === 'object') {
+  } else if (typeof data === 'object') {
     return JSON.stringify(data)
   } else if (data) {
     return data.toString()

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -592,6 +592,15 @@ describe('MockInterceptor - different payloads', () => {
     ['bytes', 'string', 'Uint8Array', '{"test":true}', new TextEncoder().encode('{"test":true}')],
     ['text', 'string', 'string', '{"test":true}', '{"test":true}'],
 
+    // DataView
+    ['arrayBuffer', 'DataView', 'ArrayBuffer', new DataView(new TextEncoder().encode('{"test":true}').buffer), new TextEncoder().encode('{"test":true}').buffer],
+    ['json', 'DataView', 'Object', new DataView(new TextEncoder().encode('{"test":true}').buffer), { test: true }],
+    ['bytes', 'DataView', 'Uint8Array', new DataView(new TextEncoder().encode('{"test":true}').buffer), new TextEncoder().encode('{"test":true}')],
+    ['text', 'DataView', 'string', new DataView(new TextEncoder().encode('{"test":true}').buffer), '{"test":true}'],
+
+    // DataView covering only part of its backing ArrayBuffer
+    ['text', 'DataView with an offset', 'string', new DataView(new TextEncoder().encode('xx{"test":true}yy').buffer, 2, 13), '{"test":true}'],
+
     // object
     ['arrayBuffer', 'Object', 'ArrayBuffer', { test: true }, new TextEncoder().encode('{"test":true}').buffer],
     ['json', 'Object', 'Object', { test: true }, { test: true }],

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -511,6 +511,61 @@ describe('https://github.com/nodejs/undici/issues/3649', () => {
   })
 })
 
+describe('MockInterceptor - ignoreTrailingSlash with non-string path matchers', () => {
+  [
+    ['RegExp', /^\/api\/some-path$/],
+    ['Function', (path) => path === '/api/some-path']
+  ].forEach(([matcherType, path]) => {
+    ['/api/some-path', '/api/some-path/', '/api/some-path///'].forEach((fetchedPath) => {
+      test(`a ${matcherType} path matcher matches '${fetchedPath}' as a MockAgent option`, async (t) => {
+        t.plan(1)
+
+        const mockAgent = new MockAgent({ ignoreTrailingSlash: true })
+        mockAgent.disableNetConnect()
+        t.after(() => mockAgent.close())
+        mockAgent
+          .get('https://localhost')
+          .intercept({ path }).reply(200, { ok: true })
+
+        const res = await fetch(new URL(fetchedPath, 'https://localhost'), { dispatcher: mockAgent })
+
+        t.assert.deepStrictEqual(await res.json(), { ok: true })
+      })
+
+      test(`a ${matcherType} path matcher matches '${fetchedPath}' as an intercept option`, async (t) => {
+        t.plan(1)
+
+        const mockAgent = new MockAgent()
+        mockAgent.disableNetConnect()
+        t.after(() => mockAgent.close())
+        mockAgent
+          .get('https://localhost')
+          .intercept({ path, ignoreTrailingSlash: true }).reply(200, { ok: true })
+
+        const res = await fetch(new URL(fetchedPath, 'https://localhost'), { dispatcher: mockAgent })
+
+        t.assert.deepStrictEqual(await res.json(), { ok: true })
+      })
+    })
+
+    test(`a ${matcherType} path matcher still rejects a non-matching path`, async (t) => {
+      t.plan(1)
+
+      const mockAgent = new MockAgent({ ignoreTrailingSlash: true })
+      mockAgent.disableNetConnect()
+      t.after(() => mockAgent.close())
+      mockAgent
+        .get('https://localhost')
+        .intercept({ path }).reply(200, { ok: true })
+
+      await t.assert.rejects(
+        fetch(new URL('/api/other-path', 'https://localhost'), { dispatcher: mockAgent }),
+        (err) => err.cause instanceof MockNotMatchedError
+      )
+    })
+  })
+})
+
 describe('MockInterceptor - different payloads', () => {
   [
     // Buffer

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -244,7 +244,7 @@ describe('getResponseData', () => {
   test('it should handle null', (t) => {
     t.plan(1)
     const responseData = getResponseData(null)
-    t.assert.strictEqual(responseData, '')
+    t.assert.strictEqual(responseData, 'null')
   })
 })
 

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -240,6 +240,12 @@ describe('getResponseData', () => {
     const responseData = getResponseData(undefined)
     t.assert.strictEqual(responseData, '')
   })
+
+  test('it should handle null', (t) => {
+    t.plan(1)
+    const responseData = getResponseData(null)
+    t.assert.strictEqual(responseData, '')
+  })
 })
 
 test('getStatusText', (t) => {

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -124,6 +124,44 @@ describe('getMockDispatch', () => {
     }), new MockNotMatchedError('Mock dispatch not matched for body \'wrong\' on path \'path\''))
   })
 
+  test('it should match a RegExp path with ignoreTrailingSlash', (t) => {
+    t.plan(2)
+    const dispatch = {
+      path: /^\/path$/,
+      method: 'method',
+      ignoreTrailingSlash: true,
+      consumed: false
+    }
+
+    t.assert.deepStrictEqual(getMockDispatch([dispatch], {
+      path: '/path',
+      method: 'method'
+    }), dispatch)
+    t.assert.deepStrictEqual(getMockDispatch([dispatch], {
+      path: '/path/',
+      method: 'method'
+    }), dispatch)
+  })
+
+  test('it should match a function path with ignoreTrailingSlash', (t) => {
+    t.plan(2)
+    const dispatch = {
+      path: (path) => path === '/path',
+      method: 'method',
+      ignoreTrailingSlash: true,
+      consumed: false
+    }
+
+    t.assert.deepStrictEqual(getMockDispatch([dispatch], {
+      path: '/path',
+      method: 'method'
+    }), dispatch)
+    t.assert.deepStrictEqual(getMockDispatch([dispatch], {
+      path: '/path/',
+      method: 'method'
+    }), dispatch)
+  })
+
   test('it should throw if no dispatch matches headers', (t) => {
     t.plan(1)
     const dispatches = [

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -214,6 +214,27 @@ describe('getResponseData', () => {
     t.assert.ok(responseData instanceof ArrayBuffer)
   })
 
+  test('it should return the bytes of a DataView', (t) => {
+    t.plan(2)
+    const responseData = getResponseData(new DataView(new TextEncoder().encode('{"test":true}').buffer))
+    t.assert.ok(responseData instanceof Uint8Array)
+    t.assert.strictEqual(Buffer.from(responseData).toString('utf8'), '{"test":true}')
+  })
+
+  test('it should return only the bytes a DataView covers', (t) => {
+    t.plan(1)
+    const buffer = new TextEncoder().encode('xx{"test":true}yy').buffer
+    const responseData = getResponseData(new DataView(buffer, 2, 13))
+    t.assert.strictEqual(Buffer.from(responseData).toString('utf8'), '{"test":true}')
+  })
+
+  test('it should return the bytes of a typed array that is not a Uint8Array', (t) => {
+    t.plan(2)
+    const responseData = getResponseData(new Uint8ClampedArray([1, 2, 3]))
+    t.assert.ok(responseData instanceof Uint8Array)
+    t.assert.deepStrictEqual([...responseData], [1, 2, 3])
+  })
+
   test('it should handle undefined', (t) => {
     t.plan(1)
     const responseData = getResponseData(undefined)


### PR DESCRIPTION
Two independent MockAgent defects, one commit each.

### `ignoreTrailingSlash` throws on a non-string path matcher

`removeTrailingSlash()` calls `path.endsWith('/')` unconditionally, but it is only reached on the `ignoreTrailingSlash` branch, where the argument is the *registered matcher* — documented in `docs/docs/api/MockPool.md:97` as `{string|RegExp|Function}`. `safeUrl()` a few lines up gets this right with a `typeof` guard. So

```js
const agent = new MockAgent({ ignoreTrailingSlash: true })
agent.get(origin).intercept({ path: /\/foo/, method: 'GET' }).reply(200, 'ok')
```

throws a `TypeError` instead of matching.

### A `DataView` reply body is delivered as `{}`

`getResponseData()` checks for `Buffer`, then `Uint8Array`, then `ArrayBuffer`, and everything else that is an object falls to `JSON.stringify`. A `DataView` is none of the first three, so `reply(200, someDataView)` sent the two characters `{}`.

Measured through `getResponseData()` on `main` before the change:

| body | returns | delivered |
| --- | --- | --- |
| `Buffer` | object | 9 bytes, correct |
| `Uint8Array` | object | 3 bytes, correct |
| `ArrayBuffer` | object | 6 bytes, correct |
| **`DataView`** | **string, length 2** | **`{}`** |

The fix returns a `Uint8Array` over the same memory, and deliberately passes `byteOffset` and `byteLength`:

```js
return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
```

A `DataView` is frequently a window into a larger buffer, so `new Uint8Array(data.buffer)` alone would send bytes the caller never offered. There is a test for exactly that case.

### Tests

Added to `test/mock-utils.js` and `test/mock-interceptor.js`, in the style of the neighbours. Reverting `lib/mock/mock-utils.js` and keeping the tests:

```
test/mock-utils.js        36 pass / 0 fail  ->  31 pass / 5 fail
test/mock-interceptor.js  86 pass / 0 fail  ->  67 pass / 19 fail

  ✖ it should match a RegExp path with ignoreTrailingSlash
  ✖ it should match a function path with ignoreTrailingSlash
  ✖ it should return the bytes of a DataView
  ✖ it should return only the bytes a DataView covers
```

With both fixes in place: `mock-agent.js` 99/99, `mock-utils.js` 36/36, `mock-interceptor.js` 86/86, `mock-pool.js` 16/16, `mock-client.js` 18/18, `mock-scope.js` 5/5, `mock-errors.js` 2/2, `mock-interceptor-unused-assertions.js` 7/7, `mock-call-history.js` 46/46. eslint clean.

### Possible drawbacks

**`ArrayBuffer.isView()` widens the second fix past `DataView` to every non-`Uint8Array` typed array, and that is an observable behaviour change.** `reply(200, new Int32Array([1, 2]))` previously delivered `{"0":1,"1":2}` and now delivers 8 raw bytes. I think the byte reading is obviously the intended one for a typed array, but anyone who was relying on the index-keyed JSON would notice. Say the word and I will narrow it to `DataView` only.

Related and worth knowing: `content-length` for a `DataView` reply also becomes correct as a side effect, because `Uint8Array.length` is the byte length where the old string had length 2.

Not exercised: no real socket — both changes are on the mock dispatch path, and `getResponseData`/`removeTrailingSlash` have no callers outside `lib/mock/`. Single local Node on Windows, so the CI matrix is untested from here, and `test:typescript`, `test:fuzzing` and `test:wpt` were not run.
