### PR TITLE
fix(fetch): guard stream close after cancellation

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -661,8 +661,18 @@ function ReadableStreamFrom (iterable) {
         return iterator.next().then(({ done, value }) => {
           if (done) {
             return queueMicrotask(() => {
-              controller.close()
-              controller.byobRequest?.respond(0)
+              try {
+                controller.close()
+                controller.byobRequest?.respond(0)
+              } catch (err) {
+                // The consumer may have cancelled the stream while
+                // iterator.next() was still in flight, which closes the
+                // controller before we get here.
+                if (!err.message.includes('Controller is already closed') &&
+                    !err.message.includes('ReadableStream is already closed')) {
+                  throw err
+                }
+              }
             })
           } else {
             const buf = Buffer.isBuffer(value) ? value : Buffer.from(value)

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -661,18 +661,7 @@ function ReadableStreamFrom (iterable) {
         return iterator.next().then(({ done, value }) => {
           if (done) {
             return queueMicrotask(() => {
-              try {
-                controller.close()
-                controller.byobRequest?.respond(0)
-              } catch (err) {
-                // The consumer may have cancelled the stream while
-                // iterator.next() was still in flight, which closes the
-                // controller before we get here.
-                if (!err.message.includes('Controller is already closed') &&
-                    !err.message.includes('ReadableStream is already closed')) {
-                  throw err
-                }
-              }
+              readableStreamClose(controller)
             })
           } else {
             const buf = Buffer.isBuffer(value) ? value : Buffer.from(value)

--- a/test/fetch/readable-stream-from.js
+++ b/test/fetch/readable-stream-from.js
@@ -27,3 +27,38 @@ test('ReadableStream empty enqueue', async (t) => {
   const response = new Response(iterable)
   t.assert.deepStrictEqual(await response.text(), '')
 })
+
+// https://github.com/nodejs/undici/issues/5715
+test('ReadableStream cancellation while iterator.next() is in flight', async (t) => {
+  let resolveNext
+  let startNext
+  const nextStarted = new Promise((resolve) => {
+    startNext = resolve
+  })
+  const iterable = {
+    [Symbol.asyncIterator] () {
+      return {
+        next () {
+          startNext()
+          return new Promise((resolve) => {
+            resolveNext = resolve
+          })
+        },
+        return () {
+          return Promise.resolve({ done: true, value: undefined })
+        }
+      }
+    }
+  }
+
+  const reader = new Response(iterable).body.getReader()
+  const read = reader.read()
+  await nextStarted
+  await reader.cancel()
+  resolveNext({ done: true, value: undefined })
+  t.assert.deepStrictEqual(await read, { done: true, value: undefined })
+
+  // Let the microtask that closes the controller run. It must not throw if
+  // cancellation already closed the stream.
+  await new Promise((resolve) => setImmediate(resolve))
+})


### PR DESCRIPTION
## This relates to...

Fixes #5715.

## Rationale

`ReadableStreamFrom` defers closing its controller after an async iterator finishes. If the consumer cancels while `iterator.next()` is still pending, the delayed close runs against an already-closed controller and throws an uncatchable `ERR_INVALID_STATE`.

## Changes

### Features

N/A

### Bug Fixes

- Ignore the recognized already-closed controller errors when cancellation wins the race with the delayed close.
- Re-throw unexpected controller errors.
- Add a deterministic regression test that cancels while `iterator.next()` is in flight.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (not applicable)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
