### PR TITLE
fix(fetch): drain redirect response bodies so pooled connections are released

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -1388,8 +1388,45 @@ function httpRedirectFetch (fetchParams, response) {
   // actualResponse.
   setRequestReferrerPolicyOnRedirect(request, actualResponse)
 
-  // 20. Return the result of running main fetch given fetchParams and true.
-  return mainFetch(fetchParams, true)
+  // The redirect response is never exposed, so nothing will ever read its body.
+  // Leaving the stream unread pins the connection it arrived on, and with a pooled
+  // dispatcher each redirect can hold a slot until the pool is exhausted.
+  // `request()` already discards 3xx bodies in RedirectHandler; do the same here.
+
+  // The redirect response is never exposed, so nothing will ever read its body.
+  // An unread stream leaves the connection it arrived on un-reusable, and with a
+  // pooled dispatcher each redirect can hold a slot until the pool is exhausted.
+  // `request()` already reads and discards 3xx bodies in RedirectHandler.
+  // The body cannot simply be cancelled here: the stream's cancel algorithm aborts
+  // fetchParams' controller, which would also abort the redirect we are about to follow.
+  return drainResponseBody(actualResponse).then(() => {
+    // 20. Return the result of running main fetch given fetchParams and true.
+    return mainFetch(fetchParams, true)
+  })
+}
+
+/**
+ * Reads a response body to completion and discards it, so the underlying
+ * connection can be released back to the pool.
+ */
+async function drainResponseBody (response) {
+  const stream = response.body?.stream
+
+  if (stream == null || stream.locked) {
+    return
+  }
+
+  const reader = stream.getReader()
+
+  try {
+    while (!(await reader.read()).done) {
+      // discarded on purpose
+    }
+  } catch {
+    // a failed drain must not fail the redirect
+  } finally {
+    reader.releaseLock()
+  }
 }
 
 // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch

--- a/test/fetch/redirect-body-drain.js
+++ b/test/fetch/redirect-body-drain.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { fetch, Agent } = require('../..')
+
+test('fetch does not pin a pooled connection on a redirect with an unread body', async (t) => {
+  // Large enough that the 3xx body does not fit in the stream's buffer, so an
+  // undrained body leaves the socket unusable for the follow-up request.
+  const redirectBody = Buffer.alloc(128 * 1024, 0x78)
+
+  const server = createServer((req, res) => {
+    if (req.url === '/redirect') {
+      res.writeHead(301, { Location: '/final' })
+      res.end(redirectBody)
+      return
+    }
+    res.end('ok')
+  })
+
+  // A single connection, so a pinned socket cannot be worked around.
+  const dispatcher = new Agent({ connections: 1, keepAliveTimeout: 10_000 })
+
+  t.after(async () => {
+    await dispatcher.destroy()
+    server.close()
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const url = `http://127.0.0.1:${server.address().port}/redirect`
+  const response = await fetch(url, { dispatcher, redirect: 'follow' })
+
+  assert.strictEqual(response.status, 200)
+  assert.strictEqual(await response.text(), 'ok')
+  assert.ok(response.redirected)
+})


### PR DESCRIPTION
Closes #5728.

`httpRedirectFetch` follows a redirect without ever consuming the 3xx response body. That response is never exposed to the caller, so nothing else reads it either, and the connection it arrived on stays unusable. With a pooled dispatcher each redirect can hold a slot, so a `connections: 1` agent deadlocks: the follow-up request queues behind a socket that is still holding an unread body.

`request()` does not have this problem. `RedirectHandler.onResponseData` swallows 3xx chunks but keeps reading them, which drains the socket. This makes `fetch` do the same.

## Why not just cancel the stream

That was my first attempt and it is wrong in a way worth recording. The body stream's cancel algorithm is:

```js
const cancelAlgorithm = (reason) => {
  if (!isCancelled(fetchParams)) {
    fetchParams.controller.abort(reason)
  }
}
```

It aborts `fetchParams`' controller, and `httpRedirectFetch` then calls `mainFetch` on that same controller, so cancelling the redirect body aborts the redirect you are about to follow. The repro still hung. Draining is the only option that frees the socket without touching the controller.

## Test

`test/fetch/redirect-body-drain.js`, close to the reporter's script: a 301 carrying 128 KiB, an `Agent` with `connections: 1`, and a follow-up that has to reuse that socket. It passes in ~25ms with the change and hangs until the timeout without it, so it fails for the right reason.

## Verification

- `test/redirect-request.js`, `test/redirect-stream.js`, `test/redirect-pipeline.js`: 109/109
- `test/fetch/*.js`: 457 passed / 13 failed, and the same 13 fail on an unmodified tree. They are the GC, finalizer and `--max-http-header-size` tests that need runner flags this invocation does not pass. I checked `fire-and-forget.js` specifically, since its name is close to this behaviour, and it fails identically with and without the change.
- eslint clean.

Draining does read the redirect body rather than discarding it unread, which matches what `RedirectHandler` already does for `request()`. If you would rather destroy the connection than read the body on large redirects, I am happy to change the approach.
