### PR TITLE
fix(retry): forward rawHeaders writes through RetryController

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -65,7 +65,18 @@ class RetryController {
   get aborted () { return this.target?.aborted ?? false }
   get reason () { return this.target?.reason ?? null }
   get rawHeaders () { return this.target?.rawHeaders ?? null }
+  set rawHeaders (value) {
+    if (this.target) {
+      this.target.rawHeaders = value
+    }
+  }
+
   get rawTrailers () { return this.target?.rawTrailers ?? null }
+  set rawTrailers (value) {
+    if (this.target) {
+      this.target.rawTrailers = value
+    }
+  }
 }
 
 class RetryHandler {

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -51,6 +51,47 @@ test('should decompress gzip response', async t => {
   await t.completed
 })
 
+test('retry composed before decompress can rewrite rawHeaders', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const data = 'ok'
+  const compressed = gzipSync(data)
+  const server = createServer({ joinDuplicateHeaders: true }, (_req, res) => {
+    res.writeHead(200, {
+      'content-encoding': 'gzip',
+      'content-length': String(compressed.length)
+    })
+    res.end(compressed)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose([
+    interceptors.retry({ maxRetries: 0 }),
+    interceptors.decompress()
+  ])
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/',
+    headers: { 'accept-encoding': 'gzip' }
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(await response.body.text(), data)
+
+  await t.completed
+})
+
 test('should preserve trailers when decompressing response', async t => {
   const data = 'Response with trailers'
   const compressed = gzipSync(data)

--- a/test/retry-handler-controller-proxy.js
+++ b/test/retry-handler-controller-proxy.js
@@ -56,11 +56,13 @@ test('controller proxy returns safe defaults and is a no-op before a connection 
     proxy.pause()
     proxy.resume()
     proxy.abort(new Error('ignored'))
+    proxy.rawHeaders = ['x', 'y']
+    proxy.rawTrailers = ['z', '1']
   })
 })
 
 test('controller proxy forwards reads/writes to the active connection and stays stable across callbacks', (t) => {
-  t = tspl(t, { plan: 9 })
+  t = tspl(t, { plan: 11 })
 
   let downstreamController = null
   let upgradeController = null
@@ -101,6 +103,14 @@ test('controller proxy forwards reads/writes to the active connection and stays 
   downstreamController.resume()
   downstreamController.abort('stop')
   t.deepStrictEqual(connection.calls, ['pause', 'resume', ['abort', 'stop']])
+
+  // Decompress (and other interceptors) rewrite rawHeaders/rawTrailers on the
+  // controller they were given. Those assignments must reach the active
+  // connection instead of throwing on a getter-only proxy.
+  downstreamController.rawHeaders = ['x-foo', 'bar']
+  downstreamController.rawTrailers = ['x-end', '1']
+  t.deepStrictEqual(connection.rawHeaders, ['x-foo', 'bar'])
+  t.deepStrictEqual(connection.rawTrailers, ['x-end', '1'])
 
   // An upgrade on the same dispatch is forwarded through the very same proxy
   // instance (not the raw controller), keeping the downstream wiring stable.


### PR DESCRIPTION
Fixes #5726

`RetryController` forwarded `rawHeaders` / `rawTrailers` as getters only. `DecompressHandler` assigns a filtered list onto `controller.rawHeaders` when it strips `content-encoding`, so the documented order `compose([retry(), decompress()])` threw:

```
TypeError: Cannot set property rawHeaders of #<RetryController> which has only a getter
```

This adds setters that write through to the active connection controller (no-ops before a connection is attached, same as `pause`/`resume`).

**Tests**
- Before: `test/retry-handler-controller-proxy.js` failed with the getter-only TypeError; `retry composed before decompress can rewrite rawHeaders` failed.
- After: those tests pass, plus the full decompress interceptor file (28), retry-handler (47), and interceptors/retry (16).