### PR TITLE
fix(cache): refetch when 304 adds vary fields

### DIFF
--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -6,7 +6,15 @@ const util = require('../core/util')
 const CacheHandler = require('../handler/cache-handler')
 const MemoryCacheStore = require('../cache/memory-cache-store')
 const CacheRevalidationHandler = require('../handler/cache-revalidation-handler')
-const { assertCacheStore, assertCacheMethods, makeCacheKey, normalizeHeaders, parseCacheControlHeader, isInvalidOrWildcardVaryHeader } = require('../util/cache.js')
+const {
+  assertCacheStore,
+  assertCacheMethods,
+  makeCacheKey,
+  normalizeHeaders,
+  parseCacheControlHeader,
+  isInvalidOrWildcardVaryHeader,
+  parseVaryHeader
+} = require('../util/cache.js')
 const { AbortError } = require('../core/errors.js')
 const { parseHttpDate } = require('../util/date.js')
 
@@ -133,6 +141,25 @@ function revalidationResponseDisallowsCachedReuse (cacheType, headers) {
 
 function revalidationResponseUpdatesCacheControl (headers) {
   return headers['cache-control'] !== undefined
+}
+
+/**
+ * @param {import('../../types/cache-interceptor.d.ts').default.GetResult} result
+ * @param {Record<string, string | string[] | null> | undefined} varyDirectives
+ * @returns {boolean}
+ */
+function revalidationResponseAddsVary (result, varyDirectives) {
+  if (!varyDirectives) {
+    return false
+  }
+
+  for (const key in varyDirectives) {
+    if (result.vary == null || !Object.hasOwn(result.vary, key)) {
+      return true
+    }
+  }
+
+  return false
 }
 
 function deleteCachedValue (store, cacheKey) {
@@ -471,6 +498,13 @@ function handleResult (
 
               if (revalidationResponseUpdatesCacheControl(headers)) {
                 deleteCachedValue(globalOpts.store, cacheKey)
+              } else if (revalidationResponseAddsVary(result, headers.vary ? parseVaryHeader(headers.vary, opts.headers) : undefined)) {
+                if (util.isStream(result.body)) {
+                  result.body.on('error', nop).destroy()
+                }
+
+                deleteCachedValue(globalOpts.store, cacheKey)
+                return dispatch(opts, new CacheHandler(globalOpts, cacheKey, handler))
               }
             }
 

--- a/test/interceptors/cache-async-store.js
+++ b/test/interceptors/cache-async-store.js
@@ -117,6 +117,82 @@ describe('cache interceptor with async store', () => {
     strictEqual(count304, 1)
   })
 
+  test('synchronous 304 revalidation refetches when Vary adds a request header', async () => {
+    const clock = FakeTimers.install({ now: 1, toFake: ['Date'] })
+    let count200 = 0
+    let count304 = 0
+
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      res.sendDate = false
+      res.setHeader('date', new Date(clock.now).toUTCString())
+
+      if (req.headers['if-none-match']) {
+        count304++
+        res.statusCode = 304
+        res.setHeader('vary', 'x-variant')
+        res.end()
+        return
+      }
+
+      count200++
+      res.setHeader('cache-control', `public, max-age=${count200 === 1 ? 10 : 60}`)
+      res.setHeader('etag', `"response-${count200}"`)
+
+      if (count200 === 1) {
+        res.end('cached')
+      } else {
+        res.setHeader('vary', 'x-variant')
+        res.end(`variant ${req.headers['x-variant']}`)
+      }
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const store = new AsyncCacheStore()
+    const dispatcher = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache({ store }))
+    const url = `http://localhost:${server.address().port}`
+    const makeRequest = variant => request(url, {
+      dispatcher,
+      headers: {
+        'x-variant': variant
+      }
+    })
+
+    try {
+      {
+        const res = await makeRequest('a')
+        strictEqual(await res.body.text(), 'cached')
+      }
+
+      clock.tick(12000)
+
+      {
+        const res = await makeRequest('b')
+        strictEqual(await res.body.text(), 'variant b')
+        strictEqual(count304, 1)
+        strictEqual(count200, 2)
+      }
+
+      {
+        const res = await makeRequest('c')
+        strictEqual(await res.body.text(), 'variant c')
+        strictEqual(count200, 3)
+      }
+
+      {
+        const res = await makeRequest('b')
+        strictEqual(await res.body.text(), 'variant b')
+        strictEqual(count200, 3)
+      }
+    } finally {
+      await dispatcher.close()
+      await new Promise(resolve => server.close(resolve))
+      clock.uninstall()
+    }
+  })
+
   test('stale-while-revalidate 200 refreshes cache with async store', async () => {
     const clock = FakeTimers.install({ now: 1 })
     after(() => clock.uninstall())

--- a/test/interceptors/cache.js
+++ b/test/interceptors/cache.js
@@ -810,7 +810,6 @@ describe('Cache Interceptor', () => {
     let serverError
     const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.setHeader('date', 0)
-      res.setHeader('cache-control', 'max-age=1, stale-while-revalidate=10')
 
       try {
         const ifNoneMatch = req.headers['if-none-match']
@@ -821,9 +820,11 @@ describe('Cache Interceptor', () => {
           notEqual(req.headers['b-mixed-case'], undefined)
 
           res.statusCode = 304
+          res.setHeader('vary', 'a, B-MIXED-CASe')
           res.end()
         } else {
           requestsToOrigin++
+          res.setHeader('cache-control', 'max-age=1')
           res.setHeader('vary', 'a, B-MIXED-CASe')
           res.setHeader('etag', '"asd"')
           res.end('asd')
@@ -888,8 +889,6 @@ describe('Cache Interceptor', () => {
       strictEqual(await response.body.text(), 'asd')
     }
 
-    // Wait for background revalidation to complete
-    await sleep(100)
     strictEqual(revalidationRequests, 1)
   })
 
@@ -1600,6 +1599,88 @@ describe('Cache Interceptor', () => {
         await new Promise(resolve => server.close(resolve))
         clock.uninstall()
       }
+    }
+  })
+
+  test('304 synchronous revalidation refetches when Vary adds a request header', async () => {
+    const clock = FakeTimers.install({
+      toFake: ['Date']
+    })
+
+    let requestsToOrigin = 0
+    let conditionalRequests = 0
+    let unconditionalRefetches = 0
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      requestsToOrigin++
+      res.setHeader('date', new Date().toUTCString())
+
+      if (req.headers['if-none-match'] || req.headers['if-modified-since']) {
+        conditionalRequests++
+        res.statusCode = 304
+        res.setHeader('vary', 'x-variant')
+        res.end()
+        return
+      }
+
+      if (requestsToOrigin === 1) {
+        res.setHeader('cache-control', 'public, max-age=1')
+        res.setHeader('etag', '"cached"')
+        res.end('cached')
+        return
+      }
+
+      unconditionalRefetches++
+      res.setHeader('cache-control', 'public, max-age=60')
+      res.setHeader('etag', `"variant-${req.headers['x-variant']}"`)
+      res.setHeader('vary', 'x-variant')
+      res.end(`variant ${req.headers['x-variant']}`)
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.cache())
+
+    try {
+      await once(server, 'listening')
+
+      const request = variant => ({
+        origin: 'localhost',
+        method: 'GET',
+        path: '/',
+        headers: {
+          'x-variant': variant
+        }
+      })
+
+      {
+        const res = await client.request(request('a'))
+        equal(requestsToOrigin, 1)
+        strictEqual(await res.body.text(), 'cached')
+      }
+
+      clock.tick(1500)
+
+      {
+        const res = await client.request(request('b'))
+        equal(conditionalRequests, 1)
+        equal(unconditionalRefetches, 1)
+        strictEqual(await res.body.text(), 'variant b')
+      }
+
+      {
+        const res = await client.request(request('c'))
+        equal(unconditionalRefetches, 2)
+        strictEqual(await res.body.text(), 'variant c')
+      }
+
+      {
+        const res = await client.request(request('b'))
+        equal(requestsToOrigin, 4)
+        strictEqual(await res.body.text(), 'variant b')
+      }
+    } finally {
+      await client.close()
+      await new Promise(resolve => server.close(resolve))
+      clock.uninstall()
     }
   })
 


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

Foreground `304 Not Modified` revalidation bypasses `CacheHandler`'s metadata update path. If that response introduces a valid `Vary` field that is absent from the stored entry, the cached variant metadata remains incomplete.

## Changes

### Features

N/A

### Bug Fixes

- Detect newly introduced `Vary` request-header fields during synchronous revalidation.
- Evict the stale entry and refetch through `CacheHandler` so the replacement is stored with complete variant metadata.
- Add regression coverage for synchronous and asynchronous cache stores.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented (no documentation changes needed)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
