### PR TITLE
fix(cookies): support valueless unparsed attributes in stringify

### DIFF
--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -328,6 +328,9 @@ function stringify (cookie) {
       const [key, ...value] = part.split('=')
 
       const trimmedKey = key.trim()
+      if (trimmedKey.length === 0) {
+        throw new Error('Invalid unparsed')
+      }
       const joinedValue = value.join('=')
 
       validateCookieName(trimmedKey)
@@ -336,6 +339,9 @@ function stringify (cookie) {
       out.push(`${trimmedKey}=${joinedValue}`)
     } else {
       const trimmedKey = part.trim()
+      if (trimmedKey.length === 0) {
+        throw new Error('Invalid unparsed')
+      }
       validateCookieName(trimmedKey)
       out.push(trimmedKey)
     }

--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -324,19 +324,21 @@ function stringify (cookie) {
   }
 
   for (const part of cookie.unparsed) {
-    if (!part.includes('=')) {
-      throw new Error('Invalid unparsed')
+    if (part.includes('=')) {
+      const [key, ...value] = part.split('=')
+
+      const trimmedKey = key.trim()
+      const joinedValue = value.join('=')
+
+      validateCookieName(trimmedKey)
+      validateCookieValue(joinedValue)
+
+      out.push(`${trimmedKey}=${joinedValue}`)
+    } else {
+      const trimmedKey = part.trim()
+      validateCookieName(trimmedKey)
+      out.push(trimmedKey)
     }
-
-    const [key, ...value] = part.split('=')
-
-    const trimmedKey = key.trim()
-    const joinedValue = value.join('=')
-
-    validateCookieName(trimmedKey)
-    validateCookieValue(joinedValue)
-
-    out.push(`${trimmedKey}=${joinedValue}`)
   }
 
   return out.join('; ')

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -793,4 +793,16 @@ test('Cookie setCookie supports valueless unparsed attributes (e.g. Partitioned)
     unparsed: ['Partitioned']
   })
   assert.equal(headers.get('Set-Cookie'), 'session=abc; Secure; Path=/; Partitioned')
+
+  assert.throws(() => {
+    setCookie(headers, { name: 'session', value: 'abc', unparsed: [''] })
+  }, /Invalid unparsed/)
+
+  assert.throws(() => {
+    setCookie(headers, { name: 'session', value: 'abc', unparsed: ['  '] })
+  }, /Invalid unparsed/)
+
+  assert.throws(() => {
+    setCookie(headers, { name: 'session', value: 'abc', unparsed: ['=val'] })
+  }, /Invalid unparsed/)
 })

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -782,3 +782,15 @@ test('Set-Cookie parser ignores an unparseable Expires', () => {
     value: 'a3fWa'
   }])
 })
+
+test('Cookie setCookie supports valueless unparsed attributes (e.g. Partitioned)', () => {
+  const headers = new Headers()
+  setCookie(headers, {
+    name: 'session',
+    value: 'abc',
+    secure: true,
+    path: '/',
+    unparsed: ['Partitioned']
+  })
+  assert.equal(headers.get('Set-Cookie'), 'session=abc; Secure; Path=/; Partitioned')
+})


### PR DESCRIPTION
## Summary

Allows `setCookie()` / `stringify()` to handle valueless (boolean) extension attributes in `cookie.unparsed`, such as `Partitioned` (CHIPS / RFC 6265bis) or other name-only extension flags, without throwing `Invalid unparsed`.

## Motivation & Background

RFC 6265bis section 5.4 defines `extension-av` as containing either `name=value` or name-only attributes (e.g. `Partitioned`). Previously, `stringify()` in `lib/web/cookies/util.js` strictly required every entry in `cookie.unparsed` to include an `=` character, throwing `new Error('Invalid unparsed')` when passing valueless attributes.

```ts
const headers = new Headers()
setCookie(headers, {
  name: 'session',
  value: 'abc',
  secure: true,
  path: '/',
  unparsed: ['Partitioned']
})
// Before: throws Error: Invalid unparsed
// After: Set-Cookie: session=abc; Secure; Path=/; Partitioned
```

## Changes

- Update `stringify()` in `lib/web/cookies/util.js` to branch on `part.includes('=')`:
  - If `=`, validate name & value and format as `name=value`.
  - If no `=`, validate name against cookie-name grammar and format as `name`.
- Add regression test in `test/cookie/cookies.js`.

## Verification

- `node --test test/cookie/*.js`: **92/92 tests pass**.
- `npm run test:unit`: **1,517/1,517 tests pass** (0 failures).
- `npm run lint`: Clean (0 warnings, 0 errors).
