### PR TITLE
fix(websocket): don't require Sec-WebSocket-Accept on an h2 handshake

### DIFF
--- a/lib/web/websocket/connection.js
+++ b/lib/web/websocket/connection.js
@@ -159,9 +159,10 @@ function establishWebSocketConnection (url, protocols, client, handler, options)
       //    E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and
       //    trailing whitespace, the client MUST _Fail the WebSocket
       //    Connection_.
+      //    For H2, no Sec-WebSocket-Accept header is expected.
       const secWSAccept = response.headersList.get('Sec-WebSocket-Accept')
       const digest = crypto.hash('sha1', keyValue + uid, 'base64')
-      if (secWSAccept !== digest) {
+      if (response.socket.session == null && secWSAccept !== digest) {
         failWebsocketConnection(handler, 1002, 'Incorrect hash received in Sec-WebSocket-Accept header.')
         return
       }

--- a/test/websocket/opening-handshake.js
+++ b/test/websocket/opening-handshake.js
@@ -227,6 +227,46 @@ test('WebSocket over H2 fails the handshake when the extended CONNECT response i
   await planner.completed
 })
 
+// RFC 8441 §5: an h2 extended CONNECT handshake does not use Sec-WebSocket-Accept.
+test('WebSocket over H2 opens when the extended CONNECT response has no Sec-WebSocket-Accept header', async (t) => {
+  const sessions = new Set()
+  const h2Server = createSecureServer({ cert, key, settings: { enableConnectProtocol: true } })
+    .on('session', (session) => {
+      sessions.add(session)
+      session.on('close', () => sessions.delete(session))
+    })
+    .on('stream', (stream, headers) => {
+      t.assert.strictEqual(headers[':protocol'], 'websocket')
+      stream.respond({ ':status': 200 })
+    })
+    .listen(0)
+
+  t.after(async () => {
+    for (const session of sessions) {
+      session.destroy()
+    }
+
+    await new Promise((resolve) => h2Server.close(resolve))
+  })
+
+  await once(h2Server, 'listening')
+
+  const dispatcher = new Agent({
+    allowH2: true,
+    connect: {
+      rejectUnauthorized: false
+    }
+  })
+  t.after(() => dispatcher.close())
+
+  const ws = new WebSocket(`wss://localhost:${h2Server.address().port}`, { dispatcher })
+
+  await new Promise((resolve, reject) => {
+    ws.onopen = resolve
+    ws.onerror = ({ error }) => reject(error)
+  })
+})
+
 test('WebSocket on H2 with a server that does not support extended CONNECT protocol', async (t) => {
   const planner = tspl(t, { plan: 1 })
   const h2Server = createSecureServer({ cert, key, settings: { enableConnectProtocol: false } })


### PR DESCRIPTION
## This relates to...

WebSocket over h2 ([RFC 8441](https://www.rfc-editor.org/rfc/rfc8441.html#section-5)) handshake validation.

Reported in #5681 and closed as a server-compliance issue — but per RFC 8441 §5 the response is valid: `Sec-WebSocket-Accept` is not processed on an h2 handshake.

## Rationale

Over h1, the handshake response is validated against [RFC 6455 §4.1 steps 2–6](https://www.rfc-editor.org/rfc/rfc6455.html#page-19).
Over h2, `Sec-WebSocket-Key` and `Sec-WebSocket-Accept` are not processed at all — [RFC 8441 §5](https://www.rfc-editor.org/rfc/rfc8441.html#section-5):

> Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.

undici already skips steps 2 (`Upgrade`) and 3 (`Connection`) for h2, but not step 4 (`Sec-WebSocket-Accept`).
An h2 server that responds without `Sec-WebSocket-Accept` therefore fails step 4 and closes with 1006.

<details>
<summary>Repro(.mjs) — 1006 on <code>main</code>, opens with this PR</summary>

```js
import { readFileSync } from "node:fs";
import { once } from "node:events";
import { createSecureServer } from "node:http2";
import { WebSocket, Agent } from "./index.js";

const server = createSecureServer({
  key: readFileSync("./test/fixtures/key.pem"),
  cert: readFileSync("./test/fixtures/cert.pem"),
  settings: { enableConnectProtocol: true },
});
server.on("stream", (stream) => {
  stream.respond({ ":status": 200 }); // no Sec-WebSocket-Accept
  stream.on("error", () => {});
});
await once(server.listen(0), "listening");

const dispatcher = new Agent({
  allowH2: true,
  connect: { rejectUnauthorized: false },
});
const ws = new WebSocket(`wss://localhost:${server.address().port}`, {
  dispatcher,
});
const stop = () => {
  ws.onerror = ws.onclose = null;
  dispatcher.destroy();
  server.close();
};
ws.onopen = () => {
  console.log("open");
  stop();
};
ws.onclose = ({ code }) => {
  console.log("close:", code);
  stop();
};
```

</details>

## Changes

- `lib/web/websocket/connection.js`: give step 4 the same h2 gate steps 2 and 3 have.
- `test/websocket/opening-handshake.js`: an h2 server responds `200` without `Sec-WebSocket-Accept` and the test awaits `open`. Fails on `main`, passes with the patch.

### Features

N/A

### Bug Fixes

- WebSocket over h2 now connects to servers that follow RFC 8441 and omit `Sec-WebSocket-Accept`.

### Breaking Changes and Deprecations

N/A

## Test results (Node 24.20.0)

- `npm run lint` clean
- `test/websocket/**/*.js` 148/148

Assisted-by: Claude Code

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
