### PR TITLE
fix(proxy-agent): guard Proxy-Authorization in iterable header containers

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -9,6 +9,7 @@ const buildConnector = require('../core/connect')
 const Client = require('./client')
 const { channels } = require('../core/diagnostics')
 const Socks5ProxyAgent = require('./socks5-proxy-agent')
+const { hasSafeIterator } = require('../core/util')
 
 const kAgent = Symbol('proxy agent')
 const kClient = Symbol('proxy client')
@@ -340,6 +341,21 @@ function buildHeaders (headers) {
       }
 
       headersPair[headers[i]] = headers[i + 1]
+    }
+
+    return headersPair
+  }
+
+  // Materialize iterable header containers (e.g. Map, Headers) into a record so
+  // that throwIfProxyAuthIsSent() can inspect their entries. Object.keys and
+  // for...in see nothing on a Map/Headers instance, so without this the
+  // Proxy-Authorization guard is bypassed and proxy credentials can reach the
+  // origin server (GHSA-6cv7-626c-qhqw).
+  if (headers && typeof headers === 'object' && hasSafeIterator(headers)) {
+    const headersPair = {}
+
+    for (const [key, value] of headers) {
+      headersPair[key] = value
     }
 
     return headersPair

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -3,7 +3,7 @@
 const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const diagnosticsChannel = require('node:diagnostics_channel')
-const { request, fetch, setGlobalDispatcher, getGlobalDispatcher } = require('..')
+const { request, fetch, Headers, setGlobalDispatcher, getGlobalDispatcher } = require('..')
 const { InvalidArgumentError, ConnectTimeoutError, SecureProxyConnectionError } = require('../lib/core/errors')
 const ProxyAgent = require('../lib/dispatcher/proxy-agent')
 const Pool = require('../lib/dispatcher/pool')
@@ -837,7 +837,7 @@ test('use proxy-agent with custom headers with tunneling enabled', async (t) => 
 })
 
 test('sending proxy-authorization in request headers should throw', async (t) => {
-  t = tspl(t, { plan: 3 })
+  t = tspl(t, { plan: 5 })
   const server = await buildServer()
   const proxy = await buildProxy()
 
@@ -883,6 +883,29 @@ test('sending proxy-authorization in request headers should throw', async (t) =>
         headers: {
           'Proxy-Authorization': Buffer.from('user:pass').toString('base64')
         }
+      }
+    ),
+    'Proxy-Authorization should be sent in ProxyAgent'
+  )
+
+  // Iterable containers (Map/Headers) must not bypass the guard (GHSA-6cv7-626c-qhqw)
+  await t.rejects(
+    request(
+      serverUrl + '/hello?foo=bar',
+      {
+        dispatcher: proxyAgent,
+        headers: new Map([['proxy-authorization', Buffer.from('user:pass').toString('base64')]])
+      }
+    ),
+    'Proxy-Authorization should be sent in ProxyAgent'
+  )
+
+  await t.rejects(
+    request(
+      serverUrl + '/hello?foo=bar',
+      {
+        dispatcher: proxyAgent,
+        headers: new Headers({ 'proxy-authorization': Buffer.from('user:pass').toString('base64') })
       }
     ),
     'Proxy-Authorization should be sent in ProxyAgent'


### PR DESCRIPTION
Materialize iterable header containers (Map, Headers) into a record in `buildHeaders()` before the Proxy-Authorization guard runs in `ProxyAgent.dispatch`.

`buildHeaders()` previously only converted arrays; a `Map` or `Headers` carrying `proxy-authorization` passed through untouched and bypassed `throwIfProxyAuthIsSent()`, whose `Object.keys`/`for...in` scan sees no entries on those containers. The header was then forwarded through the CONNECT tunnel to the origin server, disclosing proxy credentials (GHSA-6cv7-626c-qhqw).

Adds regression tests asserting the guard rejects `proxy-authorization` for `Map` and `Headers` request headers.
