### PR TITLE
fix(mock): re-invoke reply callback for persistent mocks

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -333,8 +333,7 @@ function mockDispatch (opts, handler) {
             handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
             return
           }
-          mockDispatch.data = { ...responseDefaults, ...resolvedData }
-          dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
+          dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler, { ...responseDefaults, ...resolvedData })
         },
         (error) => {
           handler.onResponseError(null, error)
@@ -347,7 +346,7 @@ function mockDispatch (opts, handler) {
       throw new InvalidArgumentError('reply options callback must return an object')
     }
 
-    mockDispatch.data = { ...responseDefaults, ...callbackResult }
+    return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler, { ...responseDefaults, ...callbackResult })
   }
 
   return dispatchMockReply(mockDispatches, mockDispatch, key, opts, handler)
@@ -356,9 +355,13 @@ function mockDispatch (opts, handler) {
 /**
  * Replies to a request once the mock dispatch data is fully resolved
  */
-function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
-  // Parse mockDispatch data
-  const { data: response, delay } = mockDispatch
+function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler, resolvedResponse) {
+  // Parse mockDispatch data. When a reply callback has already been resolved
+  // in mockDispatch() (i.e. no body lifecycle hooks are involved), the resolved
+  // response is passed in here, leaving mockDispatch.data untouched so the
+  // callback can be re-invoked for persistent / times() replies.
+  const { data: responseData, delay } = mockDispatch
+  const response = resolvedResponse ?? responseData
 
   // If specified, trigger dispatch error
   if (response.error !== null) {
@@ -454,8 +457,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
               handler.onResponseError(null, new InvalidArgumentError('reply options callback must return an object'))
               return
             }
-            mockDispatch.data = { ...responseDefaults, ...resolvedData }
-            handleReply(dispatches, mockDispatch.data)
+            handleReply(dispatches, { ...responseDefaults, ...resolvedData })
           },
           (err) => {
             handler.onResponseError(null, err)
@@ -468,8 +470,7 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler) {
         throw new InvalidArgumentError('reply options callback must return an object')
       }
 
-      mockDispatch.data = { ...responseDefaults, ...callbackResult }
-      handleReply(dispatches, mockDispatch.data)
+      handleReply(dispatches, { ...responseDefaults, ...callbackResult })
       return
     }
 

--- a/test/mock-interceptor.js
+++ b/test/mock-interceptor.js
@@ -232,6 +232,35 @@ describe('MockInterceptor - reply options callback', () => {
       onResponseError: () => {}
     }), new InvalidArgumentError('statusCode must be defined'))
   })
+
+  test('should re-invoke the callback for every persistent reply', async t => {
+    t.plan(7)
+
+    const baseUrl = 'http://localhost:9999'
+    const mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+
+    let calls = 0
+
+    mockPool.intercept({
+      path: '/test',
+      method: 'GET'
+    }).reply(() => ({
+      statusCode: 200,
+      data: `call ${++calls}`
+    })).persist()
+
+    for (let i = 1; i <= 3; i++) {
+      const { statusCode, body } = await request(`${baseUrl}/test`, { dispatcher: mockAgent })
+      t.assert.strictEqual(statusCode, 200)
+      t.assert.strictEqual(await body.text(), `call ${i}`)
+    }
+
+    t.assert.strictEqual(calls, 3)
+  })
 })
 
 describe('MockInterceptor - asynchronous reply options callback', () => {
@@ -306,6 +335,35 @@ describe('MockInterceptor - asynchronous reply options callback', () => {
     }
 
     await t.assert.rejects(request(`${baseUrl}/test`, { dispatcher: mockAgent }), MockNotMatchedError)
+  })
+
+  test('should re-invoke an asynchronous callback for every persistent reply', async t => {
+    t.plan(5)
+
+    const baseUrl = 'http://localhost:9999'
+    const mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
+    after(() => mockAgent.close())
+
+    const mockPool = mockAgent.get(baseUrl)
+
+    let calls = 0
+
+    mockPool.intercept({
+      path: '/test',
+      method: 'GET'
+    }).reply(async () => ({
+      statusCode: 200,
+      data: `async call ${++calls}`
+    })).persist()
+
+    for (let i = 1; i <= 2; i++) {
+      const { statusCode, body } = await request(`${baseUrl}/test`, { dispatcher: mockAgent })
+      t.assert.strictEqual(statusCode, 200)
+      t.assert.strictEqual(await body.text(), `async call ${i}`)
+    }
+
+    t.assert.strictEqual(calls, 2)
   })
 
   test('should reject if an asynchronous callback resolves to an invalid format', async t => {


### PR DESCRIPTION
Resolve reply option callbacks without replacing mockDispatch.data, so
the callback is preserved and re-invoked for every matching request on
persistent (.persist()) or .times(n) interceptors.

Regression introduced in #5367.
