### PR TITLE
[v6.x] fix(retry): settle exposed body on terminal failure

### DIFF
--- a/lib/handler/retry-handler.js
+++ b/lib/handler/retry-handler.js
@@ -205,7 +205,10 @@ class RetryHandler {
     this.retryCount += 1
 
     if (statusCode >= 300) {
-      if (this.retryOpts.statusCodes.includes(statusCode) === false) {
+      // Only expose a response if no earlier attempt has reached the caller.
+      // Otherwise abort this attempt so the error settles the existing body
+      // instead of replacing it with a new response.
+      if (!this.headersSent && this.retryOpts.statusCodes.includes(statusCode) === false) {
         this.headersSent = true
         this.checkpointResponseEnd(headers, resume)
         return this.handler.onHeaders(

--- a/test/retry-handler-terminal.js
+++ b/test/retry-handler-terminal.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+const { RetryHandler } = require('..')
+
+function noop () {}
+
+for (const statusCode of [300, 404, 416]) {
+  test(`RetryHandler settles an exposed response on terminal status ${statusCode}`, () => {
+    const errors = []
+    let aborts = 0
+    const handler = new RetryHandler({ method: 'GET', path: '/' }, {
+      dispatch () {
+        assert.fail('a terminal status must not dispatch another attempt')
+      },
+      handler: {
+        onConnect: noop,
+        onHeaders () {
+          assert.fail('an exposed response must not be replaced')
+        },
+        onError (err) {
+          errors.push(err)
+        }
+      }
+    })
+
+    // Model an attempt whose response is already owned by the caller.
+    handler.headersSent = true
+    handler.resume = noop
+    handler.start = 1
+    handler.end = 3
+    handler.onConnect(err => {
+      aborts++
+      handler.onError(err)
+    })
+
+    const rawHeaders = ['content-length', '0']
+    assert.equal(handler.onHeaders(statusCode, rawHeaders, noop, 'Terminal'), false)
+    assert.equal(aborts, 1)
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'UND_ERR_REQ_RETRY')
+    assert.equal(errors[0].statusCode, statusCode)
+    assert.deepEqual(errors[0].headers, { 'content-length': '0' })
+    assert.equal(handler.start, 1)
+    assert.equal(handler.end, 3)
+  })
+
+  test(`RetryHandler preserves an initial non-retryable response with status ${statusCode}`, () => {
+    const rawHeaders = ['content-length', '0']
+    let responses = 0
+    let completions = 0
+    const resume = noop
+    const handler = new RetryHandler({ method: 'GET', path: '/' }, {
+      dispatch () {
+        assert.fail('an initial non-retryable response must not be retried')
+      },
+      handler: {
+        onConnect: noop,
+        onHeaders (status, headers, receivedResume, statusMessage) {
+          responses++
+          assert.equal(status, statusCode)
+          assert.equal(headers, rawHeaders)
+          assert.equal(receivedResume, resume)
+          assert.equal(statusMessage, 'Terminal')
+          return true
+        },
+        onComplete () {
+          completions++
+        },
+        onError (err) {
+          assert.fail(err)
+        }
+      }
+    })
+    handler.onConnect(() => assert.fail('the initial response must not be aborted'))
+
+    assert.equal(handler.onHeaders(statusCode, rawHeaders, resume, 'Terminal'), true)
+    handler.onComplete([])
+    assert.equal(responses, 1)
+    assert.equal(completions, 1)
+    assert.equal(handler.headersSent, true)
+    assert.equal(handler.end, -1)
+  })
+}


### PR DESCRIPTION
## Summary

Adapt the response-ownership guard from e905b5b87e6953bcc542af90557b2fee5b7b5974 (`fix(retry): settle exposed body on terminal failure`) to the legacy v6 handler interface.

- Do not forward a replacement response after an earlier attempt has already exposed one downstream.
- Use the existing abort/error path to settle the exposed response on terminal failure.
- Preserve forwarding and completion of an initial non-retryable response.
- Add six handler-level regression cases covering terminal error propagation and initial-response compatibility.

This is an adapted backport, not a clean cherry-pick. It does not establish a new security classification or affected-version range.

## Validation

- Retry handler, retry agent, and retry interceptor tests: **38 passed** on each of Node **18.20.8, 20.20.0, 22.22.1, and 24.18.1**.
- Complete interceptor suite: **112 passed** on Node 24.18.1.
- `npm run lint` and direct `standard`: passed.
- `npm run test:typescript`: passed.
- Syntax checks for both changed files, `git diff --check`, and `npm pack --dry-run`: passed.
- Full `npm test` was attempted on Node 24.18.1 but did **not** complete: it reached the 10-minute local execution limit during the unit suite and reported `no memory leak with TLS certificate errors` as failing. No changes were made to that test, and the full suite is not claimed to pass.
