### PR TITLE
fix(websocket): fail the connection on a non-200 h2 extended CONNECT response

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -59,6 +59,7 @@ const {
 const EE = require('node:events')
 const { Readable, pipeline, finished, isErrored, isReadable } = require('node:stream')
 const { addAbortListener, bufferToLowerCasedHeaderName } = require('../../core/util')
+const { SocketError } = require('../../core/errors')
 const { dataURLProcessor, serializeAMimeType, minimizeSupportedMimeType } = require('./data-url')
 const { getGlobalDispatcher } = require('../../global')
 const { webidl } = require('../webidl')
@@ -2396,6 +2397,11 @@ async function httpNetworkFetch (
             // We need to support 200 for websocket over h2 as per RFC-8441
             // Absence of session means H1
             if ((socket.session != null && status !== 200) || (socket.session == null && status !== 101)) {
+              if (socket.session != null) {
+                // The server refused the extended CONNECT, and nothing further
+                // will settle this request. Fail the opening handshake here.
+                controller.abort(new SocketError('bad upgrade', null))
+              }
               return false
             }
 

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -179,6 +179,54 @@ test('WebSocket connecting to server that isn\'t a Websocket server (h2 - suppor
   }
 })
 
+// A regression here hangs rather than fails, so bound the test.
+test('WebSocket over H2 fails the handshake when the extended CONNECT response is not 200', { timeout: 10000 }, async (t) => {
+  const planner = tspl(t, { plan: 3 })
+  const sessions = new Set()
+  const h2Server = createSecureServer({ cert, key, settings: { enableConnectProtocol: true } })
+    .on('session', (session) => {
+      sessions.add(session)
+      session.on('close', () => sessions.delete(session))
+    })
+    .on('stream', (stream) => {
+      stream.respond({ ':status': 401 })
+      stream.end()
+    })
+    .listen(0)
+
+  await once(h2Server, 'listening')
+
+  const dispatcher = new Agent({
+    allowH2: true,
+    connect: {
+      rejectUnauthorized: false
+    }
+  })
+  const ws = new WebSocket(`wss://localhost:${h2Server.address().port}`, { dispatcher })
+
+  t.after(async () => {
+    for (const session of sessions) {
+      session.close()
+    }
+
+    await new Promise((resolve) => h2Server.close(resolve))
+    await dispatcher.close()
+  })
+
+  ws.onmessage = ws.onopen = () => planner.fail('should not open')
+
+  ws.addEventListener('error', ({ error }) => {
+    planner.ok(error)
+  })
+
+  ws.addEventListener('close', ({ code, wasClean }) => {
+    planner.equal(code, 1006)
+    planner.equal(wasClean, false)
+  })
+
+  await planner.completed
+})
+
 test('WebSocket on H2 with a server that does not support extended CONNECT protocol', async (t) => {
   const planner = tspl(t, { plan: 1 })
   const h2Server = createSecureServer({ cert, key, settings: { enableConnectProtocol: false } })


### PR DESCRIPTION
## This relates to...

Refs #5063: fixed for `client.upgrade()` in #5072, but the fetch/`WebSocket` path was left out — with no assertion to crash, it hangs instead of failing.

## Rationale

When the server enables the extended CONNECT protocol and answers the handshake with anything but 200 (e.g. 401), the client gets no `error` and no `close`: it just hangs in `CONNECTING` forever, with nothing for the caller to await or catch.

<details>
<summary>Standalone repro — hangs forever on <code>main</code>, fails cleanly with this patch</summary>

Save as `repro.mjs` in the repo root and run `node repro.mjs`:

```js
import { readFileSync } from "node:fs";
import { once } from "node:events";
import { createSecureServer } from "node:http2";
import { WebSocket, Agent } from "./index.js";

// A WebSocket endpoint that refuses the handshake with 401.
const server = createSecureServer({
  key: readFileSync("./test/fixtures/key.pem"),
  cert: readFileSync("./test/fixtures/cert.pem"),
  settings: { enableConnectProtocol: true },
});

server.on("stream", (stream) => {
  stream.respond({ ":status": 401 });
  stream.end();
});

await once(server.listen(0), "listening");

const dispatcher = new Agent({
  allowH2: true,
  connect: { rejectUnauthorized: false },
});
const ws = new WebSocket(`wss://localhost:${server.address().port}`, {
  dispatcher,
});

const stop = () => {
  clearTimeout(timer);
  dispatcher.destroy();
  server.close();
};

ws.onopen = () => {
  console.log("open");
  stop();
};
ws.onerror = ({ error }) => console.log("error:", error?.constructor.name);
ws.onclose = ({ code, wasClean }) => {
  console.log("close:", code, "wasClean:", wasClean);
  stop();
};

const timer = setTimeout(() => {
  console.log(
    "5s later: no event, readyState =",
    ws.readyState,
    "(0 = CONNECTING)",
  );
  stop();
}, 5000);
```

On `main` nothing is ever emitted:

```
5s later: no event, readyState = 0 (0 = CONNECTING)
```

With this patch the connection fails as it should:

```
error: TypeError
close: 1006 wasClean: false
```

</details>

`onRequestUpgrade` in `lib/web/fetch/index.js` returns `false` for a non-200 h2 response, but nothing honors that return value: `onUpgradeResponse` in `client-h2.js` finalizes the request regardless, so neither `resolve` nor `reject` ever runs and the WebSocket is stranded.

## Changes

- `lib/web/fetch/index.js`: abort with the existing `SocketError('bad upgrade')` when the h2 extended CONNECT response is not 200, so the handshake fails instead of hanging.
- `test/websocket/opening-handshake.js`: regression test — the server answers 401, asserts `error` + `close`, and times out when nothing is emitted (as on `main`); passes with this patch.

### Features

N/A

### Bug Fixes

- WebSocket over h2 now fails the handshake instead of hanging in `CONNECTING` forever when the extended CONNECT response is not 200

### Breaking Changes and Deprecations

N/A

Assisted-by: Claude Code

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
