### PR TITLE
fix(h2): detach upgrade close handler after GOAWAY

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -228,6 +228,9 @@ function severRequestStream (stream) {
 
   stream[kRequestStreamState] = null
   stream.off('close', completeRequestStream)
+  // Upgrade streams use their own close cleanup, which would otherwise release
+  // the session a second time after the stream has been severed for GOAWAY.
+  stream.off('close', onUpgradeStreamClose)
 
   if (stream[kHTTP2Session] != null) {
     closeStreamSession(stream)

--- a/test/issue-5638.js
+++ b/test/issue-5638.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const net = require('node:net')
+const { H2CClient } = require('..')
+
+const frame = (type, flags, streamId, payload = Buffer.alloc(0)) => {
+  const head = Buffer.alloc(9)
+  head.writeUIntBE(payload.length, 0, 3)
+  head[3] = type
+  head[4] = flags
+  head.writeUInt32BE(streamId, 5)
+  return Buffer.concat([head, payload])
+}
+
+const SETTINGS = frame(0x4, 0x0, 0)
+const SETTINGS_ACK = frame(0x4, 0x1, 0)
+const GOAWAY = frame(0x7, 0x0, 0, Buffer.alloc(8))
+
+test('h2 CONNECT settles when GOAWAY names an older stream', { timeout: 30000 }, async (t) => {
+  const server = net.createServer((socket) => {
+    let buffer = Buffer.alloc(0)
+    let receivedPreface = false
+    let sentGoAway = false
+
+    socket.on('error', () => {})
+    socket.write(SETTINGS)
+
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, chunk])
+      if (!receivedPreface) {
+        if (buffer.length < 24) return
+        buffer = buffer.subarray(24)
+        receivedPreface = true
+      }
+
+      while (buffer.length >= 9) {
+        const length = buffer.readUIntBE(0, 3)
+        const type = buffer[3]
+        const flags = buffer[4]
+        if (buffer.length < 9 + length) break
+        buffer = buffer.subarray(9 + length)
+
+        if (type === 0x4 && !(flags & 0x1)) socket.write(SETTINGS_ACK)
+        if (type === 0x1 && !sentGoAway) {
+          sentGoAway = true
+          socket.write(GOAWAY)
+          setTimeout(() => socket.end(), 50)
+        }
+      }
+    })
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  t.after(() => server.close())
+
+  const client = new H2CClient(`http://127.0.0.1:${server.address().port}`)
+  t.after(() => client.close())
+
+  await assert.rejects(client.connect({ path: '/' }))
+})


### PR DESCRIPTION
## This relates to...

Fixes #5638.

## Rationale

When GOAWAY marks an upgrade stream as unaccepted, `severRequestStream()`
already releases its HTTP/2 session. Upgrade streams also retain
`onUpgradeStreamClose`, which later attempts the same release after the stream
closes. The second release dereferences a cleared session and escapes as an
uncaught exception.

Detaching that upgrade-specific close handler at sever time makes the cleanup
ownership unambiguous. The request remains on the existing GOAWAY retry/error
path and settles normally.

## Changes

- Detach `onUpgradeStreamClose` along with the regular request close handler.
- Add a raw h2c regression test: GOAWAY with `lastStreamID = 0` while a CONNECT
  stream is opening must settle rather than crash the process.

## Validation

- HTTP/2 core suite: 98 passed, 1 skipped.
- ESLint passed for the changed implementation and test.

Implementation and validation used Codex assistance; I reviewed the final diff and results.

## Verification

Every command below was run and its output captured verbatim. The record is reproducible — the exact commands are included so you can re-run them yourself.

**red — without detaching the upgrade close handler** (must fail without the fix)

```
$ node --test --test-timeout=35000 --test-force-exit test/issue-5638.js
[…]
ℹ duration_ms 305.762
✖ failing tests:
test at test\issue-5638.js:21:1
✖ h2 CONNECT settles when GOAWAY names an older stream (29.0696ms)
  TypeError: Cannot read properties of null (reading 'Symbol(open streams)')
      at closeStreamSession (~\AppData\Local\Temp\undici-5638-repro\lib\dispatcher\client-h2.js:767:11)
      at ClientHttp2Stream.onUpgradeStreamClose (~\AppData\Local\Temp\undici-5638-repro\lib\dispatcher\client-h2.js:781:3)
      at Object.onceWrapper (node:events:622:28)
      at ClientHttp2Stream.emit (node:events:508:28)
      at emitCloseNT (node:internal/streams/destroy:148:10)
      at emitErrorCloseNT (node:internal/streams/destroy:130:3)
      at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
[exit code 1]
```

**green — fix intact** (must pass) — 3 runs, identical exit code

```
$ node --test --test-timeout=35000 --test-force-exit test/issue-5638.js
✔ h2 CONNECT settles when GOAWAY names an older stream (35.6737ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 346.9513
[exit code 0]
```

<details><summary>Environment and output hashes</summary>

```
so: Windows 11 (AMD64)
python: 3.13.14
node --version: v24.14.1
git rev-parse HEAD: 964ce931029fdcd48fca24adbc15c42f58b82162
git status --short:
sha256(red — without detaching the upgrade close handler run 1) = 8fcf06da733ec7cd…  exit 1  0.43s
sha256(green — fix intact run 1) = 6d0099dbf983e900…  exit 0  0.47s
sha256(green — fix intact run 2) = 8848a52d1b4728cc…  exit 0  0.48s
sha256(green — fix intact run 3) = 8f41e847e930672b…  exit 0  0.43s
acta: 0fba181ecbcf4801
```

</details>

## Status

- [x] I have read and agreed to the Developer's Certificate of Origin.
- [x] Tested.
- [x] Documented by regression coverage.
