### PR TITLE
fix(h2): handle GOAWAY for CONNECT streams

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -218,9 +218,9 @@ function detachRequestStreamForClose (request) {
 }
 
 // Unbind a stream from its request for good. releaseRequestStream() alone
-// leaves the 'close' listener attached and kRequestStreamState populated, so a
-// stream abandoned here would still run completeRequestStream() later — and
-// splice out the request that has since been requeued onto another session.
+// leaves the 'close' listener attached and kRequestStreamState populated. A
+// stream abandoned here must not complete a requeued request or release its
+// session a second time when it eventually closes.
 function severRequestStream (stream) {
   if (stream == null || stream[kRequestStreamState] == null) {
     return
@@ -228,6 +228,7 @@ function severRequestStream (stream) {
 
   stream[kRequestStreamState] = null
   stream.off('close', completeRequestStream)
+  stream.off('close', onUpgradeStreamClose)
 
   if (stream[kHTTP2Session] != null) {
     closeStreamSession(stream)

--- a/test/http2-connect-goaway.js
+++ b/test/http2-connect-goaway.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const net = require('node:net')
+const { H2CClient } = require('..')
+
+const frame = (type, flags, streamId, payload = Buffer.alloc(0)) => {
+  const head = Buffer.alloc(9)
+  head.writeUIntBE(payload.length, 0, 3)
+  head[3] = type
+  head[4] = flags
+  head.writeUInt32BE(streamId, 5)
+  return Buffer.concat([head, payload])
+}
+
+const SETTINGS = frame(0x4, 0x0, 0)
+const SETTINGS_ACK = frame(0x4, 0x1, 0)
+const GOAWAY = frame(0x7, 0x0, 0, Buffer.alloc(8))
+
+test('#5638 - h2 CONNECT settles when GOAWAY names an older stream', { timeout: 30000 }, async (t) => {
+  const server = net.createServer((socket) => {
+    let buf = Buffer.alloc(0)
+    let preface = false
+    let sent = false
+
+    socket.on('error', () => {})
+    socket.write(SETTINGS)
+
+    socket.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk])
+      if (!preface) {
+        if (buf.length < 24) {
+          return
+        }
+        buf = buf.subarray(24)
+        preface = true
+      }
+
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3)
+        const type = buf[3]
+        const flags = buf[4]
+        if (buf.length < 9 + length) {
+          break
+        }
+        buf = buf.subarray(9 + length)
+
+        if (type === 0x4 && !(flags & 0x1)) {
+          socket.write(SETTINGS_ACK)
+        }
+        if (type === 0x1 && !sent) {
+          sent = true
+          socket.write(GOAWAY)
+          setTimeout(() => socket.end(), 50)
+        }
+      }
+    })
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  t.after(() => server.close())
+
+  const client = new H2CClient(`http://127.0.0.1:${server.address().port}`)
+  t.after(() => client.close())
+
+  await assert.rejects(
+    client.connect({ path: '/' }),
+    {
+      name: 'InformationalError',
+      message: 'HTTP/2: "GOAWAY" frame received with code 0'
+    }
+  )
+})


### PR DESCRIPTION
## This relates to...

Closes #5638.

## Rationale

When a GOAWAY frame rejected an HTTP/2 CONNECT stream, the request was detached and requeued, but the upgrade-specific `close` listener remained attached. The late close then released the already-cleared session a second time and raised an uncaught exception.

## Changes

### Features

N/A

### Bug Fixes

- Remove both ordinary-request and upgrade-request terminal close listeners when severing an abandoned HTTP/2 stream.
- Add a raw h2c regression test covering CONNECT followed by `GOAWAY(lastStreamID=0)`.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (not applicable)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

### Validation

- `npx borp -p "test/http2-connect-goaway.js"`
- `npx borp -p "test/http2-goaway*.js"`
- `npx borp -p "test/h2c-client.js"`
- `npm run lint`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
