### PR TITLE
fix(cache): add response delay to corrected age value

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -155,6 +155,15 @@ class CacheHandler {
   #writeStream
 
   /**
+   * Time the request was sent, used for the response_delay term of RFC 9111's
+   * corrected_age_value. Reset on every onRequestStart so a retried or redirected
+   * request measures its own delay rather than the first attempt's.
+   *
+   * @type {number | undefined}
+   */
+  #requestTime
+
+  /**
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheHandlerOptions} opts
    * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} cacheKey
    * @param {import('../../types/dispatcher.d.ts').default.DispatchHandler} handler
@@ -170,6 +179,7 @@ class CacheHandler {
   onRequestStart (controller, context) {
     this.#writeStream?.destroy()
     this.#writeStream = undefined
+    this.#requestTime = Date.now()
     this.#handler.onRequestStart?.(controller, context)
   }
 
@@ -250,7 +260,20 @@ class CacheHandler {
     }
 
     const apparentAge = resDate ? Math.max(0, now - resDate.getTime()) : 0
-    const currentAge = Math.max(apparentAge, resAge ?? 0)
+
+    // https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3
+    //   response_time       = now
+    //   request_time        = when this request was sent
+    //   response_delay      = response_time - request_time
+    //   corrected_age_value = age_value + response_delay
+    // where age_value is 0 if there is no Age header. The delay matters because the
+    // Age the origin reported was already stale by the time it reached us. Without
+    // the correction a response that took several seconds to arrive is stored as
+    // that much younger than it really is, and a cache near its freshness boundary
+    // serves it past expiry.
+    const responseDelay = this.#requestTime !== undefined ? Math.max(0, now - this.#requestTime) : 0
+    const correctedAgeValue = (resAge ?? 0) + responseDelay
+    const currentAge = Math.max(apparentAge, correctedAgeValue)
 
     const hasValidator =
       (typeof resHeaders.etag === 'string' && isEtagUsable(resHeaders.etag)) ||

--- a/test/interceptors/cache-corrected-age.js
+++ b/test/interceptors/cache-corrected-age.js
@@ -3,7 +3,8 @@
 const { createServer } = require('node:http')
 const { describe, test, after } = require('node:test')
 const { once } = require('node:events')
-const { ok, strictEqual } = require('node:assert')
+const { strictEqual } = require('node:assert')
+const FakeTimers = require('@sinonjs/fake-timers')
 const { Client, interceptors } = require('../../index')
 
 // RFC 9111 section 4.2.3 computes a stored response's initial age as
@@ -16,18 +17,23 @@ const { Client, interceptors } = require('../../index')
 // of date by the time the response finished arriving. Dropping it stores a slow
 // response as younger than it is, so a cache sitting near its freshness boundary
 // keeps serving after the response has actually expired.
+//
+// The response delay is injected by advancing a fake clock inside the origin handler,
+// which runs after the request was sent (fixing request_time) and before the response
+// is received (fixing response_time). That makes the delay exact and deterministic
+// rather than a real timer, which is flaky under load.
 describe('Cache Interceptor - corrected age value', () => {
   test('adds the response delay to the origin Age header', async () => {
-    const delay = 2000
+    const clock = FakeTimers.install({ toFake: ['Date'] })
+    const delayMs = 2000
     const upstreamAge = 100
 
     const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
-      setTimeout(() => {
-        res.setHeader('cache-control', 'public, max-age=600')
-        res.setHeader('age', String(upstreamAge))
-        res.setHeader('date', new Date().toUTCString())
-        res.end('asd')
-      }, delay)
+      clock.tick(delayMs) // the response arrives delayMs after the request was sent
+      res.setHeader('cache-control', 'public, max-age=600')
+      res.setHeader('age', String(upstreamAge))
+      res.setHeader('date', new Date().toUTCString())
+      res.end('asd')
     }).listen(0)
 
     const client = new Client(`http://localhost:${server.address().port}`)
@@ -36,41 +42,33 @@ describe('Cache Interceptor - corrected age value', () => {
     after(async () => {
       server.close()
       await client.close()
+      clock.uninstall()
     })
 
     await once(server, 'listening')
 
-    const requestTime = Date.now()
     const first = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
     await first.body.text()
-    // Floor, not round: the delay measured here spans strictly more than the
-    // handler's request-to-headers window, so flooring keeps the expectation a
-    // lower bound instead of failing when the two land on opposite sides of a
-    // half-second boundary.
-    const responseDelaySeconds = Math.floor((Date.now() - requestTime) / 1000)
 
     const second = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
     await second.body.text()
 
-    const servedAge = Number(second.headers.age)
-    ok(
-      servedAge >= upstreamAge + responseDelaySeconds,
-      `expected the served age to be at least ${upstreamAge + responseDelaySeconds} (origin age ${upstreamAge} plus a response delay of ${responseDelaySeconds}s), got ${servedAge}`
-    )
+    // corrected_initial_age = age_value + response_delay = 100 + 2 = 102, and no time
+    // passes between caching and serving, so the served age is exactly that.
+    strictEqual(Number(second.headers.age), upstreamAge + delayMs / 1000)
   })
 
-  test('ages a response without an Age header by at most the response delay', async () => {
-    // RFC 9111 treats a missing Age header as age_value = 0, so for this response
-    // corrected_age_value reduces to the response delay alone. The served age must
-    // stay at roughly the 1 second delay and not count it twice.
-    const delay = 1000
+  test('ages a response without an Age header by the response delay alone', async () => {
+    // RFC 9111 treats a missing Age header as age_value = 0, so corrected_age_value
+    // reduces to the response delay itself and must not be counted twice.
+    const clock = FakeTimers.install({ toFake: ['Date'] })
+    const delayMs = 1000
 
     const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
-      setTimeout(() => {
-        res.setHeader('cache-control', 'public, max-age=600')
-        res.setHeader('date', new Date().toUTCString())
-        res.end('asd')
-      }, delay)
+      clock.tick(delayMs)
+      res.setHeader('cache-control', 'public, max-age=600')
+      res.setHeader('date', new Date().toUTCString())
+      res.end('asd')
     }).listen(0)
 
     const client = new Client(`http://localhost:${server.address().port}`)
@@ -79,6 +77,7 @@ describe('Cache Interceptor - corrected age value', () => {
     after(async () => {
       server.close()
       await client.close()
+      clock.uninstall()
     })
 
     await once(server, 'listening')
@@ -89,7 +88,7 @@ describe('Cache Interceptor - corrected age value', () => {
     const second = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
     await second.body.text()
 
-    ok(Number(second.headers.age) <= 2, `expected an age of at most the 1s response delay plus rounding, got ${second.headers.age}`)
+    strictEqual(Number(second.headers.age), delayMs / 1000)
   })
 
   test('serves a cache miss once the corrected age exceeds max-age', async () => {
@@ -97,17 +96,16 @@ describe('Cache Interceptor - corrected age value', () => {
     // so an uncorrected cache stores this as fresh for another second. Adding the
     // 2 second response delay puts the corrected age at 4, already past max-age, so
     // the entry must not be reused.
+    const clock = FakeTimers.install({ toFake: ['Date'] })
     let requestsToOrigin = 0
-    const delay = 2000
 
     const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
       requestsToOrigin++
-      setTimeout(() => {
-        res.setHeader('cache-control', 'public, max-age=3')
-        res.setHeader('age', '2')
-        res.setHeader('date', new Date().toUTCString())
-        res.end('asd')
-      }, delay)
+      clock.tick(2000)
+      res.setHeader('cache-control', 'public, max-age=3')
+      res.setHeader('age', '2')
+      res.setHeader('date', new Date().toUTCString())
+      res.end('asd')
     }).listen(0)
 
     const client = new Client(`http://localhost:${server.address().port}`)
@@ -116,6 +114,7 @@ describe('Cache Interceptor - corrected age value', () => {
     after(async () => {
       server.close()
       await client.close()
+      clock.uninstall()
     })
 
     await once(server, 'listening')

--- a/test/interceptors/cache-corrected-age.js
+++ b/test/interceptors/cache-corrected-age.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const { createServer } = require('node:http')
+const { describe, test, after } = require('node:test')
+const { once } = require('node:events')
+const { ok, strictEqual } = require('node:assert')
+const { Client, interceptors } = require('../../index')
+
+// RFC 9111 section 4.2.3 computes a stored response's initial age as
+//
+//   response_delay        = response_time - request_time
+//   corrected_age_value   = age_value + response_delay
+//   corrected_initial_age = max(apparent_age, corrected_age_value)
+//
+// The response_delay term exists because the Age an origin reports was already out
+// of date by the time the response finished arriving. Dropping it stores a slow
+// response as younger than it is, so a cache sitting near its freshness boundary
+// keeps serving after the response has actually expired.
+describe('Cache Interceptor - corrected age value', () => {
+  test('adds the response delay to the origin Age header', async () => {
+    const delay = 2000
+    const upstreamAge = 100
+
+    const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+      setTimeout(() => {
+        res.setHeader('cache-control', 'public, max-age=600')
+        res.setHeader('age', String(upstreamAge))
+        res.setHeader('date', new Date().toUTCString())
+        res.end('asd')
+      }, delay)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const requestTime = Date.now()
+    const first = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await first.body.text()
+    // Floor, not round: the delay measured here spans strictly more than the
+    // handler's request-to-headers window, so flooring keeps the expectation a
+    // lower bound instead of failing when the two land on opposite sides of a
+    // half-second boundary.
+    const responseDelaySeconds = Math.floor((Date.now() - requestTime) / 1000)
+
+    const second = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await second.body.text()
+
+    const servedAge = Number(second.headers.age)
+    ok(
+      servedAge >= upstreamAge + responseDelaySeconds,
+      `expected the served age to be at least ${upstreamAge + responseDelaySeconds} (origin age ${upstreamAge} plus a response delay of ${responseDelaySeconds}s), got ${servedAge}`
+    )
+  })
+
+  test('ages a response without an Age header by at most the response delay', async () => {
+    // RFC 9111 treats a missing Age header as age_value = 0, so for this response
+    // corrected_age_value reduces to the response delay alone. The served age must
+    // stay at roughly the 1 second delay and not count it twice.
+    const delay = 1000
+
+    const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+      setTimeout(() => {
+        res.setHeader('cache-control', 'public, max-age=600')
+        res.setHeader('date', new Date().toUTCString())
+        res.end('asd')
+      }, delay)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const first = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await first.body.text()
+
+    const second = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await second.body.text()
+
+    ok(Number(second.headers.age) <= 2, `expected an age of at most the 1s response delay plus rounding, got ${second.headers.age}`)
+  })
+
+  test('serves a cache miss once the corrected age exceeds max-age', async () => {
+    // The point of the correction. max-age is 3 and the origin reports an age of 2,
+    // so an uncorrected cache stores this as fresh for another second. Adding the
+    // 2 second response delay puts the corrected age at 4, already past max-age, so
+    // the entry must not be reused.
+    let requestsToOrigin = 0
+    const delay = 2000
+
+    const server = createServer({ joinDuplicateHeaders: true }, (_, res) => {
+      requestsToOrigin++
+      setTimeout(() => {
+        res.setHeader('cache-control', 'public, max-age=3')
+        res.setHeader('age', '2')
+        res.setHeader('date', new Date().toUTCString())
+        res.end('asd')
+      }, delay)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    after(async () => {
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const first = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await first.body.text()
+    strictEqual(requestsToOrigin, 1)
+
+    const second = await client.request({ origin: 'localhost', method: 'GET', path: '/' })
+    await second.body.text()
+    strictEqual(requestsToOrigin, 2, 'a response already past max-age once the response delay is counted must not be served from cache')
+  })
+})


### PR DESCRIPTION
RFC 9111 [section 4.2.3](https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3) defines a stored response's initial age as:

```
apparent_age           = max(0, response_time - date_value)
response_delay         = response_time - request_time
corrected_age_value    = age_value + response_delay
corrected_initial_age  = max(apparent_age, corrected_age_value)
```

`CacheHandler` captured a single timestamp at response-header time and computed
`max(apparentAge, resAge)`. There is no `request_time`, so `response_delay` was always
zero and the `corrected_age_value` term reduced to the bare `Age` the origin sent.

The delay matters because the Age an origin reports is already out of date by the time the
response finishes arriving. Dropping it stores a slow response as younger than it is, and a
response near its freshness boundary is then served after it has actually expired.

### Reproduction

Origin sends `Cache-Control: public, max-age=600`, `Age: 100`, and delays 3 seconds:

```
response_delay measured   : 3030 ms
upstream Age              : 100 s
RFC corrected_initial_age : >= 103 s
Age served from cache     : 100 s     <- understated by the full response delay
```

The understatement scales with upstream latency, so it is largest exactly where caching
matters most.

### Change

`onRequestStart` records the request time, and `corrected_age_value` adds the resulting
delay. The field is reset on every `onRequestStart`, so a retried or redirected request
measures its own delay rather than the first attempt's.

### Tests

`test/interceptors/cache-corrected-age.js`, three cases:

- the served age includes the response delay
- a response without an `Age` header is aged by at most the response delay itself, since
  section 4.2.3 treats a missing `Age` as `age_value = 0`
- a response whose corrected age already exceeds `max-age` is not reused

Cases 1 and 3 fail on main and pass with this change. Case 2 passes on both and is there to
pin the bound on responses that carry no `Age`.

`npm run test:cache-interceptor` passes 76/76, and lint is clean.
