### PR TITLE
ci: extend macOS Node.js workflow timeout

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   test:
     name: Test ${{ inputs.codecov == true && 'and Coverage ' || '' }}with Node.js ${{ inputs.node-version }} on ${{ inputs.runs-on }}
-    timeout-minutes: ${{ inputs.runs-on == 'windows-latest' && 30 || 20 }}
+    timeout-minutes: ${{ (inputs.runs-on == 'windows-latest' || inputs.runs-on == 'macos-latest') && 30 || 20 }}
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

Increase the reusable Node.js workflow timeout from 20 to 30 minutes for macOS jobs. Windows remains at 30 minutes and Ubuntu remains at 20 minutes.

## Motivation

The macOS Node.js 22 job in run `33859213479` was cancelled while WPT was still actively progressing at the 20-minute job timeout. The Node.js 26 macOS job in the same run completed WPT only seconds before reaching the same boundary.

This gives slower macOS runners enough time to finish WPT and cleanup without weakening the timeout for faster Ubuntu jobs.

## Validation

- `npm run lint`
- Parsed all workflow YAML files with the repository `yaml` package
- `git diff --check`
