### PR TITLE
test: restore /xhr to the WPT filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "test:websocket:autobahn": "node test/autobahn/client.js",
     "test:websocket:autobahn:report": "node test/autobahn/report.js",
     "test:wpt:setup": "node test/web-platform-tests/wpt-runner.mjs setup",
-    "test:wpt": "npm run test:wpt:setup && node test/web-platform-tests/wpt-runner.mjs run /fetch /mimesniff /websockets /serviceWorkers /eventsource",
+    "test:wpt": "npm run test:wpt:setup && node test/web-platform-tests/wpt-runner.mjs run /fetch /mimesniff /xhr /websockets /eventsource",
     "test:cache-tests": "node test/cache-interceptor/cache-tests.mjs --ci",
     "coverage": "npm run coverage:clean && cross-env NODE_V8_COVERAGE=./coverage/tmp npm run test:javascript && npm run coverage:report",
     "coverage:ci": "npm run coverage:clean && cross-env NODE_V8_COVERAGE=./coverage/tmp npm run test:javascript && npm run coverage:report:ci",

--- a/test/web-platform-tests/expectation.json
+++ b/test/web-platform-tests/expectation.json
@@ -39934,11 +39934,6 @@
       "success": true,
       "cases": [
         {
-          "name": "idl_test setup",
-          "success": false,
-          "message": "promise_test: Unhandled rejection with value: object \"ReferenceError: document is not defined\""
-        },
-        {
           "name": "idl_test validation",
           "success": true
         },
@@ -40691,6 +40686,11 @@
           "name": "ProgressEvent interface: new ProgressEvent(\"type\") must inherit property \"total\" with the proper type",
           "success": false,
           "message": "assert_equals: Unexpected exception when evaluating object expected null but got object \"ReferenceError: ProgressEvent is not defined\""
+        },
+        {
+          "name": "idl_test setup",
+          "success": false,
+          "message": "promise_test: Unhandled rejection with value: object \"ReferenceError: document is not defined\""
         }
       ]
     },
@@ -40750,10 +40750,6 @@
           "name": "Use text/xml as fallback MIME type, 2",
           "success": false,
           "message": "XMLHttpRequest is not defined"
-        },
-        {
-          "name": "Loading data…",
-          "success": true
         },
         {
           "name": "1) MIME types need to be parsed and serialized: text/html;charset=gbk",
@@ -41124,6 +41120,10 @@
           "name": "74) MIME types need to be parsed and serialized: \"text/html\"",
           "success": false,
           "message": "XMLHttpRequest is not defined"
+        },
+        {
+          "name": "Loading data…",
+          "success": true
         }
       ]
     },
@@ -42196,6 +42196,71 @@
     "xmlhttprequest-timeout-worker-twice.html?timeout%20fires%20normally%20with%20same%20timeout%20set%20twice": {
       "success": false,
       "cases": []
+    },
+    "abort-during-navigation.window.html": {
+      "success": true,
+      "cases": [
+        {
+          "name": "XHR should not fire abort or error events when cancelled by navigation",
+          "success": false,
+          "message": "document is not defined"
+        }
+      ]
+    },
+    "abort-progress-events.any.html": {
+      "success": true,
+      "cases": [
+        {
+          "name": "Events must not fire when state is UNSENT after abort()",
+          "success": false,
+          "message": "XMLHttpRequest is not defined"
+        },
+        {
+          "name": "Calling open/abort in readystatechange should not crash",
+          "success": false,
+          "message": "XMLHttpRequest is not defined"
+        }
+      ]
+    },
+    "sync-xhr-supported-by-permissions-policy.tentative.html": {
+      "success": true,
+      "cases": [
+        {
+          "name": "document.permissionsPolicy.features should advertise sync-xhr.",
+          "success": false,
+          "message": "document is not defined"
+        }
+      ]
+    },
+    "xmlhttprequest-sync-default-permissions-policy.tentative.sub.html": {
+      "success": true,
+      "cases": [
+        {
+          "name": "Default \"sync-xhr\" permissions policy [\"*\"] allows the top-level document.",
+          "success": false,
+          "message": "promise_test: Unhandled rejection with value: object \"[object Object]\""
+        },
+        {
+          "name": "Default \"sync-xhr\" permissions policy [\"*\"] allows same-origin iframes.",
+          "success": false,
+          "message": "document is not defined"
+        },
+        {
+          "name": "Default \"sync-xhr\" permissions policy [\"*\"] allows cross-origin iframes.",
+          "success": false,
+          "message": "document is not defined"
+        },
+        {
+          "name": "permissions policy \"sync-xhr\" can be disabled in cross-origin iframes using \"allow\" attribute.",
+          "success": false,
+          "message": "document is not defined"
+        },
+        {
+          "name": "permissions policy \"sync-xhr\" can be disabled in same-origin iframes using \"allow\" attribute.",
+          "success": false,
+          "message": "document is not defined"
+        }
+      ]
     }
   },
   "eventsource": {


### PR DESCRIPTION
Fixes #5710.

`/xhr` was dropped from the `test:wpt` filter in #4786, which is not mentioned in that PR's description and looks incidental. The practical effect is that undici lost WPT `FormData` coverage, because that suite lives under `/xhr/formdata` rather than under `/fetch`. The `xhr` subtree of `expectation.json` has been frozen since, while `fetch`, `websockets`, `eventsource` and `mimesniff` all moved on.

I ran the suite rather than assuming the stored data still held:

- `wpt-runner.mjs run /xhr` against the untouched committed expectations exits 0. 161 test files, 82 passing and 495 expected-fail subtests, matching the 583 stored `xhr` expectations. The runner exits non-zero only when a `success` value drifts, and none did, so the frozen data is still accurate.
- Full `npm run test:wpt` with the amended filter exits 0: 1201 test files, 4869 passing and 4537 expected-fail subtests. Nothing outside `xhr` moved.
- Re-running `/xhr` against the finished branch leaves the working tree byte identical, so the refresh is stable rather than churning on every run.

The expectations refresh is 83 lines, all inside the `xhr` subtree: four WPT test files added since the removal, recorded with their observed expected-fail cases, plus two deterministic case-order moves. I diffed the parsed JSON to confirm that `xhr` is the only top-level subtree that changed.

This restores 82 passing subtests, roughly 60 of them `FormData` conformance: the `formdata/` suites plus the `FormData` block in `xhr/idlharness`.

`/serviceWorkers` is dropped from the same list. The WPT directory is `service-workers` and the filter is a case-sensitive `startsWith` on the pathname, so the argument has never matched anything. I confirmed it empirically: `wpt-runner.mjs run /serviceWorkers` reports 0 test files, and `expectation.json` has never had a key for it. Correcting the spelling instead would be the wrong move, since those tests are browser scoped and the runner's skip guard matches `serviceworker` without the hyphen, so removing the dead argument is a no-op.

One tradeoff to be aware of: the `xhr` suite adds roughly two minutes to a `test:wpt` invocation. Until #5588 lands, that cost falls on every local `npm test`, which is presumably why the removal went unnoticed. If you would rather have the coverage without the whole suite, the runner supports the narrower `/xhr/formdata`; I restored the full `/xhr` since it is the exact revert of what was dropped and its expectations verifiably still hold.
