### PR TITLE
fix(env-http-proxy-agent): ignore trailing dots when matching no_proxy

### DIFF
--- a/docs/docs/api/EnvHttpProxyAgent.md
+++ b/docs/docs/api/EnvHttpProxyAgent.md
@@ -25,8 +25,9 @@ it is used only for HTTPS requests.
 proxied. Each entry may include a leading dot or `*.` wildcard (for example
 `.example.com`) to match subdomains, and an optional `:port` suffix to restrict
 the match to a specific port. A request bypasses the proxy when its host equals
-an entry or is a subdomain of one. Setting `no_proxy` to `*` bypasses the proxy
-for every request.
+an entry or is a subdomain of one. A trailing dot is ignored on both sides, so
+`example.com.` and `example.com` match each other. Setting `no_proxy` to `*`
+bypasses the proxy for every request.
 
 The uppercase variants `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are also
 honored. When both the lowercase and uppercase forms of a variable are set, the

--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -69,6 +69,13 @@ class EnvHttpProxyAgent extends DispatcherBase {
     // brackets from IPv6 literals (e.g. "[::1]" -> "::1") so that the
     // result matches the unbracketed form stored by #parseNoProxy.
     hostname = hostname.replace(/:\d*$/, '').replace(/^\[(.+)\]$/, '$1').toLowerCase()
+    // Drop a trailing dot: it only marks the fully qualified form of a domain
+    // name ("example.com." and "example.com" are the same name, RFC 1034 root
+    // label). This runs on every dispatch, so it is a charCode check rather
+    // than a third regex. `length > 1` leaves the degenerate host "." alone.
+    if (hostname.length > 1 && hostname.charCodeAt(hostname.length - 1) === 46) {
+      hostname = hostname.slice(0, -1)
+    }
     port = Number.parseInt(port, 10) || DEFAULT_PORTS[protocol] || 0
     if (!this.#shouldProxy(hostname, port)) {
       return this[kNoProxyAgent]
@@ -143,8 +150,8 @@ class EnvHttpProxyAgent extends DispatcherBase {
       }
 
       noProxyEntries.push({
-        // strip leading dot or asterisk with dot
-        hostname: hostname.replace(/^\*?\./, '').toLowerCase(),
+        // strip leading dot or asterisk with dot, and any trailing dot
+        hostname: hostname.replace(/^\*?\./, '').replace(/^(.+)\.$/, '$1').toLowerCase(),
         port
       })
     }

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -398,6 +398,23 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
+  test('trailing dot is ignored on both sides', async (t) => {
+    // `example.com.` is the fully qualified form of `example.com` (the RFC 1034
+    // root label). curl ignores a trailing dot on the request host and on the
+    // no_proxy entry alike (lib/proxy.c).
+    t = tspl(t, { plan: 7 })
+    process.env.no_proxy = 'example.com,other.com.'
+    const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(7)
+    t.ok(await doesNotProxy('http://example.com./'))
+    t.ok(await doesNotProxy('https://example.com./'))
+    t.ok(await doesNotProxy('http://example.com.:1337/'))
+    t.ok(await doesNotProxy('http://sub.example.com./'))
+    t.ok(await doesNotProxy('http://other.com/'))
+    t.ok(await doesNotProxy('http://other.com./'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://notexample.com./'))
+    return dispatcher.close()
+  })
+
   test('substring suffix are NOT supported', async (t) => {
     t = tspl(t, { plan: 6 })
     process.env.no_proxy = '*example'


### PR DESCRIPTION
## This relates to...

No open issue. This is the same class of `no_proxy` matching bug as #5623 (bare IPv6 addresses), which landed in this same file last week, so I followed that PR's shape: one small fix plus a test in the existing `describe('no_proxy')` block.

Not filed through the security process, deliberately — see the note at the end of the Rationale.

## Rationale

A trailing dot is the fully qualified form of a domain name (the RFC 1034 root label): `example.com.` and `example.com` are the same name. `EnvHttpProxyAgent` compares host strings, and neither side of the comparison normalises that dot, so the two forms never match each other.

Concretely, on `main`:

* with `no_proxy=example.com`, a request to `http://example.com./` (or `https://`, or with an explicit port, or to `http://sub.example.com./`) is routed **through the proxy** instead of going direct;
* with `no_proxy=example.com.`, that entry matches nothing at all — not even `http://example.com/`.

The trailing dot is not something people type by accident. It is how you pin a name to the DNS root and skip `search` domain expansion — Kubernetes' own guidance is to use `svc.cluster.local.` in latency-sensitive paths for exactly this reason, and plenty of internal tooling emits FQDNs in that form. The user-visible symptom is that traffic meant to stay inside the network is handed to the corporate proxy, which normally can't reach the internal host, so the request fails to connect (or, at best, takes a slower path).

Standalone reproduction, fully local, no network needed. From an undici checkout:

```js
const { createServer } = require('node:http')
const { EnvHttpProxyAgent } = require('./index.js')

const server = createServer((req, res) => res.end('direct'))
server.listen(0, '127.0.0.1', async () => {
  const { port } = server.address()
  const agent = new EnvHttpProxyAgent({
    httpProxy: 'http://127.0.0.1:1/', // nothing is listening here
    noProxy: '127.0.0.1,localhost,example.test'
  })
  for (const origin of ['http://localhost:' + port, 'http://localhost.:' + port]) {
    try {
      const res = await agent.request({ origin, path: '/', method: 'GET' })
      console.log(origin, '->', await res.body.text())
    } catch (err) {
      console.log(origin, '-> ERROR', err.code ?? err.message)
    }
  }
  await agent.close()
  server.close()
})
```

```
# on main
http://localhost:43453  -> direct
http://localhost.:43453 -> ERROR ECONNREFUSED     <-- sent to the dead proxy
# with this PR
http://localhost:43447  -> direct
http://localhost.:43447 -> direct
```

**Prior art.** curl ignores a trailing dot on *both* sides of the `no_proxy` comparison — on the entry (`lib/proxy.c`, "ignore trailing dots in the token to check") and on the request hostname ("ignore trailing dots in the hostname"). This PR does the same thing in the same two places, which is why it touches both `#getProxyAgentForUrl` and `#parseNoProxy`.

**On framing:** I am explicitly *not* presenting this as a security issue. `SECURITY.md` puts "any proxy server configured by the application, runtime, or environment" inside the trusted set and states that undici's proxy support "is not intended to ... bypass organizational, regulatory, or legal controls". Sending a request to the configured, trusted proxy is therefore not a boundary violation in undici's threat model. This is a correctness bug and a parity gap with curl; the practical impact is connectivity, and the scope is limited to hosts written with a trailing dot. Low to medium impact, and I'd rather say so than oversell it.

## Changes

Both sides of the `no_proxy` comparison now drop a single trailing dot before matching:

* `#getProxyAgentForUrl` — the request host, alongside the existing port-suffix and IPv6-bracket stripping.
* `#parseNoProxy` — each `no_proxy` entry, alongside the existing leading-dot / `*.` stripping.
* `docs/docs/api/EnvHttpProxyAgent.md` — one sentence documenting the behaviour.

Notes on the edges, since this is host-matching code:

* CONTRIBUTING.md asks for a `test/issue-XXXX.js` reproduction. There is no issue here to number, and `createEnvHttpProxyAgentWithMocks` plus the whole `describe('no_proxy')` block already live in `test/env-http-proxy-agent.js`, so the test goes there — same as #5623 did in this file last week. The standalone script above is the CONTRIBUTING-style reproduction; happy to add it as a file if you'd rather have one.
* Only one dot is stripped, matching curl (a single check, not a loop). `example.com..` becomes `example.com.` on both sides, so those still match each other consistently.
* On the request side, `length > 1` leaves the degenerate host `.` untouched (`new URL('http://./')` does parse, host === `.`). On the entry side nothing new happens for `.` or `*.`: the existing leading-dot strip already turns them into an empty entry, before and after this change.
* IPv4 literals never reach this code with a dot — the WHATWG host parser already canonicalises `new URL('http://127.0.0.1./').host` to `127.0.0.1`.
* IPv6 literals cannot carry a trailing dot at all — `new URL('http://[::1]./')` throws `ERR_INVALID_URL`. The bare-IPv6 handling added in #5623 is untouched.
* The two sides use different shapes on purpose. `#getProxyAgentForUrl` runs on every dispatch, so it uses a `charCodeAt` check instead of a third regex — `/^(.+)\.$/` has a capture group and backtracks over the whole string on the common (no-dot) case, which measured ~2.3x the cost of the existing two-regex chain on this line (139 ns -> 320 ns/call vs 145 ns for the charCode check, Node v24.18.1, 2M iterations). `#parseNoProxy` runs once per `no_proxy` change, not per request, so it keeps the regex style of the line it sits on.

### Features

N/A

### Bug Fixes

* `EnvHttpProxyAgent` now honours `no_proxy` for hosts written in fully qualified form with a trailing dot (`http://example.com./` with `no_proxy=example.com`), including subdomains and `host:port` entries.
* A `no_proxy` entry written with a trailing dot (`no_proxy=example.com.`) now matches, instead of silently matching nothing.

### Breaking Changes and Deprecations

N/A. No public API change. The only behaviour that changes is host matching for names carrying a trailing dot, which previously never matched and had no useful semantics.

One accidental behaviour does go away: because `no_proxy=.` stores an empty entry, the subdomain rule currently degenerates into `hostname.endsWith('.')`, i.e. `no_proxy=.` today bypasses the proxy for exactly the hosts written with a trailing dot. After this change those hosts no longer end in a dot, so that stops. It had no defensible semantics and no test covers it.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

---

### Verification

```
node --test test/env-http-proxy-agent.js
npm run test:unit
npm run lint
```

Results on `main` @ ae4a3e3, Node v24.18.1:

| state | `test/env-http-proxy-agent.js` |
| --- | --- |
| test only, no fix | 36 pass, **1 fail** (first assertion, `http://example.com./`) |
| test + request-side hunk only | **1 fail** (the entry-side assertion) |
| test + entry-side hunk only | **1 fail** (the request-side assertion) |
| test + both hunks | **37 pass, 0 fail** |

So each hunk is independently necessary and independently covered by an assertion. `npm run test:unit` is 1489 tests / 0 failures / 4 skipped with the patch applied, and `npm run lint` is clean with the cache cleared. The 36 pre-existing tests in the file — leading dot, `*.`, IPv4, bare IPv6, ports, case-insensitivity — are unchanged.

*Disclosure: I used an AI assistant while investigating this and drafting the patch. I don't see a policy on this in `CONTRIBUTING.md`, so I'm mentioning it for transparency. The diff, the test and every number above are the result of running this locally, and I'm happy to defend or rework any part of it.*

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin


