### PR TITLE
fix: propagate dispatcher options to base class

### DIFF
--- a/lib/dispatcher/balanced-pool.js
+++ b/lib/dispatcher/balanced-pool.js
@@ -54,7 +54,7 @@ class BalancedPool extends PoolBase {
       throw new InvalidArgumentError('factory must be a function.')
     }
 
-    super()
+    super(opts)
 
     this[kOptions] = { ...util.deepClone(opts) }
     this[kIndex] = -1

--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -16,7 +16,7 @@ class EnvHttpProxyAgent extends DispatcherBase {
   #opts = null
 
   constructor (opts = {}) {
-    super()
+    super(opts)
     this.#opts = opts
 
     const { httpProxy, httpsProxy, noProxy, ...agentOpts } = opts

--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -120,7 +120,7 @@ class ProxyAgent extends DispatcherBase {
 
     const { proxyTunnel, connectTimeout } = opts
 
-    super()
+    super(opts)
 
     const url = this.#getUrl(opts)
     const { href, origin, port, protocol, username, password, hostname: proxyHostname } = url

--- a/lib/dispatcher/round-robin-pool.js
+++ b/lib/dispatcher/round-robin-pool.js
@@ -65,7 +65,7 @@ class RoundRobinPool extends PoolBase {
       })
     }
 
-    super()
+    super(options)
 
     this[kConnections] = connections || null
     this[kUrl] = util.parseOrigin(origin)

--- a/lib/dispatcher/socks5-proxy-agent.js
+++ b/lib/dispatcher/socks5-proxy-agent.js
@@ -29,7 +29,7 @@ let experimentalWarningEmitted = false
  */
 class Socks5ProxyAgent extends DispatcherBase {
   constructor (proxyUrl, options = {}) {
-    super()
+    super(options)
 
     // Emit experimental warning only once
     if (!experimentalWarningEmitted) {

--- a/test/websocket/dispatcher-options.js
+++ b/test/websocket/dispatcher-options.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { test } = require('node:test')
+const {
+  BalancedPool,
+  EnvHttpProxyAgent,
+  ProxyAgent,
+  RoundRobinPool,
+  Socks5ProxyAgent
+} = require('../..')
+
+const webSocket = {
+  maxFragments: 8,
+  maxPayloadSize: 1024
+}
+
+const dispatchers = {
+  BalancedPool: () => new BalancedPool([], { webSocket }),
+  EnvHttpProxyAgent: () => new EnvHttpProxyAgent({
+    httpProxy: '',
+    httpsProxy: '',
+    noProxy: '*',
+    webSocket
+  }),
+  ProxyAgent: () => new ProxyAgent({
+    uri: 'http://localhost',
+    webSocket
+  }),
+  RoundRobinPool: () => new RoundRobinPool('http://localhost', { webSocket }),
+  Socks5ProxyAgent: () => new Socks5ProxyAgent('socks5://localhost', { webSocket })
+}
+
+for (const [name, createDispatcher] of Object.entries(dispatchers)) {
+  test(`${name} applies WebSocket options`, async (t) => {
+    const dispatcher = createDispatcher()
+
+    t.after(() => dispatcher.close())
+
+    t.assert.deepStrictEqual(dispatcher.webSocketOptions, webSocket)
+  })
+}


### PR DESCRIPTION
Pass dispatcher options to `DispatcherBase` in proxy and pool wrappers so their configured WebSocket limits are exposed to the WebSocket parser instead of being replaced by the defaults.

Add regression coverage for `BalancedPool`, `RoundRobinPool`, `ProxyAgent`, `EnvHttpProxyAgent`, and `Socks5ProxyAgent`.