### PR TITLE
test: add unexpected disconnect guards to remaining http2 tests

### DIFF
--- a/test/http2-agent.js
+++ b/test/http2-agent.js
@@ -37,6 +37,12 @@ test('Agent should support H2 connection', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     origin: `https://localhost:${server.address().port}`,
     path: '/',

--- a/test/http2-alpn.js
+++ b/test/http2-alpn.js
@@ -63,6 +63,12 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for GET', async (t) => 
   // close the client on teardown
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   // make an undici request using where it wants http/2
   const response = await client.request({
     path: '/',
@@ -210,6 +216,12 @@ test('Should upgrade to HTTP/2 when HTTPS/1 is available for POST', async (t) =>
 
   // close the client on teardown
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   // make an undici request using where it wants http/2
   const response = await client.request({

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -45,6 +45,12 @@ test('Dispatcher#Stream', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   await client.stream(
     { path: '/', opaque: { bufs }, method: 'POST', body: expectedBody },
     ({ statusCode, headers, opaque: { bufs } }) => {
@@ -98,6 +104,12 @@ test('Dispatcher#Pipeline', async t => {
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   pipeline(
     new Readable({
@@ -159,6 +171,12 @@ test('Dispatcher#Connect', async t => {
     })
     after(() => forward.close())
 
+    forward.on('disconnect', () => {
+      if (!forward.closed && !forward.destroyed) {
+        t.fail('unexpected disconnect')
+      }
+    })
+
     try {
       const response = await forward.request({
         path: '/',
@@ -205,6 +223,12 @@ test('Dispatcher#Connect', async t => {
   after(() => client.close())
   after(() => proxy.close())
   after(() => server.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   const { statusCode, headers, socket } = await client.connect({ path: '/', headers: { 'x-my-header': 'foo' } })
   t.strictEqual(statusCode, 200)
@@ -589,6 +613,12 @@ test('Should handle h2 request without body', async t => {
   })
   after(() => client.close())
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const response = await client.request({
     path: '/',
     method: 'POST',
@@ -634,6 +664,12 @@ test('Should clear h2 request stream references before completing a response', a
     allowH2: true
   })
   after(() => client.close())
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
 
   let requestStreamIdSymbol = null
   let requestStreamSymbol = null
@@ -925,6 +961,12 @@ test('Should send http2 PING frames', async t => {
     server.close()
   })
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   client.dispatch({
     path: '/',
     method: 'PUT',
@@ -994,6 +1036,12 @@ test('Should not send http2 PING frames if interval === 0', async t => {
 
   after(async () => {
     server.close()
+  })
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
   })
 
   client.dispatch({
@@ -1066,6 +1114,12 @@ test('Should not send http2 PING frames after connection is closed', async t => 
   after(async () => {
     session.close()
     server.close()
+  })
+
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
   })
 
   client.dispatch({

--- a/test/http2-trailers.js
+++ b/test/http2-trailers.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const assert = require('node:assert')
-const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
 const { createSecureServer } = require('node:http2')
 const { once } = require('node:events')
 
@@ -10,10 +10,12 @@ const pem = require('@metcoder95/https-pem')
 const { Client } = require('..')
 
 test('Should handle http2 trailers', async t => {
+  t = tspl(t, { plan: 4 })
+
   const server = createSecureServer(pem)
   let client = null
 
-  t.after(async () => {
+  after(async () => {
     await client?.close()
     await new Promise(resolve => server.close(resolve))
   })
@@ -44,14 +46,22 @@ test('Should handle http2 trailers', async t => {
     allowH2: true
   })
 
+  client.on('disconnect', () => {
+    if (!client.closed && !client.destroyed) {
+      t.fail('unexpected disconnect')
+    }
+  })
+
   const { statusCode, headers, body, trailers } = await client.request({
     path: '/',
     method: 'PUT',
     body: 'hello'
   })
 
-  assert.strictEqual(statusCode, 200)
-  assert.strictEqual(headers['content-type'], 'text/plain; charset=utf-8')
-  assert.strictEqual(await body.text(), 'hello h2!')
-  assert.deepStrictEqual(trailers, { 'x-trailer': 'hello' })
+  t.strictEqual(statusCode, 200)
+  t.strictEqual(headers['content-type'], 'text/plain; charset=utf-8')
+  t.strictEqual(await body.text(), 'hello h2!')
+  t.deepStrictEqual(trailers, { 'x-trailer': 'hello' })
+
+  await t.completed
 })


### PR DESCRIPTION
Adds the disconnect guard pattern from `docs/docs/best-practices/writing-tests.md` to the remaining happy-path HTTP/2 test files, so silent disconnect/reconnect cycles fail the tests instead of passing unnoticed. Follow-up to #5533.

Files covered (13 guards): `http2-agent.js` (1, on an `Agent`), `http2-alpn.js` (2), `http2-trailers.js` (1, converted to tspl since every existing guard relies on tspl's `t.fail`), `http2-dispatcher.js` (9, including the `forward` client in `Dispatcher#Connect`).

Intentionally skipped: the upgrade/abort/destroy/reject tests in `http2-dispatcher.js` (disconnect expected or no connection), `http2-stream.js` (server destroys every stream), `http2-max-concurrent-streams-zero.js` (drain behavior under test), and 4 unit-test files that mock the h2 internals with no real connection (`http2-late-data.js`, `http2-response-after-completion.js`, `http2-window-size.js`, `http2-resume-null-request.js`).

Verified: all 23 tests pass, 10 consecutive full runs with no flakes, and a manual spot check confirmed the guard turns a mid-test session teardown into a failure instead of a silent reconnect.

Refs: #251
