### PR TITLE
fix(deduplicate): detach the primary on abort instead of rejecting the group

### DIFF
--- a/lib/handler/deduplication-handler.js
+++ b/lib/handler/deduplication-handler.js
@@ -81,6 +81,29 @@ class DeduplicationHandler {
   #controller = null
 
   /**
+   * Proxied controller handed to the primary handler. Aborting it detaches the
+   * primary from the group instead of tearing down the shared dispatch.
+   *
+   * @type {import('../../types/dispatcher.d.ts').default.DispatchController | null}
+   */
+  #primaryController = null
+
+  /**
+   * True once the primary caller has aborted/detached from the group.
+   *
+   * @type {boolean}
+   */
+  #primaryDetached = false
+
+  /**
+   * Reason recorded when the primary detaches, reused to tear down the shared
+   * dispatch once the last member has left.
+   *
+   * @type {Error | null}
+   */
+  #primaryReason = null
+
+  /**
    * @type {(() => void) | null}
    */
   #onComplete = null
@@ -146,7 +169,8 @@ class DeduplicationHandler {
    */
   onRequestStart (controller, context) {
     this.#controller = controller
-    this.#primaryHandler.onRequestStart?.(controller, context)
+    this.#primaryController = this.#createPrimaryController()
+    this.#primaryHandler.onRequestStart?.(this.#primaryController, context)
   }
 
   /**
@@ -156,7 +180,7 @@ class DeduplicationHandler {
    * @param {Socket} socket
    */
   onRequestUpgrade (controller, statusCode, headers, socket) {
-    this.#primaryHandler.onRequestUpgrade?.(controller, statusCode, headers, socket)
+    this.#primaryHandler.onRequestUpgrade?.(this.#primaryController ?? controller, statusCode, headers, socket)
   }
 
   /**
@@ -171,7 +195,9 @@ class DeduplicationHandler {
     this.#headers = headers
     this.#statusMessage = statusMessage
 
-    this.#primaryHandler.onResponseStart?.(controller, statusCode, headers, statusMessage)
+    if (!this.#primaryDetached) {
+      this.#primaryHandler.onResponseStart?.(this.#primaryController, statusCode, headers, statusMessage)
+    }
 
     for (const waitingHandler of this.#waitingHandlers) {
       const { handler, controller: waitingController } = waitingHandler
@@ -211,7 +237,9 @@ class DeduplicationHandler {
 
     this.#responseDataStarted = true
 
-    this.#primaryHandler.onResponseData?.(controller, chunk)
+    if (!this.#primaryDetached) {
+      this.#primaryHandler.onResponseData?.(this.#primaryController, chunk)
+    }
 
     for (const waitingHandler of this.#waitingHandlers) {
       const { handler, controller: waitingController } = waitingHandler
@@ -252,7 +280,9 @@ class DeduplicationHandler {
     }
 
     this.#completed = true
-    this.#primaryHandler.onResponseEnd?.(controller, trailers)
+    if (!this.#primaryDetached) {
+      this.#primaryHandler.onResponseEnd?.(this.#primaryController, trailers)
+    }
 
     for (const waitingHandler of this.#waitingHandlers) {
       if (waitingHandler.done || waitingHandler.controller.aborted) {
@@ -297,13 +327,94 @@ class DeduplicationHandler {
     this.#aborted = true
     this.#completed = true
 
-    this.#primaryHandler.onResponseError?.(controller, err)
+    if (!this.#primaryDetached) {
+      this.#primaryHandler.onResponseError?.(this.#primaryController ?? controller, err)
+    }
 
     for (const waitingHandler of this.#waitingHandlers) {
       this.#errorWaitingHandler(waitingHandler, err)
     }
 
     this.#waitingHandlers = []
+    this.#onComplete?.()
+  }
+
+  /**
+   * Build the proxied controller handed to the primary handler.
+   *
+   * Flow control (pause/resume) is forwarded to the real dispatch controller so
+   * the primary still drives backpressure. Aborting it, however, only detaches
+   * the primary: the shared dispatch is torn down solely when no member — primary
+   * or waiting handler — is left waiting for the response.
+   *
+   * @returns {import('../../types/dispatcher.d.ts').default.DispatchController}
+   */
+  #createPrimaryController () {
+    // Object-literal getters run with `this` bound to the literal, not the
+    // handler instance, so capture the instance explicitly.
+    const self = this
+
+    const primaryController = {
+      resume: () => {
+        self.#controller?.resume()
+      },
+      pause: () => {
+        self.#controller?.pause()
+      },
+      get paused () { return self.#controller?.paused ?? false },
+      get aborted () { return self.#primaryDetached || (self.#controller?.aborted ?? false) },
+      get reason () { return self.#primaryReason ?? self.#controller?.reason ?? null },
+      get rawHeaders () { return self.#controller?.rawHeaders },
+      abort: (reason) => {
+        if (self.#primaryDetached) {
+          return
+        }
+
+        self.#primaryDetached = true
+        self.#primaryReason = reason ?? new RequestAbortedError()
+
+        try {
+          self.#primaryHandler.onResponseError?.(primaryController, self.#primaryReason)
+        } catch {
+          // Ignore errors from the primary handler
+        }
+
+        // Only cancel the real request once nobody is left waiting on it.
+        self.#maybeAbortRealDispatch()
+      }
+    }
+
+    return primaryController
+  }
+
+  /**
+   * Tear down the shared dispatch once the primary has detached and no waiting
+   * handler remains. Releases the `pendingRequests` entry via `onComplete` so a
+   * later request never joins a group with no consumers left.
+   */
+  #maybeAbortRealDispatch () {
+    if (this.#completed || this.#aborted) {
+      return
+    }
+
+    if (!this.#primaryDetached) {
+      return
+    }
+
+    for (const waitingHandler of this.#waitingHandlers) {
+      if (!waitingHandler.done && !waitingHandler.controller.aborted) {
+        // Someone still wants the response; keep the dispatch alive.
+        return
+      }
+    }
+
+    this.#aborted = true
+    this.#completed = true
+
+    // Aborting re-enters onResponseError, which returns early now that
+    // #completed is set, so it neither re-settles a handler nor calls
+    // onComplete a second time.
+    this.#controller?.abort(this.#primaryReason ?? new RequestAbortedError())
     this.#onComplete?.()
   }
 
@@ -381,6 +492,10 @@ class DeduplicationHandler {
         } catch {
           // Ignore errors from waiting handlers
         }
+
+        // If the primary has already detached, this waiter leaving may be the
+        // last consumer — tear the shared dispatch down if so.
+        this.#maybeAbortRealDispatch()
       }
     }
 

--- a/test/interceptors/deduplicate.js
+++ b/test/interceptors/deduplicate.js
@@ -1444,4 +1444,132 @@ describe('Deduplicate Interceptor', () => {
     const res = await primary
     strictEqual(await res.body.text(), 'response-body')
   })
+
+  // https://github.com/nodejs/undici/issues/5711
+  test('aborting the primary request must not reject the coalesced waiters', async () => {
+    let requestsToOrigin = 0
+    let releaseResponse
+    const responseGate = new Promise((resolve) => { releaseResponse = resolve })
+    let markRequestReached
+    const requestReached = new Promise((resolve) => { markRequestReached = resolve })
+    const server = createServer(async (req, res) => {
+      requestsToOrigin++
+      markRequestReached()
+      // Hold the response open until the test releases it (no timers), so the
+      // primary can abort while the waiter is still attached.
+      await responseGate
+      res.end('response-body')
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.deduplicate())
+
+    after(async () => {
+      releaseResponse()
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const request = { origin: 'localhost', method: 'GET', path: '/' }
+
+    const abortController = new AbortController()
+
+    // The primary carries a signal; the waiter carries none.
+    const primary = client.request({ ...request, signal: abortController.signal })
+    const waiter = client.request({ ...request })
+
+    // Catch the primary's rejection eagerly so aborting it does not surface as
+    // an unhandled rejection while we await the waiter.
+    const primaryOutcome = primary.then(() => 'resolved', err => err)
+
+    // The single coalesced request has reached the origin, so the waiter has
+    // joined the group: abort the primary (deterministic, no timers).
+    await requestReached
+    abortController.abort()
+
+    const outcome = await primaryOutcome
+    strictEqual(outcome?.name, 'AbortError')
+
+    // The waiter never passed a signal: it must still receive the response.
+    releaseResponse()
+    const res = await waiter
+    strictEqual(res.statusCode, 200)
+    strictEqual(await res.body.text(), 'response-body')
+
+    // Coalescing held: only one request ever reached the origin.
+    strictEqual(requestsToOrigin, 1)
+  })
+
+  // https://github.com/nodejs/undici/issues/5711
+  test('when every member of a coalesced group aborts, the pending entry is released', async () => {
+    let requestsToOrigin = 0
+    let releaseResponse
+    const responseGate = new Promise((resolve) => { releaseResponse = resolve })
+    let markRequestReached
+    const requestReached = new Promise((resolve) => { markRequestReached = resolve })
+    const server = createServer(async (req, res) => {
+      requestsToOrigin++
+      markRequestReached()
+      await responseGate
+      res.end('response-body')
+    }).listen(0)
+
+    const client = new Client(`http://localhost:${server.address().port}`)
+      .compose(interceptors.deduplicate())
+
+    const events = []
+    let markEntryRemoved
+    const entryRemoved = new Promise((resolve) => { markEntryRemoved = resolve })
+    const onPending = (msg) => {
+      events.push(msg)
+      if (msg.type === 'removed') markEntryRemoved()
+    }
+    diagnosticsChannel.subscribe('undici:request:pending-requests', onPending)
+
+    after(async () => {
+      diagnosticsChannel.unsubscribe('undici:request:pending-requests', onPending)
+      releaseResponse()
+      server.close()
+      await client.close()
+    })
+
+    await once(server, 'listening')
+
+    const request = { origin: 'localhost', method: 'GET', path: '/' }
+
+    const acPrimary = new AbortController()
+    const acWaiter = new AbortController()
+
+    const primary = client.request({ ...request, signal: acPrimary.signal })
+    const waiter = client.request({ ...request, signal: acWaiter.signal })
+
+    const primaryOutcome = primary.then(() => 'resolved', err => err)
+    const waiterOutcome = waiter.then(() => 'resolved', err => err)
+
+    // The single coalesced request has reached the origin (both members joined).
+    await requestReached
+
+    // Detach the primary first: the waiter still wants the response, so the
+    // shared dispatch must survive.
+    acPrimary.abort()
+    strictEqual((await primaryOutcome)?.name, 'AbortError')
+
+    // Now the last remaining member leaves; the shared dispatch is torn down
+    // and the pending entry must be released.
+    acWaiter.abort()
+    strictEqual((await waiterOutcome)?.name, 'AbortError')
+
+    // Wait for the entry-released event instead of a timer.
+    await entryRemoved
+
+    // Exactly one 'added' and one 'removed' event: the entry was released.
+    strictEqual(events.filter(e => e.type === 'added').length, 1)
+    strictEqual(events.filter(e => e.type === 'removed').length, 1)
+    strictEqual(events[events.length - 1].size, 0)
+
+    // Coalescing held: only one request ever reached the origin.
+    strictEqual(requestsToOrigin, 1)
+  })
 })


### PR DESCRIPTION
Fixes #5711.

### Problem
With `interceptors.deduplicate()`, aborting the **primary** request of a coalesced group rejected **every** waiter with `AbortError` — even waiters that passed no `signal`. The primary received the real dispatch controller, so its abort tore down the shared dispatch and rejected all members.

### Fix
The primary now receives a **proxied controller** (mirroring the existing `#createWaitingHandler`). Aborting it detaches only the primary and defers to `#maybeAbortRealDispatch`, which tears down the shared dispatch **only once no member (primary or waiter) is left waiting**, releasing the `pendingRequests` entry via `onComplete`. Pause/resume still forward to the real controller, so backpressure is unchanged. With no waiters, abort propagates exactly as before.

### Test
`test/interceptors/deduplicate.js`:
- "aborting the primary request must not reject the coalesced waiters" — **RED** on main (waiter rejects with AbortError), **GREEN** with fix (waiter gets 200, origin hit once).
- "when every member aborts, the pending entry is released" — guards the new teardown path.

deduplicate 38/38 + cache 88/88 + retry 16/16, `npm run lint` — all green.
