### PR TITLE
test: make stale-while-revalidate cache update test deterministic

### DIFF
--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -3146,16 +3146,24 @@ describe('Cache Interceptor', () => {
       strictEqual(await res.body.text(), 'original-response')
     }
 
-    // Wait for background revalidation
-    await sleep(500)
-    equal(revalidationRequests, 1)
-
-    // Second stale request - should get updated content from cache
-    // (still within stale-while-revalidate window)
+    // Wait for the background revalidation to complete and the cache to be
+    // updated with the revalidated content. Poll until the cache actually
+    // returns the updated response instead of relying on a fixed sleep, which
+    // is flaky on slow/loaded CI runners (the revalidation round-trip plus
+    // cache write can take longer than a hardcoded delay).
     {
-      const res = await client.request(request)
-      strictEqual(await res.body.text(), 'updated-response')
+      const deadline = Date.now() + 5000
+      let body = 'original-response'
+      while (Date.now() < deadline && body === 'original-response') {
+        const res = await client.request(request)
+        body = await res.body.text()
+        if (body === 'original-response') {
+          await sleep(50)
+        }
+      }
+      strictEqual(body, 'updated-response')
       equal(requestsToOrigin, 1) // Still only one origin request
+      equal(revalidationRequests >= 1, true, 'Background revalidation should have occurred')
     }
   })
 


### PR DESCRIPTION
Fixes the flaky `stale-while-revalidate updates cache after background revalidation (receiving new data)` test in `test/interceptors/cache.js`, which intermittently fails on slow CI runners (e.g. macos) with `AssertionError: Expected values to be strictly equal: 'original-response' vs 'updated-response'`.

The test triggered a background revalidation (RFC 5861) and then slept a fixed `500ms` before asserting the cache had been updated with the revalidated content. On loaded runners the revalidation round-trip plus the cache write can take longer than that window, so the cache was still stale when asserted.

The fix replaces the fixed sleep with a poll that keeps issuing stale requests until the cache actually returns the updated response (bounded by a 5s deadline). This makes the test deterministic regardless of runner load: repeated stale requests are served from cache (so `requestsToOrigin` stays 1) and each triggers background revalidation, so `revalidationRequests >= 1` confirms revalidation occurred.

Verified by:
- running the full `test/interceptors/*.js` suite (323 tests, 0 failures)
- simulating a slow revalidation (800ms server delay) where the old fixed-sleep version reproduces the exact CI assertion error while the polling version passes
