### PR TITLE
fix: complete upgrade diagnostics lifecycle

### DIFF
--- a/docs/docs/api/DiagnosticsChannel.md
+++ b/docs/docs/api/DiagnosticsChannel.md
@@ -120,7 +120,8 @@ diagnosticsChannel.channel('undici:request:bodySent').subscribe(({ request }) =>
 added: v6.3.0
 -->
 
-Published after the response headers have been received.
+Published after the response headers have been received. This includes a
+successful CONNECT or protocol upgrade response.
 
 * `message` {Object}
   * `request` {Object} The same object published by
@@ -128,8 +129,9 @@ Published after the response headers have been received.
   * `response` {Object} The response being received.
     * `statusCode` {number} The HTTP status code.
     * `statusText` {string} The HTTP status message.
-    * `headers` {Buffer[]} The raw response headers as an array of buffers,
-      alternating between header name and value.
+    * `headers` {Buffer[]|Object} HTTP/1.1 response headers are an array of
+      buffers alternating between header name and value. HTTP/2 response
+      headers are an object.
 
 ```mjs
 import diagnosticsChannel from 'node:diagnostics_channel'
@@ -137,7 +139,7 @@ import diagnosticsChannel from 'node:diagnostics_channel'
 diagnosticsChannel.channel('undici:request:headers').subscribe(({ request, response }) => {
   console.log('statusCode', response.statusCode)
   console.log(response.statusText)
-  console.log(response.headers.map((x) => x.toString()))
+  console.log(response.headers)
 })
 ```
 
@@ -168,8 +170,9 @@ diagnosticsChannel.channel('undici:request:bodyChunkReceived').subscribe(({ requ
 added: v6.3.0
 -->
 
-Published after the response body and trailers have been received, that is, once
-the response has fully completed.
+Published once the response has fully completed. After an upgraded socket has
+been passed to the request handler, this event is published with an empty
+`trailers` array.
 
 * `message` {Object}
   * `request` {Object} The same object published by

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -391,13 +391,7 @@ class Request {
 
     const parsedHeaders = Array.isArray(headers) ? parseHeaders(headers) : headers
 
-    let result
-    try {
-      result = this[kHandler].onRequestUpgrade?.(controller, statusCode, parsedHeaders, socket)
-    } catch (error) {
-      this.abort(error)
-      throw error
-    }
+    const result = this[kHandler].onRequestUpgrade?.(controller, statusCode, parsedHeaders, socket)
 
     if (!this.aborted) {
       this.completed = true

--- a/lib/core/request.js
+++ b/lib/core/request.js
@@ -368,9 +368,21 @@ class Request {
     }
   }
 
-  onRequestUpgrade (statusCode, headers, socket) {
+  /**
+   * @param {number} statusCode
+   * @param {Buffer[]|string[]|import('../../types/header.d.ts').IncomingHttpHeaders} headers
+   * @param {import('node:stream').Duplex} socket
+   * @param {string} [statusText]
+   */
+  onRequestUpgrade (statusCode, headers, socket, statusText = '') {
+    this.onFinally()
+
     assert(!this.aborted)
     assert(!this.completed)
+
+    if (channels.headers.hasSubscribers) {
+      channels.headers.publish({ request: this, response: { statusCode, headers, statusText } })
+    }
 
     const controller = this[kController]
     if (controller) {
@@ -379,7 +391,22 @@ class Request {
 
     const parsedHeaders = Array.isArray(headers) ? parseHeaders(headers) : headers
 
-    return this[kHandler].onRequestUpgrade?.(controller, statusCode, parsedHeaders, socket)
+    let result
+    try {
+      result = this[kHandler].onRequestUpgrade?.(controller, statusCode, parsedHeaders, socket)
+    } catch (error) {
+      this.abort(error)
+      throw error
+    }
+
+    if (!this.aborted) {
+      this.completed = true
+      if (channels.trailers.hasSubscribers) {
+        channels.trailers.publish({ request: this, trailers: [] })
+      }
+    }
+
+    return result
   }
 
   onResponseEnd (trailers) {

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -598,6 +598,7 @@ class Parser {
     try {
       request.onRequestUpgrade(statusCode, headers, socket, statusText)
     } catch (err) {
+      util.errorRequest(client, request, err)
       util.destroy(socket, err)
     }
 

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -561,7 +561,7 @@ class Parser {
    * @param {Buffer} head
    */
   onUpgrade (head) {
-    const { upgrade, client, socket, headers, statusCode } = this
+    const { upgrade, client, socket, headers, statusCode, statusText } = this
 
     assert(upgrade)
     assert(client[kSocket] === socket)
@@ -596,7 +596,7 @@ class Parser {
     client.emit('disconnect', client[kUrl], [client], new InformationalError('upgrade'))
 
     try {
-      request.onRequestUpgrade(statusCode, headers, socket)
+      request.onRequestUpgrade(statusCode, headers, socket, statusText)
     } catch (err) {
       util.destroy(socket, err)
     }

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -933,7 +933,7 @@ function onUpgradeResponse (headers, _flags) {
 
   request.onRequestUpgrade(statusCode, headers, stream)
 
-  if (request.aborted || request.completed) {
+  if (request.aborted) {
     return
   }
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -931,7 +931,12 @@ function onUpgradeResponse (headers, _flags) {
   const statusCode = headers[HTTP2_HEADER_STATUS]
   delete headers[HTTP2_HEADER_STATUS]
 
-  request.onRequestUpgrade(statusCode, headers, stream)
+  try {
+    request.onRequestUpgrade(statusCode, headers, stream)
+  } catch (err) {
+    state.abort(err)
+    return
+  }
 
   if (request.aborted) {
     return

--- a/test/node-test/diagnostics-channel/upgrade.js
+++ b/test/node-test/diagnostics-channel/upgrade.js
@@ -199,7 +199,7 @@ test('an aborted upgrade emits an error without successful completion', async (t
   assert.strictEqual(records[0].request.completed, false)
 })
 
-test('an HTTP/2 upgrade completes the request diagnostics lifecycle', async (testContext) => {
+test('HTTP/2 upgrades publish terminal request diagnostics', async (testContext) => {
   const server = createSecureServer({
     ...(await pem.generate({ opts: { keySize: 2048 } })),
     settings: { enableConnectProtocol: true }
@@ -241,4 +241,25 @@ test('an HTTP/2 upgrade completes the request diagnostics lifecycle', async (tes
   assert.strictEqual(records.length, 2)
   assert.deepStrictEqual(records[1].events, ['create', 'headers', 'error'])
   assert.strictEqual(records[1].request.completed, false)
+
+  const expectedError = new Error('upgrade handler failed')
+  const responseError = new Promise((resolve, reject) => {
+    client.dispatch({ method: 'GET', path: '/', upgrade: 'websocket' }, {
+      onRequestStart () {},
+      onRequestUpgrade () {
+        throw expectedError
+      },
+      onResponseError (_controller, error) {
+        if (error === expectedError) resolve()
+        else reject(error)
+      }
+    })
+  })
+  await responseError
+
+  assert.strictEqual(records.length, 3)
+  assert.deepStrictEqual(records[2].events, ['create', 'headers', 'error'])
+  assert.strictEqual(records[2].request.completed, false)
+  assert.strictEqual(records[2].request.aborted, true)
+  assert.strictEqual(client.stats.running, 0)
 })

--- a/test/node-test/diagnostics-channel/upgrade.js
+++ b/test/node-test/diagnostics-channel/upgrade.js
@@ -1,0 +1,244 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const diagnosticsChannel = require('node:diagnostics_channel')
+const { once } = require('node:events')
+const { createServer } = require('node:http')
+const { createSecureServer } = require('node:http2')
+const { PassThrough } = require('node:stream')
+const { test } = require('node:test')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Agent, Client, connect, getGlobalDispatcher, setGlobalDispatcher } = require('../../..')
+
+const requestChannels = {
+  bodySent: diagnosticsChannel.channel('undici:request:bodySent'),
+  create: diagnosticsChannel.channel('undici:request:create'),
+  error: diagnosticsChannel.channel('undici:request:error'),
+  headers: diagnosticsChannel.channel('undici:request:headers'),
+  trailers: diagnosticsChannel.channel('undici:request:trailers')
+}
+
+function onExpectedTeardownError (error) {
+  if (error.code !== 'ECONNRESET') {
+    throw error
+  }
+}
+
+function observeRequestLifecycles (testContext) {
+  const records = []
+  const recordsByRequest = new Map()
+  const subscriptions = {
+    bodySent ({ request }) {
+      recordsByRequest.get(request).events.push('bodySent')
+    },
+    create ({ request }) {
+      const record = { request, events: ['create'], responses: [], trailers: [] }
+      records.push(record)
+      recordsByRequest.set(request, record)
+    },
+    error ({ request }) {
+      recordsByRequest.get(request).events.push('error')
+    },
+    headers ({ request, response }) {
+      const record = recordsByRequest.get(request)
+      record.events.push('headers')
+      record.responses.push(response)
+    },
+    trailers ({ request, trailers }) {
+      const record = recordsByRequest.get(request)
+      record.events.push('trailers')
+      record.trailers.push(trailers)
+    }
+  }
+
+  for (const name of Object.keys(subscriptions)) {
+    requestChannels[name].subscribe(subscriptions[name])
+  }
+  testContext.after(() => {
+    for (const name of Object.keys(subscriptions)) {
+      requestChannels[name].unsubscribe(subscriptions[name])
+    }
+  })
+
+  return records
+}
+
+test('successful upgrades complete the request diagnostics lifecycle', async (testContext) => {
+  const server = createServer()
+  server.on('upgrade', (_request, socket) => {
+    socket.end('HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n')
+  })
+  server.on('connect', (_request, socket) => {
+    socket.end('HTTP/1.1 200 Connection Established\r\n\r\n')
+  })
+  testContext.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const records = observeRequestLifecycles(testContext)
+  const client = new Client(origin)
+  testContext.after(() => client.close())
+
+  const body = new PassThrough({ autoDestroy: false })
+  const upgrade = client.upgrade({ path: '/', protocol: 'test', body })
+  body.end()
+  const { socket } = await upgrade
+  socket.destroy()
+
+  assert.strictEqual(records.length, 1)
+  assert.deepStrictEqual(records[0].events, ['create', 'bodySent', 'headers', 'trailers'])
+  assert.strictEqual(records[0].request.completed, true)
+  assert.strictEqual(records[0].responses[0].statusCode, 101)
+  assert.strictEqual(records[0].responses[0].statusText, 'Switching Protocols')
+  assert.deepStrictEqual(records[0].trailers, [[]])
+  assert.strictEqual(body.listenerCount('end'), 0)
+  assert.strictEqual(body.listenerCount('error'), 0)
+
+  const previousDispatcher = getGlobalDispatcher()
+  const agent = new Agent()
+  setGlobalDispatcher(agent)
+  testContext.after(() => {
+    setGlobalDispatcher(previousDispatcher)
+    return agent.close()
+  })
+
+  const tunnel = await connect(origin)
+  tunnel.socket.destroy()
+
+  assert.strictEqual(records.length, 2)
+  assert.deepStrictEqual(records[1].events, ['create', 'bodySent', 'headers', 'trailers'])
+  assert.strictEqual(records[1].request.completed, true)
+  assert.strictEqual(records[1].responses[0].statusCode, 200)
+  assert.strictEqual(records[1].responses[0].statusText, 'Connection Established')
+  assert.deepStrictEqual(records[1].trailers, [[]])
+})
+
+test('a rejected upgrade emits an error without successful completion', async (testContext) => {
+  const server = createServer((_request, response) => response.end())
+  testContext.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const records = observeRequestLifecycles(testContext)
+  const client = new Client(`http://127.0.0.1:${server.address().port}`)
+  testContext.after(() => client.close())
+
+  await assert.rejects(client.upgrade({ path: '/', protocol: 'test' }))
+
+  assert.strictEqual(records.length, 1)
+  assert.deepStrictEqual(records[0].events, ['create', 'bodySent', 'headers', 'error'])
+  assert.strictEqual(records[0].request.completed, false)
+})
+
+test('an upgrade handler error aborts the request diagnostics lifecycle', async (testContext) => {
+  const server = createServer()
+  server.on('upgrade', (_request, socket) => {
+    socket.end('HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n')
+  })
+  testContext.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const records = observeRequestLifecycles(testContext)
+  const client = new Client(`http://127.0.0.1:${server.address().port}`)
+  testContext.after(() => client.close())
+
+  const expectedError = new Error('upgrade handler failed')
+  const responseError = new Promise((resolve, reject) => {
+    client.dispatch({ method: 'GET', path: '/', upgrade: 'test' }, {
+      onRequestStart () {},
+      onRequestUpgrade () {
+        throw expectedError
+      },
+      onResponseError (_controller, error) {
+        if (error === expectedError) resolve()
+        else reject(error)
+      }
+    })
+  })
+  await responseError
+
+  assert.strictEqual(records.length, 1)
+  assert.deepStrictEqual(records[0].events, ['create', 'bodySent', 'headers', 'error'])
+  assert.strictEqual(records[0].request.completed, false)
+  assert.strictEqual(records[0].request.aborted, true)
+})
+
+test('an aborted upgrade emits an error without successful completion', async (testContext) => {
+  let serverSocket
+  const server = createServer()
+  server.on('upgrade', (_request, socket) => {
+    serverSocket = socket
+  })
+  testContext.after(() => {
+    serverSocket?.destroy()
+    server.close()
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const records = observeRequestLifecycles(testContext)
+  const client = new Client(`http://127.0.0.1:${server.address().port}`)
+  testContext.after(() => client.close())
+
+  const abortController = new AbortController()
+  const upgrade = client.upgrade({ path: '/', protocol: 'test', signal: abortController.signal })
+  await once(server, 'upgrade')
+  abortController.abort()
+  await assert.rejects(upgrade)
+
+  assert.strictEqual(records.length, 1)
+  assert.deepStrictEqual(records[0].events, ['create', 'bodySent', 'error'])
+  assert.strictEqual(records[0].request.completed, false)
+})
+
+test('an HTTP/2 upgrade completes the request diagnostics lifecycle', async (testContext) => {
+  const server = createSecureServer({
+    ...(await pem.generate({ opts: { keySize: 2048 } })),
+    settings: { enableConnectProtocol: true }
+  })
+  server.on('stream', (stream, headers) => {
+    stream.on('error', onExpectedTeardownError)
+    const statusCode = headers[':path'] === '/rejected' ? 403 : 200
+    stream.respond({ ':status': statusCode }, { endStream: false })
+    stream.resume()
+    stream.once('end', () => stream.end())
+  })
+  testContext.after(() => server.close())
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const records = observeRequestLifecycles(testContext)
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    allowH2: true,
+    connect: { rejectUnauthorized: false }
+  })
+  testContext.after(() => client.close())
+
+  const { socket } = await client.upgrade({ path: '/', protocol: 'websocket' })
+  testContext.after(() => socket.destroy())
+
+  assert.strictEqual(records.length, 1)
+  assert.deepStrictEqual(records[0].events, ['create', 'headers', 'trailers'])
+  assert.strictEqual(records[0].request.completed, true)
+  assert.strictEqual(records[0].responses[0].statusCode, 200)
+  assert.strictEqual(records[0].responses[0].statusText, '')
+  assert.deepStrictEqual(records[0].trailers, [[]])
+
+  socket.end()
+  await once(socket, 'close')
+
+  await assert.rejects(client.upgrade({ path: '/rejected', protocol: 'websocket' }))
+
+  assert.strictEqual(records.length, 2)
+  assert.deepStrictEqual(records[1].events, ['create', 'headers', 'error'])
+  assert.strictEqual(records[1].request.completed, false)
+})

--- a/test/types/diagnostics-channel.test-d.ts
+++ b/test/types/diagnostics-channel.test-d.ts
@@ -35,6 +35,14 @@ expectAssignable<DiagnosticsChannel.RequestHeadersMessage>({
   request,
   response
 })
+expectAssignable<DiagnosticsChannel.RequestHeadersMessage>({
+  request,
+  response: {
+    statusCode: 200,
+    statusText: '',
+    headers: { ':protocol': 'websocket' }
+  }
+})
 expectAssignable<DiagnosticsChannel.RequestBodyChunkReceivedMessage>({ request, chunk: Buffer.from('') })
 expectAssignable<DiagnosticsChannel.RequestTrailersMessage>({
   request,

--- a/types/diagnostics-channel.d.ts
+++ b/types/diagnostics-channel.d.ts
@@ -2,6 +2,7 @@ import { Socket } from 'node:net'
 import { URL } from 'node:url'
 import buildConnector from './connector'
 import Dispatcher from './dispatcher'
+import { IncomingHttpHeaders } from './header'
 
 declare namespace DiagnosticsChannel {
   interface Request {
@@ -14,7 +15,7 @@ declare namespace DiagnosticsChannel {
   interface Response {
     statusCode: number;
     statusText: string;
-    headers: Array<Buffer>;
+    headers: Array<Buffer> | IncomingHttpHeaders;
   }
   interface ConnectParams {
     host: URL['host'];


### PR DESCRIPTION
Successful CONNECT and protocol upgrades stop before Undici marks the request complete. Diagnostics subscribers retain per-request state, and streamed request-body listeners remain attached for the lifetime of the upgraded socket.

Complete accepted upgrades through the existing response-header and trailers events. Rejected and aborted upgrades retain the existing error terminal event.