### PR TITLE
fix: forward onBodySent/onRequestSent through interceptor handlers

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -173,6 +173,14 @@ class CacheHandler {
     this.#handler.onRequestStart?.(controller, context)
   }
 
+  onBodySent (chunk) {
+    this.#handler.onBodySent?.(chunk)
+  }
+
+  onRequestSent () {
+    this.#handler.onRequestSent?.()
+  }
+
   onRequestUpgrade (controller, statusCode, headers, socket) {
     this.#handler.onRequestUpgrade?.(controller, statusCode, headers, socket)
   }

--- a/lib/handler/decorator-handler.js
+++ b/lib/handler/decorator-handler.js
@@ -62,5 +62,11 @@ module.exports = class DecoratorHandler {
   /**
    * @deprecated
    */
-  onBodySent () {}
+  onBodySent (...args) {
+    return this.#handler.onBodySent?.(...args)
+  }
+
+  onRequestSent (...args) {
+    return this.#handler.onRequestSent?.(...args)
+  }
 }

--- a/lib/handler/redirect-handler.js
+++ b/lib/handler/redirect-handler.js
@@ -43,6 +43,14 @@ class RedirectHandler {
     this.handler.onRequestStart?.(controller, { ...context, history: this.history })
   }
 
+  onBodySent (chunk) {
+    this.handler.onBodySent?.(chunk)
+  }
+
+  onRequestSent () {
+    this.handler.onRequestSent?.()
+  }
+
   onRequestUpgrade (controller, statusCode, headers, socket) {
     this.handler.onRequestUpgrade?.(controller, statusCode, headers, socket)
   }

--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -207,6 +207,14 @@ class RetryHandler {
     }
   }
 
+  onBodySent (chunk) {
+    this.handler.onBodySent?.(chunk)
+  }
+
+  onRequestSent () {
+    this.handler.onRequestSent?.()
+  }
+
   onRequestUpgrade (_controller, statusCode, headers, socket) {
     this.handler.onRequestUpgrade?.(this.controllerProxy, statusCode, headers, socket)
   }

--- a/test/decorator-handler.js
+++ b/test/decorator-handler.js
@@ -191,6 +191,42 @@ describe('DecoratorHandler', () => {
       })
     })
 
+    describe('#onBodySent', () => {
+      test('should delegate onBodySent-method', t => {
+        t = tspl(t, { plan: 1 })
+        const decorator = new DecoratorHandler({
+          onBodySent: (chunk) => {
+            t.equal(chunk, 'chunk')
+          }
+        })
+        decorator.onBodySent('chunk')
+      })
+
+      test('should not throw if onBodySent-method is not defined in the handler', t => {
+        t = tspl(t, { plan: 1 })
+        const decorator = new DecoratorHandler({})
+        t.doesNotThrow(() => decorator.onBodySent('chunk'))
+      })
+    })
+
+    describe('#onRequestSent', () => {
+      test('should delegate onRequestSent-method', t => {
+        t = tspl(t, { plan: 1 })
+        const decorator = new DecoratorHandler({
+          onRequestSent: () => {
+            t.ok(true)
+          }
+        })
+        decorator.onRequestSent()
+      })
+
+      test('should not throw if onRequestSent-method is not defined in the handler', t => {
+        t = tspl(t, { plan: 1 })
+        const decorator = new DecoratorHandler({})
+        t.doesNotThrow(() => decorator.onRequestSent())
+      })
+    })
+
     describe('#onResponseError', () => {
       test('should delegate onResponseError-method', t => {
         t = tspl(t, { plan: 1 })

--- a/test/interceptors/body-sent-hooks.js
+++ b/test/interceptors/body-sent-hooks.js
@@ -1,0 +1,99 @@
+'use strict'
+
+// Regression test for https://github.com/nodejs/undici/issues/5695
+// DecoratorHandler used to swallow onBodySent (empty method) and omit
+// onRequestSent, so composing any interceptor dropped those hooks.
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { Client, DecoratorHandler, interceptors } = require('../../')
+
+const BODY = '{"hello":"world"}'
+
+function dispatchAndTrack (dispatcher) {
+  const seen = { bodySent: [], requestSent: 0 }
+  return new Promise((resolve, reject) => {
+    dispatcher.dispatch(
+      {
+        method: 'POST',
+        path: '/',
+        headers: { 'content-type': 'application/json' },
+        body: BODY
+      },
+      {
+        onRequestStart () {},
+        onBodySent (chunk) {
+          seen.bodySent.push(Buffer.from(chunk).toString())
+        },
+        onRequestSent () {
+          seen.requestSent++
+        },
+        onResponseStart () {},
+        onResponseData () {},
+        onResponseEnd () {
+          resolve(seen)
+        },
+        onResponseError (_controller, err) {
+          reject(err)
+        }
+      }
+    )
+  })
+}
+
+async function withClient (t, compose) {
+  const server = createServer((req, res) => {
+    req.resume()
+    req.on('end', () => res.end('ok'))
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  let client = new Client(`http://localhost:${server.address().port}`)
+  if (compose) {
+    client = compose(client)
+  }
+  t.after(() => client.close())
+  return client
+}
+
+test('onBodySent/onRequestSent fire on a bare Client', async (t) => {
+  const client = await withClient(t)
+  const seen = await dispatchAndTrack(client)
+  t.assert.deepStrictEqual(seen.bodySent, [BODY])
+  t.assert.strictEqual(seen.requestSent, 1)
+})
+
+test('onBodySent/onRequestSent survive DecoratorHandler', async (t) => {
+  const client = await withClient(t, (c) =>
+    c.compose((dispatch) => (opts, handler) => dispatch(opts, new DecoratorHandler(handler)))
+  )
+  const seen = await dispatchAndTrack(client)
+  t.assert.deepStrictEqual(seen.bodySent, [BODY])
+  t.assert.strictEqual(seen.requestSent, 1)
+})
+
+test('onBodySent/onRequestSent survive interceptors.retry()', async (t) => {
+  const client = await withClient(t, (c) => c.compose(interceptors.retry()))
+  const seen = await dispatchAndTrack(client)
+  t.assert.deepStrictEqual(seen.bodySent, [BODY])
+  t.assert.strictEqual(seen.requestSent, 1)
+})
+
+test('onBodySent/onRequestSent survive interceptors.cache()', async (t) => {
+  const client = await withClient(t, (c) => c.compose(interceptors.cache()))
+  const seen = await dispatchAndTrack(client)
+  t.assert.deepStrictEqual(seen.bodySent, [BODY])
+  t.assert.strictEqual(seen.requestSent, 1)
+})
+
+test('onBodySent/onRequestSent survive interceptors.redirect()', async (t) => {
+  const client = await withClient(t, (c) =>
+    c.compose(interceptors.redirect({ maxRedirections: 0 }))
+  )
+  const seen = await dispatchAndTrack(client)
+  t.assert.deepStrictEqual(seen.bodySent, [BODY])
+  t.assert.strictEqual(seen.requestSent, 1)
+})


### PR DESCRIPTION
Fixes #5695.

`Request` only calls `onBodySent` / `onRequestSent` when those methods exist on the handler. `DecoratorHandler` defined `onBodySent` as a no-op, so the chunk was swallowed, and `onRequestSent` was missing entirely. `RetryHandler`, `RedirectHandler`, and `CacheHandler` wrap the user handler themselves and never forwarded either hook.

Composing `interceptors.retry()`, `redirect()`, `cache()`, or anything that extends `DecoratorHandler` therefore silently dropped both callbacks. They now pass through the same way `onRequestStart` already does.

## Test plan
- [x] `node --test test/decorator-handler.js test/interceptors/body-sent-hooks.js`
- [x] Bare `Client` still fires both hooks
- [x] Same after `DecoratorHandler`, `interceptors.retry()`, `interceptors.cache()`, and `interceptors.redirect()`

Made with [Cursor](https://cursor.com)