### PR TITLE
types: expose PendingInterceptor and PendingInterceptorsFormatter on the MockAgent namespace

### DIFF
--- a/test/types/mock-agent.test-d.ts
+++ b/test/types/mock-agent.test-d.ts
@@ -78,6 +78,22 @@ expectAssignable<MockAgent>(new MockAgent({}))
       format(pendingInterceptors: readonly PendingInterceptor[]): string;
     }
   }) => void>(agent.assertNoPendingInterceptors)
+
+  // the same types have to be reachable from outside the package
+  expectAssignable<MockAgent.PendingInterceptor>({
+    origin: 'http://localhost',
+    path: '/',
+    method: 'GET',
+    data: { error: null, statusCode: 200, data: '', headers: {}, trailers: {} },
+    consumed: false,
+    times: null,
+    persist: false
+  })
+  expectAssignable<MockAgent.PendingInterceptorsFormatter>({
+    format (pendingInterceptors: readonly MockAgent.PendingInterceptor[]): string {
+      return String(pendingInterceptors.length)
+    }
+  })
 }
 
 // issue #3444

--- a/types/mock-agent.d.ts
+++ b/types/mock-agent.d.ts
@@ -6,10 +6,6 @@ import { MockCallHistory } from './mock-call-history'
 
 export default MockAgent
 
-interface PendingInterceptor extends MockDispatch {
-  origin: string;
-}
-
 /** A mocked Agent class that implements the Agent API. It allows one to intercept HTTP requests made through undici and return mocked responses instead. */
 declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.Options> extends Dispatcher {
   constructor (options?: TMockAgentOptions)
@@ -40,17 +36,22 @@ declare class MockAgent<TMockAgentOptions extends MockAgent.Options = MockAgent.
   enableCallHistory (): this
   /** Disable call history. Any subsequence calls will then not be registered. */
   disableCallHistory (): this
-  pendingInterceptors (): PendingInterceptor[]
+  pendingInterceptors (): MockAgent.PendingInterceptor[]
   assertNoPendingInterceptors (options?: {
-    pendingInterceptorsFormatter?: PendingInterceptorsFormatter;
+    pendingInterceptorsFormatter?: MockAgent.PendingInterceptorsFormatter;
   }): void
 }
 
-interface PendingInterceptorsFormatter {
-  format(pendingInterceptors: readonly PendingInterceptor[]): string;
-}
-
 declare namespace MockAgent {
+  /** An interceptor that was registered on a mock dispatcher and has not been consumed yet. */
+  export interface PendingInterceptor extends MockDispatch {
+    origin: string;
+  }
+
+  export interface PendingInterceptorsFormatter {
+    format(pendingInterceptors: readonly PendingInterceptor[]): string;
+  }
+
   /** MockAgent options. */
   export interface Options extends Agent.Options {
     /** A custom agent to be encapsulated by the MockAgent. */


### PR DESCRIPTION
Fixes #5563.

Both interfaces are declared at the top level of `types/mock-agent.d.ts` and never exported, so a consumer writing a helper around `pendingInterceptors()`, or a custom `pendingInterceptorsFormatter`, has no way to name the argument type and ends up copying the declaration into their own code, where it then drifts from this one.

They move into the `MockAgent` namespace, next to `Options` and the other public members, and the two class members now point at the namespaced names. Nothing else in `types/` or `index.d.ts` referenced them, so this is additive for consumers and a no-op for the existing declarations.

`test/types/mock-agent.test-d.ts` gains an assertion that both names are reachable as `MockAgent.PendingInterceptor` and `MockAgent.PendingInterceptorsFormatter` from outside the module.
