### PR TITLE
fix: skip drain dispatch for clientTtl-evicted clients in PoolBase

### DIFF
--- a/lib/dispatcher/pool-base.js
+++ b/lib/dispatcher/pool-base.js
@@ -28,6 +28,10 @@ class PoolBase extends DispatcherBase {
   [kNeedDrain] = false;
 
   [kOnDrain] (client, origin, targets) {
+    if (client.closed || client.destroyed) {
+      return
+    }
+
     const queue = this[kQueue]
 
     let needDrain = false

--- a/test/pool.js
+++ b/test/pool.js
@@ -1351,3 +1351,78 @@ test('stats', async (t) => {
 
   await t.completed
 })
+
+test('pool does not dispatch to clientTtl-evicted client when stale drain fires', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  let created = 0
+  const clients = []
+
+  class FakeClient extends EventEmitter {
+    constructor () {
+      super()
+      this.id = ++created
+      this.closed = false
+      this.destroyed = false
+      clients.push(this)
+    }
+
+    dispatch (opts, handler) {
+      if (this.closed) {
+        throw new errors.ClientClosedError()
+      }
+      if (this.id === 1) {
+        // Emit connect on first dispatch so the pool records a TTL timestamp
+        if (!this.ttl) {
+          this.emit('connect', new URL('http://notahost'), [this])
+        }
+        return true
+      }
+      // Simulate C2 mid-TLS-handshake: accepted the request but at capacity
+      return false
+    }
+
+    close (cb) {
+      this.closed = true
+      if (cb) cb()
+    }
+
+    destroy () {
+      this.destroyed = true
+    }
+  }
+
+  const pool = new Pool('http://notahost', {
+    connections: 1,
+    clientTtl: 1,
+    factory: () => new FakeClient()
+  })
+  after(() => pool.destroy())
+
+  const handler = { onResponseError (_controller, err) { throw err } }
+
+  // First dispatch: creates C1, C1 emits connect (TTL timestamp recorded), returns true
+  pool.dispatch({ path: '/', method: 'GET' }, handler)
+  t.strictEqual(created, 1, 'C1 created')
+
+  // Wait for clientTtl to expire
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  // Second dispatch: C1's TTL expired → evicted (closed=true), C2 created.
+  // C2.dispatch returns false (mid-handshake) → C2[kNeedDrain]=true → pool at capacity.
+  pool.dispatch({ path: '/', method: 'GET' }, handler)
+  t.strictEqual(created, 2, 'C2 created after C1 evicted by TTL')
+
+  const c1 = clients[0]
+  t.strictEqual(c1.closed, true, 'C1 closed after TTL eviction')
+
+  // Third dispatch: C2 is at capacity and connections limit reached → item queued in pool
+  pool.dispatch({ path: '/', method: 'GET' }, handler)
+  t.strictEqual(pool.stats.queued, 1, 'request sits in pool queue while C2 is connecting')
+
+  // Simulate C1 completing an in-flight response — its stale drain listener fires.
+  // Without the fix kOnDrain(C1) dispatches the queued item to the closed C1,
+  // throwing ClientClosedError. With the fix it returns early for closed clients.
+  c1.emit('drain', new URL('http://notahost'), [c1])
+  t.ok(true, 'no ClientClosedError when evicted client emits drain')
+})


### PR DESCRIPTION
## Problem

When a Pool is configured with clientTtl, evicted clients can still emit drain events after being closed — typically when an in-flight request completes after the client has been removed from the pool. kOnDrain has no guard against this and will attempt to dispatch queued pool items to the closed client, throwing ClientClosedError.

The race window is narrow in low-latency environments (same-region) but widens significantly with cross-region TLS connection times (hundreds of milliseconds), making the error reliably reproducible under load.

## Sequence that triggers the bug:

1. Pool has connections: 1. Client C1 is active, its clientTtl expires.
2. A new request arrives → kGetDispatcher evicts C1 (client.close(), kClosed = true), creates C2.
3. C2 starts a TLS handshake. While it's connecting, further requests fill the pool queue (kQueue), because C2 has kNeedDrain = true and the connections limit is reached.
4. C1 finishes an in-flight response → resume() → emitDrain() → C1.emit('drain').
5. kOnDrain(C1) dequeues an item from kQueue and calls C1.dispatch() → ClientClosedError.

## Fix

Return early in kOnDrain when the client is already closed or destroyed. The queued items remain in kQueue and are correctly drained when C2 connects and emits its own drain event.

## Why connections: 2 doesn't prevent this alone

The drain listener is added in kAddClient and bound to the specific client instance. kRemoveClient removes the client from kClients but never removes the listener. So even with a second connection available, the stale listener on C1 still fires and attempts to dispatch to C1.
