### PR TITLE
test(h2): cover stream reset with NGHTTP2_INTERNAL_ERROR

### DIFF
--- a/test/http2-stream-internal-error.js
+++ b/test/http2-stream-internal-error.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { createServer, constants } = require('node:http2')
+const { once } = require('node:events')
+const { Agent } = require('..')
+
+// A stream reset before the response headers arrive must settle the request
+// promise rather than leave it pending. Streams closed with an explicit error
+// code surface an ERR_HTTP2_STREAM_ERROR carrying that code, which is a
+// different path from a plain stream.close().
+
+test('request rejects when the stream is reset with NGHTTP2_INTERNAL_ERROR', async (t) => {
+  const server = createServer()
+  server.on('stream', (stream) => {
+    // The server side emits 'error' for its own reset stream as well.
+    stream.on('error', () => {})
+    stream.close(constants.NGHTTP2_INTERNAL_ERROR)
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  const origin = `http://localhost:${server.address().port}`
+  const dispatcher = new Agent({ useH2c: true })
+  t.after(() => dispatcher.close())
+
+  await assert.rejects(
+    dispatcher.request({ origin, path: '/', method: 'GET' }),
+    (err) => {
+      assert.strictEqual(err.code, 'ERR_HTTP2_STREAM_ERROR')
+      assert.strictEqual(err.http2ErrorCode, constants.NGHTTP2_INTERNAL_ERROR)
+      return true
+    }
+  )
+})
+
+test('a reset stream does not prevent other requests from completing', async (t) => {
+  const server = createServer()
+  server.on('stream', (stream, headers) => {
+    stream.on('error', () => {})
+    if (headers[':path'] === '/bad') {
+      stream.close(constants.NGHTTP2_INTERNAL_ERROR)
+    } else {
+      stream.respond({ ':status': 200 })
+      stream.end('ok')
+    }
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  t.after(() => server.close())
+
+  const origin = `http://localhost:${server.address().port}`
+  const dispatcher = new Agent({ connections: 1, useH2c: true })
+  t.after(() => dispatcher.close())
+
+  await assert.rejects(
+    dispatcher.request({ origin, path: '/bad', method: 'GET' }),
+    { code: 'ERR_HTTP2_STREAM_ERROR' }
+  )
+
+  const res = await dispatcher.request({ origin, path: '/good', method: 'GET' })
+  assert.strictEqual(res.statusCode, 200)
+  assert.strictEqual(await res.body.text(), 'ok')
+})


### PR DESCRIPTION
A stream reset before the response headers arrive settles the request promise
with `ERR_HTTP2_STREAM_ERROR`, carrying the reset code in `http2ErrorCode`.
That is a different path from a plain `stream.close()`, which surfaces an
`InformationalError`:

| server sends | `code` | `http2ErrorCode` |
| --- | --- | --- |
| `stream.close()` | `UND_ERR_INFO` | – |
| `stream.close(INTERNAL_ERROR)` | `ERR_HTTP2_STREAM_ERROR` | `2` |
| `stream.close(CANCEL)` | `UND_ERR_INFO` | – |

`test/http2-destroy-after-failed-stream.js` covers the first row, and the only
existing use of `NGHTTP2_INTERNAL_ERROR` in the test suite is a session-level
`goaway()`. The stream-level reset path is currently untested.

### Changes

Adds two tests:

- a request whose stream is reset with `NGHTTP2_INTERNAL_ERROR` rejects with
  the expected `code` and `http2ErrorCode`
- the failed stream does not prevent other requests on the same connection
  from completing

No production code is changed; this only pins down existing behaviour.

I verified the tests actually catch a regression by removing the
`state.abort(err)` call in `onError` (reproducing the behaviour reported in
 #2675) and confirming both tests fail, then restoring it.

Refs: https://github.com/nodejs/undici/issues/2675
