### PR TITLE
test(mock): make the delayed-abort test discriminate instead of asserting true

### DIFF
--- a/test/mock-delayed-abort.js
+++ b/test/mock-delayed-abort.js
@@ -5,7 +5,7 @@ const { MockAgent, interceptors } = require('..')
 const DecoratorHandler = require('../lib/handler/decorator-handler')
 const { tspl } = require('@matteo.collina/tspl')
 
-test('MockAgent with delayed response and AbortSignal should not cause uncaught errors', async (t) => {
+test('MockAgent with delayed response and AbortSignal must not deliver the response after abort', async (t) => {
   const p = tspl(t, { plan: 2 })
 
   const agent = new MockAgent()
@@ -15,6 +15,49 @@ test('MockAgent with delayed response and AbortSignal should not cause uncaught 
   mockPool.intercept({ path: '/test', method: 'GET' })
     .reply(200, { success: true }, { headers: { 'content-type': 'application/json' } })
     .delay(100)
+
+  // Observe the handler contract directly: once the request is aborted
+  // (onResponseError), the delayed reply must never reach onResponseStart /
+  // onResponseData / onResponseEnd. Without this the test could only assert
+  // `true`, which stays green even if the delayed reply is delivered on top
+  // of the abort — a tautology. The DecoratorHandler test below asserts only
+  // onResponseStart is not called after onError; here we assert the whole
+  // response side of the contract (start, data and end) is suppressed.
+  let onErrorCalled = false
+  let deliveredAfterError = false
+
+  class TrackingDecoratorHandler extends DecoratorHandler {
+    #flag () {
+      if (onErrorCalled) {
+        deliveredAfterError = true
+      }
+    }
+
+    onResponseStart (...args) {
+      this.#flag()
+      return super.onResponseStart(...args)
+    }
+
+    onResponseData (...args) {
+      this.#flag()
+      return super.onResponseData(...args)
+    }
+
+    onResponseEnd (...args) {
+      this.#flag()
+      return super.onResponseEnd(...args)
+    }
+
+    onResponseError (controller, err) {
+      onErrorCalled = true
+      return super.onResponseError(controller, err)
+    }
+  }
+
+  const originalDispatch = agent.dispatch.bind(agent)
+  agent.dispatch = (opts, handler) => {
+    return originalDispatch(opts, new TrackingDecoratorHandler(handler))
+  }
 
   const ac = new AbortController()
 
@@ -35,10 +78,10 @@ test('MockAgent with delayed response and AbortSignal should not cause uncaught 
     p.ok(err.message === 'Request aborted' || err.name === 'AbortError', 'Error should be related to abort')
   }
 
-  // Wait for the delayed response to fire - should not cause any uncaught errors
+  // Wait for the delayed response to fire; it must be dropped, not delivered.
   await new Promise(resolve => setTimeout(resolve, 150))
 
-  p.ok(true, 'No uncaught errors after delayed response')
+  p.strictEqual(deliveredAfterError, false, 'delayed response must not be delivered after the abort')
 })
 
 test('MockAgent with delayed response and composed interceptor (decompress) should not cause uncaught errors', async (t) => {


### PR DESCRIPTION
### Problem

The first test in `test/mock-delayed-abort.js` ended with:

```js
p.ok(true, 'No uncaught errors after delayed response')
```

That assertion is a tautology — it stays green no matter what the code under test does. The bare `MockAgent.request` path throws no *uncaught* error when a delayed reply is delivered after an abort, so the test passed even against a fully-broken guard. It documented an intent it never actually enforced: that a mocked reply delivered *after* the request was aborted must not still be pushed to the handler.

### What this hardens

The post-abort guards live in `lib/mock/mock-utils.js` (the timer-clear on abort plus the two `if (aborted) return` guards in `handleReply`). To prove the test now discriminates, I reverted those three guards and re-ran:

| variant | test 1 (this one) |
|---|---|
| **real code** | passes |
| **guards reverted** | **fails** |

Previously, test 1 passed in *both* variants.

### The change

The delayed-abort test now wraps the dispatched handler in a `DecoratorHandler` subclass that records any `onResponseStart` / `onResponseData` / `onResponseEnd` delivered *after* `onResponseError`, and asserts none occur:

```js
p.strictEqual(deliveredAfterError, false)
```

This covers the full response side of the contract for the bare-agent path — the sibling `DecoratorHandler` test in the same file asserts only `onResponseStart`. Test-only change; no source touched.

Verified with the repo runner: `borp -p "test/mock-*.js"` → **339 pass / 0 fail**; `npm run lint` → clean.
