### PR TITLE
fix(fetch): dump the body of a 3xx response that will be followed

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2218,6 +2218,7 @@ async function httpNetworkFetch (
         {
           body: null,
           abort: null,
+          dumpBody: false,
 
           onRequestStart (controller) {
             // TODO (fix): Do we need connection here?
@@ -2265,6 +2266,12 @@ async function httpNetworkFetch (
 
             const willFollow = location && request.redirect === 'follow' &&
               redirectStatusSet.has(status)
+
+            // https://tools.ietf.org/html/rfc7231#section-6.4
+            // The body of a 3xx response that will be followed is never exposed,
+            // so it is discarded as it arrives. Buffering it would leave the
+            // socket unread and pin it for the lifetime of the redirect chain.
+            this.dumpBody = willFollow
 
             const decoders = []
 
@@ -2335,7 +2342,7 @@ async function httpNetworkFetch (
           },
 
           onResponseData (controller, chunk) {
-            if (fetchParams.controller.dump) {
+            if (fetchParams.controller.dump || this.dumpBody) {
               return
             }
 

--- a/test/fetch/redirect.js
+++ b/test/fetch/redirect.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { fetch } = require('../..')
+const { fetch, Agent } = require('../..')
 const { closeServerAsPromise } = require('../utils/node-http')
 
 // https://github.com/nodejs/undici/issues/1776
@@ -72,6 +72,31 @@ test('Redirecting with a body does not fail to write body - #2543', async (t) =>
     method: 'POST',
     body: 'body'
   })
+  t.assert.strictEqual(await resp.text(), 'ok')
+  t.assert.ok(resp.redirected)
+})
+
+// https://github.com/nodejs/undici/issues/5728
+test('Following a redirect with a large body releases the connection - #5728', async (t) => {
+  const redirectBody = Buffer.alloc(128 * 1024, 0x78)
+
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    if (req.url === '/redirect') {
+      res.writeHead(301, { location: '/target' })
+      res.end(redirectBody)
+    } else {
+      res.end('ok')
+    }
+  }).listen(0)
+
+  const dispatcher = new Agent({ connections: 1, keepAliveTimeout: 10_000 })
+
+  t.after(closeServerAsPromise(server))
+  t.after(() => dispatcher.destroy())
+  await once(server, 'listening')
+
+  const resp = await fetch(`http://localhost:${server.address().port}/redirect`, { dispatcher })
+  t.assert.strictEqual(resp.status, 200)
   t.assert.strictEqual(await resp.text(), 'ok')
   t.assert.ok(resp.redirected)
 })


### PR DESCRIPTION
## This relates to...

Fixes https://github.com/nodejs/undici/issues/5728

## Rationale

When `fetch()` follows a redirect, the body of the 3xx response is pushed into a `Readable` that nothing ever reads. Once the buffered body exceeds the stream highWaterMark, `push()` returns `false` and the socket is paused.

Nothing resumes it. The call that resumes the socket lives in that stream's `read()`, and `read()` only fires when a consumer pulls from the stream. For a followed redirect the response is never exposed to the caller, so no consumer is ever attached: resuming the socket requires reading the body, and the reader only appears once the redirect chain has been followed. The connection stays in a running state and is never returned to the pool.

With a pooled dispatcher this is worse than a single stalled request, since every redirect pins a connection until the `connections` limit is exhausted. In the reported case a 301 carrying a 128 KiB body with `Agent({ connections: 1 })` makes `fetch()` never settle, and the follow-up request never reaches the server at all.

`RedirectHandler` already discards 3xx bodies on the dispatcher path, citing RFC 7231 section 6.4. This applies the same behaviour to the fetch path.

## Changes

The fix reuses the `willFollow` value that `onResponseStart` already computes for content-encoding handling, and discards the chunks in `onResponseData` instead of pushing them into the stream.

The flag is stored on the dispatch handler rather than on `fetchParams.controller`. The controller is created once per `fetch()` call and shared across the whole redirect chain, so setting `dump` there would also discard the final response body. The handler object is created per dispatch, which scopes the change to the redirect response alone.

### Features

N/A

### Bug Fixes

- The body of a 3xx response that will be followed is now discarded as it arrives, so the connection is released instead of being pinned for the lifetime of the redirect chain.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
