### PR TITLE
fix(h2): handle GOAWAY for CONNECT streams

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -617,6 +617,7 @@ function writeH2 (client, request) {
       ++session[kOpenStreams]
       completeRequest(client, request)
     })
+    stream.on('error', abort)
     stream.once('close', () => {
       session[kOpenStreams] -= 1
       if (session[kOpenStreams] === 0) session.unref()

--- a/test/issue-5638.js
+++ b/test/issue-5638.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const net = require('node:net')
+const { H2CClient } = require('..')
+
+const frame = (type, flags, streamId, payload = Buffer.alloc(0)) => {
+  const head = Buffer.alloc(9)
+  head.writeUIntBE(payload.length, 0, 3)
+  head[3] = type
+  head[4] = flags
+  head.writeUInt32BE(streamId, 5)
+  return Buffer.concat([head, payload])
+}
+
+const SETTINGS = frame(0x4, 0x0, 0)
+const SETTINGS_ACK = frame(0x4, 0x1, 0)
+const GOAWAY = frame(0x7, 0x0, 0, Buffer.alloc(8))
+
+test('#5638 - h2 CONNECT settles after GOAWAY(lastStreamID=0)', { timeout: 5000 }, async (t) => {
+  const server = net.createServer((socket) => {
+    let buf = Buffer.alloc(0)
+    let preface = false
+    let sent = false
+
+    socket.on('error', () => {})
+    socket.write(SETTINGS)
+
+    socket.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk])
+      if (!preface) {
+        if (buf.length < 24) return
+        buf = buf.subarray(24)
+        preface = true
+      }
+
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3)
+        const type = buf[3]
+        const flags = buf[4]
+        if (buf.length < 9 + length) break
+        buf = buf.subarray(9 + length)
+
+        if (type === 0x4 && !(flags & 0x1)) socket.write(SETTINGS_ACK)
+        if (type === 0x1 && !sent) {
+          sent = true
+          socket.write(GOAWAY)
+          setTimeout(() => socket.end(), 50)
+        }
+      }
+    })
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  t.after(() => server.close())
+
+  const client = new H2CClient(`http://127.0.0.1:${server.address().port}`)
+  t.after(() => client.close())
+
+  await assert.rejects(client.connect({ path: '/' }), {
+    code: 'UND_ERR_SOCKET',
+    message: 'HTTP/2: "GOAWAY" frame received with code 0'
+  })
+})


### PR DESCRIPTION
## This relates to...

Backport of the fix for #5638 to `v7.x`.

## Rationale

The `v7.x` HTTP/2 implementation predates the stream-severing machinery on `main`, but plain CONNECT streams have the analogous failure: unlike ordinary and WebSocket streams, they do not attach an error handler. GOAWAY teardown can therefore emit an unhandled stream error and terminate the process.

## Changes

### Features

N/A

### Bug Fixes

- Route CONNECT stream errors through the request's existing abort path.
- Add a raw h2c regression test covering CONNECT followed by `GOAWAY(lastStreamID=0)`.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (not applicable)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

### Validation

- `npx borp -p "test/issue-5638.js"`
- `npx borp -p "test/http2-goaway.js" -p "test/http2-dispatcher.js"`
- `npx eslint lib/dispatcher/client-h2.js test/issue-5638.js`
- `git diff origin/v7.x...HEAD --check`

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
