### PR TITLE
test(h2): isolate connection churn seeds

### DIFF
--- a/test/http2-request-never-settles.js
+++ b/test/http2-request-never-settles.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
-const { test, after } = require('node:test')
+const { test } = require('node:test')
 const { constants, createSecureServer } = require('node:http2')
 const { once } = require('node:events')
 const { Readable } = require('node:stream')
@@ -115,7 +115,7 @@ async function churningServer (rnd) {
 }
 
 for (const seed of SEEDS) {
-  test(`every h2 request settles under connection churn (seed ${seed})`, async () => {
+  test(`every h2 request settles under connection churn (seed ${seed})`, async (t) => {
     const timer = setInterval(() => {}, 1000)
     const rnd = makeRandom(seed)
     const server = await churningServer(rnd)
@@ -127,10 +127,16 @@ for (const seed of SEEDS) {
       headersTimeout: 500,
       bodyTimeout: 500
     })
-    after(async () => {
-      await agent.destroy()
-      server.shutdown()
-      clearInterval(timer)
+    // Release each seed's resources before the next test starts. A file-level
+    // after hook kept every TLS server and keepalive timer until all seeds had
+    // finished, making this churn test sensitive to CI load.
+    t.after(async () => {
+      try {
+        await agent.destroy()
+      } finally {
+        server.shutdown()
+        clearInterval(timer)
+      }
     })
 
     const unsettled = []

--- a/test/http2-request-never-settles.js
+++ b/test/http2-request-never-settles.js
@@ -10,6 +10,8 @@ const pem = require('@metcoder95/https-pem')
 
 const { Agent } = require('..')
 
+const skipOnNode24 = Number(process.versions.node.split('.')[0]) === 24
+
 // completeRequestStream() runs on an h2 stream's 'close':
 //
 //   releaseRequestStream(this)
@@ -115,7 +117,9 @@ async function churningServer (rnd) {
 }
 
 for (const seed of SEEDS) {
-  test(`every h2 request settles under connection churn (seed ${seed})`, async (t) => {
+  test(`every h2 request settles under connection churn (seed ${seed})`, {
+    skip: skipOnNode24 && 'Node.js 24 has an HTTP/2 memory corruption bug'
+  }, async (t) => {
     const timer = setInterval(() => {}, 1000)
     const rnd = makeRandom(seed)
     const server = await churningServer(rnd)


### PR DESCRIPTION
Scope the HTTP/2 churn test cleanup to each seed so its TLS server, sessions, agent, and keepalive timer are released before the next seed starts.

Native Linux x64 investigation showed that the remaining Node.js 24 failures are process-level memory-corruption crashes, not assertions from this test. Although the cores usually fail later in V8's concurrent Maglev compiler, the source is Node's HTTP/2 binding calling nghttp2 send/close paths reentrantly while `nghttp2_session_mem_recv()` is active.

Skip this stress test on Node.js 24 until the HTTP/2 fix in nodejs/node#65093 reaches a release. Other Node.js versions continue to run both seeded churn cases.
