### PR TITLE
fix(retry): reject invalid resumed responses

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -293,18 +293,6 @@ class RetryHandler {
     this.statusCode = statusCode
     this.headers = headers
 
-    if (statusCode >= 300) {
-      const err = new RequestRetryError('Request failed', statusCode, {
-        headers,
-        data: {
-          count: this.retryCount
-        }
-      })
-
-      this.onResponseStartWithRetry(controller, statusCode, headers, statusMessage, err)
-      return
-    }
-
     // Checkpoint for resume from where we left it
     if (this.headersSent) {
       // Only Partial Content 206 supposed to provide Content-Range,
@@ -344,6 +332,18 @@ class RetryHandler {
       assert(this.start === start, 'content-range mismatch')
       assert(this.end == null || this.end === end, 'content-range mismatch')
 
+      return
+    }
+
+    if (statusCode >= 300) {
+      const err = new RequestRetryError('Request failed', statusCode, {
+        headers,
+        data: {
+          count: this.retryCount
+        }
+      })
+
+      this.onResponseStartWithRetry(controller, statusCode, headers, statusMessage, err)
       return
     }
 

--- a/test/retry-agent.js
+++ b/test/retry-agent.js
@@ -4,6 +4,7 @@ const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
+const { Writable } = require('node:stream')
 
 const { RetryAgent, Client } = require('..')
 test('Should retry status code', async t => {
@@ -65,3 +66,61 @@ test('Should retry status code', async t => {
 
   await t.completed
 })
+
+for (const throwOnError of [true, false]) {
+  test(`Should reject a non-206 response when resuming a partially consumed response | throwOnError: ${throwOnError}`, async context => {
+    const t = tspl(context, { plan: 4 })
+
+    let requestCount = 0
+    const chunks = []
+    const server = createServer((req, res) => {
+      if (requestCount++ === 0) {
+        res.writeHead(200, { 'content-length': '12' })
+        res.write('AAAA')
+        const socket = res.socket
+        setTimeout(() => socket.destroy(), 50)
+        return
+      }
+
+      t.equal(req.headers.range, 'bytes=4-11')
+      res.writeHead(412, { 'content-length': '8' })
+      res.end('XXXXXXXX')
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+    const agent = new RetryAgent(client, {
+      throwOnError,
+      maxRetries: 3,
+      minTimeout: 10,
+      maxTimeout: 10
+    })
+
+    context.after(async () => {
+      await agent.close()
+      server.close()
+      await once(server, 'close')
+    })
+
+    await t.rejects(agent.stream({
+      method: 'GET',
+      path: '/'
+    }, ({ statusCode }) => {
+      t.equal(statusCode, 200)
+      return new Writable({
+        write (chunk, encoding, callback) {
+          chunks.push(chunk)
+          callback()
+        }
+      })
+    }), {
+      code: 'UND_ERR_REQ_RETRY',
+      message: 'server does not support the range header and the payload was partially consumed'
+    })
+
+    t.equal(Buffer.concat(chunks).toString(), 'AAAA')
+    await t.completed
+  })
+}


### PR DESCRIPTION
## Summary

- validate resumed responses before generic status-code retry handling
- reject non-`206` continuations after response bytes have already been forwarded
- cover both `throwOnError` modes and verify that continuation bytes are not appended downstream

## Rationale

Once a response has been partially consumed, a retry can only continue it with a valid `206 Partial Content` response. Previously, responses with a status code of 300 or greater were handled before the continuation checks, allowing an invalid continuation body to be forwarded to the existing downstream stream.

## Tests

- `npm run lint`
- `node --test test/retry-handler.js test/retry-handler2.js test/retry-agent.js test/retry-handler-controller-proxy.js test/client-retry-resume-backpressure.js test/http2-goaway-retry-body.js` (56 passed)
- `node --test test/issue-3934.js test/issue-5087.js test/issue-5137.js test/issue-3356.js test/issue-4691.js` (8 passed)
