### PR TITLE
fix(retry): make RetryController rawHeaders/rawTrailers writable

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -65,7 +65,9 @@ class RetryController {
   get aborted () { return this.target?.aborted ?? false }
   get reason () { return this.target?.reason ?? null }
   get rawHeaders () { return this.target?.rawHeaders ?? null }
+  set rawHeaders (value) { if (this.target) this.target.rawHeaders = value }
   get rawTrailers () { return this.target?.rawTrailers ?? null }
+  set rawTrailers (value) { if (this.target) this.target.rawTrailers = value }
 }
 
 class RetryHandler {

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -1206,3 +1206,48 @@ test('should work with global dispatcher for both fetch() and request()', async 
 
   await t.completed
 })
+
+test('should decompress when retry is composed before decompress (issue #5726)', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const data = 'retry composed before decompress'
+  const compressed = gzipSync(data)
+  const server = createServer({ joinDuplicateHeaders: true }, (_req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Content-Encoding': 'gzip',
+      'Content-Length': String(compressed.length)
+    })
+    res.end(compressed)
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  // Retry ahead of decompress hands the decompress interceptor the retry
+  // controller proxy. The proxy must accept the rawHeaders write the decompress
+  // interceptor performs to strip content-encoding/content-length, otherwise it
+  // throws "Cannot set property rawHeaders ... which has only a getter".
+  const client = new Client(
+    `http://localhost:${server.address().port}`
+  ).compose([interceptors.retry({ maxRetries: 0 }), interceptors.decompress()])
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  const response = await client.request({
+    method: 'GET',
+    path: '/'
+  })
+
+  const body = await response.body.text()
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['content-encoding'], undefined)
+  t.equal(body, data)
+
+  await t.completed
+})

--- a/test/retry-handler-controller-proxy.js
+++ b/test/retry-handler-controller-proxy.js
@@ -109,6 +109,42 @@ test('controller proxy forwards reads/writes to the active connection and stays 
   t.deepStrictEqual(upgradeArgs, [101, { upgrade: 'websocket' }, 'SOCKET'])
 })
 
+test('controller proxy forwards rawHeaders/rawTrailers writes to the active connection', (t) => {
+  t = tspl(t, { plan: 5 })
+
+  let downstreamController = null
+
+  const handler = new RetryHandler(baseOpts, {
+    dispatch: () => {},
+    handler: {
+      onRequestStart (controller) {
+        downstreamController = controller
+      }
+    }
+  })
+
+  const connection = activeConnectionController()
+  handler.onRequestStart(connection, {})
+
+  // Regression for https://github.com/nodejs/undici/issues/5726: interceptors
+  // composed downstream of retry (e.g. decompress, cache) reassign rawHeaders to
+  // strip headers they consumed. rawHeaders/rawTrailers used to be getter-only on
+  // the proxy, so the assignment threw "Cannot set property rawHeaders ... which
+  // has only a getter". The proxy must forward the write to the active connection.
+  t.doesNotThrow(() => {
+    downstreamController.rawHeaders = ['content-type', 'text/plain']
+    downstreamController.rawTrailers = ['x-checksum', 'verified']
+  })
+
+  // The write reaches the active connection's controller...
+  t.deepStrictEqual(connection.rawHeaders, ['content-type', 'text/plain'])
+  t.deepStrictEqual(connection.rawTrailers, ['x-checksum', 'verified'])
+
+  // ...and reads back through the proxy reflect it.
+  t.deepStrictEqual(downstreamController.rawHeaders, ['content-type', 'text/plain'])
+  t.deepStrictEqual(downstreamController.rawTrailers, ['x-checksum', 'verified'])
+})
+
 test('controller proxy is forwarded downstream on a 206 whose content-range is unparseable', (t) => {
   t = tspl(t, { plan: 3 })
 


### PR DESCRIPTION
Fixes #5726.

### Problem
`RetryController` (`lib/handler/retry-handler.js`) exposed `rawHeaders` and `rawTrailers` as **getter-only** accessors, but the real `RequestController` (`lib/core/request.js`) declares them as **writable** data properties. Interceptors composed downstream of retry legitimately reassign them — the decompress interceptor does `controller.rawHeaders = filteredHeaders` (to strip `content-encoding`/`content-length`), and the cache interceptor does the same. When retry sits ahead of decompress, the interceptor gets the retry proxy and the assignment throws:

`TypeError: Cannot set property rawHeaders of #<RetryController> which has only a getter`

`rawTrailers` had the identical latent defect (assigned by `request.js` and `mock-utils.js`).

### Fix
Add forwarding **setters** to the proxy, mirroring the existing getters and the writable fields of the real controller — making the proxy transparent for writes as it already is for reads. Consistent with the proxy's design ("always forwards to the controller of the currently active connection").

### Test
- `test/retry-handler-controller-proxy.js` — unit: forwards `rawHeaders`/`rawTrailers` writes (RED: getter-only TypeError; GREEN: forwarded).
- `test/interceptors/decompress.js` — end-to-end: retry composed before decompress (RED at HEAD; GREEN with fix).

decompress 28/28, retry-handler/retry-agent suites, `npm run lint` — all green.
