### PR TITLE
fix(websocket): strip surrounding whitespace in parseExtensions

### DIFF
--- a/lib/web/websocket/util.js
+++ b/lib/web/websocket/util.js
@@ -210,8 +210,8 @@ function parseExtensions (extensions) {
     const [name, value = ''] = pair.split('=', 2)
 
     extensionList.set(
-      removeHTTPWhitespace(name, true, false),
-      removeHTTPWhitespace(value, false, true)
+      removeHTTPWhitespace(name, true, true),
+      removeHTTPWhitespace(value, true, true)
     )
 
     position.position++

--- a/test/websocket/util.js
+++ b/test/websocket/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { describe, test } = require('node:test')
-const { isValidSubprotocol } = require('../../lib/web/websocket/util')
+const { isValidSubprotocol, parseExtensions } = require('../../lib/web/websocket/util')
 
 describe('isValidSubprotocol', () => {
   test('empty string returns false', t => {
@@ -25,6 +25,26 @@ describe('isValidSubprotocol', () => {
 
     for (let i = 0; i < chars.length; ++i) {
       t.assert.strictEqual(isValidSubprotocol('valid' + chars[i]), false)
+    }
+  })
+})
+
+describe('parseExtensions', () => {
+  test('keeps whitespace out of parameter names and values', t => {
+    // Optional whitespace is allowed around the ";" and "=" delimiters of an
+    // extension header, so it must be stripped from both ends of every name
+    // and value before the map is keyed on them.
+    const cases = {
+      'permessage-deflate; client_max_window_bits': [['permessage-deflate', ''], ['client_max_window_bits', '']],
+      'permessage-deflate ; client_max_window_bits': [['permessage-deflate', ''], ['client_max_window_bits', '']],
+      'permessage-deflate;\tclient_max_window_bits': [['permessage-deflate', ''], ['client_max_window_bits', '']],
+      'permessage-deflate; server_max_window_bits = 10': [['permessage-deflate', ''], ['server_max_window_bits', '10']],
+      'permessage-deflate; server_max_window_bits=10 ': [['permessage-deflate', ''], ['server_max_window_bits', '10']]
+    }
+
+    t.plan(Object.keys(cases).length)
+    for (const [header, expected] of Object.entries(cases)) {
+      t.assert.deepStrictEqual([...parseExtensions(header).entries()], expected, header)
     }
   })
 })


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

`parseExtensions` in `lib/web/websocket/util.js` strips only leading whitespace from an extension parameter name and only trailing whitespace from its value:

```js
extensionList.set(
  removeHTTPWhitespace(name, true, false),
  removeHTTPWhitespace(value, false, true)
)
```

RFC 6455 section 9.1 defines `Sec-WebSocket-Extensions` on the RFC 7230 header grammar, which allows optional whitespace around the `;` and `=` delimiters. A spec-valid response header therefore keeps whitespace on the untrimmed side of a token, and it lands inside the map key or value:

```js
parseExtensions('permessage-deflate ; client_max_window_bits')
// Map(2) { 'permessage-deflate ' => '', 'client_max_window_bits' => '' }
```

The handshake then runs `extensions.has('permessage-deflate')` in `connection.js`, which is `false` because of the trailing space, and the connection is failed for a header the server was allowed to send. Parameter values have the mirror problem:

```js
parseExtensions('permessage-deflate; server_max_window_bits = 10')
// Map(2) { 'permessage-deflate' => '', 'server_max_window_bits ' => ' 10' }
```

`PerMessageDeflate` looks up `server_max_window_bits` and gets `undefined` (the key carries a trailing space), and even where the key matches, `isValidClientWindowBits(' 10')` rejects the leading space. The window size the server negotiated is dropped.

Only the whitespace handling is touched here; the wider section 9.1 work tracked by the existing TODO (comma-separated extension lists, quoted-string values) is left as is.

## Changes

Trim whitespace from both ends of the parameter name and value in `parseExtensions`.

### Features

N/A

### Bug Fixes

- `parseExtensions` no longer retains delimiter-adjacent whitespace in extension parameter names and values, so valid `Sec-WebSocket-Extensions` responses that use optional whitespace around `;`/`=` negotiate correctly. Covered by a new case in `test/websocket/util.js`.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
