### PR TITLE
types: support exactOptionalPropertyTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:node-test": "borp --timeout 180000 -p \"test/node-test/**/*.js\"",
     "test:tdd": "borp --timeout 180000 --expose-gc -p \"test/*.js\"",
     "test:tdd:node-test": "borp --timeout 180000 -p \"test/node-test/**/*.js\" -w",
-    "test:typescript": "tsd && tsc test/imports/undici-import.ts --typeRoots ./types --noEmit && tsc ./types/*.d.ts --noEmit --typeRoots ./types",
+    "test:typescript": "tsd && tsc test/imports/undici-import.ts --typeRoots ./types --noEmit --exactOptionalPropertyTypes && tsc ./types/*.d.ts --noEmit --typeRoots ./types --exactOptionalPropertyTypes",
     "test:webidl": "borp --timeout 180000 -p \"test/webidl/*.js\"",
     "test:websocket": "borp --timeout 180000 -p \"test/websocket/**/*.js\"",
     "test:websocket:autobahn": "node test/autobahn/client.js",
@@ -139,6 +139,7 @@
     "directory": "test/types",
     "compilerOptions": {
       "esModuleInterop": true,
+      "exactOptionalPropertyTypes": true,
       "lib": [
         "esnext"
       ]

--- a/test/types/exact-optional-property-types.test-d.ts
+++ b/test/types/exact-optional-property-types.test-d.ts
@@ -1,0 +1,150 @@
+import { expectAssignable } from 'tsd'
+import {
+  Agent,
+  Client,
+  Dispatcher,
+  EventSource,
+  MockAgent,
+  Pool,
+  ProxyAgent,
+  RequestInit,
+  ResponseInit,
+  RetryHandler,
+  WebSocket,
+  interceptors,
+  request
+} from '../..'
+
+// These assertions only mean something when the type tests run with
+// `exactOptionalPropertyTypes: true` (see the `tsd` config in package.json):
+// every optional property has to accept an explicit `undefined`, because
+// undici treats a missing option and an `undefined` option the same way at
+// runtime.
+
+expectAssignable<Client.Options>({
+  bodyTimeout: undefined,
+  headersTimeout: undefined,
+  keepAliveTimeout: undefined,
+  maxHeaderSize: undefined,
+  pipelining: undefined,
+  connect: undefined,
+  strictContentLength: undefined,
+  allowH2: undefined
+})
+
+expectAssignable<Pool.Options>({
+  connections: undefined,
+  clientTtl: undefined,
+  factory: undefined
+})
+
+expectAssignable<Agent.Options>({
+  factory: undefined,
+  maxOrigins: undefined,
+  connections: undefined
+})
+
+expectAssignable<ProxyAgent.Options>({
+  uri: '',
+  auth: undefined,
+  token: undefined,
+  headers: undefined,
+  requestTls: undefined,
+  proxyTls: undefined,
+  clientFactory: undefined
+})
+
+expectAssignable<MockAgent.Options>({
+  agent: undefined,
+  ignoreTrailingSlash: undefined,
+  acceptNonStandardSearchParameters: undefined
+})
+
+expectAssignable<Dispatcher.DispatchOptions>({
+  origin: '',
+  path: '',
+  method: 'GET',
+  body: undefined,
+  headers: undefined,
+  query: undefined,
+  idempotent: undefined,
+  blocking: undefined,
+  upgrade: undefined,
+  bodyTimeout: undefined,
+  headersTimeout: undefined,
+  expectContinue: undefined,
+  reset: undefined
+})
+
+expectAssignable<Dispatcher.RequestOptions>({
+  origin: '',
+  path: '',
+  method: 'GET',
+  opaque: undefined,
+  onInfo: undefined,
+  responseHeaders: undefined,
+  highWaterMark: undefined
+})
+
+expectAssignable<Dispatcher.DispatchHandler>({
+  onRequestStart: undefined,
+  onRequestUpgrade: undefined,
+  onResponseStart: undefined,
+  onResponseData: undefined,
+  onResponseEnd: undefined,
+  onResponseError: undefined,
+  onResponseStarted: undefined,
+  onBodySent: undefined,
+  onRequestSent: undefined
+})
+
+expectAssignable<RetryHandler.RetryOptions>({
+  retry: undefined,
+  maxRetries: undefined,
+  maxTimeout: undefined,
+  minTimeout: undefined,
+  timeoutFactor: undefined,
+  retryAfter: undefined,
+  methods: undefined,
+  statusCodes: undefined,
+  errorCodes: undefined
+})
+
+expectAssignable<RequestInit>({
+  method: undefined,
+  headers: undefined,
+  body: undefined,
+  redirect: undefined,
+  signal: undefined,
+  dispatcher: undefined,
+  duplex: undefined
+})
+
+expectAssignable<ResponseInit>({
+  status: undefined,
+  statusText: undefined,
+  headers: undefined
+})
+
+expectAssignable<Parameters<typeof interceptors.retry>[0]>({
+  maxRetries: undefined,
+  methods: undefined
+})
+
+expectAssignable<Parameters<typeof interceptors.redirect>[0]>({
+  maxRedirections: undefined,
+  throwOnMaxRedirect: undefined
+})
+
+expectAssignable<Parameters<typeof request>[1]>({
+  dispatcher: undefined,
+  headers: undefined,
+  body: undefined
+})
+
+// Constructing the classes with explicitly-undefined options must work too.
+expectAssignable<Client>(new Client('http://localhost', { pipelining: undefined }))
+expectAssignable<Pool>(new Pool('http://localhost', { connections: undefined }))
+expectAssignable<Agent>(new Agent({ factory: undefined }))
+expectAssignable<EventSource>(new EventSource('http://localhost', { withCredentials: undefined, dispatcher: undefined, node: undefined }))
+expectAssignable<WebSocket>(new WebSocket('ws://localhost', { protocols: undefined, dispatcher: undefined, headers: undefined }))

--- a/test/types/proxy-agent.test-d.ts
+++ b/test/types/proxy-agent.test-d.ts
@@ -10,7 +10,7 @@ expectAssignable<ProxyAgent>(
     uri: '',
     auth: '',
     token: '',
-    factory: (_origin: URL, opts: Object) => new Agent(opts),
+    factory: (_origin: string | URL, opts: Object) => new Agent(opts),
     requestTls: {
       ca: [''],
       key: '',

--- a/test/types/retry-handler.test-d.ts
+++ b/test/types/retry-handler.test-d.ts
@@ -7,7 +7,7 @@ expectType<RetryHandler.RetryCallback>((err, context, callback) => {
   expectType<{
     state: RetryHandler.RetryState;
     opts: Dispatcher.DispatchOptions & {
-      retryOptions?: RetryHandler.RetryOptions;
+      retryOptions?: RetryHandler.RetryOptions | undefined;
     };
   }>(context)
   expectType<RetryHandler.OnRetryCallback>(callback)
@@ -45,5 +45,5 @@ const contextTest: Parameters<RetryHandler.RetryCallback>[1] = {
 }
 expectType<RetryHandler.RetryState>(contextTest.state)
 expectType<
-  Dispatcher.DispatchOptions & { retryOptions?: RetryHandler.RetryOptions }
+  Dispatcher.DispatchOptions & { retryOptions?: RetryHandler.RetryOptions | undefined }
 >(contextTest.opts)

--- a/test/types/snapshot-agent.test-d.ts
+++ b/test/types/snapshot-agent.test-d.ts
@@ -259,7 +259,7 @@ expectAssignable<SnapshotAgent.Options>({
     method: string
     url: string
     headers: Record<string, string>
-    body?: string
+    body?: string | undefined
   }>(info.request)
   expectType<number>(info.responseCount)
   expectType<number>(info.callCount)

--- a/types/agent.d.ts
+++ b/types/agent.d.ts
@@ -21,8 +21,8 @@ declare class Agent extends Dispatcher {
 declare namespace Agent {
   export interface Options extends Pool.Options {
     /** Default: `(origin, opts) => new Pool(origin, opts)`. */
-    factory?(origin: string | URL, opts: Object): Dispatcher;
-    maxOrigins?: number
+    factory?: ((origin: string | URL, opts: Object) => Dispatcher) | undefined;
+    maxOrigins?: number | undefined
   }
 
   export interface DispatchOptions extends Dispatcher.DispatchOptions {

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -5,33 +5,33 @@ import Dispatcher from './dispatcher'
 /** Performs an HTTP request. */
 declare function request<TOpaque = null> (
   url: string | URL | UrlObject,
-  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions<TOpaque>, 'origin' | 'path' | 'method'> & Partial<Pick<Dispatcher.RequestOptions, 'method'>>,
+  options?: { dispatcher?: Dispatcher | undefined } & Omit<Dispatcher.RequestOptions<TOpaque>, 'origin' | 'path' | 'method'> & Partial<Pick<Dispatcher.RequestOptions, 'method'>>,
 ): Promise<Dispatcher.ResponseData<TOpaque>>
 
 /** A faster version of `request`. */
 declare function stream<TOpaque = null> (
   url: string | URL | UrlObject,
-  options: { dispatcher?: Dispatcher } & Omit<Dispatcher.RequestOptions<TOpaque>, 'origin' | 'path'>,
+  options: { dispatcher?: Dispatcher | undefined } & Omit<Dispatcher.RequestOptions<TOpaque>, 'origin' | 'path'>,
   factory: Dispatcher.StreamFactory<TOpaque>
 ): Promise<Dispatcher.StreamData<TOpaque>>
 
 /** For easy use with `stream.pipeline`. */
 declare function pipeline<TOpaque = null> (
   url: string | URL | UrlObject,
-  options: { dispatcher?: Dispatcher } & Omit<Dispatcher.PipelineOptions<TOpaque>, 'origin' | 'path'>,
+  options: { dispatcher?: Dispatcher | undefined } & Omit<Dispatcher.PipelineOptions<TOpaque>, 'origin' | 'path'>,
   handler: Dispatcher.PipelineHandler<TOpaque>
 ): Duplex
 
 /** Starts two-way communications with the requested resource. */
 declare function connect<TOpaque = null> (
   url: string | URL | UrlObject,
-  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.ConnectOptions<TOpaque>, 'origin' | 'path'>
+  options?: { dispatcher?: Dispatcher | undefined } & Omit<Dispatcher.ConnectOptions<TOpaque>, 'origin' | 'path'>
 ): Promise<Dispatcher.ConnectData<TOpaque>>
 
 /** Upgrade to a different protocol. */
 declare function upgrade (
   url: string | URL | UrlObject,
-  options?: { dispatcher?: Dispatcher } & Omit<Dispatcher.UpgradeOptions, 'origin' | 'path'>
+  options?: { dispatcher?: Dispatcher | undefined } & Omit<Dispatcher.UpgradeOptions, 'origin' | 'path'>
 ): Promise<Dispatcher.UpgradeData>
 
 export {

--- a/types/cache-interceptor.d.ts
+++ b/types/cache-interceptor.d.ts
@@ -8,13 +8,13 @@ declare namespace CacheHandler {
   export interface CacheHandlerOptions {
     store: CacheStore
 
-    cacheByDefault?: number
+    cacheByDefault?: number | undefined
 
-    type?: CacheOptions['type']
+    type?: CacheOptions['type'] | undefined
   }
 
   export interface CacheOptions {
-    store?: CacheStore
+    store?: CacheStore | undefined
 
     /**
      * The methods to cache
@@ -23,7 +23,7 @@ declare namespace CacheHandler {
      * @see https://www.rfc-editor.org/rfc/rfc9111.html#name-invalidating-stored-respons
      * @see https://www.rfc-editor.org/rfc/rfc9110#section-9.2.1
      */
-    methods?: CacheMethods[]
+    methods?: CacheMethods[] | undefined
 
     /**
      * RFC9111 allows for caching responses that we aren't explicitly told to
@@ -31,55 +31,55 @@ declare namespace CacheHandler {
      * @see https://www.rfc-editor.org/rfc/rfc9111.html#section-3-5
      * @default undefined
      */
-    cacheByDefault?: number
+    cacheByDefault?: number | undefined
 
     /**
      * TODO docs
      * @default 'shared'
      */
-    type?: 'shared' | 'private'
+    type?: 'shared' | 'private' | undefined
 
     /**
      * Array of origins to cache. Only requests to these origins will be cached.
      * Supports strings (case insensitive) and RegExp patterns.
      * @default undefined (cache all origins)
      */
-    origins?: (string | RegExp)[]
+    origins?: (string | RegExp)[] | undefined
   }
 
   export interface CacheControlDirectives {
-    'max-stale'?: number;
-    'min-fresh'?: number;
-    'max-age'?: number;
-    's-maxage'?: number;
-    'stale-while-revalidate'?: number;
-    'stale-if-error'?: number;
-    public?: true;
-    private?: true | string[];
-    'no-store'?: true;
-    'no-cache'?: true | string[];
-    'must-revalidate'?: true;
-    'proxy-revalidate'?: true;
-    immutable?: true;
-    'no-transform'?: true;
-    'must-understand'?: true;
-    'only-if-cached'?: true;
+    'max-stale'?: number | undefined;
+    'min-fresh'?: number | undefined;
+    'max-age'?: number | undefined;
+    's-maxage'?: number | undefined;
+    'stale-while-revalidate'?: number | undefined;
+    'stale-if-error'?: number | undefined;
+    public?: true | undefined;
+    private?: true | string[] | undefined;
+    'no-store'?: true | undefined;
+    'no-cache'?: true | string[] | undefined;
+    'must-revalidate'?: true | undefined;
+    'proxy-revalidate'?: true | undefined;
+    immutable?: true | undefined;
+    'no-transform'?: true | undefined;
+    'must-understand'?: true | undefined;
+    'only-if-cached'?: true | undefined;
   }
 
   export interface CacheKey {
     origin: string
     method: string
     path: string
-    headers?: Record<string, string | string[]>
+    headers?: Record<string, string | string[]> | undefined
   }
 
   export interface CacheValue {
     statusCode: number
     statusMessage: string
     headers: Record<string, string | string[]>
-    vary?: Record<string, string | string[] | null>
-    etag?: string
-    cacheControlDirectives?: CacheControlDirectives
+    vary?: Record<string, string | string[] | null> | undefined
+    etag?: string | undefined
+    cacheControlDirectives?: CacheControlDirectives | undefined
     cachedAt: number
     staleAt: number
     deleteAt: number
@@ -95,9 +95,9 @@ declare namespace CacheHandler {
     statusCode: number
     statusMessage: string
     headers: Record<string, string | string[]>
-    vary?: Record<string, string | string[] | null>
-    etag?: string
-    body?: Readable | Iterable<Buffer> | AsyncIterable<Buffer> | Buffer | Iterable<string> | AsyncIterable<string> | string
+    vary?: Record<string, string | string[] | null> | undefined
+    etag?: string | undefined
+    body?: Readable | Iterable<Buffer> | AsyncIterable<Buffer> | Buffer | Iterable<string> | AsyncIterable<string> | string | undefined
     cacheControlDirectives: CacheControlDirectives,
     cachedAt: number
     staleAt: number
@@ -119,19 +119,19 @@ declare namespace CacheHandler {
     /**
        * @default Infinity
        */
-    maxCount?: number
+    maxCount?: number | undefined
 
     /**
      * @default Infinity
      */
-    maxSize?: number
+    maxSize?: number | undefined
 
     /**
      * @default Infinity
      */
-    maxEntrySize?: number
+    maxEntrySize?: number | undefined
 
-    errorCallback?: (err: Error) => void
+    errorCallback?: ((err: Error) => void) | undefined
   }
 
   export class MemoryCacheStore implements CacheStore {
@@ -149,17 +149,17 @@ declare namespace CacheHandler {
      * Location of the database
      * @default ':memory:'
      */
-    location?: string
+    location?: string | undefined
 
     /**
      * @default Infinity
      */
-    maxCount?: number
+    maxCount?: number | undefined
 
     /**
      * @default Infinity
      */
-    maxEntrySize?: number
+    maxEntrySize?: number | undefined
   }
 
   export class SqliteCacheStore implements CacheStore {

--- a/types/cache.d.ts
+++ b/types/cache.d.ts
@@ -24,13 +24,13 @@ export interface Cache {
 }
 
 export interface CacheQueryOptions {
-  ignoreSearch?: boolean,
-  ignoreMethod?: boolean,
-  ignoreVary?: boolean
+  ignoreSearch?: boolean | undefined,
+  ignoreMethod?: boolean | undefined,
+  ignoreVary?: boolean | undefined
 }
 
 export interface MultiCacheQueryOptions extends CacheQueryOptions {
-  cacheName?: string
+  cacheName?: string | undefined
 }
 
 export declare const caches: CacheStorage

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -37,112 +37,112 @@ export class Client extends Dispatcher {
 export declare namespace Client {
   export interface Options {
     /** The maximum length of request headers in bytes. Default: Node.js' `--max-http-header-size` or `16384` (16KiB). */
-    maxHeaderSize?: number;
+    maxHeaderSize?: number | undefined;
     /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `300e3` milliseconds (300s). HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
-    headersTimeout?: number;
+    headersTimeout?: number | undefined;
     /** @deprecated unsupported socketTimeout, use headersTimeout & bodyTimeout instead */
-    socketTimeout?: never;
+    socketTimeout?: never | undefined;
     /** @deprecated unsupported requestTimeout, use headersTimeout & bodyTimeout instead */
-    requestTimeout?: never;
+    requestTimeout?: never | undefined;
     /** The timeout for establishing a socket connection, in milliseconds. Use `0` to disable it entirely. Default: `10e3` milliseconds (10s). */
-    connectTimeout?: number;
+    connectTimeout?: number | undefined;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `300e3` milliseconds (300s). HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
-    bodyTimeout?: number;
+    bodyTimeout?: number | undefined;
     /** @deprecated unsupported idleTimeout, use keepAliveTimeout instead */
-    idleTimeout?: never;
+    idleTimeout?: never | undefined;
     /** @deprecated unsupported keepAlive, use pipelining=0 instead */
-    keepAlive?: never;
+    keepAlive?: never | undefined;
     /** the timeout, in milliseconds, after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overridden by *keep-alive* hints from the server. Default: `4e3` milliseconds (4s). */
-    keepAliveTimeout?: number;
+    keepAliveTimeout?: number | undefined;
     /** @deprecated unsupported maxKeepAliveTimeout, use keepAliveMaxTimeout instead */
-    maxKeepAliveTimeout?: never;
+    maxKeepAliveTimeout?: never | undefined;
     /** the maximum allowed `idleTimeout`, in milliseconds, when overridden by *keep-alive* hints from the server. Default: `600e3` milliseconds (10min). */
-    keepAliveMaxTimeout?: number;
+    keepAliveMaxTimeout?: number | undefined;
     /** A number of milliseconds subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuracies caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
-    keepAliveTimeoutThreshold?: number;
+    keepAliveTimeoutThreshold?: number | undefined;
     /** An IPC endpoint, either a Unix domain socket or Windows named pipe. Default: `null`. */
-    socketPath?: string;
+    socketPath?: string | undefined;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Only enable values greater than `1` when the remote server is trusted. Default: `1`. */
-    pipelining?: number;
+    pipelining?: number | undefined;
     /** @deprecated use the connect option instead */
-    tls?: never;
+    tls?: never | undefined;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
-    strictContentLength?: boolean;
+    strictContentLength?: boolean | undefined;
     /** Maximum number of TLS cached sessions used by the built-in connector. Use `0` to disable TLS session caching. Default: `100`. */
-    maxCachedSessions?: number;
+    maxCachedSessions?: number | undefined;
     /** Connector options passed to `buildConnector`, or a custom connector function. Default: `null`. */
-    connect?: Partial<buildConnector.BuildOptions> | buildConnector.connector;
+    connect?: Partial<buildConnector.BuildOptions> | buildConnector.connector | undefined;
     /** The maximum number of requests to send over a single connection before it is reset. Use `0` to disable this limit. Default: `null`. */
-    maxRequestsPerClient?: number;
+    maxRequestsPerClient?: number | undefined;
     /** Local IP address the socket should connect from. */
-    localAddress?: string;
+    localAddress?: string | undefined;
     /** Max response body size in bytes, -1 is disabled */
-    maxResponseSize?: number;
+    maxResponseSize?: number | undefined;
     /** WebSocket-specific options */
-    webSocket?: Client.WebSocketOptions;
+    webSocket?: Client.WebSocketOptions | undefined;
     /** EventSource-specific options */
-    eventSource?: Client.EventSourceOptions;
+    eventSource?: Client.EventSourceOptions | undefined;
     /** Enables a family autodetection algorithm that loosely implements section 5 of RFC 8305. */
-    autoSelectFamily?: boolean;
+    autoSelectFamily?: boolean | undefined;
     /** The amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the `autoSelectFamily` option. */
-    autoSelectFamilyAttemptTimeout?: number;
+    autoSelectFamilyAttemptTimeout?: number | undefined;
     /**
      * @description Enables support for H2 if the server has assigned bigger priority to it through ALPN negotiation.
      * @default true
      */
-    allowH2?: boolean;
+    allowH2?: boolean | undefined;
     /**
      * @description Dictates the maximum number of concurrent streams for a single H2 session. It can be overridden by a SETTINGS remote frame.
      * @default 100
      * @deprecated Use h2Options.maxConcurrentStreams instead
      */
-    maxConcurrentStreams?: number;
+    maxConcurrentStreams?: number | undefined;
     /**
      * @description Sets the HTTP/2 stream-level flow-control window size (SETTINGS_INITIAL_WINDOW_SIZE).
      * @default 262144
      * @deprecated Use h2Options.settings.initialWindowSize instead
      */
-    initialWindowSize?: number;
+    initialWindowSize?: number | undefined;
     /**
      * @description Sets the HTTP/2 connection-level flow-control window size (ClientHttp2Session.setLocalWindowSize).
      * @default 524288
      * @deprecated Use h2Options.connectionWindowSize instead
      */
-    connectionWindowSize?: number;
+    connectionWindowSize?: number | undefined;
     /**
      * @description Time interval between PING frames dispatch
      * @default 60000
      * @deprecated Use h2Options.connectionWindowSize instead
      */
-    pingInterval?: number;
+    pingInterval?: number | undefined;
     /**
      * @description HTTP/2 configuration options
      */
-    h2Options?: Client.H2Options;
+    h2Options?: Client.H2Options | undefined;
   }
   export interface SocketInfo {
-    localAddress?: string
-    localPort?: number
-    remoteAddress?: string
-    remotePort?: number
-    remoteFamily?: string
-    timeout?: number
-    bytesWritten?: number
-    bytesRead?: number
+    localAddress?: string | undefined
+    localPort?: number | undefined
+    remoteAddress?: string | undefined
+    remotePort?: number | undefined
+    remoteFamily?: string | undefined
+    timeout?: number | undefined
+    bytesWritten?: number | undefined
+    bytesRead?: number | undefined
   }
   export interface WebSocketOptions {
     /**
      * Maximum number of fragments in a message. Set to 0 to disable the limit.
      * @default 131072
      */
-    maxFragments?: number;
+    maxFragments?: number | undefined;
     /**
      * Maximum allowed payload size in bytes for WebSocket messages.
      * Applied to uncompressed messages, compressed frame payloads, and decompressed (permessage-deflate) messages.
      * Set to 0 to disable the limit.
      * @default 134217728 (128 MB)
      */
-    maxPayloadSize?: number;
+    maxPayloadSize?: number | undefined;
   }
 
   export interface H2Options extends Omit<SessionOptions, keyof buildConnector.BuildOptions> {
@@ -150,26 +150,26 @@ export declare namespace Client {
      * @description Sets the HTTP/2 connection-level flow-control window size (ClientHttp2Session.setLocalWindowSize).
      * @default 524288
      */
-    connectionWindowSize?: number;
+    connectionWindowSize?: number | undefined;
     /**
      * @description Time interval between PING frames dispatch
      * @default 60000
      */
-    pingInterval?: number;
+    pingInterval?: number | undefined;
     /**
      * @description Dictates the maximum number of concurrent streams for a single H2 session. It can be overridden by a SETTINGS remote frame.
      * @default 100
     */
-    maxConcurrentStreams?: number;
+    maxConcurrentStreams?: number | undefined;
     /**
      * @description Enable support for H2C (plain text)
      * @default false
      */
-    useH2c?: boolean;
+    useH2c?: boolean | undefined;
     /**
      * @description SETTINGS frame object. Default to 'node:http2' defaults
      */
-    settings?: Omit<SessionOptions['settings'], 'enablePush' | 'maxConcurrentStreams' | 'enableConnectProtocol'>
+    settings?: Omit<SessionOptions['settings'], 'enablePush' | 'maxConcurrentStreams' | 'enableConnectProtocol'> | undefined
   }
   export interface EventSourceOptions {
     /**
@@ -177,7 +177,7 @@ export declare namespace Client {
      * Set to 0 to disable the limit.
      * @default buffer.kStringMaxLength
      */
-    maxEventSize?: number;
+    maxEventSize?: number | undefined;
   }
 }
 

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -6,26 +6,26 @@ declare function buildConnector (options?: buildConnector.BuildOptions): buildCo
 
 declare namespace buildConnector {
   export type BuildOptions = (ConnectionOptions | TcpNetConnectOpts | IpcNetConnectOpts) & {
-    allowH2?: boolean;
-    preferH2?: boolean;
-    maxCachedSessions?: number | null;
-    socketPath?: string | null;
-    timeout?: number | null;
-    port?: number;
-    keepAlive?: boolean | null;
-    keepAliveInitialDelay?: number | null;
-    typeOfService?: number | null;
+    allowH2?: boolean | undefined;
+    preferH2?: boolean | undefined;
+    maxCachedSessions?: number | null | undefined;
+    socketPath?: string | null | undefined;
+    timeout?: number | null | undefined;
+    port?: number | undefined;
+    keepAlive?: boolean | null | undefined;
+    keepAliveInitialDelay?: number | null | undefined;
+    typeOfService?: number | null | undefined;
   }
 
   export interface Options {
     hostname: string
-    host?: string
+    host?: string | undefined
     protocol: string
     port: string
-    servername?: string
-    localAddress?: string | null
-    socketPath?: string | null
-    httpSocket?: Socket
+    servername?: string | undefined
+    localAddress?: string | null | undefined
+    socketPath?: string | null | undefined
+    httpSocket?: Socket | undefined
   }
 
   export type Callback = (...args: CallbackArgs) => void

--- a/types/cookies.d.ts
+++ b/types/cookies.d.ts
@@ -5,20 +5,20 @@ import type { Headers } from './fetch'
 export interface Cookie {
   name: string
   value: string
-  expires?: Date | number
-  maxAge?: number
-  domain?: string
-  path?: string
-  secure?: boolean
-  httpOnly?: boolean
-  sameSite?: 'Strict' | 'Lax' | 'None'
-  unparsed?: string[]
+  expires?: Date | number | undefined
+  maxAge?: number | undefined
+  domain?: string | undefined
+  path?: string | undefined
+  secure?: boolean | undefined
+  httpOnly?: boolean | undefined
+  sameSite?: 'Strict' | 'Lax' | 'None' | undefined
+  unparsed?: string[] | undefined
 }
 
 export function deleteCookie (
   headers: Headers,
   name: string,
-  attributes?: { path?: string, domain?: string }
+  attributes?: { path?: string | undefined, domain?: string | undefined }
 ): void
 
 export function getCookies (headers: Headers): Record<string, string>

--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -5,9 +5,9 @@ import Dispatcher from './dispatcher'
 
 declare namespace DiagnosticsChannel {
   interface Request {
-    origin?: string | URL;
+    origin?: string | URL | undefined;
     completed: boolean;
-    method?: Dispatcher.HttpMethod;
+    method?: Dispatcher.HttpMethod | undefined;
     path: string;
     headers: any;
   }

--- a/types/dispatcher.d.ts
+++ b/types/dispatcher.d.ts
@@ -98,72 +98,72 @@ declare namespace Dispatcher {
   export type Dispatch = Dispatcher['dispatch']
   export type DispatcherComposeInterceptor = (dispatch: Dispatch) => Dispatch
   export interface DispatchOptions {
-    origin?: string | URL;
+    origin?: string | URL | undefined;
     path: string;
     method: HttpMethod;
     /** Default: `null` */
-    body?: string | Buffer | Uint8Array | Readable | null | FormData;
+    body?: string | Buffer | Uint8Array | Readable | null | FormData | undefined;
     /** Default: `null` */
-    headers?: UndiciHeaders;
+    headers?: UndiciHeaders | undefined;
     /** Query string params to be embedded in the request URL. Default: `null` */
-    query?: Record<string, any>;
+    query?: Record<string, any> | undefined;
     /** Whether the requests can be safely retried or not. If `false` the request won't be sent until all preceding requests in the pipeline have completed. Default: `true` if `method` is `HEAD` or `GET`. */
-    idempotent?: boolean;
+    idempotent?: boolean | undefined;
     /** Whether the response is expected to take a long time and would end up blocking the pipeline. When this is set to `true` further pipelining will be avoided on the same connection until headers have been received. Defaults to `method !== 'HEAD'`. */
-    blocking?: boolean;
+    blocking?: boolean | undefined;
     /** The IP Type of Service (ToS) value for the request socket. Must be an integer between 0 and 255. */
-    typeOfService?: number | null;
+    typeOfService?: number | null | undefined;
     /** Upgrade the request. Should be used to specify the kind of upgrade i.e. `'Websocket'`. Default: `method === 'CONNECT' || null`. */
-    upgrade?: boolean | string | null;
+    upgrade?: boolean | string | null | undefined;
     /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers. Defaults to 300 seconds. HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
-    headersTimeout?: number | null;
+    headersTimeout?: number | null | undefined;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use 0 to disable it entirely. Defaults to 300 seconds. HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
-    bodyTimeout?: number | null;
+    bodyTimeout?: number | null | undefined;
     /** Whether the request should stablish a keep-alive or not. Default `false` */
-    reset?: boolean;
+    reset?: boolean | undefined;
     /** For H2, it appends the expect: 100-continue header, and halts the request body until a 100-continue is received from the remote server */
-    expectContinue?: boolean;
+    expectContinue?: boolean | undefined;
   }
   export interface ConnectOptions<TOpaque = null> {
     origin: string | URL;
     path: string;
     /** Default: `null` */
-    headers?: UndiciHeaders;
+    headers?: UndiciHeaders | undefined;
     /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
+    signal?: AbortSignal | EventEmitter | null | undefined;
     /** This argument parameter is passed through to `ConnectData` */
-    opaque?: TOpaque;
+    opaque?: TOpaque | undefined;
     /** Default: `null` */
-    responseHeaders?: 'raw' | null;
+    responseHeaders?: 'raw' | null | undefined;
   }
   export interface RequestOptions<TOpaque = null> extends DispatchOptions {
     /** Default: `null` */
-    opaque?: TOpaque;
+    opaque?: TOpaque | undefined;
     /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
+    signal?: AbortSignal | EventEmitter | null | undefined;
     /** Default: `null` */
-    onInfo?: (info: { statusCode: number, headers: Record<string, string | string[]> }) => void;
+    onInfo?: ((info: { statusCode: number, headers: Record<string, string | string[]> }) => void) | undefined;
     /** Default: `null` */
-    responseHeaders?: 'raw' | null;
+    responseHeaders?: 'raw' | null | undefined;
     /** Default: `64 KiB` */
-    highWaterMark?: number;
+    highWaterMark?: number | undefined;
   }
   export interface PipelineOptions<TOpaque = null> extends RequestOptions<TOpaque> {
     /** `true` if the `handler` will return an object stream. Default: `false` */
-    objectMode?: boolean;
+    objectMode?: boolean | undefined;
   }
   export interface UpgradeOptions {
     path: string;
     /** Default: `'GET'` */
-    method?: string;
+    method?: string | undefined;
     /** Default: `null` */
-    headers?: UndiciHeaders;
+    headers?: UndiciHeaders | undefined;
     /** A string of comma separated protocols, in descending preference order. Default: `'Websocket'` */
-    protocol?: string;
+    protocol?: string | undefined;
     /** Default: `null` */
-    signal?: AbortSignal | EventEmitter | null;
+    signal?: AbortSignal | EventEmitter | null | undefined;
     /** Default: `null` */
-    responseHeaders?: 'raw' | null;
+    responseHeaders?: 'raw' | null | undefined;
   }
   export interface ConnectData<TOpaque = null> {
     statusCode: number;
@@ -208,27 +208,27 @@ declare namespace Dispatcher {
     get aborted(): boolean
     get paused(): boolean
     get reason(): Error | null
-    rawHeaders?: Buffer[] | string[] | IncomingHttpHeaders | null
-    rawTrailers?: Buffer[] | string[] | IncomingHttpHeaders | null
+    rawHeaders?: Buffer[] | string[] | IncomingHttpHeaders | null | undefined
+    rawTrailers?: Buffer[] | string[] | IncomingHttpHeaders | null | undefined
     abort(reason: Error): void
     pause(): void
     resume(): void
   }
 
   export interface DispatchHandler {
-    onRequestStart?(controller: DispatchController, context: any): void;
-    onRequestUpgrade?(controller: DispatchController, statusCode: number, headers: IncomingHttpHeaders, socket: Duplex): void;
-    onResponseStart?(controller: DispatchController, statusCode: number, headers: IncomingHttpHeaders, statusMessage?: string): void;
-    onResponseData?(controller: DispatchController, chunk: Buffer): void;
-    onResponseEnd?(controller: DispatchController, trailers: IncomingHttpHeaders): void;
-    onResponseError?(controller: DispatchController, error: Error): void;
+    onRequestStart?: ((controller: DispatchController, context: any) => void) | undefined;
+    onRequestUpgrade?: ((controller: DispatchController, statusCode: number, headers: IncomingHttpHeaders, socket: Duplex) => void) | undefined;
+    onResponseStart?: ((controller: DispatchController, statusCode: number, headers: IncomingHttpHeaders, statusMessage?: string) => void) | undefined;
+    onResponseData?: ((controller: DispatchController, chunk: Buffer) => void) | undefined;
+    onResponseEnd?: ((controller: DispatchController, trailers: IncomingHttpHeaders) => void) | undefined;
+    onResponseError?: ((controller: DispatchController, error: Error) => void) | undefined;
 
     /** Invoked when response is received, before headers have been read. **/
-    onResponseStarted?(): void;
+    onResponseStarted?: (() => void) | undefined;
     /** Invoked when a body chunk is sent to the server. May be invoked multiple times for chunked requests */
-    onBodySent?(chunk: Buffer): void;
+    onBodySent?: ((chunk: Buffer) => void) | undefined;
     /** Invoked after the request body is fully sent. */
-    onRequestSent?(): void;
+    onRequestSent?: (() => void) | undefined;
   }
   export type PipelineHandler<TOpaque = null> = (data: PipelineHandlerData<TOpaque>) => Readable
   export type HttpMethod = Autocomplete<'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH'>
@@ -237,7 +237,7 @@ declare namespace Dispatcher {
    * @link https://fetch.spec.whatwg.org/#body-mixin
    */
   interface BodyMixin {
-    readonly body?: never;
+    readonly body?: never | undefined;
     readonly bodyUsed: boolean;
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;

--- a/types/env-http-proxy-agent.d.ts
+++ b/types/env-http-proxy-agent.d.ts
@@ -13,10 +13,10 @@ declare class EnvHttpProxyAgent extends Dispatcher {
 declare namespace EnvHttpProxyAgent {
   export interface Options extends Omit<ProxyAgent.Options, 'uri'> {
     /** Overrides the value of the HTTP_PROXY environment variable  */
-    httpProxy?: string;
+    httpProxy?: string | undefined;
     /** Overrides the value of the HTTPS_PROXY environment variable  */
-    httpsProxy?: string;
+    httpsProxy?: string | undefined;
     /** Overrides the value of the NO_PROXY environment variable  */
-    noProxy?: string;
+    noProxy?: string | undefined;
   }
 }

--- a/types/errors.d.ts
+++ b/types/errors.d.ts
@@ -38,8 +38,8 @@ declare namespace Errors {
       message: string,
       code: number,
       options: {
-        headers?: IncomingHttpHeaders | string[] | null,
-        body?: null | Record<string, any> | string
+        headers?: IncomingHttpHeaders | string[] | null | undefined,
+        body?: null | Record<string, any> | string | undefined
       }
     )
     name: 'ResponseError'

--- a/types/eventsource.d.ts
+++ b/types/eventsource.d.ts
@@ -56,11 +56,11 @@ export declare const EventSource: {
 }
 
 interface EventSourceInit {
-  withCredentials?: boolean
+  withCredentials?: boolean | undefined
   // @deprecated use `node.dispatcher` instead
-  dispatcher?: Dispatcher
+  dispatcher?: Dispatcher | undefined
   node?: {
-    dispatcher?: Dispatcher
-    reconnectionTime?: number
-  }
+    dispatcher?: Dispatcher | undefined
+    reconnectionTime?: number | undefined
+  } | undefined
 }

--- a/types/fetch.d.ts
+++ b/types/fetch.d.ts
@@ -144,21 +144,21 @@ type RequestDestination =
   | 'xslt'
 
 export interface RequestInit {
-  body?: BodyInit | null
-  cache?: RequestCache
-  credentials?: RequestCredentials
-  dispatcher?: Dispatcher
-  duplex?: RequestDuplex
-  headers?: HeadersInit
-  integrity?: string
-  keepalive?: boolean
-  method?: string
-  mode?: RequestMode
-  redirect?: RequestRedirect
-  referrer?: string
-  referrerPolicy?: ReferrerPolicy
-  signal?: AbortSignal | null
-  window?: null
+  body?: BodyInit | null | undefined
+  cache?: RequestCache | undefined
+  credentials?: RequestCredentials | undefined
+  dispatcher?: Dispatcher | undefined
+  duplex?: RequestDuplex | undefined
+  headers?: HeadersInit | undefined
+  integrity?: string | undefined
+  keepalive?: boolean | undefined
+  method?: string | undefined
+  mode?: RequestMode | undefined
+  redirect?: RequestRedirect | undefined
+  referrer?: string | undefined
+  referrerPolicy?: ReferrerPolicy | undefined
+  signal?: AbortSignal | null | undefined
+  window?: null | undefined
 }
 
 export type ReferrerPolicy =
@@ -201,9 +201,9 @@ export declare class Request extends BodyMixin {
 }
 
 export interface ResponseInit {
-  readonly status?: number
-  readonly statusText?: string
-  readonly headers?: HeadersInit
+  readonly status?: number | undefined
+  readonly statusText?: string | undefined
+  readonly headers?: HeadersInit | undefined
 }
 
 export type ResponseType =

--- a/types/h2c-client.d.ts
+++ b/types/h2c-client.d.ts
@@ -29,44 +29,44 @@ export class H2CClient extends Dispatcher {
 export declare namespace H2CClient {
   export interface Options {
     /** The maximum length of request headers in bytes. Default: Node.js' `--max-http-header-size` or `16384` (16KiB). */
-    maxHeaderSize?: number;
+    maxHeaderSize?: number | undefined;
     /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `300e3` milliseconds (300s). */
-    headersTimeout?: number;
+    headersTimeout?: number | undefined;
     /** The timeout for establishing a socket connection, in milliseconds. Use `0` to disable it entirely. Default: `10e3` milliseconds (10s). */
-    connectTimeout?: number;
+    connectTimeout?: number | undefined;
     /** The timeout after which a request will time out, in milliseconds. Monitors time between receiving body data. Use `0` to disable it entirely. Default: `300e3` milliseconds (300s). */
-    bodyTimeout?: number;
+    bodyTimeout?: number | undefined;
     /** the timeout, in milliseconds, after which a socket without active requests will time out. Monitors time between activity on a connected socket. This value may be overridden by *keep-alive* hints from the server. Default: `4e3` milliseconds (4s). */
-    keepAliveTimeout?: number;
+    keepAliveTimeout?: number | undefined;
     /** the maximum allowed `idleTimeout`, in milliseconds, when overridden by *keep-alive* hints from the server. Default: `600e3` milliseconds (10min). */
-    keepAliveMaxTimeout?: number;
+    keepAliveMaxTimeout?: number | undefined;
     /** A number of milliseconds subtracted from server *keep-alive* hints when overriding `idleTimeout` to account for timing inaccuracies caused by e.g. transport latency. Default: `1e3` milliseconds (1s). */
-    keepAliveTimeoutThreshold?: number;
+    keepAliveTimeoutThreshold?: number | undefined;
     /** An IPC endpoint, either a Unix domain socket or Windows named pipe. Default: `null`. */
-    socketPath?: string;
+    socketPath?: string | undefined;
     /** The amount of concurrent requests to be sent over the single TCP/TLS connection according to [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`. */
-    pipelining?: number;
+    pipelining?: number | undefined;
     /** If `true`, an error is thrown when the request content-length header doesn't match the length of the request body. Default: `true`. */
-    strictContentLength?: boolean;
+    strictContentLength?: boolean | undefined;
     /** Maximum number of TLS cached sessions used by the built-in connector. Use `0` to disable TLS session caching. Default: `100`. */
-    maxCachedSessions?: number;
+    maxCachedSessions?: number | undefined;
     /** Connector options passed to `buildConnector`, or a custom connector function. Default: `null`. */
-    connect?: Omit<Partial<buildConnector.BuildOptions>, 'allowH2'> | buildConnector.connector;
+    connect?: Omit<Partial<buildConnector.BuildOptions>, 'allowH2'> | buildConnector.connector | undefined;
     /** The maximum number of requests to send over a single connection before it is reset. Use `0` to disable this limit. Default: `null`. */
-    maxRequestsPerClient?: number;
+    maxRequestsPerClient?: number | undefined;
     /** Local IP address the socket should connect from. */
-    localAddress?: string;
+    localAddress?: string | undefined;
     /** Max response body size in bytes, -1 is disabled */
-    maxResponseSize?: number;
+    maxResponseSize?: number | undefined;
     /** Enables a family autodetection algorithm that loosely implements section 5 of RFC 8305. */
-    autoSelectFamily?: boolean;
+    autoSelectFamily?: boolean | undefined;
     /** The amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the `autoSelectFamily` option. */
-    autoSelectFamilyAttemptTimeout?: number;
+    autoSelectFamilyAttemptTimeout?: number | undefined;
     /**
      * @description Dictates the maximum number of concurrent streams for a single H2 session. It can be overridden by a SETTINGS remote frame.
      * @default 100
     */
-    maxConcurrentStreams?: number
+    maxConcurrentStreams?: number | undefined
   }
 }
 

--- a/types/interceptors.d.ts
+++ b/types/interceptors.d.ts
@@ -6,12 +6,12 @@ import { LookupOptions } from 'node:dns'
 export default Interceptors
 
 declare namespace Interceptors {
-  export type DumpInterceptorOpts = { maxSize?: number }
+  export type DumpInterceptorOpts = { maxSize?: number | undefined }
   export type RetryInterceptorOpts = RetryHandler.RetryOptions
-  export type RedirectInterceptorOpts = { maxRedirections?: number, throwOnMaxRedirect?: boolean, stripHeadersOnRedirect?: string[], stripHeadersOnCrossOriginRedirect?: string[] }
+  export type RedirectInterceptorOpts = { maxRedirections?: number | undefined, throwOnMaxRedirect?: boolean | undefined, stripHeadersOnRedirect?: string[] | undefined, stripHeadersOnCrossOriginRedirect?: string[] | undefined }
   export type DecompressInterceptorOpts = {
-    skipErrorResponses?: boolean
-    skipStatusCodes?: number[]
+    skipErrorResponses?: boolean | undefined
+    skipStatusCodes?: number[] | undefined
   }
 
   export type ResponseErrorInterceptorOpts = { throwOnError: boolean }
@@ -28,13 +28,13 @@ declare namespace Interceptors {
     full(): boolean
   }
   export type DNSInterceptorOpts = {
-    maxTTL?: number
-    maxItems?: number
-    lookup?: (origin: URL, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void
-    pick?: (origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord
-    dualStack?: boolean
-    affinity?: 4 | 6
-    storage?: DNSStorage
+    maxTTL?: number | undefined
+    maxItems?: number | undefined
+    lookup?: ((origin: URL, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, addresses: DNSInterceptorRecord[]) => void) => void) | undefined
+    pick?: ((origin: URL, records: DNSInterceptorOriginRecords, affinity: 4 | 6) => DNSInterceptorRecord) | undefined
+    dualStack?: boolean | undefined
+    affinity?: 4 | 6 | undefined
+    storage?: DNSStorage | undefined
   }
 
   // Deduplicate interceptor
@@ -45,13 +45,13 @@ declare namespace Interceptors {
      * Note: Only safe HTTP methods can be deduplicated.
      * @default ['GET']
      */
-    methods?: DeduplicateMethods[]
+    methods?: DeduplicateMethods[] | undefined
     /**
      * Header names that, if present in a request, will cause the request to skip deduplication.
      * Header name matching is case-insensitive.
      * @default []
      */
-    skipHeaderNames?: string[]
+    skipHeaderNames?: string[] | undefined
     /**
      * Header names to exclude from the deduplication key.
      * Requests with different values for these headers will still be deduplicated together.
@@ -59,14 +59,14 @@ declare namespace Interceptors {
      * Header name matching is case-insensitive.
      * @default []
      */
-    excludeHeaderNames?: string[]
+    excludeHeaderNames?: string[] | undefined
     /**
      * Maximum bytes buffered per paused waiting deduplicated handler.
      * If a waiting handler remains paused and exceeds this threshold,
      * it is failed with an abort error to prevent unbounded memory growth.
      * @default 5 * 1024 * 1024
      */
-    maxBufferSize?: number
+    maxBufferSize?: number | undefined
   }
 
   export function dump (opts?: DumpInterceptorOpts): Dispatcher.DispatcherComposeInterceptor

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -42,7 +42,7 @@ declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.
   disableCallHistory (): this
   pendingInterceptors (): PendingInterceptor[]
   assertNoPendingInterceptors (options?: {
-    pendingInterceptorsFormatter?: PendingInterceptorsFormatter;
+    pendingInterceptorsFormatter?: PendingInterceptorsFormatter | undefined;
   }): void
 }
 
@@ -54,15 +54,15 @@ declare namespace MockAgent {
   /** MockAgent options. */
   export interface Options extends Agent.Options {
     /** A custom agent to be encapsulated by the MockAgent. */
-    agent?: Dispatcher;
+    agent?: Dispatcher | undefined;
 
     /** Ignore trailing slashes in the path */
-    ignoreTrailingSlash?: boolean;
+    ignoreTrailingSlash?: boolean | undefined;
 
     /** Accept URLs with search parameters using non standard syntaxes. default false */
-    acceptNonStandardSearchParameters?: boolean;
+    acceptNonStandardSearchParameters?: boolean | undefined;
 
     /** Enable call history. you can either call MockAgent.enableCallHistory(). default false */
-    enableCallHistory?: boolean
+    enableCallHistory?: boolean | undefined
   }
 }

--- a/types/mock-call-history.d.ts
+++ b/types/mock-call-history.d.ts
@@ -44,7 +44,7 @@ declare namespace MockCallHistory {
   /** modify the filtering behavior */
   export interface FilterCallsOptions {
     /** the operator to apply when filtering. 'OR' will adds any MockCallHistoryLog matching any criteria given. 'AND' will adds only MockCallHistoryLog matching every criteria given. (default 'OR')  */
-    operator?: FilterCallsOperator | Lowercase<FilterCallsOperator>
+    operator?: FilterCallsOperator | Lowercase<FilterCallsOperator> | undefined
   }
   /** a function to be executed for filtering MockCallHistoryLog */
   export type FilterCallsFunctionCriteria = (log: MockCallHistoryLog) => boolean
@@ -55,21 +55,21 @@ declare namespace MockCallHistory {
   /** an object to execute multiple filtering at once */
   export interface FilterCallsObjectCriteria extends Record<string, FilterCallsParameter> {
     /** filter by request protocol. ie https: */
-    protocol?: FilterCallsParameter;
+    protocol?: FilterCallsParameter | undefined;
     /** filter by request host. */
-    host?: FilterCallsParameter;
+    host?: FilterCallsParameter | undefined;
     /** filter by request port. */
-    port?: FilterCallsParameter;
+    port?: FilterCallsParameter | undefined;
     /** filter by request origin. */
-    origin?: FilterCallsParameter;
+    origin?: FilterCallsParameter | undefined;
     /** filter by request path. */
-    path?: FilterCallsParameter;
+    path?: FilterCallsParameter | undefined;
     /** filter by request hash. */
-    hash?: FilterCallsParameter;
+    hash?: FilterCallsParameter | undefined;
     /** filter by request fullUrl. */
-    fullUrl?: FilterCallsParameter;
+    fullUrl?: FilterCallsParameter | undefined;
     /** filter by request method. */
-    method?: FilterCallsParameter;
+    method?: FilterCallsParameter | undefined;
   }
 }
 

--- a/types/mock-interceptor.d.ts
+++ b/types/mock-interceptor.d.ts
@@ -39,13 +39,13 @@ declare namespace MockInterceptor {
     /** Path to intercept on. */
     path: string | RegExp | ((path: string) => boolean);
     /** Method to intercept on. Defaults to GET. */
-    method?: string | RegExp | ((method: string) => boolean);
+    method?: string | RegExp | ((method: string) => boolean) | undefined;
     /** Body to intercept on. */
-    body?: string | RegExp | ((body: string) => boolean);
+    body?: string | RegExp | ((body: string) => boolean) | undefined;
     /** Headers to intercept on. */
-    headers?: Record<string, string | RegExp | ((body: string) => boolean)> | ((headers: Record<string, string>) => boolean);
+    headers?: Record<string, string | RegExp | ((body: string) => boolean)> | ((headers: Record<string, string>) => boolean) | undefined;
     /** Query params to intercept on */
-    query?: Record<string, any>;
+    query?: Record<string, any> | undefined;
   }
   export interface MockDispatch<TData extends object = object, TError extends Error = Error> extends Options {
     times: number | null;
@@ -55,20 +55,20 @@ declare namespace MockInterceptor {
   }
   export interface MockDispatchData<TData extends object = object, TError extends Error = Error> extends MockResponseOptions {
     error: TError | null;
-    statusCode?: number;
-    data?: TData | string;
+    statusCode?: number | undefined;
+    data?: TData | string | undefined;
   }
   export interface MockResponseOptions {
-    headers?: IncomingHttpHeaders;
-    trailers?: Record<string, string>;
+    headers?: IncomingHttpHeaders | undefined;
+    trailers?: Record<string, string> | undefined;
   }
 
   export interface MockResponseCallbackOptions {
     path: string;
     method: string;
-    headers?: Headers | Record<string, string>;
-    origin?: string;
-    body?: BodyInit | Dispatcher.DispatchOptions['body'] | null;
+    headers?: Headers | Record<string, string> | undefined;
+    origin?: string | undefined;
+    body?: BodyInit | Dispatcher.DispatchOptions['body'] | null | undefined;
   }
 
   export type MockResponseDataHandler<TData extends object = object> = (
@@ -76,7 +76,7 @@ declare namespace MockInterceptor {
   ) => TData | Buffer | string
 
   export type MockReplyOptions<TData extends object = object> = {
-    statusCode: number, data?: TData | Buffer | string, responseOptions?: MockResponseOptions
+    statusCode: number, data?: TData | Buffer | string | undefined, responseOptions?: MockResponseOptions | undefined
   }
 
   export type MockReplyOptionsCallback<TData extends object = object> = (

--- a/types/patch.d.ts
+++ b/types/patch.d.ts
@@ -3,19 +3,19 @@
 // See https://github.com/nodejs/undici/issues/1740
 
 export interface EventInit {
-  bubbles?: boolean
-  cancelable?: boolean
-  composed?: boolean
+  bubbles?: boolean | undefined
+  cancelable?: boolean | undefined
+  composed?: boolean | undefined
 }
 
 export interface EventListenerOptions {
-  capture?: boolean
+  capture?: boolean | undefined
 }
 
 export interface AddEventListenerOptions extends EventListenerOptions {
-  once?: boolean
-  passive?: boolean
-  signal?: AbortSignal
+  once?: boolean | undefined
+  passive?: boolean | undefined
+  signal?: AbortSignal | undefined
 }
 
 export type EventListenerOrEventListenerObject = EventListener | EventListenerObject

--- a/types/pool.d.ts
+++ b/types/pool.d.ts
@@ -30,10 +30,10 @@ declare namespace Pool {
   export type PoolStats = TPoolStats
   export interface Options extends Client.Options {
     /** Default: `(origin, opts) => new Client(origin, opts)`. */
-    factory?(origin: URL, opts: object): Dispatcher;
+    factory?: ((origin: URL, opts: object) => Dispatcher) | undefined;
     /** The max number of clients to create. `null` if no limit. Default `null`. */
-    connections?: number | null;
+    connections?: number | null | undefined;
     /** The amount of time before a client is removed from the pool and closed. `null` if no time limit. Default `null` */
-    clientTtl?: number | null;
+    clientTtl?: number | null | undefined;
   }
 }

--- a/types/proxy-agent.d.ts
+++ b/types/proxy-agent.d.ts
@@ -18,12 +18,12 @@ declare namespace ProxyAgent {
     /**
      * @deprecated use opts.token
      */
-    auth?: string;
-    token?: string;
-    headers?: OutgoingHttpHeaders;
-    requestTls?: buildConnector.BuildOptions;
-    proxyTls?: buildConnector.BuildOptions;
-    clientFactory?(origin: URL, opts: object): Dispatcher;
+    auth?: string | undefined;
+    token?: string | undefined;
+    headers?: OutgoingHttpHeaders | undefined;
+    requestTls?: buildConnector.BuildOptions | undefined;
+    proxyTls?: buildConnector.BuildOptions | undefined;
+    clientFactory?: ((origin: URL, opts: object) => Dispatcher) | undefined;
     /**
      * Undici tunnels via CONNECT when the target endpoint uses HTTPS, and
      * forwards (HTTP/1.1 absolute-form request-target, per RFC 9112 §3.2.2)
@@ -31,6 +31,6 @@ declare namespace ProxyAgent {
      * non-tunneled forwarding path does not negotiate HTTP/2 with the proxy.
      * Set to true to force tunneling for plain HTTP requests as well.
      */
-    proxyTunnel?: boolean;
+    proxyTunnel?: boolean | undefined;
   }
 }

--- a/types/readable.d.ts
+++ b/types/readable.d.ts
@@ -7,9 +7,9 @@ declare class BodyReadable extends Readable {
   constructor (opts: {
     resume: (this: Readable, size: number) => void | null;
     abort: () => void | null;
-    contentType?: string;
-    contentLength?: number;
-    highWaterMark?: number;
+    contentType?: string | undefined;
+    contentLength?: number | undefined;
+    highWaterMark?: number | undefined;
   })
 
   /** Consumes and returns the body as a string
@@ -64,5 +64,5 @@ declare class BodyReadable extends Readable {
    * @param opts.limit Number of bytes to read (optional) - Default: 131072
    * @param opts.signal AbortSignal to cancel the operation (optional)
    */
-  dump (opts?: { limit: number; signal?: AbortSignal }): Promise<void>
+  dump (opts?: { limit: number; signal?: AbortSignal | undefined }): Promise<void>
 }

--- a/types/retry-handler.d.ts
+++ b/types/retry-handler.d.ts
@@ -5,7 +5,7 @@ export default RetryHandler
 declare class RetryHandler implements Dispatcher.DispatchHandler {
   constructor (
     options: Dispatcher.DispatchOptions & {
-      retryOptions?: RetryHandler.RetryOptions;
+      retryOptions?: RetryHandler.RetryOptions | undefined;
     },
     retryHandlers: RetryHandler.RetryHandlers
   )
@@ -17,7 +17,7 @@ declare namespace RetryHandler {
   export type RetryContext = {
     state: RetryState;
     opts: Dispatcher.DispatchOptions & {
-      retryOptions?: RetryHandler.RetryOptions;
+      retryOptions?: RetryHandler.RetryOptions | undefined;
     };
   }
 
@@ -28,7 +28,7 @@ declare namespace RetryHandler {
     context: {
       state: RetryState;
       opts: Dispatcher.DispatchOptions & {
-        retryOptions?: RetryHandler.RetryOptions;
+        retryOptions?: RetryHandler.RetryOptions | undefined;
       };
     },
     callback: OnRetryCallback
@@ -43,7 +43,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default true
      */
-    throwOnError?: boolean;
+    throwOnError?: boolean | undefined;
     /**
      * Callback to be invoked on every retry iteration.
      * It receives the error, current state of the retry object and the options object
@@ -52,7 +52,7 @@ declare namespace RetryHandler {
      * @type {RetryCallback}
      * @memberof RetryOptions
      */
-    retry?: RetryCallback;
+    retry?: RetryCallback | undefined;
     /**
      * Maximum number of retries to allow.
      *
@@ -60,7 +60,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default 5
      */
-    maxRetries?: number;
+    maxRetries?: number | undefined;
     /**
      * Max number of milliseconds allow between retries
      *
@@ -68,7 +68,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default 30000
      */
-    maxTimeout?: number;
+    maxTimeout?: number | undefined;
     /**
      * Initial number of milliseconds to wait before retrying for the first time.
      *
@@ -76,7 +76,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default 500
      */
-    minTimeout?: number;
+    minTimeout?: number | undefined;
     /**
      * Factior to multiply the timeout factor between retries.
      *
@@ -84,7 +84,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default 2
      */
-    timeoutFactor?: number;
+    timeoutFactor?: number | undefined;
     /**
      * It enables to automatically infer timeout between retries based on the `Retry-After` header.
      *
@@ -92,7 +92,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default true
      */
-    retryAfter?: boolean;
+    retryAfter?: boolean | undefined;
     /**
      * HTTP methods to retry.
      *
@@ -100,14 +100,14 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE', 'TRACE'],
      */
-    methods?: Dispatcher.HttpMethod[];
+    methods?: Dispatcher.HttpMethod[] | undefined;
     /**
      * Error codes to be retried. e.g. `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, `ECONNREFUSED`, etc.
      *
      * @type {string[]}
      * @default ['ECONNRESET','ECONNREFUSED','ENOTFOUND','ENETDOWN','ENETUNREACH','EHOSTDOWN','EHOSTUNREACH','EPIPE']
      */
-    errorCodes?: string[];
+    errorCodes?: string[] | undefined;
     /**
      * HTTP status codes to be retried.
      *
@@ -115,7 +115,7 @@ declare namespace RetryHandler {
      * @memberof RetryOptions
      * @default [500, 502, 503, 504, 429],
      */
-    statusCodes?: number[];
+    statusCodes?: number[] | undefined;
   }
 
   export interface RetryHandlers {

--- a/types/round-robin-pool.d.ts
+++ b/types/round-robin-pool.d.ts
@@ -30,10 +30,10 @@ declare namespace RoundRobinPool {
   export type RoundRobinPoolStats = TPoolStats
   export interface Options extends Client.Options {
     /** Default: `(origin, opts) => new Client(origin, opts)`. */
-    factory?(origin: URL, opts: object): Dispatcher;
+    factory?: ((origin: URL, opts: object) => Dispatcher) | undefined;
     /** The max number of clients to create. `null` if no limit. Default `null`. */
-    connections?: number | null;
+    connections?: number | null | undefined;
     /** The amount of time before a client is removed from the pool and closed. `null` if no time limit. Default `null` */
-    clientTtl?: number | null;
+    clientTtl?: number | null | undefined;
   }
 }

--- a/types/snapshot-agent.d.ts
+++ b/types/snapshot-agent.d.ts
@@ -21,22 +21,22 @@ declare namespace SnapshotRecorder {
   type SnapshotRecorderMode = 'record' | 'playback' | 'update'
 
   export interface Options {
-    snapshotPath?: string
-    mode?: SnapshotRecorderMode
-    maxSnapshots?: number
-    autoFlush?: boolean
-    flushInterval?: number
-    matchHeaders?: string[]
-    ignoreHeaders?: string[]
-    excludeHeaders?: string[]
-    matchBody?: boolean
-    normalizeBody?: (body: string | Buffer | null | undefined) => string
-    matchQuery?: boolean
-    normalizeQuery?: (query: URLSearchParams) => string
-    caseSensitive?: boolean
-    shouldRecord?: (requestOpts: any) => boolean
-    shouldPlayback?: (requestOpts: any) => boolean
-    excludeUrls?: (string | RegExp)[]
+    snapshotPath?: string | undefined
+    mode?: SnapshotRecorderMode | undefined
+    maxSnapshots?: number | undefined
+    autoFlush?: boolean | undefined
+    flushInterval?: number | undefined
+    matchHeaders?: string[] | undefined
+    ignoreHeaders?: string[] | undefined
+    excludeHeaders?: string[] | undefined
+    matchBody?: boolean | undefined
+    normalizeBody?: ((body: string | Buffer | null | undefined) => string) | undefined
+    matchQuery?: boolean | undefined
+    normalizeQuery?: ((query: URLSearchParams) => string) | undefined
+    caseSensitive?: boolean | undefined
+    shouldRecord?: ((requestOpts: any) => boolean) | undefined
+    shouldPlayback?: ((requestOpts: any) => boolean) | undefined
+    excludeUrls?: (string | RegExp)[] | undefined
   }
 
   export interface Snapshot {
@@ -44,7 +44,7 @@ declare namespace SnapshotRecorder {
       method: string
       url: string
       headers: Record<string, string>
-      body?: string
+      body?: string | undefined
     }
     responses: {
       statusCode: number
@@ -62,7 +62,7 @@ declare namespace SnapshotRecorder {
       method: string
       url: string
       headers: Record<string, string>
-      body?: string
+      body?: string | undefined
     }
     responseCount: number
     callCount: number
@@ -91,22 +91,22 @@ declare class SnapshotAgent extends MockAgent {
 
 declare namespace SnapshotAgent {
   export interface Options extends MockAgent.Options {
-    mode?: SnapshotRecorder.SnapshotRecorderMode
-    snapshotPath?: string
-    maxSnapshots?: number
-    autoFlush?: boolean
-    flushInterval?: number
-    matchHeaders?: string[]
-    ignoreHeaders?: string[]
-    excludeHeaders?: string[]
-    matchBody?: boolean
-    normalizeBody?: (body: string | Buffer | null | undefined) => string
-    matchQuery?: boolean
-    normalizeQuery?: (query: URLSearchParams) => string
-    caseSensitive?: boolean
-    shouldRecord?: (requestOpts: any) => boolean
-    shouldPlayback?: (requestOpts: any) => boolean
-    excludeUrls?: (string | RegExp)[]
+    mode?: SnapshotRecorder.SnapshotRecorderMode | undefined
+    snapshotPath?: string | undefined
+    maxSnapshots?: number | undefined
+    autoFlush?: boolean | undefined
+    flushInterval?: number | undefined
+    matchHeaders?: string[] | undefined
+    ignoreHeaders?: string[] | undefined
+    excludeHeaders?: string[] | undefined
+    matchBody?: boolean | undefined
+    normalizeBody?: ((body: string | Buffer | null | undefined) => string) | undefined
+    matchQuery?: boolean | undefined
+    normalizeQuery?: ((query: URLSearchParams) => string) | undefined
+    caseSensitive?: boolean | undefined
+    shouldRecord?: ((requestOpts: any) => boolean) | undefined
+    shouldPlayback?: ((requestOpts: any) => boolean) | undefined
+    excludeUrls?: (string | RegExp)[] | undefined
   }
 }
 

--- a/types/socks5-proxy-agent.d.ts
+++ b/types/socks5-proxy-agent.d.ts
@@ -12,14 +12,14 @@ declare class Socks5ProxyAgent extends Dispatcher {
 declare namespace Socks5ProxyAgent {
   export interface Options extends Pool.Options {
     /** Additional headers to send with the proxy connection */
-    headers?: OutgoingHttpHeaders;
+    headers?: OutgoingHttpHeaders | undefined;
     /** SOCKS5 proxy username for authentication */
-    username?: string;
+    username?: string | undefined;
     /** SOCKS5 proxy password for authentication */
-    password?: string;
+    password?: string | undefined;
     /** Custom connector function for proxy connection */
-    connect?: buildConnector.connector;
+    connect?: buildConnector.connector | undefined;
     /** TLS options for the proxy connection (for SOCKS5 over TLS) */
-    proxyTls?: buildConnector.BuildOptions;
+    proxyTls?: buildConnector.BuildOptions | undefined;
   }
 }

--- a/types/webidl.d.ts
+++ b/types/webidl.d.ts
@@ -315,10 +315,10 @@ export interface Webidl {
    */
   dictionaryConverter (converters: {
     key: string,
-    defaultValue?: () => unknown,
-    required?: boolean,
+    defaultValue?: (() => unknown) | undefined,
+    required?: boolean | undefined,
     converter: (...args: unknown[]) => unknown,
-    allowedValues?: unknown[]
+    allowedValues?: unknown[] | undefined
   }[]): (V: unknown) => Record<string, unknown>
 
   /**

--- a/types/websocket.d.ts
+++ b/types/websocket.d.ts
@@ -76,9 +76,9 @@ export declare const WebSocket: {
 }
 
 interface CloseEventInit extends EventInit {
-  code?: number
-  reason?: string
-  wasClean?: boolean
+  code?: number | undefined
+  reason?: string | undefined
+  wasClean?: boolean | undefined
 }
 
 interface CloseEvent extends Event {
@@ -93,11 +93,11 @@ export declare const CloseEvent: {
 }
 
 interface MessageEventInit<T = any> extends EventInit {
-  data?: T
-  lastEventId?: string
-  origin?: string
-  ports?: MessagePort[]
-  source?: MessagePort | null
+  data?: T | undefined
+  lastEventId?: string | undefined
+  origin?: string | undefined
+  ports?: MessagePort[] | undefined
+  source?: MessagePort | null | undefined
 }
 
 interface MessageEvent<T = any> extends Event {
@@ -124,10 +124,10 @@ export declare const MessageEvent: {
 }
 
 interface ErrorEventInit extends EventInit {
-  message?: string
-  filename?: string
-  lineno?: number
-  colno?: number
+  message?: string | undefined
+  filename?: string | undefined
+  lineno?: number | undefined
+  colno?: number | undefined
   error?: any
 }
 
@@ -145,14 +145,14 @@ export declare const ErrorEvent: {
 }
 
 interface WebSocketInit {
-  protocols?: string | string[],
-  dispatcher?: Dispatcher,
-  headers?: HeadersInit
+  protocols?: string | string[] | undefined,
+  dispatcher?: Dispatcher | undefined,
+  headers?: HeadersInit | undefined
 }
 
 interface WebSocketStreamOptions {
-  protocols?: string | string[]
-  signal?: AbortSignal
+  protocols?: string | string[] | undefined
+  signal?: AbortSignal | undefined
 }
 
 interface WebSocketCloseInfo {


### PR DESCRIPTION
## Problem

Undici's type declarations cannot be consumed from a project compiled with TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes). Under that flag, an optional property declared as `foo?: T` accepts a *missing* property but rejects an *explicitly `undefined`* one, so ordinary code fails to compile:

```ts
// error TS2379: Argument of type '{ maxRedirections: number | undefined; }'
// is not assignable to parameter of type 'RequestOptions'
// with 'exactOptionalPropertyTypes: true'.
await request(url, { maxRedirections: config.maxRedirections })
```

This does not reflect runtime behaviour: undici resolves options with `??`/`||` defaults throughout, so a missing option and an `undefined` option behave identically.

## Changes

- Add `| undefined` to the 334 optional properties across `types/*.d.ts`. This is a no-op for readers — reading `foo?: T` already yields `T | undefined` — and only relaxes assignability for writers.
- Convert the optional *methods* affected by the same rule into optional properties holding a function type: the handler hooks on `Dispatcher.DispatchHandler`, plus `Agent.Options.factory`, `Pool.Options.factory`, `RoundRobinPool.Options.factory` and `ProxyAgent.Options.clientFactory`.
- Enable `exactOptionalPropertyTypes` for the `tsd` run and for both `tsc` invocations in `test:typescript`, so the property declarations cannot regress.
- Add `test/types/exact-optional-property-types.test-d.ts`, asserting that an explicit `undefined` is accepted across the main option types (`Client`, `Pool`, `Agent`, `ProxyAgent`, `MockAgent`, `DispatchOptions`, `RequestOptions`, `DispatchHandler`, `RetryOptions`, `RequestInit`, `ResponseInit`, the interceptor options and `request()`).

## Compatibility note

The method-to-property conversion is the one part of this change that can surface a new error in existing code. Method signatures are compared bivariantly, whereas property function types are checked contravariantly under `strictFunctionTypes`, so explicitly annotated callback parameters must now match the declared types.

Callbacks whose parameter types are inferred from context — the form used throughout the documentation, e.g. `factory: (origin, opts) => new Pool(origin, opts)` — are unaffected. One existing type test annotated `factory` as taking a `URL`, while `Agent.Options.factory` is invoked with `opts.origin` (a `string | URL`, see `lib/dispatcher/agent.js`); it has been widened to match.

## Notes

No runtime code is touched; this is a declaration-only change. `npm run test:typescript` and `npm run lint` pass.
