### PR TITLE
fix(h2): keep a request header named __proto__

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -824,31 +824,50 @@ function shouldSendContentLength (method) {
   return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS' && method !== 'TRACE' && method !== 'CONNECT'
 }
 
+/**
+ * Writes a header without going through the Object.prototype `__proto__`
+ * setter, which would drop it. Same guard as parseHeaders in lib/core/util.js.
+ */
+function setHeader (headers, name, value) {
+  if (name === '__proto__') {
+    Object.defineProperty(headers, name, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    })
+  } else {
+    headers[name] = value
+  }
+}
+
 function buildRequestHeaders (reqHeaders) {
   const headers = {}
 
   for (let n = 0; n < reqHeaders.length; n += 2) {
     const key = reqHeaders[n + 0]
     const val = reqHeaders[n + 1]
-    const current = headers[key]
+    // Reading headers[key] directly resolves `__proto__` through the prototype
+    // chain instead of reporting the header as absent.
+    const current = Object.hasOwn(headers, key) ? headers[key] : undefined
 
     if (key === 'cookie') {
       if (current != null) {
-        headers[key] = Array.isArray(current) ? (current.push(val), current) : [current, val]
+        setHeader(headers, key, Array.isArray(current) ? (current.push(val), current) : [current, val])
       } else {
-        headers[key] = val
+        setHeader(headers, key, val)
       }
 
       continue
     }
 
     if (typeof val === 'string') {
-      headers[key] = current ? `${current}, ${val}` : val
+      setHeader(headers, key, current ? `${current}, ${val}` : val)
       continue
     }
 
     for (let i = 0; i < val.length; i++) {
-      headers[key] = headers[key] ? `${headers[key]}, ${val[i]}` : val[i]
+      setHeader(headers, key, Object.hasOwn(headers, key) ? `${headers[key]}, ${val[i]}` : val[i])
     }
   }
 

--- a/test/prototype-headers.js
+++ b/test/prototype-headers.js
@@ -82,3 +82,41 @@ test('request handles response trailers that shadow Object.prototype', async (t)
   assert.strictEqual(Object.getOwnPropertyDescriptor(trailers, '__proto__').value, 'trailer')
   assert.strictEqual(Object.getOwnPropertyDescriptor(trailers, 'constructor').value, 'built-in-trailer')
 })
+
+test('h2 sends a request header named __proto__', async (t) => {
+  const { createSecureServer } = require('node:http2')
+  const { once } = require('node:events')
+  const pem = require('@metcoder95/https-pem')
+
+  let received = null
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream, headers) => {
+    received = headers
+    stream.respond({ ':status': 200 })
+    stream.end('OK')
+  })
+
+  t.after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    allowH2: true,
+    connect: { rejectUnauthorized: false }
+  })
+  t.after(() => client.close())
+
+  const { body } = await client.request({
+    path: '/',
+    method: 'GET',
+    // The flat array form is what buildRequestHeaders receives.
+    headers: ['__proto__', 'pwned', 'x-control', 'sent']
+  })
+  await body.text()
+
+  assert.strictEqual(received['x-control'], 'sent')
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(received, '__proto__')?.value,
+    'pwned'
+  )
+})


### PR DESCRIPTION
## This relates to...

The h2 half of what I flagged in a comment on #5667. `test/prototype-headers.js` already covers this concern for `client.request` over HTTP/1.

## Rationale

`buildRequestHeaders` in `lib/dispatcher/client-h2.js` probes the accumulator by index:

```js
const current = headers[key]
...
headers[key] = current ? `${current}, ${val}` : val
```

For `__proto__` that probe returns `Object.prototype`, which is truthy, so the header takes the "already present" branch and the value becomes `"[object Object], pwned"`. That string is then assigned through the `Object.prototype` setter, which refuses a string, so nothing is stored and the header never reaches the wire.

Reproduced over a real HTTP/2 connection, before the change:

```
x-control arrived: sent
__proto__ arrived: no
```

`__proto__` is a valid field name, and the flat array form is exactly what this function receives from the dispatcher.

There is no `Object.prototype` pollution: the setter refuses the string, so the global prototype is untouched.

## Changes

The probe uses `Object.hasOwn` so an inherited name is not mistaken for an existing header, and all four writes go through a `setHeader` helper using `Object.defineProperty`, the guard `parseHeaders` already uses in `lib/core/util.js`.

Test added to `test/prototype-headers.js`, alongside the HTTP/1 cases: an h2 request carrying `__proto__` reaches the server with that header, with a control header that already worked.

`test/+(http2|h2)*.js` 104 passing with 1 skipped as before, lint clean.

### Features

N/A

### Bug Fixes

An HTTP/2 request no longer drops a header named `__proto__`, and no longer corrupts its value with `[object Object], ` first.

### Breaking Changes and Deprecations

None.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
