### PR TITLE
ci: increase Windows workflow timeout on v7.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   test:
     name: Test ${{ inputs.codecov == true && 'and Coverage ' || '' }}with Node.js ${{ inputs.node-version }} on ${{ inputs.runs-on }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.runs-on == 'windows-latest' && 30 || 20 }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

Backport the Windows CI timeout increase from #5426 to `v7.x`.

The `v7.x` workflow still gives Windows jobs a 20-minute timeout. WPT runs can exceed that under normal runner/package-install variance; for example, #5618's Windows Node.js 24 job was canceled at the 20-minute limit while WPT was still progressing.

This keeps non-Windows jobs at 20 minutes and gives Windows jobs 30 minutes.

## Testing

- Workflow-only change; no local tests run.
