### PR TITLE
fix(test): skip cache-tests when submodule is missing

### DIFF
--- a/test/cache-interceptor/cache-tests.mjs
+++ b/test/cache-interceptor/cache-tests.mjs
@@ -4,8 +4,24 @@ import { parseArgs, styleText } from 'node:util'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { exit } from 'node:process'
+import { existsSync } from 'node:fs'
 import { fork } from 'node:child_process'
 import { runtimeFeatures } from '../../lib/util/runtime-features.js'
+
+// CITGM / npm-pack installs don't include git submodules. Skip cleanly when the
+// http-tests/cache-tests checkout is missing rather than failing the whole suite
+// (https://github.com/nodejs/undici/issues/5642).
+const CACHE_TESTS_RUNNER = join(
+  import.meta.dirname,
+  '../fixtures/cache-tests/test-engine/client/runner.mjs'
+)
+if (!existsSync(CACHE_TESTS_RUNNER)) {
+  console.warn(
+    'Skipping cache-tests: test/fixtures/cache-tests submodule is not checked out. ' +
+    'Run `git submodule update --init test/fixtures/cache-tests` to enable them.'
+  )
+  exit(0)
+}
 
 /**
  * @typedef {import('../../types/cache-interceptor.d.ts').default.CacheOptions} CacheOptions


### PR DESCRIPTION
## Summary
- `npm test` runs `test:cache-tests`, which imports `test/fixtures/cache-tests/.../runner.mjs`.
- That path is a **git submodule**. CITGM (and plain npm-pack installs) do not check it out, so the suite fails with `Cannot find module '.../runner.mjs'` (#5642).
- Skip cleanly with a warning when the runner is absent — same idea as the WPT runner’s missing-checkout handling.

Fixes #5642

## Test plan
- [x] With empty `test/fixtures/cache-tests` (no submodule): `node test/cache-interceptor/cache-tests.mjs --ci` exits 0 and prints the skip warning
- [ ] With submodule initialized: cache-tests still run as before


Made with [Cursor](https://cursor.com)