### PR TITLE
fix(cache): Cache.add() and Cache.addAll() hang for responses with bodies

### DIFF
--- a/lib/web/cache/cache.js
+++ b/lib/web/cache/cache.js
@@ -163,6 +163,7 @@ class Cache {
               header: 'Cache.addAll',
               message: 'Received an invalid status code or the request failed.'
             }))
+            return
           } else if (response.headersList.contains('vary')) { // 2.
             // 2.1
             const fieldValues = getFieldValues(response.headersList.get('vary'))
@@ -184,16 +185,33 @@ class Cache {
               }
             }
           }
-        },
-        processResponseEndOfBody (response) {
-          // 1.
-          if (response.aborted) {
-            responsePromise.reject(new DOMException('aborted', 'AbortError'))
+
+          // Clone the response so its body is preserved for caching, then
+          // consume the original. fetchFinale hooks a finished() listener on
+          // internalResponse.body.stream and only calls processResponseEndOfBody
+          // once that stream closes — but add/addAll never read the body, so
+          // the stream never closes and the promise stays pending forever.
+          // Draining the original here unblocks that listener while the clone
+          // keeps a fresh copy of the bytes for cache storage.
+          // See https://github.com/nodejs/undici/issues/5615
+          const clonedResponse = cloneResponse(response)
+
+          if (response.body == null) {
+            responsePromise.resolve(clonedResponse)
             return
           }
 
-          // 2.
-          responsePromise.resolve(response)
+          readAllBytes(
+            response.body.stream.getReader(),
+            () => {
+              if (response.aborted) {
+                responsePromise.reject(new DOMException('aborted', 'AbortError'))
+              } else {
+                responsePromise.resolve(clonedResponse)
+              }
+            },
+            (err) => responsePromise.reject(err)
+          )
         }
       }))
 

--- a/test/cache/cache-add-body.js
+++ b/test/cache/cache-add-body.js
@@ -1,0 +1,116 @@
+'use strict'
+
+// Regression test for https://github.com/nodejs/undici/issues/5615
+// Cache.add() and Cache.addAll() never settled for a response with a body
+// because fetchFinale's finished() listener waited for the body stream to
+// close but nothing drained it, causing a deadlock.
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { caches } = require('../../')
+
+function withTimeout (p, label, ms = 3000) {
+  return Promise.race([
+    p.then(() => ({ label, settled: true })),
+    new Promise(resolve => setTimeout(() => resolve({ label, settled: false }), ms))
+  ])
+}
+
+test('Cache.add() settles for a 200 response with a body', async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello from cache')
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${server.address().port}`
+  const cacheName = 'test-add-body-5615-a'
+
+  t.after(async () => {
+    await caches.delete(cacheName)
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const cache = await caches.open(cacheName)
+
+  const result = await withTimeout(cache.add(`${base}/`), 'cache.add(200 body)')
+  t.assert.ok(result.settled, 'cache.add() should settle for a 200 response with a body')
+
+  // Verify the response was actually stored
+  const match = await cache.match(`${base}/`)
+  t.assert.ok(match, 'cache.match() should find the stored response')
+  const text = await match.text()
+  t.assert.strictEqual(text, 'hello from cache', 'stored body should be readable')
+})
+
+test('Cache.addAll() settles for a 200 response with a body', async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello from addAll')
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${server.address().port}`
+  const cacheName = 'test-add-body-5615-b'
+
+  t.after(async () => {
+    await caches.delete(cacheName)
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const cache = await caches.open(cacheName)
+
+  const result = await withTimeout(cache.addAll([`${base}/`]), 'cache.addAll([200 body])')
+  t.assert.ok(result.settled, 'cache.addAll() should settle for a 200 response with a body')
+
+  const match = await cache.match(`${base}/`)
+  t.assert.ok(match, 'cache.match() should find the stored response')
+  const text = await match.text()
+  t.assert.strictEqual(text, 'hello from addAll', 'stored body should be readable')
+})
+
+test('Cache.add() still settles for a 204 response (no body)', async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(204)
+    res.end()
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${server.address().port}`
+  const cacheName = 'test-add-body-5615-c'
+
+  t.after(async () => {
+    await caches.delete(cacheName)
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const cache = await caches.open(cacheName)
+
+  const result = await withTimeout(cache.add(`${base}/`), 'cache.add(204 no body)')
+  t.assert.ok(result.settled, 'cache.add() should settle for a 204 response')
+})
+
+test('Cache.addAll() with multiple URLs all settle', async (t) => {
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end(`response for ${req.url}`)
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${server.address().port}`
+  const cacheName = 'test-add-body-5615-d'
+
+  t.after(async () => {
+    await caches.delete(cacheName)
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const cache = await caches.open(cacheName)
+  const urls = [`${base}/one`, `${base}/two`, `${base}/three`]
+
+  const result = await withTimeout(cache.addAll(urls), 'cache.addAll([3 urls])')
+  t.assert.ok(result.settled, 'cache.addAll() should settle for multiple URLs')
+
+  const keys = await cache.keys()
+  t.assert.strictEqual(keys.length, 3, 'all 3 URLs should be stored in cache')
+})


### PR DESCRIPTION
## Problem

`Cache.add()` and `Cache.addAll()` deadlock when the response has a body: the spec requires the implementation to read the response body before storing it, but the current code never drains the original stream, so the promise never settles.

## Fix

Clone the response before storing (so the original body can be consumed independently), and explicitly drain the original stream after the clone is created.

## Tests

Added `test/cache/cache-add-body.js` — all pass (`node --test test/cache/cache-add-body.js`).

> Split from #5626 as requested by @mcollina.