### PR TITLE
fix(date): slide the rfc850-date two-digit year window

### DIFF
--- a/lib/util/date.js
+++ b/lib/util/date.js
@@ -593,14 +593,25 @@ function parseRfc850Date (date) {
 
   let year = (yearDigit1 - 48) * 10 + (yearDigit2 - 48) // Convert ASCII codes to number
 
-  // RFC 6265 states that the year is in the range 1970-2069.
-  // @see https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1
+  // "Recipients of a timestamp value in rfc850-date format, which uses a
+  // two-digit year, MUST interpret a timestamp that appears to be more than
+  // 50 years in the future as representing the most recent year in the past
+  // that had the same last two digits."
   //
-  // 3. If the year-value is greater than or equal to 70 and less than or
-  //    equal to 99, increment the year-value by 1900.
-  // 4. If the year-value is greater than or equal to 0 and less than or
-  //    equal to 69, increment the year-value by 2000.
-  year += year < 70 ? 2000 : 1900
+  // The window therefore slides with the clock. RFC 6265 pins cookies to a
+  // fixed 1970-2069 range instead, but this parser only serves the HTTP
+  // cache, which reads Date, Expires and Last-Modified.
+  //
+  // @see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7
+  // The window (currentYear - 49 .. currentYear + 50) is exactly 100 years
+  // wide, so exactly one century lands inside it.
+  const currentYear = new Date().getUTCFullYear()
+  year += Math.trunc(currentYear / 100) * 100
+  if (year > currentYear + 50) {
+    year -= 100
+  } else if (year < currentYear - 49) {
+    year += 100
+  }
 
   let hour = 0
   if (date[commaIndex + 12] === '0') {

--- a/test/utils/date.js
+++ b/test/utils/date.js
@@ -277,6 +277,36 @@ describe('parseHttpDate', () => {
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
   const fuzzingCount = 1e6
 
+  function toRfc850 (date) {
+    return `${daysLong[date.getUTCDay()]}, ` +
+      `${date.getUTCDate().toString().padStart(2, '0')}-` +
+      `${months[date.getUTCMonth()]}-` +
+      `${date.getUTCFullYear().toString().slice(-2)} ` +
+      `${date.getUTCHours().toString().padStart(2, '0')}:` +
+      `${date.getUTCMinutes().toString().padStart(2, '0')}:` +
+      `${date.getUTCSeconds().toString().padStart(2, '0')} GMT`
+  }
+
+  test('RFC850 two-digit years slide with the clock', (t) => {
+    const currentYear = new Date().getUTCFullYear()
+
+    // "Recipients of a timestamp value in rfc850-date format, which uses a
+    // two-digit year, MUST interpret a timestamp that appears to be more than
+    // 50 years in the future as representing the most recent year in the past
+    // that had the same last two digits."
+    // @see https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7
+    for (const [offset, label] of [[50, 'the last year still in range'], [-49, 'the oldest year still in range']]) {
+      const expected = new Date(Date.UTC(currentYear + offset, 5, 15, 12, 30, 45))
+      t.assert.deepStrictEqual(parseHttpDate(toRfc850(expected)), expected, `${label}: ${toRfc850(expected)}`)
+    }
+
+    // One year past the edge, the same two digits name the century below.
+    const beyond = new Date(Date.UTC(currentYear + 51, 5, 15, 12, 30, 45))
+    const wrapped = new Date(Date.UTC(currentYear - 49, 5, 15, 12, 30, 45))
+    t.assert.deepStrictEqual(parseHttpDate(toRfc850(wrapped)), wrapped, toRfc850(wrapped))
+    t.assert.notDeepStrictEqual(parseHttpDate(toRfc850(wrapped)), beyond)
+  })
+
   test('fuzzing asctime', { skip: skipFuzzing }, (t) => {
     const { randomInt } = require('node:crypto')
 
@@ -357,8 +387,12 @@ describe('parseHttpDate', () => {
       return result
     }
 
-    const minYear = 1970
-    const maxYear = 2069
+    // The rfc850-date window slides: a two-digit year more than 50 years
+    // ahead names the most recent past year with the same digits, so the
+    // round trip only holds inside (now - 49, now + 50].
+    const currentYear = new Date().getUTCFullYear()
+    const minYear = currentYear - 49
+    const maxYear = currentYear + 50
 
     for (let i = 0; i < fuzzingCount; i++) {
       const date = new Date(Date.UTC(


### PR DESCRIPTION
`parseHttpDate` maps a two-digit rfc850-date year with the fixed 1970-2069 range, citing RFC 6265:

```js
// RFC 6265 states that the year is in the range 1970-2069.
year += year < 70 ? 2000 : 1900
```

RFC 6265 is the cookie spec. This parser has no cookie callers: `cache-handler.js` reads `Date`, `Expires` and `Last-Modified` through it, and `interceptor/cache.js` validates `Last-Modified` with it. For those, RFC 9110 section 5.6.7 applies, and it asks for a sliding window:

> Recipients of a timestamp value in rfc850-date format, which uses a two-digit year, MUST interpret a timestamp that appears to be more than 50 years in the future as representing the most recent year in the past that had the same last two digits.

## What changes

The visible effect is a rejection rather than a misreading, because `makeDate` validates the weekday against the year it settled on. A date written for 2076 carries 2076's weekday, which does not match 1976's, so the whole value is thrown away.

Run against `main` and against this branch, in 2026:

| header | before | after |
|---|---|---|
| `Sunday, 15-Jun-70 12:30:45 GMT` | `undefined` | 2070-06-15 |
| `Wednesday, 15-Jun-72 12:30:45 GMT` | `undefined` | 2072-06-15 |
| `Monday, 15-Jun-76 12:30:45 GMT` | `undefined` | 2076-06-15 |
| `Wednesday, 15-Jun-77 12:30:45 GMT` | 1977-06-15 | 1977-06-15 |
| `Wednesday, 15-Jun-94 12:30:45 GMT` | 1994-06-15 | 1994-06-15 |
| `Saturday, 15-Jun-24 12:30:45 GMT` | 2024-06-15 | 2024-06-15 |
| `Wednesday, 15-Jun-50 12:30:45 GMT` | 2050-06-15 | 2050-06-15 |

So an `Expires` a server means for the 2070s is dropped and the response is not stored. Two-digit years 70 through 76 are affected today, and the range grows by one every year: in 2030 it will be 70 through 80. Everything from 1977 to 2069 is untouched.

## The change

Take the century of the current year, then step one century down when the result lands more than 50 years ahead, or one up when it lands more than 49 years back. The window is exactly 100 years wide, so exactly one century fits and no input is left without a reading.

## Tests

Two things moved in `test/utils/date.js`.

The `fuzzing rfc850` round trip pinned `minYear = 1970` / `maxYear = 2069`. Those bounds were the old window written out, so they now derive from the current year: `currentYear - 49` to `currentYear + 50`. Still 1e6 iterations, still green.

Added `RFC850 two-digit years slide with the clock`, covering both edges of the window and the year just past it. The year-just-past case is built from the past date it must resolve to, since `makeDate` validates the weekday against the year it settled on.

Every existing case in the `RFC850` table still passes unchanged, including `06-Nov-94` staying in 1994 and `18-Aug-50` staying in 2050.

`node --test test/utils/date.js`: 7 pass. With the change to `lib/util/date.js` reverted, 2 of those fail and 5 still pass, so the new assertions are the ones doing the work.

`npx eslint` is clean on both files.
