### PR TITLE
fix(env-http-proxy-agent): NO_PROXY wildcard semantics

### DIFF
--- a/lib/dispatcher/env-http-proxy-agent.js
+++ b/lib/dispatcher/env-http-proxy-agent.js
@@ -94,17 +94,25 @@ class EnvHttpProxyAgent extends DispatcherBase {
     if (this.#noProxyEntries.length === 0) {
       return true // Always proxy if NO_PROXY is not set or empty.
     }
-    if (this.#noProxyValue === '*') {
-      return false // Never proxy if wildcard is set.
-    }
 
     for (let i = 0; i < this.#noProxyEntries.length; i++) {
       const entry = this.#noProxyEntries[i]
+      // A bare `*` entry matches all hosts regardless of its position or the
+      // surrounding whitespace (e.g. ` * ` or `none.invalid,*`). If a port is
+      // attached (`*:80`) it only bypasses that port.
+      if (entry.hostname === '*') {
+        if (entry.port && entry.port !== port) {
+          continue
+        }
+        return false // Never proxy if a wildcard entry is present.
+      }
       if (entry.port && entry.port !== port) {
         continue // Skip if ports don't match.
       }
-      // Don't proxy if the hostname is equal with the no_proxy host.
-      if (hostname === entry.hostname) {
+      // Don't proxy if the hostname is equal with the no_proxy host. A
+      // `*.example.com` wildcard matches subdomains only, not the apex
+      // `example.com`, so exact matches are skipped for wildcard entries.
+      if (!entry.wildcard && hostname === entry.hostname) {
         return false
       }
       // Don't proxy if the hostname is the subdomain of the no_proxy host.
@@ -149,10 +157,17 @@ class EnvHttpProxyAgent extends DispatcherBase {
         port = parsed ? Number.parseInt(parsed[2], 10) : 0
       }
 
+      // A leading `*` marks a subdomain wildcard (`*.example.com`), distinct
+      // from a plain or leading-dot suffix (`example.com` / `.example.com`)
+      // which also matches the apex. `*.example.com` must only match
+      // subdomains, never the apex `example.com` itself.
+      const wildcard = entry.charCodeAt(0) === 42 /* '*' */
+
       noProxyEntries.push({
         // strip leading dot or asterisk with dot, and any trailing dot
         hostname: hostname.replace(/^\*?\./, '').replace(/^(.+)\.$/, '$1').toLowerCase(),
-        port
+        port,
+        wildcard
       })
     }
 

--- a/test/env-http-proxy-agent.js
+++ b/test/env-http-proxy-agent.js
@@ -268,6 +268,24 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
+  test('wildcard * with surrounding whitespace matches all hosts', async (t) => {
+    t = tspl(t, { plan: 2 })
+    process.env.no_proxy = ' * '
+    const { dispatcher, doesNotProxy } = createEnvHttpProxyAgentWithMocks(2)
+    t.ok(await doesNotProxy('https://example.com'))
+    t.ok(await doesNotProxy('http://example.com'))
+    return dispatcher.close()
+  })
+
+  test('wildcard * among other entries matches all hosts', async (t) => {
+    t = tspl(t, { plan: 2 })
+    process.env.no_proxy = 'none.invalid,*'
+    const { dispatcher, doesNotProxy } = createEnvHttpProxyAgentWithMocks(2)
+    t.ok(await doesNotProxy('https://example.com'))
+    t.ok(await doesNotProxy('http://example.com'))
+    return dispatcher.close()
+  })
+
   test('set but empty', async (t) => {
     t = tspl(t, { plan: 1 })
     process.env.no_proxy = ''
@@ -382,13 +400,16 @@ describe('no_proxy', () => {
     return dispatcher.close()
   })
 
-  test('host suffix with *. - leading dot with asterisk stripped', async (t) => {
+  test('host suffix with *. - subdomain wildcard does NOT match the apex', async (t) => {
+    // `*.example` is a subdomain wildcard: it must bypass the proxy for
+    // `sub.example` and `a.b.example`, but NOT for the apex `example` itself.
+    // This matches node:http and the usual `*.domain` convention.
     t = tspl(t, { plan: 9 })
     process.env.no_proxy = '*.example'
     const { dispatcher, doesNotProxy, usesProxyAgent } = createEnvHttpProxyAgentWithMocks(9)
-    t.ok(await doesNotProxy('http://example'))
-    t.ok(await doesNotProxy('http://example:80'))
-    t.ok(await doesNotProxy('http://example:1337'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:80'))
+    t.ok(await usesProxyAgent(kHttpProxyAgent, 'http://example:1337'))
     t.ok(await doesNotProxy('http://sub.example'))
     t.ok(await doesNotProxy('http://sub.example:80'))
     t.ok(await doesNotProxy('http://sub.example:1337'))


### PR DESCRIPTION
Fix NO_PROXY wildcard matching in `EnvHttpProxyAgent` so `fetch()` is internally consistent with `node:http` (see `nodejs/node#57872`, the `NO_PROXY` differences table).

Three non-sensible behaviors are fixed:

- `*.example.com` previously bypassed the proxy for the apex `example.com` itself. A `*.domain` entry is a subdomain wildcard and must only match `sub.example.com` / `a.b.example.com`, not the apex. `node:http` already does this.
- ` * ` (a wildcard with surrounding whitespace) was not recognized as a global wildcard because the check compared the whole `NO_PROXY` string against `*`.
- `none.invalid,*` (a `*` among other entries) was likewise not recognized as a global wildcard.

A bare `*` entry now matches all hosts regardless of position or whitespace, and is port-aware (`*:80` only bypasses that port).

Tests updated and added; all `env-http-proxy-agent` tests pass and lint is clean.

Refs: https://github.com/nodejs/node/issues/57872
