### PR TITLE
fix(websocket): defer close()/fail() events to a queued task when CONNECTING

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -317,10 +317,12 @@ function failWebsocketConnection (handler, code, reason, cause) {
   if (isConnecting(handler.readyState)) {
     // If the connection was not established, there is no underlying socket
     // whose asynchronous 'close' event would otherwise trigger onSocketClose
-    // later. Queue a task to invoke it here instead, so the 'error' and
-    // 'close' events fire after (not during) the caller's close()/send()/etc,
-    // per https://websockets.spec.whatwg.org/#feedback-from-the-protocol
-    process.nextTick(() => handler.onSocketClose())
+    // later. The spec's "queue a task" is a macrotask, not a microtask, so
+    // use setImmediate (not process.nextTick) to invoke it here instead —
+    // this way the 'error' and 'close' events fire after (not during) the
+    // caller's close()/send()/etc, per
+    // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
+    setImmediate(() => handler.onSocketClose())
   } else if (handler.socket?.destroyed === false) {
     handler.socket.destroy()
   }

--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -315,8 +315,12 @@ function failWebsocketConnection (handler, code, reason, cause) {
   handler.controller.abort()
 
   if (isConnecting(handler.readyState)) {
-    // If the connection was not established, we must still emit an 'error' and 'close' events
-    handler.onSocketClose()
+    // If the connection was not established, there is no underlying socket
+    // whose asynchronous 'close' event would otherwise trigger onSocketClose
+    // later. Queue a task to invoke it here instead, so the 'error' and
+    // 'close' events fire after (not during) the caller's close()/send()/etc,
+    // per https://websockets.spec.whatwg.org/#feedback-from-the-protocol
+    process.nextTick(() => handler.onSocketClose())
   } else if (handler.socket?.destroyed === false) {
     handler.socket.destroy()
   }

--- a/lib/web/websocket/stream/websocketstream.js
+++ b/lib/web/websocket/stream/websocketstream.js
@@ -136,6 +136,12 @@ class WebSocketStream {
       addAbortListener(signal, () => {
         // 8.3.1. If the WebSocket connection is not yet established : [WSP]
         if (!isEstablished(this.#handler.readyState)) {
+          // Set this 's handshake aborted to true before failing the
+          // connection, so that #onSocketClose (which failWebsocketConnection
+          // triggers, possibly asynchronously) defers to the rejections below
+          // instead of settling these promises itself.
+          this.#handshakeAborted = true
+
           // 8.3.1.1. Fail the WebSocket connection .
           failWebsocketConnection(this.#handler)
 
@@ -145,9 +151,6 @@ class WebSocketStream {
           // Reject this 's opened promise and closed promise with signal ’s abort reason .
           this.#openedPromise.reject(signal.reason)
           this.#closedPromise.reject(signal.reason)
-
-          // Set this 's handshake aborted to true.
-          this.#handshakeAborted = true
         }
       })
     }

--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -640,7 +640,6 @@ class WebSocket extends EventTarget {
     //    attribute initialized to the result of applying UTF-8
     //    decode without BOM to the WebSocket connection close
     //    reason.
-    // TODO: process.nextTick
     fireEvent('close', this, (type, init) => new CloseEvent(type, init), {
       wasClean, code, reason
     })

--- a/test/websocket/close.js
+++ b/test/websocket/close.js
@@ -2,6 +2,7 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { describe, test, after } = require('node:test')
+const { createServer } = require('node:net')
 const { WebSocketServer } = require('ws')
 const { WebSocket } = require('../..')
 
@@ -147,6 +148,30 @@ describe('Close', () => {
       ws.close(1000)
       ws.close(1000)
     })
+
+    await t.completed
+  })
+
+  // Regression test for https://github.com/nodejs/undici/issues/4741
+  test('close() while CONNECTING fires error/close asynchronously, not during close()', async (t) => {
+    t = tspl(t, { plan: 1 })
+
+    // Accepts the TCP connection but never responds, so the WebSocket
+    // handshake never completes and the client stays in CONNECTING.
+    const server = createServer((socket) => socket.resume())
+    after(() => server.close())
+
+    await new Promise((resolve) => server.listen(0, resolve))
+
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`)
+
+    let closeReturned = false
+    ws.addEventListener('close', () => {
+      t.ok(closeReturned, 'close event must fire after close() returns')
+    })
+
+    ws.close()
+    closeReturned = true
 
     await t.completed
   })

--- a/test/websocket/issue-4628.js
+++ b/test/websocket/issue-4628.js
@@ -4,10 +4,8 @@ const assert = require('node:assert')
 const { test } = require('node:test')
 const { WebSocket } = require('../..')
 
-test('closing before connection is established should only fire error and close events once', (t) => {
+test('closing before connection is established should only fire error and close events once', async (t) => {
   t.plan(2)
-
-  t.after(() => assert.deepStrictEqual(events, ['error', 'close']))
 
   const events = []
   const ws = new WebSocket('wss://example.com/')
@@ -19,10 +17,15 @@ test('closing before connection is established should only fire error and close 
     events.push('error')
   })
 
-  ws.addEventListener('close', () => {
-    t.assert.ok(true, 'close event fired')
-    events.push('close')
+  await new Promise((resolve) => {
+    ws.addEventListener('close', () => {
+      t.assert.ok(true, 'close event fired')
+      events.push('close')
+      resolve()
+    })
+
+    ws.close()
   })
 
-  ws.close()
+  assert.deepStrictEqual(events, ['error', 'close'])
 })

--- a/test/websocket/stream/abort-before-open.js
+++ b/test/websocket/stream/abort-before-open.js
@@ -33,11 +33,11 @@ test('WebSocketStream aborts before handshake completes', async (t) => {
 
   const [opened, closed] = await Promise.allSettled([wss.opened, wss.closed])
 
+  // Per the spec, aborting before the handshake completes rejects both
+  // promises with the abort signal's own reason.
   t.assert.strictEqual(opened.status, 'rejected')
-  t.assert.strictEqual(opened.reason.name, 'WebSocketError')
-  t.assert.strictEqual(opened.reason.message, 'Socket never opened')
+  t.assert.strictEqual(opened.reason.message, 'abort before open')
 
   t.assert.strictEqual(closed.status, 'rejected')
-  t.assert.strictEqual(closed.reason.name, 'WebSocketError')
-  t.assert.strictEqual(closed.reason.message, 'unclean close')
+  t.assert.strictEqual(closed.reason.message, 'abort before open')
 })


### PR DESCRIPTION
Fixes #4741.

## The bug

`close()` (and the internal "fail the WebSocket connection" path) calls
`handler.onSocketClose()` synchronously when the socket is still
`CONNECTING`, so `error`/`close` fire *during* `close()` instead of after it
returns. For an already-established connection this doesn't happen —
`onSocketClose` is wired to the real socket's `'close'` event, which is
naturally async. `CONNECTING` is the one path with no real socket yet, so it
took a synchronous shortcut instead.

## The fix

`lib/web/websocket/connection.js`, `failWebsocketConnection`: when
`isConnecting(handler.readyState)`, queue the `onSocketClose()` call with
`setImmediate` instead of calling it inline. This is the single call site
that both `WebSocket` and `WebSocketStream` share for this path, so one
change fixes both.

I also removed the `// TODO: process.nextTick` comment that was sitting
directly above the `close` event dispatch in `websocket.js` — with the fix
now deferring the whole `onSocketClose()` call at its one synchronous
trigger point, that per-line TODO no longer applies.

### Why `setImmediate`, not `process.nextTick`

I looked through prior attempts at this exact issue before writing this
(there have been a few: #4745, #4835, #5078, #5088, #5372). On #4745,
@domenic flagged that the spec's "queue a task" is a macrotask, and a
microtask-based fix (that PR used a Promise microtask; the maintainer TODO
this repo already had suggested `process.nextTick`, which has the same
issue) doesn't really carry that semantics — `process.nextTick` drains
before the event loop's I/O/check phases, so it's still effectively "this
turn." `setImmediate` is the macrotask primitive, so it matches "queue a
task" correctly.

I deliberately *didn't* take on rewiring `establishWebSocketConnection`,
`closeWebSocketConnection`, or message-received handling the way @domenic's
comment on #4745 also suggested — those are already driven by the real
socket's async I/O callbacks, which already give correct task-boundary
semantics for free. The only place that was actually firing events
synchronously is the one `failWebsocketConnection` call site this PR
touches; broadening the change to already-correct code seemed like
unnecessary scope for this specific, reported bug.

### A related bug this surfaced

Fixing the timing exposed a latent ordering issue in `WebSocketStream`'s
abort handling (`stream/websocketstream.js`). Its abort listener set
`#handshakeAborted = true` *after* calling `failWebsocketConnection`, so
when `onSocketClose` used to run synchronously (nested inside that same
call), the flag wasn't set yet, and `onSocketClose`'s own "was never
connected" logic would settle `opened`/`closed` first — with a generic
`WebSocketError`, not the abort signal's actual reason, contradicting the
spec comment directly above it ("reject...with signal's abort reason").
Deferring `onSocketClose` flipped which side won that race, exposing it.
I moved the `#handshakeAborted = true` assignment before the
`failWebsocketConnection` call so the intended guard is honored regardless
of timing, and updated `test/websocket/stream/abort-before-open.js`
accordingly (it was asserting the old, incorrect race outcome).

## Testing

- Added a regression test in `test/websocket/close.js` that connects to a
  TCP server which accepts the connection but never responds (so the
  handshake never completes and the client stays `CONNECTING`
  deterministically), calls `close()`, and asserts the `close` event only
  fires after `close()` has returned.
- Negative control: reverted the fix locally and confirmed the new test
  fails with the exact reported symptom (event handler running inside the
  `close()` call stack), then restored the fix.
- Updated `test/websocket/issue-4628.js`, which asserted the old
  synchronous-firing behavior via `t.plan()` on a non-async test function —
  converted it to `async`/await the `close` event instead of assuming
  same-tick completion.
- `npm run test:websocket` — 143/143 passing.
- `npm run test:unit` — 1516/1520 passing, 4 skipped; the one flaky failure
  (`test/http2-dispatcher.js`, an HTTP/2 PING-frame-count timing assertion)
  is unrelated to this change, doesn't touch WebSocket code, and passes
  cleanly when run in isolation.
- `npm run lint` clean.
