### PR TITLE
fix(env-http-proxy-agent): match bare IPv6 addresses in no_proxy

### DIFF
--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -65,9 +65,10 @@ class EnvHttpProxyAgent extends DispatcherBase {
   #getProxyAgentForUrl (url) {
     let { protocol, host: hostname, port } = url
 
-    // Stripping ports in this way instead of using parsedUrl.hostname to make
-    // sure that the brackets around IPv6 addresses are kept.
-    hostname = hostname.replace(/:\d*$/, '').toLowerCase()
+    // Remove the port suffix (e.g. ":8080") and then strip surrounding
+    // brackets from IPv6 literals (e.g. "[::1]" -> "::1") so that the
+    // result matches the unbracketed form stored by #parseNoProxy.
+    hostname = hostname.replace(/:\d*$/, '').replace(/^\[(.+)\]$/, '$1').toLowerCase()
     port = Number.parseInt(port, 10) || DEFAULT_PORTS[protocol] || 0
     if (!this.#shouldProxy(hostname, port)) {
       return this[kNoProxyAgent]
@@ -119,11 +120,32 @@ class EnvHttpProxyAgent extends DispatcherBase {
       if (!entry) {
         continue
       }
-      const parsed = entry.match(/^(.+):(\d+)$/)
+
+      // An IPv6 entry with a port must be bracketed: [::1]:443.
+      // A bare IPv6 address like ::1 contains colons that must not be
+      // confused with a host:port separator, so we handle it separately.
+      let hostname, port
+      const ipv6WithPort = entry.match(/^\[(.+)\]:(\d+)$/)
+      if (ipv6WithPort) {
+        hostname = ipv6WithPort[1]
+        port = Number.parseInt(ipv6WithPort[2], 10)
+      } else {
+        // Bracketed IPv6 without port, or plain hostname[:port], or bare IPv6.
+        // Strip optional brackets first.
+        const unbracketed = entry.replace(/^\[(.+)\]$/, '$1')
+        // A bare IPv6 address contains multiple colons; a hostname:port entry
+        // has exactly one colon followed by digits. Only attempt host:port
+        // splitting when that is unambiguously the case.
+        const colonCount = (unbracketed.match(/:/g) || []).length
+        const parsed = colonCount === 1 && unbracketed.match(/^(.+):(\d+)$/)
+        hostname = parsed ? parsed[1] : unbracketed
+        port = parsed ? Number.parseInt(parsed[2], 10) : 0
+      }
+
       noProxyEntries.push({
         // strip leading dot or asterisk with dot
-        hostname: (parsed ? parsed[1] : entry).replace(/^\*?\./, '').toLowerCase(),
-        port: parsed ? Number.parseInt(parsed[2], 10) : 0
+        hostname: hostname.replace(/^\*?\./, '').toLowerCase(),
+        port
       })
     }
 

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -443,6 +443,29 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
+  test('bare IPv6 addresses in no_proxy are matched (issue #5616)', async (t) => {
+    // A bare IPv6 address like ::1 is valid in no_proxy (curl and most tools
+    // accept it), but the old regex confused the last colon as a port separator.
+    t = tspl(t, { plan: 8 })
+    process.env.no_proxy = '::1,[::2]:80,::3'
+    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(8)
+    // ::1 without brackets – must be matched
+    t.ok(await doesNotProxy('http://[::1]/'))
+    t.ok(await doesNotProxy('http://[::1]:80/'))
+    t.ok(await doesNotProxy('http://[::1]:1337/'))
+    // [::2]:80 – only port 80 bypasses proxy
+    t.ok(await doesNotProxy('http://[::2]:80/'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://[::2]:1337/'))
+    // ::3 without brackets – must be matched
+    t.ok(await doesNotProxy('http://[::3]/'))
+    t.ok(await doesNotProxy('http://[::3]:443/'))
+    // unrelated address must still proxy
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://[::4]/'))
+    return dispatcher.close()
+  })
+
+
+
   test('CIDR is NOT supported', async (t) => {
     t = tspl(t, { plan: 2 })
     process.env.no_proxy = '127.0.0.1/32'

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -464,8 +464,6 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
-
-
   test('CIDR is NOT supported', async (t) => {
     t = tspl(t, { plan: 2 })
     process.env.no_proxy = '127.0.0.1/32'


### PR DESCRIPTION
## This relates to...

Issue #5616 — `EnvHttpProxyAgent` silently ignores a bare (unbracketed) IPv6 address in `NO_PROXY`.

## Rationale

Two bugs cooperate to produce the silent mismatch:

**1. `#parseNoProxy` misidentifies bare IPv6 as host+port.**
The regex `/^(.+):(\d+)$/` matched on `::1` and split it into host `::` with port `1`.
Entries like `::1` were stored with the wrong key and never matched.

**2. `#getProxyAgentForUrl` kept URL brackets, `#parseNoProxy` did not.**
`URL.host` returns `[::1]`; the code stripped `:PORT` but left the surrounding brackets,
so `[::1]` ≠ `::1` even if the hostname stored in `noProxyEntries` happened to be correct.

## Changes

**`lib/dispatcher/env-http-proxy-agent.js`**

- `#parseNoProxy`: handle bracketed-IPv6-with-port (`[::1]:443`) with an explicit regex first;
  for everything else, count colons — more than one colon unambiguously means a bare IPv6
  literal (store as-is, port 0), exactly one colon means `hostname:port` (split normally).

- `#getProxyAgentForUrl`: after stripping the port suffix, also strip surrounding brackets
  from the hostname so the result matches the unbracketed form stored by `#parseNoProxy`.

**`test/env-http-proxy-agent.js`**

New test: `bare IPv6 addresses in no_proxy are matched (issue #5616)` — covers `::1`, `[::2]:80`,
and `::3` in the same `NO_PROXY` string. All 36 `env-http-proxy-agent` tests pass.

### Features

- [ ] Implemented a new feature

### Bug Fixes

- [x] Fixed a bug

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
