### PR TITLE
test(h2): swallow late session errors in the issue-5087 timeout tests

### DIFF
--- a/test/issue-5087.js
+++ b/test/issue-5087.js
@@ -11,6 +11,19 @@ test('https://github.com/nodejs/undici/issues/5087 bodyTimeout over h2 rejects w
   t = tspl(t, { plan: 3 })
 
   const server = createServer()
+
+  // A timed-out request is aborted client-side, so the server session and its
+  // socket can surface a late ECONNRESET after the test body has resolved. The
+  // runner turns that into a file-level failure with no failing assertion.
+  // Same swallow pattern as test/http2-abort.js, minus the TLS-only
+  // 'secureConnection' hook: these servers are h2c.
+  server.on('error', () => {})
+  server.on('connection', (socket) => socket.on('error', () => {}))
+  server.on('session', (session) => {
+    session.on('error', () => {})
+    session.socket?.on('error', () => {})
+  })
+
   server.on('stream', (stream) => {
     stream.respond({ ':status': 200, 'content-type': 'text/plain' })
     setTimeout(() => {
@@ -51,6 +64,19 @@ test('https://github.com/nodejs/undici/issues/5087 headersTimeout over h2 reject
   t = tspl(t, { plan: 3 })
 
   const server = createServer()
+
+  // A timed-out request is aborted client-side, so the server session and its
+  // socket can surface a late ECONNRESET after the test body has resolved. The
+  // runner turns that into a file-level failure with no failing assertion.
+  // Same swallow pattern as test/http2-abort.js, minus the TLS-only
+  // 'secureConnection' hook: these servers are h2c.
+  server.on('error', () => {})
+  server.on('connection', (socket) => socket.on('error', () => {}))
+  server.on('session', (session) => {
+    session.on('error', () => {})
+    session.socket?.on('error', () => {})
+  })
+
   server.on('stream', (stream) => {
     setTimeout(() => {
       try {
@@ -89,6 +115,19 @@ test('https://github.com/nodejs/undici/issues/5087 RetryAgent retries h2 body ti
 
   let hits = 0
   const server = createServer()
+
+  // A timed-out request is aborted client-side, so the server session and its
+  // socket can surface a late ECONNRESET after the test body has resolved. The
+  // runner turns that into a file-level failure with no failing assertion.
+  // Same swallow pattern as test/http2-abort.js, minus the TLS-only
+  // 'secureConnection' hook: these servers are h2c.
+  server.on('error', () => {})
+  server.on('connection', (socket) => socket.on('error', () => {}))
+  server.on('session', (session) => {
+    session.on('error', () => {})
+    session.socket?.on('error', () => {})
+  })
+
   server.on('stream', (stream) => {
     hits += 1
 


### PR DESCRIPTION
`test/issue-5087.js` is the last of the h2 timeout tests without the late-error guard that #5674 and #5686 added to its neighbours, and it has been failing CI on that.

From the Node 26 macOS job of run 31785340849:

```
✔ https://github.com/nodejs/undici/issues/5087 headersTimeout over h2 rejects with HeadersTimeoutError (56.61675ms)
ℹ Error: Test "... headersTimeout over h2 rejects with HeadersTimeoutError" at test/issue-5087.js:50:1
  generated asynchronous activity after the test ended. This activity created the error
  "Error: read ECONNRESET" and would have caused the test to fail, but instead triggered
  an uncaughtException event.
✖ /Users/runner/work/undici/undici/test/issue-5087.js
```

The assertion passed. All three tests here abort a request client-side once the timeout fires, so the server session and its socket can surface a late `ECONNRESET` after the body resolved, and the runner turns that into a file-level failure with no failing assertion to point at.

Same swallow pattern as `test/http2-abort.js`, applied to all three servers in the file rather than only the one that has been caught, since they have the same shape. The TLS-only `secureConnection` hook is replaced by `connection`, because these servers are h2c (`createServer`, `useH2c: true`), so `secureConnection` never fires here.

## What I ran

`npm run lint` clean. `test/issue-5087.js` on its own, five consecutive runs, 3 passing and 0 failing each time. `npm run test:unit` gives 1509 tests with 0 failures.

I could not reproduce the failure locally, so I cannot claim the guard was observed catching it: I am on Windows and Node 22, and the log above is macOS and Node 26. What the local runs establish is that the guard does not change any outcome that was already green.

For context on why this one matters beyond the file: the same late-error class in `test/http2-request-never-settles.js` is currently the only red check on #5663 and #5665, and on #5670.
