### PR TITLE
fix(agent): preserve pools with pending GOAWAY replays

### DIFF
--- a/lib/dispatcher/agent.js
+++ b/lib/dispatcher/agent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { InvalidArgumentError, MaxOriginsReachedError } = require('../core/errors')
-const { kBusy, kClients, kConnected, kRunning, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
+const { kBusy, kClients, kConnected, kRunning, kPending, kClose, kDestroy, kDispatch, kUrl } = require('../core/symbols')
 const DispatcherBase = require('./dispatcher-base')
 const Pool = require('./pool')
 const Client = require('./client')
@@ -97,7 +97,12 @@ class Agent extends DispatcherBase {
           return
         }
 
-        if (dispatcher[kConnected] > 0 || dispatcher[kBusy]) {
+        // A GOAWAY detaches the HTTP/2 session before requeued requests are
+        // dispatched on a replacement connection. At that point the pool has
+        // no connected clients and is not busy, but it still has pending work.
+        // Closing it here lets the replacement Client finish those requests
+        // and then destroys that new connection with ClientDestroyedError.
+        if (dispatcher[kConnected] > 0 || dispatcher[kBusy] || dispatcher[kPending] > 0) {
           return
         }
 

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -7,7 +7,7 @@ const { once, EventEmitter } = require('node:events')
 
 const pem = require('@metcoder95/https-pem')
 
-const { Client, Pool } = require('..')
+const { Agent, Client, Pool, fetch } = require('..')
 
 test('#3046 - GOAWAY Frame', async t => {
   t = tspl(t, { plan: 8 })
@@ -202,6 +202,92 @@ test('#5468 - requeue multiplexed requests after mid-burst GOAWAY', async (t) =>
   t.ok(streams >= requests - 1)
 
   await t.completed
+})
+
+test('Agent keeps a Pool with requests requeued after GOAWAY', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  let firstSession = null
+  const sessionCounts = new Map()
+
+  server.on('session', (session) => {
+    sessionCounts.set(session, 0)
+    firstSession ??= session
+  })
+
+  server.on('stream', (stream) => {
+    stream.on('error', () => {})
+
+    const count = sessionCounts.get(stream.session) + 1
+    sessionCounts.set(stream.session, count)
+
+    // The first request warms the session. Accept two requests from the burst,
+    // then refuse the remaining streams so the Client has to requeue them.
+    if (stream.session === firstSession && count === 3) {
+      firstSession.goaway(constants.NGHTTP2_NO_ERROR, stream.id)
+    }
+
+    stream.respond({ ':status': 200 })
+    setTimeout(() => {
+      if (!stream.destroyed) {
+        stream.end('ok')
+      }
+    }, 150)
+  })
+
+  await once(server.listen(0), 'listening')
+
+  let pool = null
+  const agent = new Agent({
+    factory (origin) {
+      pool = new Pool(origin, {
+        connections: 1,
+        connect: {
+          rejectUnauthorized: false
+        }
+      })
+      return pool
+    }
+  })
+  const disconnectErrors = []
+  agent.on('disconnect', (_origin, _targets, err) => {
+    disconnectErrors.push(err)
+  })
+
+  t.after(async () => {
+    agent.removeAllListeners('disconnect')
+    await agent.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const url = `https://localhost:${server.address().port}`
+  const warmup = await fetch(url, { dispatcher: agent })
+  await warmup.text()
+
+  const disconnected = once(agent, 'disconnect')
+  const requests = Array.from({ length: 6 }, async () => {
+    const response = await fetch(url, {
+      dispatcher: agent,
+      signal: AbortSignal.timeout(3000)
+    })
+
+    return `${response.status}:${await response.text()}`
+  })
+
+  await disconnected
+  const poolWasClosed = pool.closed
+  const results = await Promise.allSettled(requests)
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  // GOAWAY detaches the session before the refused requests are replayed. The
+  // Pool must remain open while those requests are pending; otherwise its
+  // replacement Client is destroyed as soon as the replay finishes.
+  t.assert.deepStrictEqual(results, Array(6).fill(null).map(() => ({
+    status: 'fulfilled',
+    value: '200:ok'
+  })))
+  t.assert.deepStrictEqual(disconnectErrors.map(err => err.code), ['UND_ERR_INFO'])
+  t.assert.strictEqual(poolWasClosed, false)
 })
 
 test('#5089 - Handle GOAWAY Gracefully', async (t) => {


### PR DESCRIPTION
## This relates to...

Spurious `ClientDestroyedError` disconnects can occur while using `fetch()` with `AbortSignal.timeout()` against an HTTP/2 destination that sends GOAWAY.

## Rationale

When GOAWAY detaches an HTTP/2 session, refused requests are moved back to the Client's pending queue before a replacement connection is opened. During that window the owning Agent sees no connected or busy dispatcher and closes the Pool, despite the pending replays. Once those requests finish on the replacement Client, the closing Pool destroys it and emits an unexpected `UND_ERR_DESTROYED` disconnect.

Before this change the regression produced disconnect codes:

```text
UND_ERR_INFO
UND_ERR_DESTROYED
```

The second disconnect is internal cleanup rather than a request failure.

## Changes

### Features

N/A

### Bug Fixes

- Keep an Agent-managed dispatcher alive while it has pending requests.
- Add HTTP/2 regression coverage using concurrent `fetch()` requests, `AbortSignal.timeout(3000)`, and a server-issued GOAWAY.
- Assert that requeued requests complete and only the expected GOAWAY informational disconnect is emitted.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

### Validation

- `npm run test:h2:core` — 104 passed, 2 skipped
- `npx borp --timeout 180000 -p "test/node-test/agent.js"` — 35 passed
- `npx borp --timeout 180000 -p "test/issue-4806.js"` — passed
- `npx eslint lib/dispatcher/agent.js test/http2-goaway.js` — passed

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
