### PR TITLE
perf(h1): drop idle-socket timer floor with a ref'd setImmediate

### DIFF
--- a/benchmarks/fetch/sequential-keepalive.mjs
+++ b/benchmarks/fetch/sequential-keepalive.mjs
@@ -1,0 +1,48 @@
+'use strict'
+
+import { createServer } from 'node:http'
+import { Agent, fetch } from '../../index.js'
+
+const ITERATIONS = Number(process.env.SAMPLES ?? 2000)
+const WARMUP = 300
+
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end('{"ok":1}')
+})
+
+server.keepAliveTimeout = 65_000
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+const { port } = server.address()
+const url = `http://127.0.0.1:${port}/`
+const agent = new Agent({
+  keepAliveTimeout: 60_000,
+  connections: 1,
+  pipelining: 1
+})
+
+for (let i = 0; i < WARMUP; i++) {
+  await (await fetch(url, { dispatcher: agent })).text()
+}
+
+const times = new Array(ITERATIONS)
+for (let i = 0; i < ITERATIONS; i++) {
+  const t0 = process.hrtime.bigint()
+  await (await fetch(url, { dispatcher: agent })).text()
+  times[i] = Number(process.hrtime.bigint() - t0)
+}
+
+times.sort((a, b) => a - b)
+const pct = (p) => times[Math.min(ITERATIONS - 1, Math.floor(ITERATIONS * p))] / 1e6
+
+console.log(JSON.stringify({
+  iterations: ITERATIONS,
+  p50_ms: Number(pct(0.5).toFixed(3)),
+  p90_ms: Number(pct(0.9).toFixed(3)),
+  p99_ms: Number(pct(0.99).toFixed(3))
+}))
+
+await agent.close()
+server.close()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1052,7 +1052,7 @@ function onSocketClose () {
 
 function clearIdleSocketValidation (socket) {
   if (socket[kIdleSocketValidationTimeout]) {
-    clearTimeout(socket[kIdleSocketValidationTimeout])
+    clearImmediate(socket[kIdleSocketValidationTimeout])
     socket[kIdleSocketValidationTimeout] = null
   }
 
@@ -1061,15 +1061,23 @@ function clearIdleSocketValidation (socket) {
 
 function scheduleIdleSocketValidation (client, socket) {
   socket[kIdleSocketValidation] = 1
-  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+  // Yield to the check phase (after poll) so unsolicited bytes / FIN / RST
+  // already pending on this idle keep-alive socket are processed before the
+  // next request is written (GHSA-35p6-xmwp-9g52).
+  //
+  // setTimeout(0) pays Node's ~1ms timer floor on every sequential reuse
+  // (#5493). setImmediate avoids that, but an *unref'd* Immediate lets poll
+  // block for ~500ms when the event loop is otherwise idle (#5600 / #5606).
+  // A ref'd Immediate both keeps the pending request alive and makes poll
+  // return immediately — the hybrid those issues asked for.
+  socket[kIdleSocketValidationTimeout] = setImmediate(() => {
     socket[kIdleSocketValidationTimeout] = null
     socket[kIdleSocketValidation] = 2
 
     if (client[kSocket] === socket && !socket.destroyed) {
       client[kResume]()
     }
-  }, 0)
-  socket[kIdleSocketValidationTimeout].unref?.()
+  })
 }
 
 /**

--- a/test/node-test/keep-alive-reuse.js
+++ b/test/node-test/keep-alive-reuse.js
@@ -4,7 +4,7 @@ const { test } = require('node:test')
 const assert = require('node:assert')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { Pool } = require('../..')
+const { Agent, Pool, fetch } = require('../..')
 
 // Regression for #5600 / #5606:
 // Reusing an idle keep-alive socket must not stall behind the poll phase.
@@ -63,6 +63,52 @@ test('reusing an idle keep-alive socket must not stall', { timeout: 1000 }, asyn
 
     const res = await resPromise
     assert.strictEqual(await res.body.text(), 'ok')
+    assert.strictEqual(connections, 1, 'keep-alive socket must be reused')
+  }
+})
+
+test('fetch reusing an idle keep-alive socket must not stall', { timeout: 1000 }, async (t) => {
+  let connections = 0
+
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'content-length': 2 })
+    res.end('ok')
+  })
+
+  server.on('connection', () => {
+    connections++
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const url = `http://127.0.0.1:${server.address().port}`
+  const agent = new Agent({
+    connections: 1,
+    pipelining: 1,
+    keepAliveTimeout: 60_000
+  })
+
+  t.after(async () => {
+    await agent.close()
+    server.close()
+  })
+
+  {
+    const res = await fetch(`${url}/0`, { dispatcher: agent })
+    assert.strictEqual(await res.text(), 'ok')
+  }
+  assert.strictEqual(connections, 1)
+
+  for (let i = 1; i <= REUSES; i++) {
+    const requested = once(server, 'request')
+    const resPromise = fetch(`${url}/${i}`, { dispatcher: agent })
+    resPromise.catch(() => {})
+
+    await requested
+
+    const res = await resPromise
+    assert.strictEqual(await res.text(), 'ok')
     assert.strictEqual(connections, 1, 'keep-alive socket must be reused')
   }
 })


### PR DESCRIPTION
## This relates to...

- Split out of #5701 per review
- #5493 (idle-socket validation ~1.3ms timer floor)
- #5499 / #5606 (setImmediate revert due to unref'd Immediate poll stall)
- GHSA-35p6-xmwp-9g52 (response-queue poisoning; validation must stay)

## Rationale

Sequential `fetch()` / HTTP/1.1 keep-alive reuse was paying Node's `setTimeout(0)` timer floor (~1.3–1.5ms) on every request. That dominates loopback / low-RTT workloads.

`#5499` switched this to `setImmediate` and was reverted in `#5606` because an *unref'd* Immediate lets poll block for ~500ms when the event loop is otherwise idle.

## Changes

- Defer idle-socket validation with a **ref'd `setImmediate`** so it still runs after poll (poisoning protection) without the 1ms timer floor or the #5606 stall.
- Add a `fetch` keep-alive reuse stall regression test alongside the existing Pool test.
- Add `benchmarks/fetch/sequential-keepalive.mjs`.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Benchmarks

Re-run 2026-08-21 on Node v22.14.0 (linux x64, Intel Xeon, 4 cores). Medians of 5 runs vs `main` @ `181c293`.

Sequential keep-alive `fetch().text()` on loopback (`connections: 1`, `pipelining: 1`, 2000 iterations after 300 warmup):

| | p50 | p90 | p99 |
|---|---|---|---|
| main (`setTimeout(0)`) | 1.47 ms | 1.63 ms | 1.84 ms |
| this PR (`setImmediate`) | **0.20 ms** | **0.29 ms** | **0.48 ms** |

~7.5× faster at p50.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin