### PR TITLE
fix(mock): guard aborted requests in async reply callback rejection

### DIFF
--- a/lib/mock/mock-utils.js
+++ b/lib/mock/mock-utils.js
@@ -460,6 +460,14 @@ function dispatchMockReply (mockDispatches, mockDispatch, key, opts, handler, re
             handleReply(dispatches, { ...responseDefaults, ...resolvedData })
           },
           (err) => {
+            // The request may have been aborted while the reply options
+            // callback promise was still pending. controller.abort() has then
+            // already settled the request via onResponseError, so emitting a
+            // second terminal here would double-settle an aborted request,
+            // mirroring the guard handleReply() already applies.
+            if (aborted) {
+              return
+            }
             handler.onResponseError(null, err)
           }
         )

--- a/test/mock-delayed-abort.js
+++ b/test/mock-delayed-abort.js
@@ -135,3 +135,60 @@ test('MockAgent with delayed response and DecoratorHandler should not call onRes
 
   p.ok(true, 'Decorator handler invariants maintained')
 })
+
+test('MockAgent abort before an async reply options callback rejects should settle onResponseError exactly once', async (t) => {
+  const p = tspl(t, { plan: 2 })
+
+  let onResponseErrorCount = 0
+
+  class CountingHandler extends DecoratorHandler {
+    onResponseError (controller, err) {
+      onResponseErrorCount++
+      return super.onResponseError(controller, err)
+    }
+  }
+
+  const agent = new MockAgent()
+  t.after(() => agent.close())
+
+  const mockPool = agent.get('https://example.com')
+
+  // An async reply *options* callback whose promise rejects only after the
+  // request has already been aborted. A request body forces the callback to be
+  // resolved inside dispatchMockReply (rather than eagerly in mockDispatch), so
+  // the controller is already live and the abort can win the race.
+  mockPool.intercept({ path: '/test', method: 'POST' })
+    .reply(() => new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('reply callback failed')), 50)
+    }))
+
+  const ac = new AbortController()
+
+  // Abort after the callback has been invoked but before its promise rejects.
+  setTimeout(() => {
+    ac.abort(new Error('Request aborted'))
+  }, 10)
+
+  const originalDispatch = agent.dispatch.bind(agent)
+  agent.dispatch = (opts, handler) => {
+    return originalDispatch(opts, new CountingHandler(handler))
+  }
+
+  try {
+    await agent.request({
+      origin: 'https://example.com',
+      path: '/test',
+      method: 'POST',
+      body: 'a request body',
+      signal: ac.signal
+    })
+    p.fail('Should have thrown an error')
+  } catch (err) {
+    p.ok(err.message === 'Request aborted' || err.name === 'AbortError', 'Error should be related to abort')
+  }
+
+  // Wait for the rejecting callback promise to settle (at ~50ms).
+  await new Promise(resolve => setTimeout(resolve, 150))
+
+  p.strictEqual(onResponseErrorCount, 1, 'onResponseError must fire exactly once for an aborted request')
+})


### PR DESCRIPTION
### Problem
In `lib/mock/mock-utils.js`, `sendReply()` handles an async **reply options callback** (the `.reply(() => ...)` / `response.callback` path from #5534). Its resolve arm goes through `handleReply()` (guarded by `if (aborted) return`), but the **reject arm** called `handler.onResponseError(null, err)` with no abort guard.

When a request with a body is aborted while that options-callback promise is still pending, `controller.abort()` already settles the request via `onResponseError` (first terminal). The callback promise then rejects and calls `onResponseError` **again** → a double-settle of an already-aborted request.

This is distinct from #5762: that one guards the **data/body function** promise in `handleReply()`; this guards the **reply options callback** promise in `sendReply()` — different function, different call site, different feature.

### Fix
Guard the reject arm with `if (aborted) return`, mirroring the guard `handleReply()` already applies.

### Test
`test/mock-delayed-abort.js`: a `CountingHandler` counts `onResponseError`; a POST with a body and an options callback that rejects at 50ms, aborted at 10ms, asserts `onResponseError` fires exactly once.
- **Before:** `2 !== 1` (double-settle).
- **After:** exactly once.

`node --test test/mock-delayed-abort.js` (4 pass), whole mock suite via borp (340 pass), `npm run lint` — all green.
