### PR TITLE
fix(eventsource): validate Last-Event-ID on reconnect

### DIFF
--- a/lib/web/eventsource/eventsource.js
+++ b/lib/web/eventsource/eventsource.js
@@ -7,10 +7,13 @@ const { EventSourceStream } = require('./eventsource-stream')
 const { parseMIMEType } = require('../fetch/data-url')
 const { createFastMessageEvent } = require('../websocket/events')
 const { isNetworkError } = require('../fetch/response')
-const { kEnumerableProperty } = require('../../core/util')
+const { isValidHeaderValue, kEnumerableProperty } = require('../../core/util')
 const { environmentSettingsObject } = require('../fetch/util')
 const { createPotentialCORSRequest } = require('./util')
 const { getGlobalDispatcher } = require('../../global')
+const { isomorphicDecode } = require('../infra')
+
+const textEncoder = new TextEncoder()
 
 let experimentalWarned = false
 
@@ -342,8 +345,12 @@ class EventSource extends EventTarget {
       //         string, encoded as UTF-8.
       //      2. Set (`Last-Event-ID`, lastEventIDValue) in request's header
       //         list.
+      this.#request.headersList.delete('last-event-id', true)
       if (this.#state.lastEventId.length) {
-        this.#request.headersList.set('last-event-id', this.#state.lastEventId, true)
+        const lastEventId = isomorphicDecode(textEncoder.encode(this.#state.lastEventId))
+        if (isValidHeaderValue(lastEventId)) {
+          this.#request.headersList.set('last-event-id', lastEventId, true)
+        }
       }
 
       //   4. Fetch request and process the response obtained in this fashion, if any, as described earlier in this section.

--- a/test/eventsource/eventsource-reconnect.js
+++ b/test/eventsource/eventsource-reconnect.js
@@ -117,7 +117,50 @@ describe('EventSource - reconnect', () => {
     })
   })
 
-  test('Should reconnect and send lastEventId', async (t) => {
+  test('Should reconnect without an invalid lastEventId', { timeout: 2000 }, async (t) => {
+    let requestCount = 0
+    let secondRequestHeader
+    let resolveSecondRequest
+    let rejectSecondRequest
+    const secondRequest = new Promise((resolve, reject) => {
+      resolveSecondRequest = resolve
+      rejectSecondRequest = reject
+    })
+
+    const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      requestCount++
+      res.writeHead(200, 'OK', { 'Content-Type': 'text/event-stream' })
+
+      if (requestCount === 1) {
+        res.end('id: \x01poison\nretry: 0\n\n')
+      } else {
+        secondRequestHeader = req.headers['last-event-id']
+        res.end()
+        resolveSecondRequest()
+      }
+    })
+    await once(server.listen(0), 'listening')
+
+    const eventSourceInstance = new EventSource(`http://localhost:${server.address().port}`)
+    t.after(() => {
+      eventSourceInstance.close()
+      server.close()
+    })
+
+    let errorCount = 0
+    eventSourceInstance.onerror = () => {
+      if (++errorCount === 5) {
+        rejectSecondRequest(new Error('EventSource repeatedly failed before reconnecting'))
+      }
+    }
+
+    await secondRequest
+
+    t.assert.strictEqual(requestCount, 2)
+    t.assert.strictEqual(secondRequestHeader, undefined)
+  })
+
+  test('Should reconnect and UTF-8 encode lastEventId', async (t) => {
     t.plan(1)
     const clock = FakeTimers.install()
     after(() => clock.uninstall())
@@ -126,9 +169,9 @@ describe('EventSource - reconnect', () => {
 
     const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
       res.writeHead(200, 'OK', { 'Content-Type': 'text/event-stream' })
-      res.write('id: 1337\n\n')
+      res.write('id: …\n\n')
       if (++requestCount === 2) {
-        t.assert.strictEqual(req.headers['last-event-id'], '1337')
+        t.assert.strictEqual(req.headers['last-event-id'], Buffer.from('…').toString('latin1'))
       }
       res.end()
     })
@@ -137,6 +180,7 @@ describe('EventSource - reconnect', () => {
     const port = server.address().port
 
     const eventSourceInstance = new EventSource(`http://localhost:${port}`)
+    t.after(() => eventSourceInstance.close())
 
     await once(eventSourceInstance, 'open')
 


### PR DESCRIPTION
UTF-8 encode EventSource last event IDs before adding them to the internal request header list. Clear stale values and omit IDs that cannot be transported as HTTP header values, preventing repeated local reconnect failures while preserving valid Unicode IDs.

Refs: GHSA-q9qx-47rg-rhc7
