### PR TITLE
fix(fetch): keep a request header named __proto__

### DIFF
--- a/lib/web/fetch/headers.js
+++ b/lib/web/fetch/headers.js
@@ -320,7 +320,19 @@ class HeadersList {
 
     if (this.headersMap.size !== 0) {
       for (const { name, value } of this.headersMap.values()) {
-        headers[name] = value
+        if (name === '__proto__') {
+          // Plain assignment would reach the Object.prototype setter, which
+          // refuses a string and drops the header. Same guard as parseHeaders
+          // in lib/core/util.js.
+          Object.defineProperty(headers, name, {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true
+          })
+        } else {
+          headers[name] = value
+        }
       }
     }
 

--- a/test/prototype-headers.js
+++ b/test/prototype-headers.js
@@ -82,3 +82,49 @@ test('request handles response trailers that shadow Object.prototype', async (t)
   assert.strictEqual(Object.getOwnPropertyDescriptor(trailers, '__proto__').value, 'trailer')
   assert.strictEqual(Object.getOwnPropertyDescriptor(trailers, 'constructor').value, 'built-in-trailer')
 })
+
+test('fetch sends a request header named __proto__', async (t) => {
+  const { createServer } = require('node:http')
+  const { fetch, Headers } = require('..')
+
+  let rawHeaders = null
+  const server = createServer((req, res) => {
+    rawHeaders = req.rawHeaders
+    res.end('OK')
+  })
+
+  t.after(() => {
+    server.closeAllConnections?.()
+    server.close()
+  })
+
+  await promisify(server.listen.bind(server))(0)
+
+  const headers = new Headers()
+  headers.set('__proto__', 'pwned')
+  headers.set('x-control', 'sent')
+
+  const response = await fetch(`http://localhost:${server.address().port}/`, {
+    headers
+  })
+  await response.text()
+
+  const received = {}
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    Object.defineProperty(received, rawHeaders[i].toLowerCase(), {
+      configurable: true,
+      enumerable: true,
+      value: rawHeaders[i + 1],
+      writable: true
+    })
+  }
+
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(received, 'x-control').value,
+    'sent'
+  )
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(received, '__proto__')?.value,
+    'pwned'
+  )
+})


### PR DESCRIPTION
## This relates to...

No open issue. Same defect class as `test/prototype-headers.js` already covers for `client.request`, on the path that file does not reach.

## Rationale

`HeadersList.entries` builds a plain object keyed by header name:

```js
for (const { name, value } of this.headersMap.values()) {
  headers[name] = value
}
```

`__proto__` is a valid header name, and assigning it on a plain object reaches the `Object.prototype` setter instead of creating an own property. The setter only takes an object or null, the value here is always a string, so the header is dropped without an error.

`lib/web/fetch/index.js` passes this object to the dispatcher as the request headers, so a header the caller explicitly set never reaches the wire:

```js
const headers = new Headers()
headers.set('__proto__', 'pwned')
headers.set('x-control', 'sent')

await fetch(url, { headers })

headers.get('__proto__')   // 'pwned', the Headers object kept it
// server received:  x-control: sent          <- present
// server received:  __proto__: pwned         <- missing
```

`Headers` itself is fine. It stores the entry in a Map and reads it back correctly. Only the conversion to a plain object loses it.

`parseHeaders` in `lib/core/util.js` already guards this exact case, which is what `test/prototype-headers.js` exercises for `client.request`. The fetch path just never got the same treatment. `lib/web/websocket/websocket.js` reads the same getter for its response headers.

There is no prototype pollution here: the setter refuses a string, so `Object.prototype` is untouched. The bug is a silently dropped header.

## Changes

`HeadersList.entries` now writes the `__proto__` key with `Object.defineProperty`, copying the guard already used by `parseHeaders`.

I kept the object plain rather than switching it to a null prototype on purpose: `[util.inspect.custom]` formats this same object, so a null prototype would turn `Headers { ... }` into `Headers [Object: null prototype] { ... }` and change output that `test/fetch/headers-inspect-custom.js` asserts on.

Test added to `test/prototype-headers.js`: a `fetch` whose `Headers` carries `__proto__` reaches the server with that header, alongside a control header that already worked.

### Features

N/A

### Bug Fixes

`fetch` no longer drops a request header named `__proto__`.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
