### PR TITLE
fix: avoid duplicate release attempts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,17 @@ jobs:
             const version = require("./package.json").version
             const versionTag = `v${version}`
 
-            const { data: releases } = await github.rest.repos.listReleases({
-              owner,
-              repo
-            })
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: versionTag
+              })
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error
+              }
 
-            const currentMajor = versionTag.match(/^v\d+/)?.[0]
-            const previousRelease = releases.find((r) => {
-              return r.tag_name !== versionTag && r.tag_name.startsWith(`${currentMajor}.`)
-            })
-
-            if (versionTag !== previousRelease?.tag_name) {
               return versionTag
             }
 


### PR DESCRIPTION
The release workflow currently excludes the package's exact release tag before deciding whether to publish, causing unrelated `package.json` changes to queue duplicate releases. Look up the exact tag instead, return the version only when that tag does not exist, and propagate other API failures.
