### PR TITLE
fix(decompress): join a repeated content-encoding header

### DIFF
--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -163,7 +163,13 @@ class DecompressHandler extends DecoratorHandler {
    * @returns {void}
    */
   onResponseStart (controller, statusCode, headers, statusMessage) {
-    const contentEncoding = headers['content-encoding']
+    // Repeated field lines reach us as an array. RFC 9110 section 5.3 lets a
+    // recipient join them with commas, which yields the single-line form the
+    // decompression chain already handles.
+    const rawContentEncoding = headers['content-encoding']
+    const contentEncoding = Array.isArray(rawContentEncoding)
+      ? rawContentEncoding.join(',')
+      : rawContentEncoding
 
     // If content encoding is not supported or status code is in skip list
     if (this.#shouldSkipDecompression(contentEncoding, statusCode)) {

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -1206,3 +1206,50 @@ test('should work with global dispatcher for both fetch() and request()', async 
 
   await t.completed
 })
+
+test('should decompress a response whose content-encoding arrives as repeated header lines', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const net = require('node:net')
+
+  const data = 'Repeated Content-Encoding field lines, joined per RFC 9110 section 5.3.'
+  const body = gzipSync(gzipSync(data))
+
+  const server = net.createServer(socket => {
+    socket.once('data', () => {
+      socket.write(
+        'HTTP/1.1 200 OK\r\n' +
+        'Content-Type: text/plain\r\n' +
+        'Content-Encoding: gzip\r\n' +
+        'Content-Encoding: gzip\r\n' +
+        `Content-Length: ${body.length}\r\n` +
+        'Connection: close\r\n' +
+        '\r\n'
+      )
+      socket.end(body)
+    })
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(createDecompressInterceptor())
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), data)
+
+  await t.completed
+})


### PR DESCRIPTION
## This relates to...

No open issue. Found while reading `lib/interceptor/decompress.js`.

## Rationale

`DecompressHandler.onResponseStart` reads the header as a string:

```js
const contentEncoding = headers['content-encoding']
...
const decompressors = this.#createDecompressionChain(contentEncoding.toLowerCase())
```

`parseHeaders` turns a repeated field into an array (`lib/core/util.js`, the `val = [val]` branch), and the JSDoc on this very method already types `headers` as `Record<string, string | string[] | undefined>`. An array is truthy, so `#shouldSkipDecompression` lets it through and `.toLowerCase()` throws:

```
TypeError: contentEncoding.toLowerCase is not a function
```

Reproduced against a raw socket server that writes the field twice:

```
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Encoding: gzip
Content-Encoding: gzip
```

RFC 9110 section 5.3 lets a recipient combine repeated field lines into one by joining the values with commas, and that comma-joined form is exactly what `#createDecompressionChain` already splits and handles. So the fix is to join before anything else looks at the value.

The existing chain limit still applies afterwards: six repeated `Content-Encoding` lines join into six parts and hit the same `maxContentEncodings` guard as the single-line form, which the suite already covers.

## Changes

`onResponseStart` joins an array-valued `content-encoding` with commas before the skip check and the chain build.

Test added to `test/interceptors/decompress.js`: a response with two `Content-Encoding: gzip` lines and a doubly gzipped body decompresses to the original text.

### Features

N/A

### Bug Fixes

The decompress interceptor no longer throws a `TypeError` when a response repeats `Content-Encoding` across field lines, and decompresses it the same way it decompresses the comma-joined single-line form.

### Breaking Changes and Deprecations

None. Responses with a single `Content-Encoding` line take exactly the same path as before.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
