### PR TITLE
ci: align codeql-action autobuild and analyze with init at v4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v2.3.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v2.3.3
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -75,6 +75,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v2.3.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## This relates to...

CodeQL is failing on every PR right now, e.g.
https://github.com/nodejs/undici/actions/runs/31029528463/job/92399206703

## Rationale

#5634 bumped codeql-action/init to v4.37.3 and left autobuild and analyze
on the v4.36.2 commit. Autobuild then chokes on the config init wrote:

```
Loaded a configuration file for version '4.37.3', but running version '4.36.2'
```

## Changes

Move autobuild and analyze to the same commit init already uses. I checked
both hashes against the tags in github/codeql-action.

The `# v2.3.3` comments on all three were wrong before this too, so they
are corrected here as well.

### Features

N/A

### Bug Fixes

N/A, CI only.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested. actionlint passes and the pinned hash matches the v4.37.3 tag.
- [ ] Benchmarked, N/A
- [ ] Documented, N/A
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin