### PR TITLE
Cancel connection attempts after queued requests abort

### DIFF
--- a/docs/docs/api/Connector.md
+++ b/docs/docs/api/Connector.md
@@ -113,6 +113,9 @@ added: v4.3.0
   * `httpSocket` {Socket} (optional) An existing socket on which to establish the
     secure connection rather than creating a new one. May only be supplied for a
     TLS upgrade (`protocol` of `'https:'`).
+  * `signal` {AbortSignal} (optional) Aborted when undici no longer needs this
+    connection attempt. Custom connectors should stop their pending work and
+    must not reuse a socket created for an aborted attempt.
 * `callback` {Function} Called once the socket has connected or failed.
   * `err` {Error|null} The connection error, or `null` on success.
   * `socket` {Socket|TLSSocket|null} The connected socket, or `null` on failure.

--- a/lib/api/abort-signal.js
+++ b/lib/api/abort-signal.js
@@ -53,7 +53,16 @@ function removeSignal (self) {
   self[kListener] = null
 }
 
+function setAbort (self, abortRequest) {
+  if (self.reason) {
+    abortRequest(self.reason)
+  } else {
+    self.abort = abortRequest
+  }
+}
+
 module.exports = {
   addSignal,
-  removeSignal
+  removeSignal,
+  setAbort
 }

--- a/lib/api/api-connect.js
+++ b/lib/api/api-connect.js
@@ -4,7 +4,8 @@ const assert = require('node:assert')
 const { AsyncResource } = require('node:async_hooks')
 const { InvalidArgumentError, SocketError } = require('../core/errors')
 const util = require('../core/util')
-const { addSignal, removeSignal } = require('./abort-signal')
+const { addSignal, removeSignal, setAbort } = require('./abort-signal')
+const { kRequestSignal } = require('../core/symbols')
 
 class ConnectHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -98,7 +99,11 @@ function connect (opts, callback) {
 
   try {
     const connectHandler = new ConnectHandler(opts, callback)
-    const connectOptions = { ...opts, method: 'CONNECT' }
+    const connectOptions = {
+      ...opts,
+      method: 'CONNECT',
+      [kRequestSignal]: (abort) => setAbort(connectHandler, abort)
+    }
     this.dispatch(connectOptions, connectHandler)
   } catch (err) {
     if (typeof callback !== 'function') {

--- a/lib/api/api-pipeline.js
+++ b/lib/api/api-pipeline.js
@@ -13,8 +13,8 @@ const {
   RequestAbortedError
 } = require('../core/errors')
 const util = require('../core/util')
-const { kBodyUsed } = require('../core/symbols')
-const { addSignal, removeSignal } = require('./abort-signal')
+const { kBodyUsed, kRequestSignal } = require('../core/symbols')
+const { addSignal, removeSignal, setAbort } = require('./abort-signal')
 
 function noop () {}
 
@@ -255,7 +255,11 @@ class PipelineHandler extends AsyncResource {
 function pipeline (opts, handler) {
   try {
     const pipelineHandler = new PipelineHandler(opts, handler)
-    this.dispatch({ ...opts, body: pipelineHandler.req }, pipelineHandler)
+    this.dispatch({
+      ...opts,
+      body: pipelineHandler.req,
+      [kRequestSignal]: (abort) => setAbort(pipelineHandler, abort)
+    }, pipelineHandler)
     return pipelineHandler.ret
   } catch (err) {
     return new PassThrough().destroy(err)

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -230,7 +230,11 @@ function request (opts, callback) {
   try {
     const handler = new RequestHandler(opts, callback)
 
-    this.dispatch(opts, handler)
+    if (handler.reason) {
+      handler.onResponseError(null, handler.reason)
+    } else {
+      this.dispatch(opts, handler)
+    }
   } catch (err) {
     if (typeof callback !== 'function') {
       throw err

--- a/lib/api/api-request.js
+++ b/lib/api/api-request.js
@@ -5,6 +5,8 @@ const { AsyncResource } = require('node:async_hooks')
 const { Readable } = require('./readable')
 const { InvalidArgumentError, RequestAbortedError } = require('../core/errors')
 const util = require('../core/util')
+const { kRequestSignal } = require('../core/symbols')
+const { setAbort } = require('./abort-signal')
 
 function noop () {}
 
@@ -233,7 +235,10 @@ function request (opts, callback) {
     if (handler.reason) {
       handler.onResponseError(null, handler.reason)
     } else {
-      this.dispatch(opts, handler)
+      this.dispatch({
+        ...opts,
+        [kRequestSignal]: (abort) => setAbort(handler, abort)
+      }, handler)
     }
   } catch (err) {
     if (typeof callback !== 'function') {

--- a/lib/api/api-stream.js
+++ b/lib/api/api-stream.js
@@ -4,7 +4,8 @@ const assert = require('node:assert')
 const { AsyncResource } = require('node:async_hooks')
 const { InvalidArgumentError, InvalidReturnValueError } = require('../core/errors')
 const util = require('../core/util')
-const { addSignal, removeSignal } = require('./abort-signal')
+const { addSignal, removeSignal, setAbort } = require('./abort-signal')
+const { kRequestSignal } = require('../core/symbols')
 
 function noop () {}
 
@@ -257,7 +258,10 @@ function stream (opts, factory, callback) {
   try {
     const handler = new StreamHandler(opts, factory, callback)
 
-    this.dispatch(opts, handler)
+    this.dispatch({
+      ...opts,
+      [kRequestSignal]: (abort) => setAbort(handler, abort)
+    }, handler)
   } catch (err) {
     if (typeof callback !== 'function') {
       throw err

--- a/lib/api/api-upgrade.js
+++ b/lib/api/api-upgrade.js
@@ -4,8 +4,8 @@ const { InvalidArgumentError, SocketError } = require('../core/errors')
 const { AsyncResource } = require('node:async_hooks')
 const assert = require('node:assert')
 const util = require('../core/util')
-const { kHTTP2Stream } = require('../core/symbols')
-const { addSignal, removeSignal } = require('./abort-signal')
+const { kHTTP2Stream, kRequestSignal } = require('../core/symbols')
+const { addSignal, removeSignal, setAbort } = require('./abort-signal')
 
 class UpgradeHandler extends AsyncResource {
   constructor (opts, callback) {
@@ -106,7 +106,8 @@ function upgrade (opts, callback) {
     const upgradeOpts = {
       ...opts,
       method: opts.method || 'GET',
-      upgrade: opts.protocol || 'Websocket'
+      upgrade: opts.protocol || 'Websocket',
+      [kRequestSignal]: (abort) => setAbort(upgradeHandler, abort)
     }
     this.dispatch(upgradeOpts, upgradeHandler)
   } catch (err) {

--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -3,7 +3,7 @@
 const net = require('node:net')
 const assert = require('node:assert')
 const util = require('./util')
-const { InvalidArgumentError, ConnectTimeoutError } = require('./errors')
+const { InvalidArgumentError, ConnectTimeoutError, RequestAbortedError } = require('./errors')
 
 let tls // include tls conditionally since it is not always available
 
@@ -68,7 +68,7 @@ function buildConnector ({ allowH2, preferH2, useH2c, maxCachedSessions, socketP
   const sessionCache = new SessionCache(maxCachedSessions == null ? 100 : maxCachedSessions)
   timeout = timeout == null ? 10e3 : timeout
   allowH2 = allowH2 != null ? allowH2 : true
-  return function connect ({ hostname, host, protocol, port, servername, localAddress, httpSocket }, callback) {
+  return function connect ({ hostname, host, protocol, port, servername, localAddress, httpSocket, signal }, callback) {
     let socket
     if (protocol === 'https:') {
       if (!tls) {
@@ -138,11 +138,21 @@ function buildConnector ({ allowH2, preferH2, useH2c, maxCachedSessions, socketP
     }
 
     const clearConnectTimeout = util.setupConnectTimeout(new WeakRef(socket), { timeout, hostname, port })
+    const removeAbortListener = signal
+      ? util.addAbortListener(signal, () => {
+        util.destroy(socket, signal.reason ?? new RequestAbortedError())
+      })
+      : null
+
+    const cleanup = () => {
+      queueMicrotask(clearConnectTimeout)
+      removeAbortListener?.()
+    }
 
     socket
       .setNoDelay(true)
       .once(protocol === 'https:' ? 'secureConnect' : 'connect', function () {
-        queueMicrotask(clearConnectTimeout)
+        cleanup()
 
         if (callback) {
           const cb = callback
@@ -151,7 +161,7 @@ function buildConnector ({ allowH2, preferH2, useH2c, maxCachedSessions, socketP
         }
       })
       .on('error', function (err) {
-        queueMicrotask(clearConnectTimeout)
+        cleanup()
 
         if (callback) {
           const cb = callback

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -20,7 +20,8 @@ const {
   assertRequestHandler,
   getServerName,
   normalizedMethodRecords,
-  getProtocolFromUrlString
+  getProtocolFromUrlString,
+  addAbortListener
 } = require('./util')
 const { channels } = require('./diagnostics.js')
 const { headerNameLowerCasedRecord } = require('./constants')
@@ -176,6 +177,7 @@ class Request {
     this.typeOfService = typeOfService
 
     this.abort = null
+    this.removeEarlyAbortListener = null
 
     if (body == null) {
       this.body = null
@@ -306,9 +308,19 @@ class Request {
     }
   }
 
+  abortBeforeStart (reason) {
+    // RetryHandler uses the controller state to distinguish caller aborts from
+    // retryable connection failures, even before a socket controller exists.
+    this[kController] ??= new RequestController(() => {})
+    this[kController].abort(reason)
+  }
+
   onRequestStart (abort, context) {
     assert(!this.aborted)
     assert(!this.completed)
+
+    this.removeEarlyAbortListener?.()
+    this.removeEarlyAbortListener = null
 
     this[kController] = new RequestController(abort)
 
@@ -426,6 +438,9 @@ class Request {
   }
 
   onFinally () {
+    this.removeEarlyAbortListener?.()
+    this.removeEarlyAbortListener = null
+
     if (this.errorHandler) {
       this.body.off('error', this.errorHandler)
       this.errorHandler = null
@@ -435,6 +450,10 @@ class Request {
       this.body.off('end', this.endHandler)
       this.endHandler = null
     }
+  }
+
+  addEarlyAbortListener (signal, listener) {
+    this.removeEarlyAbortListener = addAbortListener(signal, listener)
   }
 
   addHeader (key, value) {

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -59,6 +59,7 @@ module.exports = {
   kHTTP2Options: Symbol('http2 options'),
   kHTTP2SessionState: Symbol('http2Session state'),
   kRetryHandlerDefaultRetry: Symbol('retry agent default retry'),
+  kRequestSignal: Symbol('request signal'),
   kConstruct: Symbol('constructable'),
   kListeners: Symbol('listeners'),
   kHTTPContext: Symbol('http context'),

--- a/lib/dispatcher/client.js
+++ b/lib/dispatcher/client.js
@@ -11,7 +11,8 @@ const DispatcherBase = require('./dispatcher-base')
 const {
   InvalidArgumentError,
   InformationalError,
-  ClientDestroyedError
+  ClientDestroyedError,
+  RequestAbortedError
 } = require('../core/errors.js')
 const buildConnector = require('../core/connect.js')
 const {
@@ -54,7 +55,8 @@ const {
   kMaxConcurrentStreams,
   kHostAuthority,
   kResume,
-  kHTTP2Options
+  kHTTP2Options,
+  kRequestSignal
 } = require('../core/symbols.js')
 const connectH1 = require('./client-h1.js')
 const connectH2 = require('./client-h2.js')
@@ -404,8 +406,34 @@ class Client extends DispatcherBase {
 
   [kDispatch] (opts, handler) {
     const request = new Request(this[kUrl].origin, opts, handler)
-
     this[kQueue].push(request)
+
+    const abort = (reason) => {
+      reason ??= new RequestAbortedError()
+      request.abortBeforeStart(reason)
+      util.errorRequest(this, request, reason)
+      queueMicrotask(() => this[kResume]())
+    }
+
+    let signalBound = false
+    if (typeof opts[kRequestSignal] === 'function') {
+      signalBound = true
+      try {
+        opts[kRequestSignal](abort)
+      } catch (err) {
+        abort(err)
+      }
+    }
+
+    const { signal } = opts
+    if (!signalBound && signal && (typeof signal.on === 'function' || typeof signal.addEventListener === 'function')) {
+      if (signal.aborted) {
+        abort(signal.reason)
+      } else {
+        request.addEarlyAbortListener(signal, () => abort(signal.reason))
+      }
+    }
+
     if (this[kResuming]) {
       // Do nothing.
     } else if (util.bodyLength(request.body) == null && util.isIterable(request.body)) {
@@ -444,6 +472,8 @@ class Client extends DispatcherBase {
           util.errorRequest(this, request, err)
         }
       }
+
+      cancelConnect(this, err)
 
       const callback = () => {
         if (this[kClosedResolve]) {
@@ -493,7 +523,7 @@ function onError (client, err) {
  * @param {Client} client
  * @returns {void}
  */
-function connect (client) {
+function connect (client, requestDriven = false) {
   assert(!client[kConnecting])
   assert(!client[kHTTPContext])
 
@@ -510,7 +540,11 @@ function connect (client) {
     hostname = ip
   }
 
-  client[kConnecting] = true
+  const attempt = {
+    controller: new AbortController(),
+    requestDriven
+  }
+  client[kConnecting] = attempt
 
   if (channels.beforeConnect.hasSubscribers) {
     channels.beforeConnect.publish({
@@ -534,8 +568,18 @@ function connect (client) {
       protocol,
       port,
       servername: client[kServerName],
-      localAddress: client[kLocalAddress]
+      localAddress: client[kLocalAddress],
+      signal: attempt.controller.signal
     }, (err, socket) => {
+      // A cancelled attempt may settle after a newer one has started. Never
+      // attach its socket or report its error against the new request queue.
+      if (client[kConnecting] !== attempt) {
+        if (socket) {
+          util.destroy(socket.on('error', noop), new RequestAbortedError())
+        }
+        return
+      }
+
       if (err) {
         handleConnectError(client, err, { host, hostname, protocol, port })
         client[kResume]()
@@ -588,9 +632,22 @@ function connect (client) {
       client[kResume]()
     })
   } catch (err) {
+    if (client[kConnecting] !== attempt) {
+      return
+    }
     handleConnectError(client, err, { host, hostname, protocol, port })
     client[kResume]()
   }
+}
+
+function cancelConnect (client, reason) {
+  const attempt = client[kConnecting]
+  if (!attempt) {
+    return
+  }
+
+  client[kConnecting] = false
+  attempt.controller.abort(reason ?? new RequestAbortedError())
 }
 
 function handleConnectError (client, err, { host, hostname, protocol, port }) {
@@ -664,6 +721,10 @@ function _resume (client, sync) {
       return
     }
 
+    if (client[kConnecting]?.requestDriven && client[kPending] === 0) {
+      cancelConnect(client)
+    }
+
     if (client[kClosedResolve] && !client[kSize]) {
       client[kClosedResolve]()
       client[kClosedResolve] = null
@@ -700,6 +761,11 @@ function _resume (client, sync) {
       return
     }
 
+    if (request.aborted) {
+      client[kQueue].splice(client[kPendingIdx], 1)
+      continue
+    }
+
     if (client[kUrl].protocol === 'https:' && client[kServerName] !== request.servername) {
       if (client[kRunning] > 0) {
         return
@@ -718,7 +784,7 @@ function _resume (client, sync) {
 
     if (!client[kHTTPContext]) {
       client[kServerName] = request.servername
-      connect(client)
+      connect(client, true)
       return
     }
 
@@ -730,7 +796,7 @@ function _resume (client, sync) {
       return
     }
 
-    if (!request.aborted && client[kHTTPContext].write(request)) {
+    if (client[kHTTPContext].write(request)) {
       client[kPendingIdx]++
     } else {
       client[kQueue].splice(client[kPendingIdx], 1)

--- a/test/client-abort-while-connecting.js
+++ b/test/client-abort-while-connecting.js
@@ -1,0 +1,325 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { setTimeout: delay } = require('node:timers/promises')
+const { EventEmitter } = require('node:events')
+const { PassThrough } = require('node:stream')
+const net = require('node:net')
+const { Client, Pool, errors, interceptors } = require('..')
+const buildConnector = require('../lib/core/connect')
+
+function requestOutcome (client, signal) {
+  return new Promise((resolve) => {
+    client.request({ path: '/', method: 'GET', signal }, (err) => resolve(err))
+  })
+}
+
+test('#386 - abort while connecting rejects before the connector settles', async (t) => {
+  let connectCallback
+  let connectCalls = 0
+  let callbackCalls = 0
+  let connectionErrors = 0
+
+  const client = new Client('http://localhost', {
+    connect (_opts, callback) {
+      connectCalls++
+      connectCallback = callback
+    }
+  })
+  client.on('connectionError', () => {
+    connectionErrors++
+  })
+  t.after(() => client.destroy())
+
+  const controller = new AbortController()
+  const reason = new Error('request aborted while connecting')
+
+  const outcome = new Promise((resolve) => {
+    client.request({
+      path: '/',
+      method: 'GET',
+      signal: controller.signal
+    }, (err) => {
+      callbackCalls++
+      resolve(err)
+    })
+  })
+
+  assert.strictEqual(connectCalls, 1)
+  assert.strictEqual(typeof connectCallback, 'function')
+
+  controller.abort(reason)
+
+  const timeout = Symbol('timeout')
+  const result = await Promise.race([
+    outcome,
+    delay(500, timeout, { ref: false })
+  ])
+
+  assert.notStrictEqual(result, timeout, 'request did not reject while the connector was pending')
+  assert.strictEqual(result, reason)
+  assert.strictEqual(callbackCalls, 1)
+
+  connectCallback(Object.assign(new Error('late connector failure'), {
+    code: 'ECONNREFUSED'
+  }))
+
+  await delay(0)
+  assert.strictEqual(callbackCalls, 1)
+  assert.strictEqual(connectionErrors, 0)
+})
+
+test('#386 - queued abort uses one user-signal listener', async (t) => {
+  const client = new Client('http://localhost', {
+    connect () {}
+  })
+  t.after(() => client.destroy())
+
+  const signal = new EventEmitter()
+  const outcome = requestOutcome(client, signal)
+
+  assert.strictEqual(signal.listenerCount('abort'), 1)
+  signal.emit('abort')
+
+  assert.ok(await outcome instanceof errors.RequestAbortedError)
+  assert.strictEqual(signal.listenerCount('abort'), 0)
+})
+
+test('#386 - shared connection attempt is cancelled only after every request aborts', async (t) => {
+  const attempts = []
+  let connectionErrors = 0
+
+  const client = new Client('http://localhost', {
+    connect (opts) {
+      attempts.push(opts.signal)
+    }
+  })
+  client.on('connectionError', () => {
+    connectionErrors++
+  })
+  t.after(() => client.destroy())
+
+  const first = new AbortController()
+  const second = new AbortController()
+  const firstReason = new Error('first request aborted')
+  const secondReason = new Error('second request aborted')
+
+  const firstOutcome = requestOutcome(client, first.signal)
+  const secondOutcome = requestOutcome(client, second.signal)
+
+  assert.strictEqual(attempts.length, 1)
+  assert.ok(attempts[0] instanceof AbortSignal)
+
+  first.abort(firstReason)
+  assert.strictEqual(await firstOutcome, firstReason)
+  await delay(0)
+  assert.strictEqual(attempts[0].aborted, false)
+
+  second.abort(secondReason)
+  assert.strictEqual(await secondOutcome, secondReason)
+  await delay(0)
+
+  assert.strictEqual(attempts[0].aborted, true)
+  assert.strictEqual(connectionErrors, 0)
+})
+
+test('#386 - a late socket from a cancelled attempt cannot replace a newer attempt', async (t) => {
+  const attempts = []
+  let connectEvents = 0
+
+  const client = new Client('http://localhost', {
+    connect (opts, callback) {
+      attempts.push({ signal: opts.signal, callback })
+    }
+  })
+  client.on('connect', () => {
+    connectEvents++
+  })
+  t.after(() => client.destroy())
+
+  const first = new AbortController()
+  const firstReason = new Error('cancel first attempt')
+  const firstOutcome = requestOutcome(client, first.signal)
+
+  first.abort(firstReason)
+  assert.strictEqual(await firstOutcome, firstReason)
+  await delay(0)
+  assert.strictEqual(attempts[0].signal.aborted, true)
+
+  const second = new AbortController()
+  const secondReason = new Error('cancel second attempt')
+  const secondOutcome = requestOutcome(client, second.signal)
+
+  assert.strictEqual(attempts.length, 2)
+  assert.strictEqual(attempts[1].signal.aborted, false)
+
+  const staleSocket = new PassThrough()
+  attempts[0].callback(null, staleSocket)
+  await delay(0)
+
+  assert.strictEqual(staleSocket.destroyed, true)
+  assert.strictEqual(connectEvents, 0)
+  assert.strictEqual(attempts[1].signal.aborted, false)
+
+  second.abort(secondReason)
+  assert.strictEqual(await secondOutcome, secondReason)
+  await delay(0)
+  assert.strictEqual(attempts[1].signal.aborted, true)
+})
+
+test('#386 - the built-in connector destroys a pending socket when its attempt aborts', async (t) => {
+  const socket = new net.Socket()
+  t.mock.method(net, 'connect', () => socket)
+
+  const connector = buildConnector({ timeout: 0 })
+  const controller = new AbortController()
+  const reason = new Error('connection attempt is no longer needed')
+  let callbackCalls = 0
+
+  const outcome = new Promise((resolve) => {
+    connector({
+      hostname: 'localhost',
+      host: 'localhost',
+      protocol: 'http:',
+      port: '80',
+      signal: controller.signal
+    }, (err) => {
+      callbackCalls++
+      resolve(err)
+    })
+  })
+
+  controller.abort(reason)
+
+  assert.strictEqual(await outcome, reason)
+  assert.strictEqual(socket.destroyed, true)
+  assert.strictEqual(callbackCalls, 1)
+})
+
+test('#386 - queued abort propagates through a composed retry interceptor', async (t) => {
+  let attemptSignal
+  const baseClient = new Client('http://localhost', {
+    connect (opts) {
+      attemptSignal = opts.signal
+    }
+  })
+  const client = baseClient.compose(interceptors.retry())
+  t.after(() => client.destroy())
+
+  const controller = new AbortController()
+  const reason = new Error('composed request aborted while connecting')
+  const outcome = requestOutcome(client, controller.signal)
+
+  controller.abort(reason)
+
+  assert.strictEqual(await outcome, reason)
+  await delay(0)
+  assert.strictEqual(attemptSignal.aborted, true)
+})
+
+for (const api of ['stream', 'connect', 'upgrade']) {
+  test(`#386 - ${api} aborts while its connector is pending`, async (t) => {
+    const attempts = []
+    const client = new Client('http://localhost', {
+      connect (opts) {
+        attempts.push(opts.signal)
+      }
+    })
+    t.after(() => client.destroy())
+
+    const controller = new AbortController()
+    const reason = new Error(`${api} aborted while connecting`)
+    let factoryCalls = 0
+
+    const outcome = new Promise((resolve) => {
+      const opts = { path: '/', method: 'GET', signal: controller.signal }
+      if (api === 'stream') {
+        client.stream(opts, () => {
+          factoryCalls++
+          return new PassThrough()
+        }, resolve)
+      } else {
+        client[api](opts, resolve)
+      }
+    })
+
+    assert.strictEqual(attempts.length, 1)
+    controller.abort(reason)
+
+    assert.strictEqual(await outcome, reason)
+    assert.strictEqual(factoryCalls, 0)
+    await delay(0)
+    assert.strictEqual(attempts[0].aborted, true)
+  })
+}
+
+test('#386 - pipeline aborts while its connector is pending', async (t) => {
+  const attempts = []
+  const client = new Client('http://localhost', {
+    connect (opts) {
+      attempts.push(opts.signal)
+    }
+  })
+  t.after(() => client.destroy())
+
+  const controller = new AbortController()
+  const reason = new Error('pipeline aborted while connecting')
+  let handlerCalls = 0
+  const duplex = client.pipeline({
+    path: '/',
+    method: 'GET',
+    signal: controller.signal
+  }, () => {
+    handlerCalls++
+    return new PassThrough()
+  })
+  const outcome = new Promise((resolve) => duplex.once('error', resolve))
+
+  duplex.end()
+  await delay(0)
+  assert.strictEqual(attempts.length, 1)
+
+  controller.abort(reason)
+
+  assert.strictEqual(await outcome, reason)
+  assert.strictEqual(handlerCalls, 0)
+  await delay(0)
+  assert.strictEqual(attempts[0].aborted, true)
+})
+
+test('#386 - cancelling a Pool attempt does not evict the client or block close', async () => {
+  const attempts = []
+  let connectionErrors = 0
+
+  const pool = new Pool('http://localhost', {
+    connections: 1,
+    connect (opts) {
+      attempts.push(opts.signal)
+    }
+  })
+  pool.on('connectionError', () => {
+    connectionErrors++
+  })
+
+  const first = new AbortController()
+  const firstOutcome = requestOutcome(pool, first.signal)
+  first.abort(new Error('first pool request aborted'))
+  await firstOutcome
+  await delay(0)
+
+  const second = new AbortController()
+  const secondOutcome = requestOutcome(pool, second.signal)
+
+  assert.strictEqual(attempts.length, 2)
+  assert.strictEqual(attempts[0].aborted, true)
+  assert.strictEqual(attempts[1].aborted, false)
+  assert.strictEqual(connectionErrors, 0)
+
+  second.abort(new Error('second pool request aborted'))
+  await secondOutcome
+  await pool.close()
+
+  assert.strictEqual(attempts[1].aborted, true)
+  assert.strictEqual(connectionErrors, 0)
+})

--- a/test/client-request.js
+++ b/test/client-request.js
@@ -1655,3 +1655,24 @@ test('#3736 - Aborted Response (without consuming body)', async (t) => {
 
   await plan.completed
 })
+
+test('#386 - pre-aborted request does not connect', async (t) => {
+  let connectCalls = 0
+  const client = new Client('http://localhost', {
+    connect (_opts, callback) {
+      connectCalls++
+      callback(new Error('unexpected connection attempt'))
+    }
+  })
+  t.after(() => client.destroy())
+
+  const reason = new Error('request aborted')
+  const signal = AbortSignal.abort(reason)
+
+  await t.assert.rejects(client.request({
+    path: '/',
+    method: 'GET',
+    signal
+  }), (err) => err === reason)
+  t.assert.strictEqual(connectCalls, 0)
+})

--- a/test/interceptors/dump-interceptor.js
+++ b/test/interceptors/dump-interceptor.js
@@ -139,32 +139,10 @@ test('Should dump on abort', { skip }, async t => {
 })
 
 test('Should dump on already aborted request', { skip }, async t => {
-  t = tspl(t, { plan: 3 })
-  let offset = 0
+  t = tspl(t, { plan: 2 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
-    const max = 1024
-    const buffer = Buffer.alloc(max)
-
-    res.writeHead(200, {
-      'Content-Type': 'application/octet-stream'
-    })
-
-    res.once('close', () => {
-      t.equal(offset, 1024)
-    })
-
-    const interval = setInterval(() => {
-      offset += 256
-      const chunk = buffer.subarray(offset - 256, offset)
-
-      if (offset === max) {
-        clearInterval(interval)
-        res.end(chunk)
-        return
-      }
-
-      res.write(chunk)
-    }, 0)
+    t.fail('pre-aborted request should not be dispatched')
+    res.end()
   })
 
   const abc = new AbortController()

--- a/test/types/connector.test-d.ts
+++ b/test/types/connector.test-d.ts
@@ -36,5 +36,6 @@ expectAssignable<buildConnector.Options>({
   port: '',
   localAddress: '127.0.0.1',
   socketPath: '/var/run/undici.sock',
-  httpSocket: new Socket()
+  httpSocket: new Socket(),
+  signal: new AbortController().signal
 })

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -26,6 +26,7 @@ declare namespace buildConnector {
     localAddress?: string | null
     socketPath?: string | null
     httpSocket?: Socket
+    signal?: AbortSignal
   }
 
   export type Callback = (...args: CallbackArgs) => void


### PR DESCRIPTION
## Summary

Fixes #386 by rejecting requests that abort while connection establishment is still pending and cancelling connection attempts once no queued request needs them.

Previously, abort handling was attached when a request reached `onRequestStart`. A request waiting behind an unresolved connector had not reached that point, so aborting its signal did not settle the request until the connector eventually succeeded or failed.

## What Changed

- Reject pre-aborted requests without starting a connection.
- Bind the existing public API abort listener to requests while they are still queued.
- Cover `request`, `stream`, `pipeline`, `connect`, and `upgrade` consistently.
- Give each request-driven connection attempt its own `AbortSignal` and abort it after every request depending on that attempt has been removed.
- Preserve intentional internal preconnect attempts that have no queued request.
- Ignore late callbacks from cancelled attempts and destroy any stale socket they return.
- Keep intentional cancellation silent instead of emitting `connectionError` and causing pools to evict an otherwise usable client.
- Document and type the optional connector `signal`.

## Validation

- `npm run lint`
- `npm run test:typescript`
- Full `test/*.js` unit corpus
- Full `test/node-test/**/*.js` corpus
- Full `test/interceptors/*.js` corpus
- Focused request, stream, pipeline, connect, upgrade, pool, preconnect, and pipelining regression suites
- 11 new tests covering exact abort reasons, listener cleanup, shared attempts, retry composition, stale connector callbacks, built-in connector cancellation, and pool lifecycle behavior

## Scope Notes

Custom connectors receive the attempt-scoped signal and should stop pending work when it aborts. A connector that ignores the signal cannot have its internal work forcibly stopped, but Undici still settles the request promptly and prevents a late socket or error from affecting a newer attempt.

The cancellation signal represents the lifetime of a connection attempt, not any single request. A shared attempt is cancelled only when all queued requests relying on it are gone.
