### PR TITLE
fix(cookies): keep a cookie named __proto__ in getCookies

### DIFF
--- a/lib/web/cookies/index.js
+++ b/lib/web/cookies/index.js
@@ -32,8 +32,10 @@ function getCookies (headers) {
 
   const cookie = headers.get('cookie')
 
+  // A null prototype keeps a cookie named `__proto__` from hitting the
+  // Object.prototype setter, which would silently drop it.
   /** @type {Record<string, string>} */
-  const out = {}
+  const out = { __proto__: null }
 
   if (!cookie) {
     return out

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -59,6 +59,24 @@ test('Cookie parser', () => {
   })
 })
 
+test('Cookie parser keeps a cookie named __proto__', () => {
+  const headers = new Headers()
+  headers.set('Cookie', '__proto__=foo; bar=baz')
+
+  const cookies = getCookies(headers)
+
+  assert.deepStrictEqual(Object.keys(cookies).sort(), ['__proto__', 'bar'])
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(cookies, '__proto__').value,
+    'foo'
+  )
+  assert.strictEqual(cookies.bar, 'baz')
+
+  for (const value of Object.values(cookies)) {
+    assert.strictEqual(typeof value, 'string')
+  }
+})
+
 test('Cookie Name Validation', () => {
   const tokens = [
     '"id"',


### PR DESCRIPTION
## This relates to...

No open issue. Found while reading `lib/web/cookies/`.

## Rationale

`getCookies()` builds its result on a plain object literal:

```js
const out = {}
for (const piece of cookie.split(';')) {
  const [name, ...value] = piece.split('=')
  out[name.trim()] = value.join('=')
}
```

`__proto__` is a valid cookie name (it is a token per RFC 6265), but assigning it on a plain object reaches the `Object.prototype` setter instead of creating an own property. The setter only accepts an object or null, and the assigned value here is always a string, so it does nothing and the cookie is dropped:

```js
const headers = new Headers()
headers.set('Cookie', '__proto__=foo; bar=baz')

getCookies(headers)              // { bar: 'baz' }, the first cookie is gone
getCookies(headers).__proto__    // Object.prototype, not the string 'foo'
```

The second line is the part that bothered me more than the missing key. `getCookies` is typed `Record<string, string>`, so a caller that indexes it by an attacker-influenced name gets an object back where the types promise a string.

There is no prototype pollution here: the setter refuses a string, so `Object.prototype` is untouched. The bug is silent data loss plus a broken type contract.

## Changes

`getCookies` now builds its record with `{ __proto__: null }`, which is already the pattern used in `lib/core/util.js`, `lib/util/runtime-features.js`, `lib/web/eventsource/eventsource.js` and `lib/web/fetch/formdata.js`.

The existing tests all use `assert.deepEqual`, which does not compare prototypes, so none of them needed changing. All 92 tests under `test/cookie/` pass.

### Features

N/A

### Bug Fixes

A cookie named `__proto__` is now returned by `getCookies()` like any other name.

### Breaking Changes and Deprecations

The returned object no longer inherits from `Object.prototype`, so calling `cookies.hasOwnProperty(name)` on it stops working. `Object.hasOwn(cookies, name)` and `name in cookies` still work, as does every form of indexing and iteration.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
