### PR TITLE
fix(fetch): dump 3xx redirect bodies without pausing so the connection is released

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2266,6 +2266,15 @@ async function httpNetworkFetch (
             const willFollow = location && request.redirect === 'follow' &&
               redirectStatusSet.has(status)
 
+            // When this 3xx response will be followed, its body is discarded and
+            // never exposed to the caller. Drain it (ignore the bytes but keep
+            // reading, see onResponseData) instead of buffering it into this.body,
+            // otherwise a redirect body larger than the stream's highWaterMark
+            // applies backpressure that pauses and pins the connection, hanging
+            // the follow-up request on a connection-limited dispatcher.
+            // See https://github.com/nodejs/undici/issues/5728
+            this.willFollow = willFollow
+
             const decoders = []
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
@@ -2335,7 +2344,10 @@ async function httpNetworkFetch (
           },
 
           onResponseData (controller, chunk) {
-            if (fetchParams.controller.dump) {
+            // Discard the body of a 3xx response that is about to be followed,
+            // but keep reading (do not pause) so the connection drains and is
+            // released back to the pool. https://github.com/nodejs/undici/issues/5728
+            if (fetchParams.controller.dump || this.willFollow) {
               return
             }
 

--- a/test/issue-5728.js
+++ b/test/issue-5728.js
@@ -1,0 +1,41 @@
+'use strict'
+
+// Repro for https://github.com/nodejs/undici/issues/5728
+// fetch({ redirect: 'follow' }) does not drain the 3xx redirect response body.
+// When the redirect body is larger than the stream highWaterMark the socket
+// stays `running`, so with an Agent limited to a single connection the
+// follow-up request can never acquire the pinned socket and fetch hangs.
+//
+// Run: node --test test/issue-5728.js
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { fetch, Agent } = require('..')
+
+test('fetch follow does not pin the keep-alive socket on a 301 with a large body', { timeout: 15_000 }, async (t) => {
+  t.plan(3)
+  // Larger than the default 64 KiB highWaterMark so the body is not fully
+  // buffered/drained implicitly.
+  const redirectBody = Buffer.alloc(128 * 1024, 0x78)
+  const server = createServer((req, res) => {
+    if (req.url === '/redirect') {
+      res.writeHead(301, { Location: '/final' })
+      res.end(redirectBody)
+      return
+    }
+    res.end('ok')
+  })
+  const dispatcher = new Agent({ connections: 1, keepAliveTimeout: 10_000 })
+  t.after(async () => {
+    await dispatcher.destroy()
+    server.close()
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  const url = `http://127.0.0.1:${server.address().port}/redirect`
+  const first = await fetch(url, { dispatcher, redirect: 'follow' })
+  t.assert.strictEqual(first.status, 200)
+  t.assert.strictEqual(await first.text(), 'ok')
+  t.assert.ok(first.redirected)
+})


### PR DESCRIPTION
Fixes #5728.

### Problem
`fetch({ redirect: 'follow' })` hangs when a 3xx redirect body is large, on a connection-limited `Agent`. In `httpNetworkFetch` (`lib/web/fetch/index.js`), `onResponseData` pushed each chunk into the internal `Readable` and called `controller.pause()` on backpressure. A redirect body larger than the highWaterMark (the repro uses 128 KiB) fills the buffer, pauses the socket, and — since the follow path discards the response and recurses into `mainFetch` — the body is never consumed. The connection stays `running`; with `Agent({ connections: 1 })` the follow-up can never acquire the pinned socket → hang.

The `request()` path (`lib/handler/redirect-handler.js`) already discards 3xx bodies **without pausing**, so it never pins the connection; the fetch path lacked the equivalent.

### Fix
Set `this.willFollow` in `onResponseStart`, and in `onResponseData` return early when `fetchParams.controller.dump || this.willFollow` — discarding the bytes but **not pausing**, so the socket drains, `onResponseEnd` fires, and the connection is released. Per-hop (the handler is per-dispatch), and correct because a followed 3xx body is never exposed to the caller.

### Test
`test/issue-5728.js`: **RED** timed out at 15s (hang); **GREEN** passes in ~31ms. Full redirect regression suite green (`redirect-request` 83, `redirect-stream` 23, `fetch/redirect`, `client-fetch` 33, …), `npm run lint` — all green.
