### PR TITLE
fix(fetch): keep cloned request abort linkage alive across GC

### DIFF
--- a/lib/web/fetch/request.js
+++ b/lib/web/fetch/request.js
@@ -30,11 +30,43 @@ const { getMaxListeners, setMaxListeners, defaultMaxListeners } = require('node:
 
 const kAbortController = Symbol('abortController')
 
+// Strong references to the abort controller(s) of the source request(s) a
+// request follows. When a request follows another request's *internal* signal
+// (via `clone()` or `new Request(otherRequest)`), that source signal — and the
+// controller that drives abort propagation through it — is only reachable
+// weakly. If the source request object is dropped, garbage collection can
+// collect the controller chain and silently sever abort propagation to the
+// clone. Holding the chain strongly for the follower's lifetime keeps the
+// linkage alive. See https://github.com/nodejs/undici/issues/4068.
+const kAbortSourceControllers = Symbol('abortSourceControllers')
+
 const requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
   signal.removeEventListener('abort', abort)
 })
 
 const dependentControllerMap = new WeakMap()
+
+// Flatten the abort-controller chain that keeps `sourceRequestObject`'s signal
+// following alive, so a request following its signal can retain the whole chain
+// (see kAbortSourceControllers). Returns `undefined` when there is nothing to
+// keep alive.
+function collectAbortSourceControllers (sourceRequestObject) {
+  if (sourceRequestObject == null) {
+    return undefined
+  }
+
+  const controllers = []
+  const ownController = sourceRequestObject[kAbortController]
+  if (ownController !== undefined) {
+    controllers.push(ownController)
+  }
+  const inherited = sourceRequestObject[kAbortSourceControllers]
+  if (inherited !== undefined) {
+    controllers.push(...inherited)
+  }
+
+  return controllers.length !== 0 ? controllers : undefined
+}
 
 let abortSignalHasEventHandlerLeakWarning
 
@@ -130,6 +162,13 @@ class Request {
     // 4. Let signal be null.
     let signal = null
 
+    // undici implementation note: when input is a Request, `signal` below is
+    // set to that request's internal signal. Track the source request object so
+    // its abort-controller chain can be kept alive if we end up following that
+    // signal (kAbortSourceControllers). Reset to null if init["signal"] later
+    // overrides it with a caller-owned signal.
+    let sourceRequestObject = null
+
     // 5. If input is a string, then:
     if (typeof input === 'string') {
       this.#dispatcher = init.dispatcher
@@ -167,6 +206,7 @@ class Request {
 
       // 9. Set signal to input’s signal.
       signal = input.#signal
+      sourceRequestObject = input
 
       this.#dispatcher = init.dispatcher || input.#dispatcher
     }
@@ -412,6 +452,9 @@ class Request {
     // 26. If init["signal"] exists, then set signal to it.
     if (init.signal !== undefined) {
       signal = init.signal
+      // A caller-owned signal replaces input's signal, so input's controller
+      // chain is no longer part of what we follow.
+      sourceRequestObject = null
     }
 
     // 27. Set this’s request to request.
@@ -434,6 +477,15 @@ class Request {
         // from being prematurely garbage collected.
         // See, https://github.com/nodejs/undici/issues/1926.
         this[kAbortController] = ac
+
+        // If we are following another request's internal signal, keep that
+        // request's abort-controller chain alive for as long as this request
+        // is alive; otherwise GC can collect it and break abort propagation.
+        // See https://github.com/nodejs/undici/issues/4068.
+        const sourceControllers = collectAbortSourceControllers(sourceRequestObject)
+        if (sourceControllers !== undefined) {
+          this[kAbortSourceControllers] = sourceControllers
+        }
 
         const acRef = new WeakRef(ac)
         const abort = buildAbort(acRef)
@@ -809,7 +861,24 @@ class Request {
     }
 
     // 4. Return clonedRequestObject.
-    return fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+    const clonedRequestObject = fromInnerRequest(clonedRequest, this.#dispatcher, ac.signal, getHeadersGuard(this.#headers))
+
+    if (!this.signal.aborted) {
+      // Keep strong references so the signal-follow linkage survives garbage
+      // collection. The dependent controller `ac` is otherwise only reachable
+      // through weak references (dependentControllerMap and the abort listener),
+      // and the source request's controller chain is only reachable while the
+      // source request object is alive. Either can be collected while the clone
+      // is still in flight, silently breaking abort propagation.
+      // See https://github.com/nodejs/undici/issues/4068.
+      clonedRequestObject[kAbortController] = ac
+      const sourceControllers = collectAbortSourceControllers(this)
+      if (sourceControllers !== undefined) {
+        clonedRequestObject[kAbortSourceControllers] = sourceControllers
+      }
+    }
+
+    return clonedRequestObject
   }
 
   [nodeUtil.inspect.custom] (depth, options) {

--- a/test/issue-4068.js
+++ b/test/issue-4068.js
@@ -1,0 +1,101 @@
+'use strict'
+
+// Regression test for https://github.com/nodejs/undici/issues/4068
+//
+// A cloned (or constructor-copied) Request must keep respecting its abort
+// signal after a garbage collection. The follow linkage that ties the clone's
+// signal to the source signal used to be reachable only through weak references
+// (dependentControllerMap / WeakRef), so once GC ran the controller chain was
+// collected and aborting the source no longer aborted the in-flight fetch,
+// which then hung until the timeout guard fired.
+//
+// This test is GC-sensitive, so it must be run deterministically with
+// `--expose-gc` and it forces `global.gc()` itself rather than relying on the
+// runtime to collect on its own.
+//
+// Run: node --expose-gc --test test/issue-4068.js
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { fetch, Request } = require('..')
+
+// Force garbage collection deterministically. Multiple passes give the runtime
+// the chance to collect objects that only became unreachable during a previous
+// pass (e.g. a controller freed once its owning request was collected).
+function forceGc () {
+  for (let i = 0; i < 10; i++) {
+    global.gc()
+  }
+}
+
+async function assertClonePropagatesAbortAfterGc (t, makeFollower) {
+  // Server that accepts the connection but never responds, so the only way the
+  // fetch settles is through abort propagation.
+  const server = createServer(() => {})
+  t.after(() => server.close())
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const url = `http://127.0.0.1:${server.address().port}`
+
+  const ac = new AbortController()
+  // The source request is intentionally dropped after the follower is created,
+  // so only the follower keeps the abort linkage reachable.
+  const req = makeFollower(url, ac.signal)
+
+  // Collect now, before the abort. If the follow linkage was weakly held it is
+  // gone at this point and the abort below will not reach the fetch.
+  forceGc()
+
+  const fetchPromise = fetch(req)
+
+  setTimeout(() => {
+    forceGc()
+    ac.abort()
+  }, 50)
+
+  await t.assert.rejects(fetchPromise, (err) => err.name === 'AbortError')
+}
+
+test('cloned request still respects its abort signal after GC', { timeout: 10_000 }, async (t) => {
+  if (typeof global.gc !== 'function') {
+    t.skip('run with --expose-gc')
+    return
+  }
+
+  await assertClonePropagatesAbortAfterGc(t, (url, signal) => {
+    let req = new Request(url, { signal })
+    req = req.clone()
+    return req
+  })
+})
+
+test('constructor-copied request still respects its abort signal after GC', { timeout: 10_000 }, async (t) => {
+  if (typeof global.gc !== 'function') {
+    t.skip('run with --expose-gc')
+    return
+  }
+
+  await assertClonePropagatesAbortAfterGc(t, (url, signal) => {
+    let req = new Request(url, { signal })
+    req = new Request(req)
+    return req
+  })
+})
+
+test('deeply cloned request still respects its abort signal after GC', { timeout: 10_000 }, async (t) => {
+  if (typeof global.gc !== 'function') {
+    t.skip('run with --expose-gc')
+    return
+  }
+
+  // A clone of a clone of a copy: every intermediate request is dropped, so the
+  // whole ancestor controller chain must be kept reachable by the final clone.
+  await assertClonePropagatesAbortAfterGc(t, (url, signal) => {
+    let req = new Request(url, { signal })
+    req = new Request(req)
+    req = req.clone()
+    req = req.clone()
+    return req
+  })
+})


### PR DESCRIPTION
Fixes #4068.

### Problem
A cloned `Request` loses abort propagation after garbage collection. The clone-follow wiring (from #3169) made the dependent controller reachable **only** through `WeakRef`s, so GC collects it and `acRef.deref()` returns `undefined`, silently dropping propagation. Deeper: a clone follows the source request's internal signal, whose controller is held only by the source `Request` object; when the source is dropped (`req = req.clone()`), that controller is collected too. Same for `new Request(existingRequest)`.

Confirmed still reproducing at HEAD (undici 8.10.1): the repro `fetch` hangs because aborting the original after a GC never rejects the clone.

### Fix
Mirror the constructor's proven strong-reference strategy (#1926) for the follow linkage, **without** altering the abort wiring (preserving #3169's firing order) and **without** adding a `FinalizationRegistry` to clones (respecting #4320):
1. `clone()` keeps the dependent controller alive (`clonedRequestObject[kAbortController] = ac`).
2. Both `clone()` and the constructor keep the **flattened source controller chain** alive via a new `kAbortSourceControllers` symbol, so arbitrarily deep clone chains survive even when every intermediate `Request` is collected. Refs release when the follower itself is GC'd (no leak — verified against `long-lived-abort-controller.js`).

### Test
`test/issue-4068.js` (run under `node --expose-gc`, deterministic `forceGc()` with 10 passes): both `clone()` and `new Request(req)` cases — **RED** time out (hang); **GREEN** 3/3 pass in ~150ms. `fetch/request` 32, `fetch/abort`, `request-signal`, `long-lived-abort-controller` all green; `npm run lint` green.
