### PR TITLE
fix: preserve MockAgent interceptors for legacy global fetch

### DIFF
--- a/lib/mock/mock-agent.js
+++ b/lib/mock/mock-agent.js
@@ -73,13 +73,25 @@ class MockAgent extends Dispatcher {
     opts.origin = normalizeOrigin(opts.origin)
 
     // Call MockAgent.get to perform additional setup before dispatching as normal
-    this.get(opts.origin)
+    const mockDispatcher = this.get(opts.origin)
 
     this[kMockAgentAddCallHistoryLog](opts)
 
     const acceptNonStandardSearchParameters = this[kMockAgentAcceptsNonStandardSearchParameters]
 
     const dispatchOpts = { ...opts }
+
+    // Agent keeps HTTP/1.1-only dispatchers under a separate key. Legacy
+    // global dispatcher consumers use that path, so mirror the mock dispatches
+    // before delegating to the internal Agent.
+    if (dispatchOpts.allowH2 === false) {
+      const http1OnlyKey = `${dispatchOpts.origin}#http1-only`
+      if (!this[kClients].has(http1OnlyKey)) {
+        const http1OnlyDispatcher = this[kFactory](dispatchOpts.origin)
+        http1OnlyDispatcher[kDispatches] = mockDispatcher[kDispatches]
+        this[kMockAgentSet](http1OnlyKey, http1OnlyDispatcher)
+      }
+    }
 
     if (acceptNonStandardSearchParameters && dispatchOpts.path) {
       const [path, searchParams] = dispatchOpts.path.split('?')

--- a/test/node-test/global-dispatcher-version.js
+++ b/test/node-test/global-dispatcher-version.js
@@ -98,6 +98,40 @@ test('setGlobalDispatcher mirrors a v1-compatible dispatcher that Node.js global
   assert.strictEqual(payload.mirroredV2, true)
 })
 
+test('setGlobalDispatcher lets Node.js global fetch use a MockAgent interceptor', () => {
+  const script = `
+    const { MockAgent, setGlobalDispatcher } = require('./index.js')
+
+    ;(async () => {
+      const agent = new MockAgent()
+      agent.disableNetConnect()
+      agent
+        .get('https://example.com')
+        .intercept({ path: '/v1/test' })
+        .reply(200, { mocked: true })
+
+      setGlobalDispatcher(agent)
+      const response = await fetch('https://example.com/v1/test')
+      process.stdout.write(JSON.stringify({
+        status: response.status,
+        body: await response.json()
+      }))
+
+      await agent.close()
+    })().catch((err) => {
+      console.error(err?.cause?.stack || err?.stack || err)
+      process.exit(1)
+    })
+  `
+
+  const result = runNode(script)
+  assert.strictEqual(result.status, 0, result.stderr)
+  assert.deepStrictEqual(JSON.parse(result.stdout), {
+    status: 200,
+    body: { mocked: true }
+  })
+})
+
 test('Dispatcher1Wrapper bridges legacy handlers to a new Agent', () => {
   const script = `
     const { Agent, Dispatcher1Wrapper } = require('./index.js')


### PR DESCRIPTION
## Summary

Fixes the regression where `MockAgent` interceptors are bypassed by Node.js global `fetch` after `setGlobalDispatcher()`.

`Dispatcher1Wrapper` correctly forces legacy consumers onto HTTP/1.1 with `allowH2: false`. The internal `Agent` then uses its `#http1-only` pool key, but `MockAgent` only initialized mocks under the normal origin key. That allowed the internal agent to create a plain pool and make a real request even after `disableNetConnect()`.

This creates the HTTP/1.1-only mock dispatcher before delegation and shares the registered interceptors with the normal-origin mock dispatcher. The legacy bridge keeps its HTTP/1.1 guarantee; only the mock selection path is fixed.

## Regression coverage

The new subprocess test uses Node.js global `fetch`, a `MockAgent`, and `disableNetConnect()`. It expects the configured JSON response, so it fails if the request escapes the mock.

## Validation

- `npm run lint -- lib/mock/mock-agent.js test/node-test/global-dispatcher-version.js`
- `node --test test/node-test/global-dispatcher-version.js`
- `node --test test/mock-pool.js`
- `git diff --check`

Fixes #5036.