### PR TITLE
fix(mock): keep a header named __proto__ in snapshots

### DIFF
--- a/lib/mock/snapshot-recorder.js
+++ b/lib/mock/snapshot-recorder.js
@@ -4,7 +4,7 @@ const { writeFile, readFile, mkdir } = require('node:fs/promises')
 const { dirname, resolve } = require('node:path')
 const { setTimeout, clearTimeout } = require('node:timers')
 const { InvalidArgumentError, UndiciError } = require('../core/errors')
-const { hashId, isUrlExcludedFactory, normalizeHeaders, createHeaderFilters } = require('./snapshot-utils')
+const { hashId, isUrlExcludedFactory, normalizeHeaders, createHeaderFilters, setHeader } = require('./snapshot-utils')
 
 /**
  * @typedef {Object} SnapshotRequestOptions
@@ -169,7 +169,7 @@ function filterHeadersForMatching (headers, headerFilters, matchOptions = {}) {
       if (!match.has(headerKey)) continue
     }
 
-    filtered[headerKey] = value
+    setHeader(filtered, headerKey, value)
   }
 
   return filtered
@@ -198,7 +198,7 @@ function filterHeadersForStorage (headers, headerFilters, matchOptions = {}) {
     // Skip if in exclude list (for security)
     if (excludeSet.has(headerKey)) continue
 
-    filtered[headerKey] = value
+    setHeader(filtered, headerKey, value)
   }
 
   return filtered

--- a/lib/mock/snapshot-utils.js
+++ b/lib/mock/snapshot-utils.js
@@ -96,6 +96,28 @@ function isUrlExcludedFactory (excludePatterns = []) {
 }
 
 /**
+ * Writes a header onto a plain object without going through the
+ * Object.prototype `__proto__` setter, which would drop it. Same guard as
+ * parseHeaders in lib/core/util.js.
+ *
+ * @param {NormalizedHeaders} headers
+ * @param {string} name lowercased header name
+ * @param {string} value
+ */
+function setHeader (headers, name, value) {
+  if (name === '__proto__') {
+    Object.defineProperty(headers, name, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    })
+  } else {
+    headers[name] = value
+  }
+}
+
+/**
  * Normalizes headers for consistent comparison
  *
  * @param {Object|UndiciHeaders} headers - Headers to normalize
@@ -116,7 +138,7 @@ function normalizeHeaders (headers) {
         // Convert Buffers to strings if needed
         const keyStr = Buffer.isBuffer(key) ? key.toString() : key
         const valueStr = Buffer.isBuffer(value) ? value.toString() : value
-        normalizedHeaders[keyStr.toLowerCase()] = valueStr
+        setHeader(normalizedHeaders, keyStr.toLowerCase(), valueStr)
       }
     }
     return normalizedHeaders
@@ -126,7 +148,7 @@ function normalizeHeaders (headers) {
   if (headers && typeof headers === 'object') {
     for (const [key, value] of Object.entries(headers)) {
       if (key && typeof key === 'string') {
-        normalizedHeaders[key.toLowerCase()] = Array.isArray(value) ? value.join(', ') : String(value)
+        setHeader(normalizedHeaders, key.toLowerCase(), Array.isArray(value) ? value.join(', ') : String(value))
       }
     }
   }
@@ -153,6 +175,7 @@ module.exports = {
   hashId,
   isUndiciHeaders,
   normalizeHeaders,
+  setHeader,
   isUrlExcludedFactory,
   validateSnapshotMode
 }

--- a/test/snapshot-recorder.js
+++ b/test/snapshot-recorder.js
@@ -422,3 +422,31 @@ test('SnapshotRecorder - redirect responses are stored correctly', (t) => {
   assert.strictEqual(snapshot.responses[0].statusCode, 302, 'First response should be redirect')
   assert.strictEqual(snapshot.responses[1].statusCode, 200, 'Second response should be final')
 })
+
+test('SnapshotRecorder - a header named __proto__ does not collide with its absence', (t) => {
+  const filters = createHeaderFilters({})
+
+  // JSON.parse is the everyday way an own `__proto__` key appears.
+  const withProto = formatRequestKey({
+    origin: 'https://example.com',
+    path: '/resource',
+    method: 'GET',
+    headers: JSON.parse('{"__proto__":"a","x-real":"same"}')
+  }, filters)
+
+  const withoutProto = formatRequestKey({
+    origin: 'https://example.com',
+    path: '/resource',
+    method: 'GET',
+    headers: { 'x-real': 'same' }
+  }, filters)
+
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(withProto.headers, '__proto__')?.value,
+    'a'
+  )
+  assert.notStrictEqual(
+    createRequestHash(withProto),
+    createRequestHash(withoutProto)
+  )
+})


### PR DESCRIPTION
## This relates to...

I raised this in a comment on #5667 and offered to send it separately. Sending it now that #5663 was approved, since it is the same guard on a subsystem where the consequence is different.

## Rationale

Three places in the snapshot mock build a plain object keyed by header name and assign into it:

- `normalizeHeaders` in `lib/mock/snapshot-utils.js`, both the array and the object branch
- `filterHeadersForMatching` and `filterHeadersForStorage` in `lib/mock/snapshot-recorder.js`

`__proto__` is a valid header name, and assigning it on a plain object reaches the `Object.prototype` setter instead of creating an own property. The value is a string, so the setter does nothing and the header is dropped.

It does not stop at a lost header. `formatRequestKey` feeds those headers to `createRequestHash`, which walks `Object.keys(...).sort()`, so two different requests produce one snapshot key:

```js
const filters = createHeaderFilters({})
const a = formatRequestKey({ origin, path, method: 'GET',
  headers: JSON.parse('{"__proto__":"a","x-real":"same"}') }, filters)
const b = formatRequestKey({ origin, path, method: 'GET',
  headers: { 'x-real': 'same' } }, filters)

createRequestHash(a) === createRequestHash(b)   // true
```

In record mode the two collapse into one entry, and in playback the recorded response for one is served for the other. `JSON.parse` is the everyday way an own `__proto__` key shows up, which is exactly how snapshots arrive from disk.

There is no `Object.prototype` pollution: the setter refuses a string, so the global prototype is untouched.

## Changes

A `setHeader` helper in `snapshot-utils.js` writes the `__proto__` key with `Object.defineProperty`, the guard `parseHeaders` already uses in `lib/core/util.js`. It is exported and used by all three writers.

The object stays plain rather than switching to a null prototype, because it is serialized into snapshot files and handed back to user code.

After the change the same pair hashes differently and the header survives:

```
headers stored: {"__proto__":"a","x-real":"same"}
hashes equal:   false
```

One test in `test/snapshot-recorder.js`, next to the existing `formatRequestKey` tests.

`test/snapshot*.js` 48 passing, `test/mock*.js` 339 passing, lint clean.

### Features

N/A

### Bug Fixes

A header named `__proto__` is no longer dropped from a recorded snapshot and no longer makes two different requests share a snapshot key.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
