### PR TITLE
fix(readable): keep body bytes that arrive after setEncoding()

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -15,7 +15,6 @@ const kContentType = Symbol('kContentType')
 const kContentLength = Symbol('kContentLength')
 const kUsed = Symbol('kUsed')
 const kBytesRead = Symbol('kBytesRead')
-const kPreservedBuffer = Symbol('kPreservedBuffer')
 
 const noop = () => {}
 
@@ -326,36 +325,14 @@ class BodyReadable extends Readable {
    */
   setEncoding (encoding) {
     if (Buffer.isEncoding(encoding)) {
-      // Preserve raw Buffer chunks for the consume path (body.text(),
-      // body.json(), etc.) before super.setEncoding() replaces them
-      // with decoded strings. Without this, the consume path would
-      // lose access to the original bytes — some of which may be held
-      // by the decoder for incomplete multi-byte sequences, and the
-      // rest converted to strings that can't be safely concatenated
-      // byte-wise.
-      const state = this._readableState
-      const buffer = state.buffer
-      if (buffer && state.length > 0) {
-        const bufferIndex = state.bufferIndex ?? 0
-        const preserved = []
-        const source = typeof buffer.slice === 'function'
-          ? buffer.slice(bufferIndex)
-          : buffer
-        for (const data of source) {
-          if (Buffer.isBuffer(data)) {
-            preserved.push(data)
-          }
-        }
-        if (preserved.length > 0) {
-          this[kPreservedBuffer] = (this[kPreservedBuffer] || []).concat(preserved)
-        }
-      }
-
       // Delegate to Node.js Readable.setEncoding() which initializes a
       // StringDecoder and re-encodes already-buffered chunks. This properly
       // handles multi-byte sequences split at chunk boundaries for the
       // for-await / on('data') paths. Without this, Node.js uses
       // buf.toString(encoding) on each chunk, producing U+FFFD for split chars.
+      //
+      // The consume path (body.text(), body.json(), ...) copes with the
+      // decoded strings this leaves in state.buffer, see consumeStart().
       super.setEncoding(encoding)
     }
     return this
@@ -464,17 +441,7 @@ function consumeStart (consume) {
 
   const { _readableState: state } = consume.stream
 
-  // If setEncoding() was called, state.buffer may contain decoded strings
-  // (which would break Buffer.concat in chunksDecode). Use the preserved
-  // raw Buffers (saved before super.setEncoding() in setEncoding()) for
-  // byte-level accurate consumption. Otherwise read from state.buffer.
-  const preserved = consume.stream[kPreservedBuffer]
-  if (preserved && preserved.length > 0) {
-    for (const chunk of preserved) {
-      consumePush(consume, chunk)
-    }
-    consume.stream[kPreservedBuffer] = null
-  } else if (state.bufferIndex) {
+  if (state.bufferIndex) {
     const start = state.bufferIndex
     const end = state.buffer.length
     for (let n = start; n < end; n++) {
@@ -484,6 +451,16 @@ function consumeStart (consume) {
     for (const chunk of state.buffer) {
       consumePush(consume, chunk)
     }
+  }
+
+  // If setEncoding() was called, state.buffer holds decoded strings, which
+  // consumePush() turns back into bytes. The trailing bytes of a multi-byte
+  // sequence split across a chunk boundary are not part of any of those
+  // strings, they are held inside the decoder until the rest arrives, so
+  // take them from there.
+  const decoder = state.decoder
+  if (decoder != null && decoder.lastNeed > 0) {
+    consumePush(consume, Buffer.from(decoder.lastChar.subarray(0, decoder.lastTotal - decoder.lastNeed)))
   }
 
   if (state.endEmitted) {
@@ -588,12 +565,20 @@ function consumeEnd (consume, encoding) {
 
 /**
  * @param {Consume} consume
- * @param {Buffer} chunk
+ * @param {Buffer|string} chunk
  * @returns {void}
  */
 function consumePush (consume, chunk) {
   if (consume.body === null) {
     return
+  }
+
+  if (typeof chunk === 'string') {
+    // Buffered before the consume started, while an encoding was set.
+    // consume.length has to stay a byte count and chunksDecode()/chunksConcat()
+    // only work on bytes, so re-encode. A string's own length is in UTF-16 code
+    // units and Uint8Array.prototype.set() ignores a string argument entirely.
+    chunk = Buffer.from(chunk, consume.stream._readableState.encoding)
   }
 
   consume.length += chunk.length

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1574,6 +1574,46 @@ test('setEncoding(\'utf8\') handles 3-byte UTF-8 characters split across chunks'
   await t.completed
 })
 
+test('#5611 - setEncoding() then .text() does not truncate a body that arrives in several chunks', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  // '傳' is 3 bytes in UTF-8, split across the two chunks below.
+  const text = 'abc傳def'
+  const buf = Buffer.from(text)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+    res.write(buf.subarray(0, 4))
+    setTimeout(() => {
+      res.end(buf.subarray(4))
+    }, 50)
+  })
+  after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+
+  server.listen(0, async () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(client.destroy.bind(client))
+
+    const { body } = await client.request({ path: '/', method: 'GET' })
+    body.setEncoding('utf8')
+
+    // Let the whole body arrive before consuming, so that every chunk is
+    // buffered as a decoded string and the split character sits inside the
+    // decoder by the time the consume starts.
+    await new Promise(resolve => setTimeout(resolve, 150))
+
+    const result = await body.text()
+
+    t.strictEqual(result, text)
+    t.strictEqual(Buffer.byteLength(result), buf.length)
+  })
+
+  await t.completed
+})
+
 test('#3736 - Aborted Response (without consuming body)', async (t) => {
   const plan = tspl(t, { plan: 1 })
 

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1581,12 +1581,15 @@ test('#5611 - setEncoding() then .text() does not truncate a body that arrives i
   const text = 'abc傳def'
   const buf = Buffer.from(text)
 
-  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+  // The rest of the body is released only once the client has called
+  // setEncoding(), which is what puts the second chunk on the wrong side of it.
+  const sendRest = new EE()
+
+  const server = createServer({ joinDuplicateHeaders: true }, async (req, res) => {
     res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
     res.write(buf.subarray(0, 4))
-    setTimeout(() => {
-      res.end(buf.subarray(4))
-    }, 50)
+    await EE.once(sendRest, 'go')
+    res.end(buf.subarray(4))
   })
   after(() => {
     server.closeAllConnections?.()
@@ -1600,10 +1603,13 @@ test('#5611 - setEncoding() then .text() does not truncate a body that arrives i
     const { body } = await client.request({ path: '/', method: 'GET' })
     body.setEncoding('utf8')
 
-    // Let the whole body arrive before consuming, so that every chunk is
-    // buffered as a decoded string and the split character sits inside the
-    // decoder by the time the consume starts.
-    await new Promise(resolve => setTimeout(resolve, 150))
+    // 'drain' means the request has run to completion, so the whole body has
+    // arrived and is buffered as decoded strings, with the split character
+    // held inside the decoder. Waiting on the body itself is not an option:
+    // reading it would disturb it and make the consume below unusable.
+    const completed = EE.once(client, 'drain')
+    sendRest.emit('go')
+    await completed
 
     const result = await body.text()
 

--- a/test/readable.js
+++ b/test/readable.js
@@ -226,4 +226,136 @@ describe('Readable', () => {
 
     t.strictEqual(text, 'hello world')
   })
+
+  test('setEncoding() then .text() keeps chunks pushed after setEncoding()', async function (t) {
+    t = tspl(t, { plan: 2 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+
+    // '傳' is 3 bytes in UTF-8, so cutting every 2 bytes splits each of them
+    // across a chunk boundary.
+    const expected = 'a傳b傳c傳d'
+    const buf = Buffer.from(expected)
+    const chunks = []
+    for (let n = 0; n < buf.length; n += 2) {
+      chunks.push(buf.subarray(n, n + 2))
+    }
+
+    // Buffered when setEncoding() runs: these are replaced by a single decoded
+    // string, with the tail of the split '傳' held inside the decoder.
+    r.push(chunks[0])
+    r.push(chunks[1])
+
+    r.setEncoding('utf8')
+
+    // Pushed after setEncoding() but before .text() is called: these are
+    // buffered as decoded strings, not as bytes.
+    r.push(chunks[2])
+    r.push(chunks[3])
+
+    const promise = r.text()
+
+    // Pushed after .text() but before the consume actually starts.
+    r.push(chunks[4])
+
+    setImmediate(() => {
+      // Pushed once the consume is running.
+      r.push(chunks[5])
+      r.push(chunks[6])
+      r.push(null)
+    })
+
+    const text = await promise
+
+    t.strictEqual(text, expected)
+    t.strictEqual(Buffer.byteLength(text), buf.length)
+  })
+
+  test('setEncoding() with only a partial character buffered', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+
+    const buf = Buffer.from('傳')
+
+    // Decodes to the empty string, so setEncoding() leaves nothing buffered
+    // and the byte stays inside the decoder.
+    r.push(buf.subarray(0, 1))
+
+    r.setEncoding('utf8')
+
+    r.push(buf.subarray(1))
+
+    process.nextTick(() => {
+      r.push(null)
+    })
+
+    t.strictEqual(await r.text(), '傳')
+  })
+
+  for (const encoding of ['utf8', 'hex', 'base64', 'latin1']) {
+    test(`setEncoding('${encoding}') before any chunk arrives`, async function (t) {
+      t = tspl(t, { plan: 5 })
+
+      function resume () {
+      }
+      function abort () {
+      }
+
+      const buf = Buffer.from('hello 傳 world')
+
+      // Nothing is buffered when setEncoding() runs, so every chunk reaches
+      // state.buffer as a decoded string.
+      function body () {
+        const r = new Readable({ resume, abort })
+        r.setEncoding(encoding)
+        r.push(buf.subarray(0, 4))
+        r.push(buf.subarray(4, 8))
+        process.nextTick(() => {
+          r.push(buf.subarray(8))
+          r.push(null)
+        })
+        return r
+      }
+
+      t.deepStrictEqual(await body().bytes(), new Uint8Array(buf))
+      t.deepStrictEqual(new Uint8Array(await body().arrayBuffer()), new Uint8Array(buf))
+
+      const blob = await body().blob()
+      t.strictEqual(blob.size, buf.length)
+      t.deepStrictEqual(Buffer.from(await blob.arrayBuffer()), buf)
+
+      t.strictEqual(await body().text(), buf.toString(encoding))
+    })
+  }
+
+  test('setEncoding() then .json()', async function (t) {
+    t = tspl(t, { plan: 1 })
+
+    function resume () {
+    }
+    function abort () {
+    }
+    const r = new Readable({ resume, abort })
+
+    const buf = Buffer.from(JSON.stringify({ hello: '傳' }))
+
+    r.setEncoding('utf8')
+    r.push(buf.subarray(0, 12))
+
+    process.nextTick(() => {
+      r.push(buf.subarray(12))
+      r.push(null)
+    })
+
+    t.deepStrictEqual(await r.json(), { hello: '傳' })
+  })
 })


### PR DESCRIPTION
Fixes #5611. Alternative to #5612, which fixes the same bug by retaining a second copy of the body.

## The bug

`setEncoding()` installs a `StringDecoder` (since #5003), so from that point `state.buffer` holds decoded **strings**, and the trailing bytes of a multi-byte sequence split across a chunk boundary sit **inside the decoder**, in neither place. #5003 worked around this by snapshotting the raw chunks that happened to be buffered at the time of the call into `kPreservedBuffer`. Chunks arriving after the call were never added to it, and `consumeStart()` treated the two sources as mutually exclusive:

```js
const preserved = consume.stream[kPreservedBuffer]
if (preserved && preserved.length > 0) {
  // ... only the snapshot
} else if (state.bufferIndex) {
```

so everything outside the snapshot was dropped, silently:

```js
body.setEncoding('utf8')
await new Promise(r => setTimeout(r, 150))   // let the body arrive
await body.text()                            // "abc�" instead of "abc傳def"
```

## The fix

Remove `kPreservedBuffer` and read the one source of truth the stream already keeps:

* `consumePush()` re-encodes a string chunk back to bytes, so `consume.length` stays a byte count. Without that `.arrayBuffer()`/`.bytes()` return a zero-filled buffer of the wrong length, because a string's `length` is in UTF-16 code units and `Uint8Array.prototype.set(string)` writes nothing.
* `consumeStart()` then appends the bytes the decoder is holding for an incomplete sequence, which are absent from every string in `state.buffer`.

That covers chunks buffered before `setEncoding()`, after it, and after the consume was requested, because all of them end up in exactly one of those two places. The "which entry of `state.buffer` is the duplicate?" problem that makes reading both sources unworkable only exists while `kPreservedBuffer` does; deleting it removes the ambiguity rather than arbitrating it.

Net effect on `lib/`: **-15 lines**, `push()` untouched, and nothing retained beyond the stream's own buffer. #5003 is not undone — `setEncoding()` + `for await` and + `on('data')` still decode a split multi-byte character correctly.

### Why not keep the raw chunks

#5612 makes `push()` append every raw chunk while an encoding is set, which is a second full copy of everything buffered, allocated on the hot path. Backpressure bounds it (`api-request.js` pauses when `push()` returns `false`), but not at one highWaterMark: with a decoder installed `state.length` counts decoded *characters*, so 64 KiB of buffered CJK is ~192 KiB of retained bytes on top. The release also lags a `push()` behind the first emitted chunk.

### Trade-off

Re-encoding a decoded string is byte-exact for `latin1`, `hex`, `base64`, `utf16le` and valid UTF-8, and only applies to what was buffered before the consume started — chunks arriving later reach `consumePush()` as raw `Buffer`s. It is lossy in two corners: **invalid** UTF-8 bytes under `setEncoding('utf8')` come back as U+FFFD, and high-bit bytes under `setEncoding('ascii')` come back masked to 7 bits, if a `.bytes()`/`.arrayBuffer()`/`.blob()` consume reads them out of the pre-consume buffer. Both mean "decode this as text, then hand me the raw bytes back", and a plain `node:stream` Readable loses the same information. Retaining raw chunks is the only way to be exact there, at the cost above.

## Tests

`test/readable.js` gains the 7 cases from #5612 (@marko1olo) — chunks pushed after `setEncoding()`, a partial character buffered, `utf8`/`hex`/`base64`/`latin1` before any chunk arrives, and `.json()` — and `test/client-request.js` gains the end-to-end repro from #5611 over a real socket. All were confirmed failing on `main` first, with the truncation, `ERR_INVALID_ARG_TYPE` from `Buffer.concat`, and a zero-filled `Uint8Array`.

`test/readable.js` 18/18, `test/client-request.js` 49/49, `npm run test:unit` 1459 pass / 0 fail, `npm run test:fetch` 47/47, `npm run test:typescript` and `npm run lint` clean. Node 24, Linux.
