### PR TITLE
feat(dns): add address filter

### DIFF
--- a/docs/docs/api/Interceptors.md
+++ b/docs/docs/api/Interceptors.md
@@ -288,6 +288,10 @@ dual-stack (IPv4 + IPv6) and custom lookup/storage implementations.
     `(origin, options, callback) => void`.
   * `pick` {Function} (optional) Custom record-selection function called with
     `(origin, records, affinity)` to choose which resolved address to use.
+  * `filter` {Function} (optional) Address policy called with
+    `(origin, record)` for every resolved address and literal IP origin. Return
+    `true` to allow the address or `false` to reject it. If all addresses are
+    rejected, the request fails before a connection is attempted.
   * `storage` {DNSStorage} (optional) Custom storage backend. Must implement
     `get`, `set`, `delete`, `full`, and `size`.
 
@@ -318,6 +322,30 @@ const agent = new Agent().compose(
   })
 )
 ```
+
+The optional `filter` hook can enforce an application-defined network policy
+without a separate DNS preflight lookup. Accepted hostnames are connected
+through the resolved IP address while the original host header and TLS
+servername are preserved. The policy is also applied to literal IPv4 and IPv6
+origins and to redirect targets when the dispatcher is used with `fetch`.
+
+```js
+import { Agent, interceptors } from 'undici'
+
+const agent = new Agent().compose(
+  interceptors.dns({
+    filter (origin, { address, family }) {
+      return addressPolicy.allows({ origin, address, family })
+    }
+  })
+)
+
+const response = await fetch(userControlledURL, { dispatcher: agent })
+```
+
+`filter` does not provide an address classification policy. Applications are
+responsible for rejecting every address range that is not permitted in their
+environment, including IPv4-mapped IPv6 addresses where applicable.
 
 ---
 

--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -141,6 +141,7 @@ class DNSInstance {
   affinity = null
   lookup = null
   pick = null
+  filter = null
   storage = null
 
   constructor (opts) {
@@ -150,14 +151,23 @@ class DNSInstance {
     this.affinity = opts.affinity
     this.lookup = opts.lookup ?? this.#defaultLookup
     this.pick = opts.pick ?? this.#defaultPick
+    this.filter = opts.filter
     this.storage = opts.storage ?? new DNSStorage(opts)
+  }
+
+  filterRecords (origin, records) {
+    if (this.filter == null) {
+      return records
+    }
+
+    return Array.from(records).filter(record => this.filter(origin, record))
   }
 
   runLookup (origin, opts, cb) {
     const ips = this.storage.get(origin.hostname)
 
-    // If full, we just return the origin
-    if (ips == null && this.storage.full()) {
+    // If full, return the origin unless a filter still needs to be enforced.
+    if (ips == null && this.storage.full() && this.filter == null) {
       cb(null, origin)
       return
     }
@@ -180,8 +190,25 @@ class DNSInstance {
           return
         }
 
-        this.setRecords(origin, addresses)
-        const records = this.storage.get(origin.hostname)
+        try {
+          addresses = this.filterRecords(origin, addresses)
+        } catch (err) {
+          cb(err)
+          return
+        }
+
+        if (addresses.length === 0) {
+          cb(new InformationalError('DNS addresses rejected by filter'))
+          return
+        }
+
+        let records
+        if (this.storage.full()) {
+          records = this.createRecords(addresses).records
+        } else {
+          this.setRecords(origin, addresses)
+          records = this.storage.get(origin.hostname)
+        }
 
         const ip = this.pick(
           origin,
@@ -350,7 +377,7 @@ class DNSInstance {
     return ip
   }
 
-  setRecords (origin, addresses) {
+  createRecords (addresses) {
     const timestamp = Date.now()
     const records = { records: { 4: null, 6: null } }
     let minTTL = this.#maxTTL
@@ -369,6 +396,12 @@ class DNSInstance {
       familyRecords.ips.push(record)
       records.records[record.family] = familyRecords
     }
+
+    return { records, minTTL }
+  }
+
+  setRecords (origin, addresses) {
+    const { records, minTTL } = this.createRecords(addresses)
 
     // We provide a default TTL if external storage will be used without TTL per record-level support
     this.storage.set(origin.hostname, records, { ttl: minTTL })
@@ -503,6 +536,13 @@ module.exports = interceptorOpts => {
   }
 
   if (
+    interceptorOpts?.filter != null &&
+    typeof interceptorOpts?.filter !== 'function'
+  ) {
+    throw new InvalidArgumentError('Invalid filter. Must be a function')
+  }
+
+  if (
     interceptorOpts?.storage != null &&
     (typeof interceptorOpts?.storage?.get !== 'function' ||
       typeof interceptorOpts?.storage?.set !== 'function' ||
@@ -525,6 +565,7 @@ module.exports = interceptorOpts => {
     maxTTL: interceptorOpts?.maxTTL ?? 10e3, // Expressed in ms
     lookup: interceptorOpts?.lookup ?? null,
     pick: interceptorOpts?.pick ?? null,
+    filter: interceptorOpts?.filter ?? null,
     dualStack,
     affinity,
     maxItems: interceptorOpts?.maxItems ?? Infinity,
@@ -544,7 +585,24 @@ module.exports = interceptorOpts => {
           ? origDispatchOpts.origin
           : new URL(origDispatchOpts.origin)
 
-      if (isIP(origin.hostname) !== 0) {
+      let address = origin.hostname
+      if (address[0] === '[' && address[address.length - 1] === ']') {
+        address = address.slice(1, -1)
+      }
+
+      const family = isIP(address)
+      if (family !== 0) {
+        let records
+        try {
+          records = instance.filterRecords(origin, [{ address, family }])
+        } catch (err) {
+          return handler.onResponseError(null, err)
+        }
+
+        if (records.length === 0) {
+          return handler.onResponseError(null, new InformationalError('DNS addresses rejected by filter'))
+        }
+
         return dispatch(origDispatchOpts, handler)
       }
 

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('node:assert/strict')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { test, after } = require('node:test')
 const net = require('node:net')
@@ -12,7 +13,7 @@ const { once } = require('node:events')
 const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
-const { interceptors, Agent, Client, Pool, request } = require('../..')
+const { interceptors, Agent, Client, Pool, fetch, request } = require('../..')
 const { dns, cache, deduplicate } = interceptors
 
 // Helper to check if IPv6 is available for localhost
@@ -33,7 +34,7 @@ function hasIPv6LocalhostSync () {
 const ipv6Available = hasIPv6LocalhostSync()
 
 test('Should validate options', t => {
-  t = tspl(t, { plan: 11 })
+  t = tspl(t, { plan: 12 })
 
   t.throws(() => dns({ dualStack: 'true' }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ dualStack: 0 }), { code: 'UND_ERR_INVALID_ARG' })
@@ -45,7 +46,202 @@ test('Should validate options', t => {
   t.throws(() => dns({ maxItems: -1 }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ lookup: {} }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ pick: [] }), { code: 'UND_ERR_INVALID_ARG' })
+  t.throws(() => dns({ filter: {} }), { code: 'UND_ERR_INVALID_ARG' })
   t.throws(() => dns({ storage: new Map() }), { code: 'UND_ERR_INVALID_ARG' })
+})
+
+test('Should reject literal IP origins blocked by the address filter', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const checked = []
+  const client = new Agent().compose(dns({
+    filter (origin, record) {
+      checked.push({ hostname: origin.hostname, ...record })
+      return false
+    }
+  }))
+
+  after(async () => {
+    await client.close()
+  })
+
+  await assert.rejects(
+    client.request({
+      method: 'GET',
+      path: '/',
+      origin: 'http://127.0.0.1:1'
+    }),
+    { code: 'UND_ERR_INFO' }
+  )
+  t.ok(true)
+
+  await assert.rejects(
+    client.request({
+      method: 'GET',
+      path: '/',
+      origin: 'http://[::1]:1'
+    }),
+    { code: 'UND_ERR_INFO' }
+  )
+  t.ok(true)
+
+  await assert.rejects(
+    client.request({
+      method: 'GET',
+      path: '/',
+      origin: 'http://[::ffff:127.0.0.1]:1'
+    }),
+    { code: 'UND_ERR_INFO' }
+  )
+  t.ok(true)
+
+  t.deepStrictEqual(checked, [
+    { hostname: '127.0.0.1', address: '127.0.0.1', family: 4 },
+    { hostname: '[::1]', address: '::1', family: 6 },
+    { hostname: '[::ffff:7f00:1]', address: '::ffff:7f00:1', family: 6 }
+  ])
+})
+
+test('Should filter resolved addresses before connecting', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const checked = []
+  const server = createServer({ joinDuplicateHeaders: true })
+  server.on('request', (req, res) => {
+    t.equal(req.headers.host, `filtered.test:${server.address().port}`)
+    res.end('hello world!')
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const client = new Agent().compose(dns({
+    lookup (_origin, _opts, cb) {
+      cb(null, [
+        { address: '127.0.0.2', family: 4 },
+        { address: '127.0.0.1', family: 4 }
+      ])
+    },
+    filter (origin, record) {
+      checked.push({ hostname: origin.hostname, ...record })
+      return record.address === '127.0.0.1'
+    }
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    origin: `http://filtered.test:${server.address().port}`
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), 'hello world!')
+  t.deepStrictEqual(checked, [
+    { hostname: 'filtered.test', address: '127.0.0.2', family: 4 },
+    { hostname: 'filtered.test', address: '127.0.0.1', family: 4 }
+  ])
+})
+
+test('Should apply the address filter to redirect targets', async t => {
+  const redirectServer = createServer({ joinDuplicateHeaders: true })
+  const blockedServer = createServer({ joinDuplicateHeaders: true })
+  let blockedRequests = 0
+
+  blockedServer.on('request', (_req, res) => {
+    blockedRequests++
+    res.end('should not be reached')
+  })
+
+  redirectServer.on('request', (_req, res) => {
+    res.writeHead(302, {
+      location: `http://blocked.test:${blockedServer.address().port}`
+    })
+    res.end()
+  })
+
+  redirectServer.listen(0, '127.0.0.1')
+  blockedServer.listen(0, '127.0.0.1')
+  await Promise.all([
+    once(redirectServer, 'listening'),
+    once(blockedServer, 'listening')
+  ])
+
+  const client = new Agent().compose(dns({
+    lookup (_origin, _opts, cb) {
+      cb(null, [{ address: '127.0.0.1', family: 4 }])
+    },
+    filter (origin) {
+      return origin.hostname !== 'blocked.test'
+    }
+  }))
+
+  t.after(async () => {
+    await client.close()
+    await Promise.all([
+      new Promise(resolve => redirectServer.close(resolve)),
+      new Promise(resolve => blockedServer.close(resolve))
+    ])
+  })
+
+  await assert.rejects(
+    fetch(`http://allowed.test:${redirectServer.address().port}`, {
+      dispatcher: client
+    }),
+    error => {
+      assert.equal(error.cause?.code, 'UND_ERR_INFO')
+      return true
+    }
+  )
+  assert.equal(blockedRequests, 0)
+})
+
+test('Should keep filtering when the DNS cache is full', async t => {
+  const server = createServer({ joinDuplicateHeaders: true })
+  let requests = 0
+
+  server.on('request', (_req, res) => {
+    requests++
+    res.end('hello world!')
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const client = new Agent().compose(dns({
+    maxItems: 1,
+    lookup (_origin, _opts, cb) {
+      cb(null, [{ address: '127.0.0.1', family: 4 }])
+    },
+    filter (origin) {
+      return origin.hostname !== 'localhost'
+    }
+  }))
+
+  t.after(async () => {
+    await client.close()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    origin: `http://allowed.test:${server.address().port}`
+  })
+  assert.equal(await response.body.text(), 'hello world!')
+
+  await assert.rejects(
+    client.request({
+      method: 'GET',
+      path: '/',
+      origin: `http://localhost:${server.address().port}`
+    }),
+    { code: 'UND_ERR_INFO' }
+  )
+  assert.equal(requests, 1)
 })
 
 test('Should automatically resolve IPs (dual stack)', async t => {

--- a/test/types/dns-interceptor.test-d.ts
+++ b/test/types/dns-interceptor.test-d.ts
@@ -28,6 +28,10 @@ const pick: Interceptors.DNSInterceptorOpts['pick'] = (origin: URL, records: Int
   throw new Error('stub')
 }
 
+const filter: Interceptors.DNSInterceptorOpts['filter'] = (origin: URL, record: Interceptors.DNSInterceptorAddress): boolean => {
+  return origin.hostname === 'example.com' && record.address !== '127.0.0.1'
+}
+
 expectAssignable<Interceptors.DNSInterceptorOpts>({})
 expectAssignable<Interceptors.DNSInterceptorOpts>({ storage })
 expectAssignable<Interceptors.DNSInterceptorOpts>({ maxTTL: 1000 })
@@ -36,8 +40,10 @@ expectAssignable<Interceptors.DNSInterceptorOpts>({ dualStack: true })
 expectAssignable<Interceptors.DNSInterceptorOpts>({ affinity: 4 })
 expectAssignable<Interceptors.DNSInterceptorOpts>({ lookup })
 expectAssignable<Interceptors.DNSInterceptorOpts>({ pick })
+expectAssignable<Interceptors.DNSInterceptorOpts>({ filter })
 
 expectAssignable<Interceptors.DNSInterceptorRecord>({ address: '127.0.0.1', ttl: 300, family: 4 })
+expectAssignable<Interceptors.DNSInterceptorAddress>({ address: '127.0.0.1', family: 4 })
 
 expectAssignable<Interceptors.DNSInterceptorOriginRecords>({ records: { 4: { ips: [{ address: '127.0.0.1', ttl: 300, family: 4 }] }, 6: null } })
 
@@ -49,6 +55,11 @@ expectNotAssignable<Interceptors.DNSInterceptorOpts>({
 })
 expectNotAssignable<Interceptors.DNSInterceptorOpts>({
   pick: (origin: string) => {
+    throw new Error('stub')
+  }
+})
+expectNotAssignable<Interceptors.DNSInterceptorOpts>({
+  filter: (origin: string) => {
     throw new Error('stub')
   }
 })

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -18,6 +18,7 @@ declare namespace Interceptors {
   export type CacheInterceptorOpts = CacheHandler.CacheOptions
 
   // DNS interceptor
+  export type DNSInterceptorAddress = { address: string, family: 4 | 6 }
   export type DNSInterceptorRecord = { address: string, ttl: number, family: 4 | 6 }
   export type DNSInterceptorOriginRecords = { records: { 4: { ips: DNSInterceptorRecord[] } | null, 6: { ips: DNSInterceptorRecord[] } | null } }
   export type DNSStorage = {
@@ -32,6 +33,7 @@ declare namespace Interceptors {
     maxItems?: number
     lookup?: (origin: URL, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void
     pick?: (origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord
+    filter?: (origin: URL, record: DNSInterceptorAddress) => boolean
     dualStack?: boolean
     affinity?: 4 | 6
     storage?: DNSStorage


### PR DESCRIPTION
## Summary

- add an optional `filter(origin, record)` policy hook to the DNS interceptor
- apply the policy to every resolved address and to literal IPv4 and IPv6 origins before connecting
- keep enforcement active for fetch redirects and when the DNS cache has reached `maxItems`
- document the application-owned policy boundary and expose the hook in the TypeScript definitions

This builds on the existing DNS interceptor so accepted hostnames are resolved once and the connection uses the accepted literal address while preserving the original Host header and TLS servername. Undici does not classify public or private ranges; callers supply that policy.

Closes #2019.

## Validation

- `npm run test:interceptors` (316 passed, 3 skipped)
- `npm run test:typescript`
- `npm run lint`
- `git diff --check`
