### PR TITLE
fix(socks5-proxy-agent): destroy socket when negotiation times out

### DIFF
--- a/lib/dispatcher/socks5-proxy-agent.js
+++ b/lib/dispatcher/socks5-proxy-agent.js
@@ -115,6 +115,7 @@ class Socks5ProxyAgent extends DispatcherBase {
     const authenticationReady = Promise.withResolvers()
 
     const authenticationTimeout = setTimeout(() => {
+      socks5Client.destroy()
       authenticationReady.reject(new Error('SOCKS5 authentication timeout'))
     }, 5000)
 
@@ -148,6 +149,7 @@ class Socks5ProxyAgent extends DispatcherBase {
     const connectionReady = Promise.withResolvers()
 
     const connectionTimeout = setTimeout(() => {
+      socks5Client.destroy()
       connectionReady.reject(new Error('SOCKS5 connection timeout'))
     }, 5000)
 

--- a/test/socks5-proxy-agent.js
+++ b/test/socks5-proxy-agent.js
@@ -428,6 +428,45 @@ test('Socks5ProxyAgent - connection failure', async (t) => {
   await p.completed
 })
 
+test('Socks5ProxyAgent - destroys socket when negotiation times out', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  // SOCKS5 proxy that accepts the TCP connection but never replies to the greeting
+  const stalledProxy = net.createServer(() => {})
+  await new Promise((resolve) => {
+    stalledProxy.listen(0, '127.0.0.1', resolve)
+  })
+
+  let connectorSocket
+  const agent = new Socks5ProxyAgent(`socks5://127.0.0.1:${stalledProxy.address().port}`, {
+    connect (opts, callback) {
+      const socket = net.connect({ host: opts.hostname, port: opts.port })
+      connectorSocket = socket
+      socket.once('connect', () => callback(null, socket))
+      socket.once('error', callback)
+      return socket
+    }
+  })
+
+  try {
+    await request('http://example.invalid/', {
+      dispatcher: agent
+    })
+    p.fail('should have thrown an error')
+  } catch (err) {
+    p.ok(err, 'should throw error when SOCKS5 negotiation stalls')
+  }
+
+  await agent.close()
+  p.ok(connectorSocket.destroyed, 'socket left by the timed out negotiation should be destroyed')
+
+  t.after(async () => {
+    stalledProxy.close()
+  })
+
+  await p.completed
+})
+
 test('Socks5ProxyAgent - proxy connection refused', async (t) => {
   const p = tspl(t, { plan: 1 })
 


### PR DESCRIPTION
## Summary

When SOCKS5 authentication or connection negotiation times out, `createSocks5Connection()` rejects its promise but never destroys the underlying socket. The socket also never reaches the per-origin pool because the connect callback is only invoked on success, so `close()` and `destroy()` cannot reach it and it stays open for the lifetime of the process. This destroys the client in both timeout branches before rejecting.

## Testing

Reproduced with a local TCP proxy that accepts a connection but never replies to the greeting: the request rejects with "SOCKS5 authentication timeout", after which `agent.close()` leaves the socket open. Added a regression test in `test/socks5-proxy-agent.js` that asserts the connector socket is destroyed after close; it fails without this change and passes with it. All socks5 test files pass (33 pass, 1 skipped) and eslint is clean.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
