### PR TITLE
ci(codeql): align CodeQL action versions to v4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
The CodeQL `Analyze (javascript)` and `Analyze (typescript)` checks fail on every PR with: `Loaded a configuration file for version '4.37.3', but running version '4.37.9'`.

The `init` and `autobuild` steps are pinned to `github/codeql-action@e4fba868...` (`v4.37.3`) while the `analyze` step runs `cdf488f5...` (`v4.37.9`). The config written by the 4.37.3 `init` step cannot be read by the 4.37.9 `analyze` step.

This pins `init` and `autobuild` to the same `v4.37.9` SHA already used by `analyze`, so the checks pass without disabling CodeQL scanning.
