### PR TITLE
docs: name the parameters these two blocks describe

### DIFF
--- a/lib/cache/memory-cache-store.js
+++ b/lib/cache/memory-cache-store.js
@@ -87,7 +87,7 @@ class MemoryCacheStore extends EventEmitter {
   }
 
   /**
-   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} req
+   * @param {import('../../types/cache-interceptor.d.ts').default.CacheKey} key
    * @returns {import('../../types/cache-interceptor.d.ts').default.GetResult | undefined}
    */
   get (key) {

--- a/lib/web/webidl/index.js
+++ b/lib/web/webidl/index.js
@@ -26,9 +26,9 @@ const webidl = {
 /**
  * @description Instantiate an error.
  *
- * @param {Object} opts
- * @param {string} opts.header
- * @param {string} opts.message
+ * @param {Object} message
+ * @param {string} message.header
+ * @param {string} message.message
  * @returns {TypeError}
  */
 webidl.errors.exception = function (message) {


### PR DESCRIPTION
## This relates to...

Nothing filed, I ran into it while reading the cache store.

## Rationale

`MemoryCacheStore.get` documents its argument as `req`, while the method takes `key` and the two neighbours in the same class, `createWriteStream` and `delete`, both document `key`. The webidl one is the more confusing of the two: `webidl.errors.exception` documents `opts`, `opts.header` and `opts.message`, but the parameter is called `message` and the body reads `message.header` and `message.message`, so the documented name collides with a field name. Its two siblings, `conversionFailed` and `invalidArgument`, name the bag `opts` and `context` and document exactly that.

## Changes

Comments only, no runtime change.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
