### PR TITLE
ci: only accept a numeric nightly major

### DIFF
--- a/.github/workflows/nodejs-nightly.yml
+++ b/.github/workflows/nodejs-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         id: resolve
         run: |
           major=$(curl -fsSL https://nodejs.org/download/nightly/index.json | jq -r '.[0].version | ltrimstr("v") | split(".")[0]')
-          if [ -z "$major" ] || [ "$major" = "null" ]; then
+          if ! [[ "$major" =~ ^[0-9]+$ ]]; then
             echo "Failed to resolve the latest nightly major" >&2
             exit 1
           fi


### PR DESCRIPTION
Follow-up to #5654.

The guard I landed there only catches an empty string and the literal
"null". Anything else the download index hands back ends up in
`needs.nightly-version.outputs.major`, which nodejs-shared.yml drops into a
github-script block. Checking for digits is what it was meant to do.

Ran the check by hand: 27 passes; empty, "null", "8abc" and a string with
quotes in it all fail.

- [x] I have read and agreed to the [Developer's Certificate of Origin](https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin)
- [x] Tested
- [x] Review ready