### PR TITLE
fix(fetch): keep a cloned request's abort chain alive across GC

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -29,6 +29,7 @@ const assert = require('node:assert')
 const { getMaxListeners, setMaxListeners, defaultMaxListeners } = require('node:events')
 
 const kAbortController = Symbol('abortController')
+const kClonedFrom = Symbol('clonedFrom')
 
 const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
   signal.removeEventListener('abort', abort)
@@ -809,7 +810,23 @@ class Request {
     }
 
     // 4. Return clonedRequestObject.
-    return fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    const clonedRequestObject = fromInnerRequest(
+      clonedRequest,
+      this.#dispatcher,
+      ac.signal,
+      getHeadersGuard(this.#headers)
+    )
+
+    // The abort travels source signal -> this request's controller -> the clone's
+    // controller, and each hop is only held weakly. Keep both alive while the clone is:
+    // its own controller, because only ac.signal is handed on and a signal does not keep
+    // its controller alive; and the request it was cloned from, which transitively keeps
+    // the rest of the chain alive when clones are cloned. Same reasoning as the
+    // constructor, see https://github.com/nodejs/undici/issues/1926.
+    clonedRequestObject[kAbortController] = ac
+    clonedRequestObject[kClonedFrom] = this
+
+    return clonedRequestObject
   }
 
   [nodeUtil.inspect.custom] (depth, options) {

--- a/test/fetch/clone-abort-after-gc.js
+++ b/test/fetch/clone-abort-after-gc.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { fetch, Request } = require('../..')
+const { closeServerAsPromise } = require('../utils/node-http')
+
+const hasGC = typeof global.gc !== 'undefined'
+
+test('a cloned request still aborts after garbage collection', async (t) => {
+  if (!hasGC) {
+    throw new Error('gc is not available. Run with \'--expose-gc\'.')
+  }
+
+  // A server that never responds, so only the abort can settle the fetch.
+  const server = createServer(() => {})
+  t.after(closeServerAsPromise(server))
+  server.listen(0)
+  await once(server, 'listening')
+
+  const controller = new AbortController()
+  let request = new Request(`http://localhost:${server.address().port}`, {
+    signal: controller.signal
+  })
+
+  // The request the clone came from is now unreachable. Its controller is only held
+  // weakly by the abort machinery, so collecting it used to break the chain that
+  // carries the abort through to the clone.
+  request = request.clone()
+
+  setTimeout(() => {
+    global.gc()
+    controller.abort()
+  }, 100)
+
+  await assert.rejects(fetch(request), { name: 'AbortError' })
+})
+
+test('a chain of clones still aborts after garbage collection', async (t) => {
+  if (!hasGC) {
+    throw new Error('gc is not available. Run with \'--expose-gc\'.')
+  }
+
+  const server = createServer(() => {})
+  t.after(closeServerAsPromise(server))
+  server.listen(0)
+  await once(server, 'listening')
+
+  const controller = new AbortController()
+  let request = new Request(`http://localhost:${server.address().port}`, {
+    signal: controller.signal
+  })
+
+  // Every intermediate is dropped, so the whole chain has to stay reachable.
+  request = request.clone()
+  request = request.clone()
+  request = request.clone()
+
+  setTimeout(() => {
+    global.gc()
+    controller.abort()
+  }, 100)
+
+  await assert.rejects(fetch(request), { name: 'AbortError' })
+})


### PR DESCRIPTION
Closes #4068.

The abort travels along a chain: the source signal, then this request's controller, then the
clone's controller. Every hop is held only weakly, and `clone()` keeps nothing alive, so a GC
between cloning and aborting breaks the chain and the fetch hangs.

The constructor already guards against exactly this for its own controller:

```js
// Keep a strong ref to ac while request object is alive. This is needed to prevent
// AbortController from being prematurely garbage collected.
// See, https://github.com/nodejs/undici/issues/1926.
this[kAbortController] = ac
```

`clone()` never did the same, so this applies the same reasoning there.

## Two hops, not one

Worth recording, because it cost me a wrong first attempt. Retaining only the clone's own
controller is not enough and the repro still hangs: only `ac.signal` is handed to
`fromInnerRequest`, and a signal does not keep its controller alive, so that one does need
holding, but the request the clone came from is collected too and its controller is what the
source signal's listener derefs. Both have to stay reachable.

Holding the source request rather than just its controller is what makes a clone of a clone
work: each link keeps the next one alive, so intermediates can go out of scope safely.

`@andreas-karlsson`, this is also why holding the original request did not help you: the clone's
own controller was being collected as well, so the chain was broken at the other end too.

## Tests

`test/fetch/clone-abort-after-gc.js`, in the style of the existing `--expose-gc` tests: one clone
and a chain of three with every intermediate dropped. Both hang until the test times out
without the change.

- `test/fetch/*.js` with `--expose-gc`: 468 passed, 5 failed, and the same 5 fail on an
  unmodified tree.
- `test/fetch/request.js`, `test/fetch/abort.js`: 35 passed.
- `test/fetch/fetch-leak.js`, `test/fetch/fire-and-forget.js`, `test/request-timeout.js`: 26 passed.
  Those are the ones that would notice references being held too long.
- eslint clean.
