### PR TITLE
fix(decompress): stop inflating compress and x-compress

### DIFF
--- a/docs/docs/api/Interceptors.md
+++ b/docs/docs/api/Interceptors.md
@@ -198,7 +198,8 @@ const agent = new Agent().compose(
 ## `interceptors.decompress([opts])`
 
 Automatically decompresses response bodies encoded with `gzip`, `x-gzip`,
-`br` (Brotli), `deflate`, `compress`, `x-compress`, or `zstd`.
+`br` (Brotli), `deflate`, or `zstd`. Any other coding, including `compress`
+and `x-compress`, is left untouched, matching `fetch()`.
 
 > **Experimental:** This interceptor is experimental and subject to change.
 > A one-time `ExperimentalWarning` is emitted on first use.

--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -9,14 +9,16 @@ const DecoratorHandler = require('../handler/decorator-handler')
 /** @typedef {import('node:stream').Transform} Controller */
 /** @typedef {Transform&import('node:zlib').Zlib} DecompressorStream */
 
+// `compress` and `x-compress` are deliberately absent. RFC 9110 section
+// 8.4.1.1 defines them as the UNIX compress (LZW) format, which zlib cannot
+// read, so inflating them turns a readable response into a Z_DATA_ERROR.
+// fetch() leaves them alone, and so does this interceptor.
 /** @type {Record<string, () => DecompressorStream>} */
 const supportedEncodings = {
   gzip: createGunzip,
   'x-gzip': createGunzip,
   br: createBrotliDecompress,
   deflate: createInflate,
-  compress: createInflate,
-  'x-compress': createInflate,
   zstd: createZstdDecompress
 }
 

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -1501,3 +1501,51 @@ test('should decompress a response whose content-encoding arrives as repeated he
 
   await t.completed
 })
+
+test('should pass through a compress-encoded response instead of inflating it', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const net = require('node:net')
+
+  // Content-Encoding: compress is the UNIX compress (LZW) format per RFC 9110
+  // section 8.4.1.1, not zlib, so this body is not inflatable.
+  const payload = Buffer.from('this body is not deflate data')
+
+  const server = net.createServer(socket => {
+    socket.once('data', () => {
+      socket.write(
+        'HTTP/1.1 200 OK\r\n' +
+        'Content-Type: text/plain\r\n' +
+        'Content-Encoding: compress\r\n' +
+        `Content-Length: ${payload.length}\r\n` +
+        'Connection: close\r\n' +
+        '\r\n'
+      )
+      socket.end(payload)
+    })
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(createDecompressInterceptor())
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-encoding'], 'compress', 'the encoding is left on the response since nothing was decoded')
+  t.equal(await response.body.text(), payload.toString())
+
+  await t.completed
+})


### PR DESCRIPTION
## This relates to...

No open issue. Found while reading `lib/interceptor/decompress.js`.

## Rationale

`supportedEncodings` maps `compress` and `x-compress` to `createInflate`:

```js
deflate: createInflate,
compress: createInflate,
'x-compress': createInflate,
```

Those are different formats. RFC 9110 section 8.4.1.1 defines `compress` as the UNIX compress (LZW) format, while `deflate` is zlib. Node has no LZW decoder, so feeding a `compress` body to inflate cannot succeed. It does not degrade, it fails the request:

```
Z_DATA_ERROR: incorrect header check
```

`fetch()` does not do this. Its coding switch in `lib/web/fetch/index.js` handles `x-gzip`, `gzip`, `deflate`, `br` and `zstd`, and anything else falls through untouched. Same response, same server, both from this repo:

```
interceptor : Z_DATA_ERROR | incorrect header check
fetch       : "this body is not deflate data"
```

So composing the decompress interceptor onto a client turns a response that `fetch` reads fine into a hard failure.

The two entries are removed. `compress` and `x-compress` now take the path every other unrecognised coding already takes: `#createDecompressionChain` returns an empty chain, the body passes through, and `Content-Encoding` stays on the response since nothing was decoded. The only case this changes is a server that labels zlib data as `compress`, which is already mislabelled and which `fetch` never decoded either.

The doc line that advertised the two codings is updated to match.

Worth noting: this touches the same file as #5664, but a different region, so the two apply independently.

## Changes

`compress` and `x-compress` removed from `supportedEncodings`, with a comment recording why.

`docs/docs/api/Interceptors.md`: the decompress section no longer lists the two codings and says unrecognised codings are left untouched.

Test added to `test/interceptors/decompress.js`: a `Content-Encoding: compress` response with a non-inflatable body arrives unchanged instead of erroring.

### Features

N/A

### Bug Fixes

A `Content-Encoding: compress` response no longer fails with `Z_DATA_ERROR` under the decompress interceptor.

### Breaking Changes and Deprecations

A server sending zlib data labelled `compress` was being decoded and now is not. That labelling is already wrong per RFC 9110, and `fetch()` in this repo has never decoded it.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
