### PR TITLE
fix(cache): keep a header named __proto__ out of the prototype chain

### DIFF
--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -164,17 +164,45 @@ function makeCacheKey (opts) {
   }
 }
 
+/**
+ * Writes a header onto a plain object without going through the
+ * Object.prototype `__proto__` setter, which would either drop the value or,
+ * when the value is an array, reprototype the accumulator. Same guard as
+ * parseHeaders in lib/core/util.js.
+ *
+ * @param {Record<string, string[] | string>} headers
+ * @param {string} name lowercased header name
+ * @param {string | string[]} value
+ */
+function setHeader (headers, name, value) {
+  if (name === '__proto__') {
+    Object.defineProperty(headers, name, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    })
+  } else {
+    headers[name] = value
+  }
+}
+
 function appendHeader (headers, key, val) {
   const headerName = key.toLowerCase()
-  const current = headers[headerName]
+  // Reading `headers[headerName]` directly would resolve `__proto__` (and any
+  // other inherited name) through the prototype chain rather than report the
+  // header as absent.
+  const current = Object.hasOwn(headers, headerName)
+    ? headers[headerName]
+    : undefined
   const values = Array.isArray(val) ? val : [val]
 
   if (current === undefined) {
-    headers[headerName] = Array.isArray(val) ? val.slice() : val
+    setHeader(headers, headerName, Array.isArray(val) ? val.slice() : val)
   } else if (Array.isArray(current)) {
     current.push(...values)
   } else {
-    headers[headerName] = [current, ...values]
+    setHeader(headers, headerName, [current, ...values])
   }
 }
 
@@ -692,7 +720,7 @@ function makeDeduplicationKey (cacheKey, excludeHeaders) {
       if (excludeHeaders?.has(header.toLowerCase())) {
         continue
       }
-      headers[header] = cacheKey.headers[header]
+      setHeader(headers, header, cacheKey.headers[header])
     }
   }
 

--- a/test/cache-interceptor/cache-utils.js
+++ b/test/cache-interceptor/cache-utils.js
@@ -138,3 +138,20 @@ test('normalizeHeaders throws on non-string key in flat array', (t) => {
     message: 'opts.headers is not a valid header map'
   })
 })
+
+test('normalizeHeaders keeps a header named __proto__ without reprototyping the result', (t) => {
+  const { strictEqual, deepStrictEqual } = tspl(t, { plan: 5 })
+
+  // JSON.parse is the everyday way an own `__proto__` key shows up, e.g.
+  // headers read from a config file or a request body.
+  const headers = normalizeHeaders({
+    headers: JSON.parse('{"__proto__":"a","x-real":"same"}')
+  })
+
+  deepStrictEqual(Object.keys(headers).sort(), ['__proto__', 'x-real'])
+  strictEqual(Object.getOwnPropertyDescriptor(headers, '__proto__').value, 'a')
+  strictEqual(headers['x-real'], 'same')
+  strictEqual(Object.getPrototypeOf(headers), Object.prototype)
+  // A header named `length` must not resolve through an array prototype.
+  strictEqual(headers.length, undefined)
+})

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -1338,6 +1338,26 @@ describe('Deduplicate Interceptor', () => {
     notStrictEqual(key1, key2)
   })
 
+  test('makeDeduplicationKey does not collide on a header named __proto__', () => {
+    const withProto = JSON.parse('{"__proto__":"a","x-real":"same"}')
+
+    const key1 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: withProto
+    })
+
+    const key2 = makeDeduplicationKey({
+      origin: 'https://example.com',
+      method: 'GET',
+      path: '/',
+      headers: { 'x-real': 'same' }
+    })
+
+    notStrictEqual(key1, key2)
+  })
+
   test('makeDeduplicationKey produces same key for identical headers', () => {
     const key1 = makeDeduplicationKey({
       origin: 'https://example.com',


### PR DESCRIPTION
## This relates to...

No open issue. Extends the collision class that #5012 covered for delimiters.

## Rationale

`appendHeader` in `lib/util/cache.js` accumulates onto a plain object and probes it by index:

```js
const current = headers[headerName]

if (current === undefined) {
  headers[headerName] = ...
} else if (Array.isArray(current)) {
  current.push(...values)
} else {
  headers[headerName] = [current, ...values]
}
```

For `__proto__` that probe returns `Object.prototype`, not `undefined`, so the header takes the last branch and the accumulator is assigned an **array**. Unlike a string, an array is accepted by the `Object.prototype` setter, so the assignment reprototypes the accumulator instead of storing the header.

An own `__proto__` key is not exotic. `JSON.parse` produces one, which is how headers read from a config file or a request body arrive:

```js
normalizeHeaders({ headers: JSON.parse('{"__proto__":"a","x-real":"same"}') })
```

Before:

```
Object.keys(headers)          -> [ 'x-real' ]
Object.getPrototypeOf(headers) -> [ [Object: null prototype] {}, 'a' ]   // an Array
headers.length                -> 2
```

Two problems from that one assignment. The header is gone, and the result now inherits from an array, so a lookup for a header named `length` answers `2` and `at`, `map`, `keys` and friends all resolve to functions. `appendHeader` itself branches on `headers[headerName] === undefined`, so a later header with one of those names takes the wrong branch.

The lost header then reaches `makeDeduplicationKey`, which rebuilds a plain object the same way, so two different requests produce one key:

```js
makeDeduplicationKey({ ..., headers: JSON.parse('{"__proto__":"a","x-real":"same"}') })
makeDeduplicationKey({ ..., headers: { 'x-real': 'same' } })
// both: ["https://example.com","GET","/",{"x-real":"same"}]
```

The comment above that function says the key format was reworked because different header sets could produce identical keys (#5012). This is the same failure, reached through the header name instead of the value.

There is no `Object.prototype` pollution: the reprototyped object is the local accumulator, and the global prototype is untouched.

## Changes

A `setHeader` helper writes the `__proto__` key with `Object.defineProperty`, matching the guard `parseHeaders` already uses in `lib/core/util.js`. `appendHeader` probes with `Object.hasOwn` so an inherited name is not mistaken for an existing header, and `makeDeduplicationKey` writes through the same helper.

I kept the accumulator a plain object rather than switching it to a null prototype: it is handed to user-supplied cache stores as part of the cache key, and dropping `Object.prototype` from it would be a visible change for that code.

After:

```
Object.keys(headers)           -> [ '__proto__', 'x-real' ]
Object.getPrototypeOf(headers) -> Object.prototype
headers.length                 -> undefined
keys collide                   -> false
```

Two tests: one in `test/cache-interceptor/cache-utils.js` for the normalization, next to the existing prototype-pollution test there, and one in `test/interceptors/deduplicate.js` beside the #5012 collision test.

`test/cache-interceptor` 77 passing, `test/interceptors` 302 passing with 14 skipped as before, `test/cache` 4 passing.

### Features

N/A

### Bug Fixes

A header named `__proto__` is no longer dropped from the normalized headers, no longer reprototypes the accumulator, and no longer makes two different requests share a deduplication key.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
