### PR TITLE
ci: test against the current Node.js nightly major

### DIFF
--- a/.github/workflows/nodejs-nightly.yml
+++ b/.github/workflows/nodejs-nightly.yml
@@ -9,38 +9,58 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test with Node.js ${{ matrix.node-version }} on ${{ matrix.runs-on }}
+  nightly-version:
+    name: Resolve current nightly major
     if: github.repository == 'nodejs/undici'
+    runs-on: ubuntu-latest
+    outputs:
+      major: ${{ steps.resolve.outputs.major }}
+    steps:
+      - name: Determine latest nightly major
+        id: resolve
+        run: |
+          major=$(curl -fsSL https://nodejs.org/download/nightly/index.json | jq -r '.[0].version | ltrimstr("v") | split(".")[0]')
+          if [ -z "$major" ] || [ "$major" = "null" ]; then
+            echo "Failed to resolve the latest nightly major" >&2
+            exit 1
+          fi
+          echo "major=$major" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Test with Node.js ${{ needs.nightly-version.outputs.major }}-nightly on ${{ matrix.runs-on }}
+    if: github.repository == 'nodejs/undici'
+    needs: nightly-version
     strategy:
       fail-fast: false
       max-parallel: 0
       matrix:
-        node-version: ['25-nightly']
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
     uses: ./.github/workflows/nodejs.yml
     with:
-      node-version: ${{ matrix.node-version }}
+      node-version: ${{ needs.nightly-version.outputs.major }}-nightly
       runs-on: ${{ matrix.runs-on }}
     secrets: inherit
 
   autobahn:
     if: github.repository == 'nodejs/undici'
+    needs: nightly-version
     uses: ./.github/workflows/autobahn.yml
     with:
-      node-version: '25-nightly'
+      node-version: ${{ needs.nightly-version.outputs.major }}-nightly
     secrets: inherit
 
   test-shared-builtin:
     if: github.repository == 'nodejs/undici'
+    needs: nightly-version
     uses: ./.github/workflows/nodejs-shared.yml
     with:
-      node-version: '25'
+      node-version: ${{ needs.nightly-version.outputs.major }}
       node-download-server-path: '/nightly'
 
   report-failure:
-    if: ${{ always() && (needs.test.result == 'failure' || needs.test-shared-builtin.result == 'failure' || needs.autobahn.result == 'failure') }}
+    if: ${{ always() && (needs.nightly-version.result == 'failure' || needs.test.result == 'failure' || needs.test-shared-builtin.result == 'failure' || needs.autobahn.result == 'failure') }}
     needs:
+      - nightly-version
       - test
       - test-shared-builtin
       - autobahn


### PR DESCRIPTION
## This relates to...

Fixes #5469.

## Rationale

Node 25 nightlies stopped in February when main moved on, and we are on
v27 now, but this workflow still asks for 25. So test-shared-builtin
downloads the same February tarball every night, v25.6.1-nightly20260209,
and runs its frozen test suite against current undici. Six of its
client-proxy tests fail because nodejs/node@0c138da5 updated them in July
for the 8.7.0 proxy behaviour, and the February copy still expects
CONNECT.

The 25-nightly test and autobahn jobs sit on those same old builds. They
stay green, so nothing has been testing current nightlies at all.

## Changes

Look up the newest nightly major from the download index and pass it to
test, autobahn and test-shared-builtin, so this does not need bumping
again when main moves to 28.

report-failure now also fires when that lookup fails, instead of skipping
the whole suite quietly.

### Features

N/A

### Bug Fixes

N/A, CI only.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested. actionlint and yamllint pass, and I checked the lookup
      against the live index: the old code resolves the February tarball,
      the new code resolves today's v27 nightly. I could not run
      test-shared-builtin end to end, since fork runs skip on the
      repository guard.
- [ ] Benchmarked, N/A
- [ ] Documented, N/A
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin