### PR TITLE
fix(interceptor/dump): reject aborted requests when response is smaller than maxSize

### DIFF
--- a/lib/interceptor/dump.js
+++ b/lib/interceptor/dump.js
@@ -84,7 +84,7 @@ class DumpHandler extends DecoratorHandler {
       return
     }
 
-    if (this.#controller.aborted === true) {
+    if (this.aborted === true) {
       super.onResponseError(controller, this.reason)
       return
     }

--- a/test/interceptors/dump-interceptor.js
+++ b/test/interceptors/dump-interceptor.js
@@ -199,6 +199,47 @@ test('Should dump on already aborted request', { skip }, async t => {
   await t.completed
 })
 
+test('Should reject aborted request when response is smaller than maxSize', { skip }, async t => {
+  t = tspl(t, { plan: 2 })
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'application/octet-stream'
+    })
+    res.end(Buffer.alloc(256))
+  })
+
+  const abc = new AbortController()
+
+  const requestOptions = {
+    method: 'GET',
+    path: '/',
+    signal: abc.signal
+  }
+
+  server.listen(0)
+
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose(dump({ maxSize: 512 }))
+
+  after(async () => {
+    await client.close()
+
+    server.close()
+    await once(server, 'close')
+  })
+
+  abc.abort()
+  client.request(requestOptions).catch(err => {
+    t.equal(err.name, 'AbortError')
+    t.equal(err.message, 'This operation was aborted')
+  })
+
+  await t.completed
+})
+
 test('Should dump response body up to limit (default)', { skip }, async t => {
   t = tspl(t, { plan: 3 })
   const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {


### PR DESCRIPTION
## This relates to...

Fixes #5684

## Rationale

`DumpHandler.onRequestStart` replaces `controller.abort` with its own method (`lib/interceptor/dump.js:31`), which only sets the handler-local `this.aborted`. The underlying `RequestController`'s `#aborted` field is only set inside its original `abort()` method (`lib/core/request.js:76-86`), which is shadowed by the hijack — so `controller.aborted` can never become `true` afterwards.

`onResponseStart` (line 48) and `onResponseData` (line 72) correctly check the handler-local `this.aborted`, but `onResponseEnd` (line 87) checked `this.#controller.aborted`, a condition that is always `false`.

Consequence: for an aborted request whose response body is smaller than `maxSize`, `onResponseStart` is swallowed and `onResponseEnd` forwards a normal end to a downstream handler that never saw `onResponseStart`. The `request()` promise never settles — it hangs forever. With a body larger than `maxSize`, the same abort correctly rejects with `AbortError` via the check in `onResponseData`, so the outcome of an abort currently depends on the response body size.

The existing test "Should dump on already aborted request" asserts the expected semantics (aborted request → `AbortError`), but only exercises the `body > maxSize` path.

## Changes

- `lib/interceptor/dump.js`: in `onResponseEnd`, check the handler-local `this.aborted` (consistent with `onResponseStart` and `onResponseData`) instead of the never-true `this.#controller.aborted`.
- `test/interceptors/dump-interceptor.js`: add a regression test mirroring "Should dump on already aborted request" with a response body (256 B) smaller than `maxSize` (512 B). Without the fix the test times out (the promise never settles); with the fix it rejects with `AbortError`.

### Features

N/A

### Bug Fixes

- Aborted requests through `interceptors.dump()` now reject with `AbortError` regardless of response body size, instead of hanging forever when the body is smaller than `maxSize`.

### Breaking Changes and Deprecations

N/A

## Test evidence

Regression test without the fix (lib change stashed):

```
node --test --test-timeout=8000 --test-name-pattern="smaller than maxSize" test/interceptors/dump-interceptor.js
  failureType: 'testTimeoutFailure'
  error: 'test timed out after 8000ms'
```

With the fix:

```
node --test test/interceptors/dump-interceptor.js
# tests 12
# pass 12
# fail 0
```

Full `test/interceptors/` suite with the fix: all 14 files pass (cache 87/87, decompress 27/27, deduplicate 34/34, dns 30 pass + 3 skip, dump 12/12, redirect 83/83, retry 16/16, response-error 6/6, ...). `npm run lint` passes.

Note: #4634 restructures the dump handler lifecycle but keeps the `this.#controller.aborted` check in `onResponseEnd`, so it does not address this hang. This one-line fix is independent and can land regardless.

_This fix was prepared with AI assistance; I reproduced the bug locally and reviewed every change._

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
