### PR TITLE
fix(h2): honour maxResponseSize

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -10,7 +10,8 @@ const {
   InformationalError,
   InvalidArgumentError,
   HeadersTimeoutError,
-  BodyTimeoutError
+  BodyTimeoutError,
+  ResponseExceededMaxSizeError
 } = require('../core/errors.js')
 const {
   kUrl,
@@ -39,7 +40,8 @@ const {
   kRemoteSettings,
   kHTTP2Stream,
   kHTTP2SessionState,
-  kHTTP2Options
+  kHTTP2Options,
+  kMaxResponseSize
 } = require('../core/symbols.js')
 const { channels } = require('../core/diagnostics.js')
 
@@ -1022,9 +1024,11 @@ function writeH2 (client, request) {
   const state = {
     abort: null,
     body: request.body,
+    bytesRead: 0,
     client,
     contentLength: null,
     expectsPayload: false,
+    maxResponseSize: client[kMaxResponseSize],
     request,
     headersTimeout,
     bodyTimeout,
@@ -1322,11 +1326,21 @@ function onData (chunk) {
     return
   }
 
-  const { request } = state
+  const { request, maxResponseSize } = state
 
   if (request.aborted || request.completed) {
     return
   }
+
+  if (maxResponseSize > -1 && state.bytesRead + chunk.length > maxResponseSize) {
+    // Unlike HTTP/1.1, which destroys the socket because it cannot abandon one
+    // response without losing framing, resetting the offending stream leaves
+    // the session usable for its siblings.
+    state.abort(new ResponseExceededMaxSizeError())
+    return
+  }
+
+  state.bytesRead += chunk.length
 
   if (request.onResponseData(chunk) === false) {
     stream.pause()

--- a/test/max-response-size.js
+++ b/test/max-response-size.js
@@ -2,8 +2,10 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after, describe } = require('node:test')
-const { Client, errors } = require('..')
+const { once } = require('node:events')
+const { Client, H2CClient, errors } = require('..')
 const { createServer } = require('node:http')
+const { createServer: createH2CServer } = require('node:http2')
 
 describe('max response size', async (t) => {
   test('default max default size should allow all responses', async (t) => {
@@ -112,6 +114,85 @@ describe('max response size', async (t) => {
         })
       })
     })
+
+    await t.completed
+  })
+
+  test('should throw an error if the response is too big over h2c', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    const server = createH2CServer()
+    after(() => {
+      server.close()
+    })
+
+    server.on('stream', (stream) => {
+      // the client resets the stream once the limit is passed
+      stream.on('error', () => {})
+      stream.respond({ ':status': 200 })
+      stream.end('hello')
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new H2CClient(`http://localhost:${server.address().port}`, {
+      maxResponseSize: 1
+    })
+    after(() => client.destroy())
+
+    let error = null
+    try {
+      const { body } = await client.request({ path: '/', method: 'GET' })
+      await body.text()
+    } catch (err) {
+      error = err
+    }
+
+    t.ok(error instanceof errors.ResponseExceededMaxSizeError)
+
+    await t.completed
+  })
+
+  test('should keep the h2c session usable after a stream exceeds the limit', async (t) => {
+    t = tspl(t, { plan: 3 })
+
+    let connections = 0
+    const server = createH2CServer()
+    after(() => {
+      server.close()
+    })
+
+    server.on('connection', () => {
+      connections++
+    })
+    server.on('stream', (stream, headers) => {
+      stream.on('error', () => {})
+      stream.respond({ ':status': 200 })
+      stream.end(headers[':path'] === '/big' ? 'hello world' : 'ok')
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new H2CClient(`http://localhost:${server.address().port}`, {
+      maxResponseSize: 2
+    })
+    after(() => client.destroy())
+
+    let error = null
+    try {
+      const { body } = await client.request({ path: '/big', method: 'GET' })
+      await body.text()
+    } catch (err) {
+      error = err
+    }
+
+    t.ok(error instanceof errors.ResponseExceededMaxSizeError)
+
+    const { body } = await client.request({ path: '/small', method: 'GET' })
+    t.strictEqual(await body.text(), 'ok')
+    t.strictEqual(connections, 1)
 
     await t.completed
   })


### PR DESCRIPTION
## This relates to...

Nothing filed. I noticed it while reading the two client implementations side by side after #5638.

## Rationale

`maxResponseSize` is documented on the HTTP/2 client's own page, `docs/docs/api/H2CClient.md`:

> `maxResponseSize` {number} The maximum allowed response body size in bytes. Use `-1` to disable. Default: `-1`.

It is declared in `types/h2c-client.d.ts` and validated in `lib/dispatcher/client.js` (an `H2CClient` with `maxResponseSize: -5` throws `InvalidArgumentError`), then stored into `client[kMaxResponseSize]`. `lib/dispatcher/client-h2.js` never reads that symbol, so the value is validated and then ignored. `onData()` forwards every chunk to `request.onResponseData(chunk)` with no byte accounting.

Server sends 4 MiB, client asks for `maxResponseSize: 1024`:

| | HTTP/1.1 `Client` | h2c `H2CClient` |
|---|---|---|
| before | `UND_ERR_RES_EXCEEDED_MAX_SIZE` | resolves with 4194304 bytes |
| after | `UND_ERR_RES_EXCEEDED_MAX_SIZE` | `UND_ERR_RES_EXCEEDED_MAX_SIZE` |

Same split for a streaming consumer: over h1 the body errors mid-stream, over h2 it just completes.

The enforcement path itself isn't a regression, h2 has never honoured the option: `git log -S kMaxResponseSize -- lib/dispatcher/client-h2.js` is empty, and 7.29.0 ignores it too once you pass `allowH2: true`.

What did change is what an ordinary caller gets. Against a TLS origin offering h2, with h2 mentioned nowhere in the code:

```js
const agent = new Agent({ maxResponseSize: 1024 })
await request(url, { dispatcher: agent })
```

| | 7.29.0 | 8.10.0 |
|---|---|---|
| plain `new Agent({ maxResponseSize })` | `UND_ERR_RES_EXCEEDED_MAX_SIZE` | resolves, 4194304 bytes |
| `connect: { allowH2: false }` | `UND_ERR_RES_EXCEEDED_MAX_SIZE` | `UND_ERR_RES_EXCEEDED_MAX_SIZE` |

That's #4828 making `allowH2` default to `true`. Opting out of h2 brings the limit back, which is the clearest sign of where it goes missing.

## Changes

`onData()` counts bytes against `maxResponseSize`, mirroring `onBody()` in `client-h1.js`. The counter and the limit live on the pre-shaped per-request `state` object, so the hidden class is unchanged.

One deliberate difference from h1, and I'd like a second opinion on it. `client-h1.js` calls `util.destroy(socket, ...)` because HTTP/1.1 can't abandon one response without losing framing. Over h2 that would take out every sibling stream on the session, so this calls the existing per-request `state.abort()` instead, which resets only the offending stream. I verified the session survives: after an oversized stream is reset, later requests on the same client still succeed and the server reports one connection.

## Tests

Two cases added to `test/max-response-size.js`, which was http/1.1 only. Both fail before the change (the oversized response resolves instead of throwing) and pass after:

- an h2c response over the limit rejects with `ResponseExceededMaxSizeError`
- the session stays usable, an oversized stream errors, a following request on the same client succeeds, and the server sees one connection

`test/max-response-size.js`: 6 pass. `test/http2*.js test/h2c-client.js`: 105 pass, 0 fail. The default (`-1`) path is unchanged, a 4 MiB body is still delivered in full with no limit set and with `maxResponseSize: -1`.
