### PR TITLE
test: harden http2-request-never-settles against late session errors

### DIFF
--- a/test/http2-request-never-settles.js
+++ b/test/http2-request-never-settles.js
@@ -100,11 +100,20 @@ async function churningServer (rnd) {
     } catch {}
   })
 
+  // Churn (client aborts, GOAWAYs, destroyed sessions, agent.destroy()) can
+  // surface a late ECONNRESET on the server, a session, or its socket after
+  // the test body has resolved. An unhandled 'error' there kills the test
+  // process outright -- CI then reports a bare 'test failed' with no TAP.
+  // Same swallow pattern as test/http2-abort.js.
+  server.on('error', () => {})
   const sessions = new Set()
   server.on('session', (session) => {
+    session.on('error', () => {})
+    session.socket?.on('error', () => {})
     sessions.add(session)
     session.on('close', () => sessions.delete(session))
   })
+  server.on('secureConnection', socket => socket.on('error', () => {}))
   server.shutdown = () => {
     for (const session of sessions) session.destroy()
     server.close()


### PR DESCRIPTION
## This relates to...

The flaky `test/http2-request-never-settles.js` (added in #5603), currently failing intermittently on `main` and painting unrelated PRs red. **Update 2026-08-09: root cause identified upstream — this is nodejs/node#64841, a V8 Maglev SIGSEGV regression in Node ≥ v24.15.0, not an undici bug. This PR no longer claims to fix the red CI; see the verification section.**

## Rationale

Since #5603 merged, this test fails intermittently in CI with a distinctive signature: `✖ test/http2-request-never-settles.js 'test failed'` with **no TAP output, no subtests, no stack**, the file finishing in 3–9 s so the 15 s watchdog never runs. That signature is the test **process dying abruptly**, with the TAP stream discarded.

The original hypothesis of this PR was a late unhandled `'error'` on the churn server (the only emitter without a handler). **That hypothesis has now been falsified as the cause of the red CI** (see below): the killer is a native crash, not a JS exception. The handlers remain correct hygiene for a churn server — an unhandled `'error'` *would* kill the process (with a visible stack, unlike the flake) — but they do not cure the flake.

## Changes

Test-only (+9/−0), copying the established pattern from `test/http2-abort.js`:

- `server.on('error', …)`, `session.on('error', …)` and `session.socket?.on('error', …)` (tracked per session), and `server.on('secureConnection', …)` — late errors are swallowed instead of killing the process.
- A comment explaining why, so the next reader doesn't "clean them up".

No library code touched; the settle invariant under test is unchanged.

## Verification

**Red→green falsification: NEGATIVE — this hardening does not fix the flake.** Reproduced locally on WSL2 (Ubuntu 24.04) using the exact recipe from nodejs/node#64841 (batches of 6 processes, `taskset -c 0,1`), on undici `86b62998`:

| Config | Result |
|---|---|
| v24.18.1, original test | 1/72 and 4/72 SIGSEGV (exit 139) in two independent run sets |
| v24.18.1, test **with this PR** | 1/72 SIGSEGV — same rate, same signature |
| v24.19.0 (current LTS), original test | 4/72 SIGSEGV — the V8 backport in 24.19.0 does **not** cure it |
| v24.18.1 `--no-maglev` | 0/48 SIGSEGV, but 1/48 SIGABRT (glibc `corrupted size vs. prev_size`) — not a clean stopgap |
| Controls: v24.14.1 (336 runs incl. ~30k amplified requests), v24.18.1 on Windows (72 runs) | 0 failures — matches the issue being Linux-only, Node ≥ 24.15.0 |

The crash log is byte-identical to the CI signature: a single TAP line (`✔ every h2 request settles under connection churn (seed 7)`) and then sudden death — no error, no stack, exit 139. A probe test dying by an unhandled EventEmitter `'error'` *does* show its stack under the test runner, confirming the CI killer is a signal death (SIGSEGV in Maglev concurrent compilation), not a JS exception.

What this means, honestly:

- **The red on `main` and on #5637/#5673/#5675 is nodejs/node#64841.** Updating Node in CI does not help today (24.19.0 is still affected); `--no-maglev` is not a clean workaround (residual native instability).
- This PR's handlers defend a *different, real* hole (a late EPIPE/ECONNRESET on the churn server would crash the process with a stack), copied from the in-repo precedent. Merge it as hardening or close it — maintainer's call; it should not land under the expectation that it turns CI green.
- If undici wants green CI before the V8 fix lands, the only real lever is skipping/marking this file on Linux with Node ≥ 24.15.0 — a maintainers' decision, deliberately not proposed as a diff here.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (test-only change)
- [x] Review ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
