### PR TITLE
fix(retry): honor the abort signal during the retry backoff

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -43,9 +43,13 @@ function validatePartialResponseContentLength (headers, range, statusCode, retry
 // The proxy always forwards to the controller of the currently active connection.
 // An abort is additionally reported to the handler so it can cancel a pending
 // retry backoff instead of letting the request hang until the backoff elapses.
+// The notification is a private callback the handler hands over on construction,
+// so nothing outside the handler can trigger it.
 class RetryController {
-  constructor (handler) {
-    this.handler = handler
+  #onAbort
+
+  constructor (onAbort) {
+    this.#onAbort = onAbort
     this.target = null
   }
 
@@ -54,7 +58,7 @@ class RetryController {
 
   abort (reason) {
     this.target?.abort(reason)
-    this.handler.onAbort(reason)
+    this.#onAbort(reason)
   }
 
   get paused () { return this.target?.paused ?? false }
@@ -120,11 +124,11 @@ class RetryHandler {
     this.etag = null
     this.statusCode = null
     this.headers = null
-    this.controllerProxy = new RetryController(this)
+    this.controllerProxy = new RetryController(reason => this.#onAbort(reason))
     // A retry decision is in flight (the policy may be holding a backoff
     // timer). While pending, a consumer abort cancels the wait.
     this.retryPending = false
-    // Backoff timer returned by the retry policy, so onAbort can cancel it.
+    // Backoff timer returned by the retry policy, so #onAbort can cancel it.
     // Null for custom policies that do not return their timer.
     this.retryTimer = null
     // Set once an abort during the backoff delivered the terminal error
@@ -465,7 +469,7 @@ class RetryHandler {
 
   onResponseError (controller, err) {
     if (this.aborted) {
-      // onAbort already delivered the terminal error downstream; the late
+      // #onAbort already delivered the terminal error downstream; the late
       // error of the torn-down connection must not be forwarded twice.
       return
     }
@@ -515,7 +519,7 @@ class RetryHandler {
     ) ?? null
   }
 
-  onAbort (reason) {
+  #onAbort (reason) {
     // A consumer abort lands on the controller proxy. If the retry policy is
     // still deciding (typically holding a backoff timer), cancel the wait and
     // surface the abort immediately instead of letting the request hang until

--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -2,7 +2,7 @@
 const assert = require('node:assert')
 
 const { kRetryHandlerDefaultRetry } = require('../core/symbols')
-const { RequestRetryError } = require('../core/errors')
+const { RequestRetryError, RequestAbortedError } = require('../core/errors')
 const {
   isDisturbed,
   parseRangeHeader,
@@ -41,14 +41,22 @@ function validatePartialResponseContentLength (headers, range, statusCode, retry
 // new one: backpressure pauses the new connection's controller, but the
 // consumer's resume() targets the old one, so the resumed body stalls forever.
 // The proxy always forwards to the controller of the currently active connection.
+// An abort is additionally reported to the handler so it can cancel a pending
+// retry backoff instead of letting the request hang until the backoff elapses.
 class RetryController {
-  constructor () {
+  constructor (handler) {
+    this.handler = handler
     this.target = null
   }
 
   pause () { this.target?.pause() }
   resume () { this.target?.resume() }
-  abort (reason) { this.target?.abort(reason) }
+
+  abort (reason) {
+    this.target?.abort(reason)
+    this.handler.onAbort(reason)
+  }
+
   get paused () { return this.target?.paused ?? false }
   get aborted () { return this.target?.aborted ?? false }
   get reason () { return this.target?.reason ?? null }
@@ -112,7 +120,16 @@ class RetryHandler {
     this.etag = null
     this.statusCode = null
     this.headers = null
-    this.controllerProxy = new RetryController()
+    this.controllerProxy = new RetryController(this)
+    // A retry decision is in flight (the policy may be holding a backoff
+    // timer). While pending, a consumer abort cancels the wait.
+    this.retryPending = false
+    // Backoff timer returned by the retry policy, so onAbort can cancel it.
+    // Null for custom policies that do not return their timer.
+    this.retryTimer = null
+    // Set once an abort during the backoff delivered the terminal error
+    // downstream; late policy callbacks and connection errors are then moot.
+    this.aborted = false
   }
 
   onResponseStartWithRetry (controller, statusCode, headers, statusMessage, err) {
@@ -135,6 +152,13 @@ class RetryHandler {
     }
 
     function shouldRetry (passedErr) {
+      if (this.aborted) {
+        // Aborted while the policy was deciding; the decision is moot.
+        return
+      }
+      this.retryPending = false
+      this.retryTimer = null
+
       if (passedErr) {
         this.headersSent = true
         this.handler.onResponseStart?.(this.controllerProxy, statusCode, headers, statusMessage)
@@ -154,14 +178,17 @@ class RetryHandler {
     // between, leaving this one paused forever -- the very stall the proxy exists
     // to prevent.
     controller.pause()
-    this.retryOpts.retry(
+    // The default policy returns its backoff timer so an abort can cancel it;
+    // a custom policy may return anything (or nothing), which is ignored.
+    this.retryPending = true
+    this.retryTimer = this.retryOpts.retry(
       err,
       {
         state: { counter: this.retryCount },
         opts: { retryOptions: this.retryOpts, ...this.opts }
       },
       shouldRetry.bind(this)
-    )
+    ) ?? null
   }
 
   onRequestStart (controller, context) {
@@ -237,7 +264,9 @@ class RetryHandler {
           ? Math.min(retryAfterHeader, maxTimeout)
           : Math.min(minTimeout * timeoutFactor ** (counter - 1), maxTimeout)
 
-    setTimeout(() => cb(null), retryTimeout)
+    // Return the backoff timer so the handler can cancel it when the
+    // consumer aborts while the retry decision is pending.
+    return setTimeout(() => cb(null), retryTimeout)
   }
 
   onResponseStart (controller, statusCode, headers, statusMessage) {
@@ -435,6 +464,12 @@ class RetryHandler {
   }
 
   onResponseError (controller, err) {
+    if (this.aborted) {
+      // onAbort already delivered the terminal error downstream; the late
+      // error of the torn-down connection must not be forwarded twice.
+      return
+    }
+
     // controller is THIS failed connection (not the proxy): we inspect whether
     // the consumer aborted it to decide retry-vs-propagate.
     if (controller?.aborted || isDisturbed(this.opts.body)) {
@@ -443,6 +478,13 @@ class RetryHandler {
     }
 
     function shouldRetry (returnedErr) {
+      if (this.aborted) {
+        // Aborted while the policy was deciding; the decision is moot.
+        return
+      }
+      this.retryPending = false
+      this.retryTimer = null
+
       if (!returnedErr) {
         this.retry()
         return
@@ -462,14 +504,31 @@ class RetryHandler {
       this.retryCount += 1
     }
 
-    this.retryOpts.retry(
+    this.retryPending = true
+    this.retryTimer = this.retryOpts.retry(
       err,
       {
         state: { counter: this.retryCount },
         opts: { retryOptions: this.retryOpts, ...this.opts }
       },
       shouldRetry.bind(this)
-    )
+    ) ?? null
+  }
+
+  onAbort (reason) {
+    // A consumer abort lands on the controller proxy. If the retry policy is
+    // still deciding (typically holding a backoff timer), cancel the wait and
+    // surface the abort immediately instead of letting the request hang until
+    // the backoff elapses.
+    if (!this.retryPending) {
+      return
+    }
+
+    this.aborted = true
+    this.retryPending = false
+    clearTimeout(this.retryTimer)
+    this.retryTimer = null
+    this.handler.onResponseError?.(this.controllerProxy, reason ?? new RequestAbortedError())
   }
 }
 

--- a/test/retry-handler.js
+++ b/test/retry-handler.js
@@ -7,8 +7,9 @@ const { once } = require('node:events')
 const { Readable } = require('node:stream')
 const FakeTimers = require('@sinonjs/fake-timers')
 
-const { RetryHandler, Client } = require('..')
+const { RetryHandler, RetryAgent, Client } = require('..')
 const { RequestHandler } = require('../lib/api/api-request')
+const { kRetryHandlerDefaultRetry } = require('../lib/core/symbols')
 
 test('Should retry status code', async t => {
   t = tspl(t, { plan: 3 })
@@ -1762,6 +1763,116 @@ test('Should use retry-after header for retries (date) but date format is wrong'
       },
       handler
     )
+  })
+
+  await t.completed
+})
+
+test('Should abort immediately when aborted during the retry backoff', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let hits = 0
+  const ac = new AbortController()
+  const startedAt = Date.now()
+  const server = createServer({ joinDuplicateHeaders: true })
+
+  server.on('request', (req, res) => {
+    hits++
+    res.writeHead(500)
+    res.end('failed')
+  })
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const agent = new RetryAgent(client, {
+      minTimeout: 10_000,
+      maxRetries: 5,
+      retry: (err, ctx, done) => {
+        // The default policy has just scheduled a 10s backoff; abort while it
+        // is pending (setImmediate so the handler captures the timer first).
+        setImmediate(() => ac.abort())
+        return RetryHandler[kRetryHandlerDefaultRetry](err, ctx, done)
+      }
+    })
+
+    after(async () => {
+      await agent.close()
+      server.close()
+
+      await once(server, 'close')
+    })
+
+    agent.request({
+      method: 'GET',
+      path: '/',
+      signal: ac.signal
+    }).then(() => {
+      t.fail('request should have been aborted')
+    }, (err) => {
+      t.strictEqual(err.name, 'AbortError', 'rejects with the abort reason')
+      t.ok(Date.now() - startedAt < 5_000, 'rejects long before the 10s backoff elapses')
+      t.strictEqual(hits, 1, 'no retry is dispatched after the abort')
+    })
+  })
+
+  await t.completed
+})
+
+test('Should ignore a late retry decision after an abort during the backoff', async t => {
+  t = tspl(t, { plan: 4 })
+
+  let hits = 0
+  let policyCalls = 0
+  const ac = new AbortController()
+  const startedAt = Date.now()
+  const server = createServer({ joinDuplicateHeaders: true })
+
+  server.on('request', (req, res) => {
+    hits++
+    res.writeHead(500)
+    res.end('failed')
+  })
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const agent = new RetryAgent(client, {
+      maxRetries: 5,
+      retry: (err, ctx, done) => {
+        policyCalls++
+        if (policyCalls > 1) {
+          done(err)
+          return
+        }
+        // A custom policy with its own 3s backoff that does not return the
+        // timer: the abort must still terminate the request immediately and
+        // the late decision must be ignored.
+        setTimeout(() => done(null), 3_000)
+        setImmediate(() => ac.abort())
+      }
+    })
+
+    after(async () => {
+      await agent.close()
+      server.close()
+
+      await once(server, 'close')
+    })
+
+    agent.request({
+      method: 'GET',
+      path: '/',
+      signal: ac.signal
+    }).then(() => {
+      t.fail('request should have been aborted')
+    }, async (err) => {
+      t.strictEqual(err.name, 'AbortError', 'rejects with the abort reason')
+      t.ok(Date.now() - startedAt < 1_500, 'rejects long before the 3s custom backoff')
+      t.strictEqual(hits, 1, 'no retry is dispatched after the abort')
+
+      // The custom policy's timer fires at 3s; its late decision is moot.
+      await new Promise(resolve => setTimeout(resolve, 3_500))
+      t.strictEqual(hits, 1, 'late retry decision is ignored')
+    })
   })
 
   await t.completed


### PR DESCRIPTION
## This relates to...

No open issue found for this; reported directly with a reproduction.

## Rationale

When a retry is scheduled, the default retry policy parks the decision in a
`setTimeout` backoff (`lib/handler/retry-handler.js`). **An abort that arrives
while that backoff is pending is ignored until the timer elapses.** The
consumer's abort reaches the controller of the connection that already
finished — a no-op — and the pending timer is not tracked anywhere, so the
request only rejects with the `AbortError` after the full backoff: 5 s in the
repro below, and minutes with a large `Retry-After` (e.g. `Retry-After: 120`
holds the caller for two minutes). The referenced (non-`unref`) timer also
keeps the process alive for the whole backoff even though nothing will come of
it.

Reproduced against current `main` (86b62998): a server that always answers 500,
a `RetryAgent` with `minTimeout: 5000`, and `abort()` fired 800 ms into the
request. The rejection arrives at ~5038 ms instead of ~800 ms.

## Changes

- The default retry policy now **returns its backoff timer**, and the handler
  tracks it while a retry decision is pending (`retryPending` / `retryTimer`).
- The `RetryController` proxy — where every consumer abort already funnels
  through — now also reports `abort(reason)` to the handler. `onAbort` cancels
  the pending wait and forwards the abort reason downstream via
  `onResponseError` immediately (a `RequestAbortedError` when no reason was
  given, matching `api-request`'s convention).
- Guards make the termination exact: a late decision callback from the policy
  (e.g. a custom retry function resolving after the abort) is ignored, and the
  torn-down connection's late error is not forwarded twice, so the downstream
  handler is errored exactly once.

Both policy call sites (the `throwOnError: false` response path and the
`onResponseError` path used by `throwOnError: true` and network errors) track
the pending decision the same way.

Scope note: a custom retry function that keeps its own timer and does not
return it cannot have that timer cancelled (we were never handed it), but the
abort still settles the request immediately and the late callback is ignored.

Out of scope (deliberately not changed): `unref()`-ing the backoff timer. A
pending retry is a live logical request; letting the process exit mid-backoff
would silently abandon it. That idea is being explored in #4470, which is
orthogonal to this fix.

### Features

N/A

### Bug Fixes

- `retry()` / `RetryAgent`: an abort that arrives while a retry backoff is
  pending now rejects immediately with the `AbortError` instead of after the
  full backoff, and no retry is dispatched after the abort.

### Breaking Changes and Deprecations

None.

## Verification

Every command below was run and its output captured verbatim. The record is
reproducible — the exact commands are included so you can re-run them yourself.

**red — main (86b62998) without the fix** (must fail: the rejection only comes
after the full backoff)

```
$ git stash push -- lib/handler/retry-handler.js   # i.e. main's version
$ node --test --test-name-pattern="backoff" test/retry-handler.js
✖ Should abort immediately when aborted during the retry backoff (10028.7502ms)
  AssertionError [ERR_ASSERTION]: rejects long before the 10s backoff elapses
✖ Should ignore a late retry decision after an abort during the backoff (3018.9959ms)
  AssertionError [ERR_ASSERTION]: rejects long before the 3s custom backoff
```

(The abort is fired while the backoff is pending — the test hooks the retry
policy invocation — yet the request only settles once the 10 s / 3 s timers
elapse.)

**green — with the fix** (must pass)

```
$ node --test --test-name-pattern="backoff" test/retry-handler.js
✔ Should abort immediately when aborted during the retry backoff (28.0084ms)
✔ Should ignore a late retry decision after an abort during the backoff (3516.7355ms)
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

(The second test's ~3.5 s are deliberate: after the immediate rejection it
waits past the custom policy's 3 s timer to assert the late decision is
ignored and no retry is dispatched. The assertions are relational — abort
during backoff → immediate rejection with the abort reason — with margins of
two orders of magnitude, so CI slowness does not flake them.)

**standalone reproduction against a live server** (`RetryAgent` with
`minTimeout: 5000`, server always 500, `abort()` at 800 ms):

```
# main:
[server] hit #1 at 19ms
[client] abort() at 803ms
[client] rejected at 5038ms: name=AbortError code=20 msg=This operation was aborted
[client] cleanup done at 5039ms        # process held by the pending timer

# with the fix:
[server] hit #1 at 19ms
[client] abort() at 813ms
[client] rejected at 814ms: name=AbortError code=20 msg=This operation was aborted
[client] cleanup done at 816ms         # timer cancelled, process exits

# control (no abort), main and fixed alike:
[server] hit #1 at 19ms
[server] hit #2 at ~5040ms
[client] resolved status=200 at ~5042ms
```

**area suites with the fix** (must pass)

```
$ node --test test/retry-handler.js test/retry-handler2.js test/retry-agent.js \
       test/retry-handler-controller-proxy.js test/interceptors/retry.js \
       test/client-retry-resume-backpressure.js
ℹ tests 68  ℹ pass 68  ℹ fail 0

$ node --test test/retry-handler.js        # full file, incl. the 2 new tests
ℹ tests 23  ℹ pass 23  ℹ fail 0

$ node --test test/http2-goaway-retry-body.js
ℹ tests 1  ℹ pass 1  ℹ fail 0
```

**lint** (must pass)

```
$ npm run lint
> undici@8.10.0 lint
> eslint --cache
[exit code 0]
```

Not verified locally: the remaining test suites (`npm test` runs 14 of them);
left to CI, as this change only touches the retry handler and its tests. No
documentation changes: no existing doc describes abort-during-backoff
behavior, and the fixed behavior now matches the general abort contract;
happy to add a note to `docs/docs/api/RetryHandler.md` if maintainers want one.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

---

Implementation and validation used AI assistance; I reviewed the final diff and results.
