### PR TITLE
test: complete the h2 settings round-trip before asserting single-session multiplexing

### DIFF
--- a/test/http2-pipelining-default.js
+++ b/test/http2-pipelining-default.js
@@ -225,7 +225,12 @@ test('fetch POST bodies dispatch concurrently on the same h2 session instead of 
     sessions.add(session)
   })
 
-  server.on('stream', stream => {
+  server.on('stream', (stream, headers) => {
+    if (headers[':path'] === '/warmup') {
+      stream.respond({ ':status': 200 })
+      stream.end('warm')
+      return
+    }
     // Hold every stream open instead of responding immediately, so a
     // serialized client would never let the second request's headers
     // reach the server until the first one's stream is released.
@@ -244,6 +249,11 @@ test('fetch POST bodies dispatch concurrently on the same h2 session instead of 
   })
 
   const origin = `http://127.0.0.1:${server.address().port}`
+
+  // Get the SETTINGS round-trip out of the way. While it is still pending
+  // the client counts as busy, and the pool would answer the second POST
+  // with a fresh connection instead of another stream.
+  await (await fetch(`${origin}/warmup`, { dispatcher, signal: AbortSignal.timeout(5000) })).text()
 
   const first = fetch(origin, { method: 'POST', body: '{"first":1}', dispatcher })
   // Wait for the first request's stream to actually open before dispatching


### PR DESCRIPTION
The `fetch POST bodies dispatch concurrently (#5494)` test flakes on the
macOS runners: sessions.size comes out 2 instead of 1, e.g.
https://github.com/nodejs/undici/actions/runs/30984506686

Over h2 the client counts as busy until the server's SETTINGS frame lands.
With h2c nothing covers that window, so on a slow runner the second fetch
goes out while it is still open and the Agent opens a second connection.

I checked with a TCP proxy that delays server to client by 80ms: no warmup
gives sessions=2 every run, a warmup gives sessions=1 every run.

So warm the session up first, like the SSE test above it does. The #5494
check still works, a client that serialises hangs on `secondArrived` until
the timeout fires.

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin)
- [x] Tested
- [x] Review ready