### PR TITLE
fix(proxy-agent): preserve repeated iterable headers

### DIFF
--- a/lib/dispatcher/proxy-agent.js
+++ b/lib/dispatcher/proxy-agent.js
@@ -325,8 +325,8 @@ class ProxyAgent extends DispatcherBase {
 }
 
 /**
- * @param {string[] | Record<string, string>} headers
- * @returns {Record<string, string>}
+ * @param {string[] | Record<string, string> | Iterable<[string, string | string[] | undefined]>} headers
+ * @returns {Record<string, string | string[] | undefined>}
  */
 function buildHeaders (headers) {
   // When using undici.fetch, the headers list is stored
@@ -355,7 +355,20 @@ function buildHeaders (headers) {
     const headersPair = {}
 
     for (const [key, value] of headers) {
-      headersPair[key] = value
+      if (!Object.hasOwn(headersPair, key)) {
+        headersPair[key] = value
+        continue
+      }
+
+      const previous = headersPair[key]
+      const values = []
+      if (previous !== undefined) {
+        values.push(...(Array.isArray(previous) ? previous : [previous]))
+      }
+      if (value !== undefined) {
+        values.push(...(Array.isArray(value) ? value : [value]))
+      }
+      headersPair[key] = values.length > 1 ? values : values[0]
     }
 
     return headersPair

--- a/test/proxy-agent.js
+++ b/test/proxy-agent.js
@@ -836,6 +836,34 @@ test('use proxy-agent with custom headers with tunneling enabled', async (t) => 
   proxyAgent.close()
 })
 
+test('use proxy-agent with repeated iterable headers', async (t) => {
+  t = tspl(t, { plan: 1 })
+  const server = await buildServer()
+  const proxy = await buildProxy()
+
+  const serverUrl = `http://localhost:${server.address().port}`
+  const proxyUrl = `http://localhost:${proxy.address().port}`
+  const proxyAgent = new ProxyAgent(proxyUrl)
+
+  server.on('request', (req, res) => {
+    t.strictEqual(req.headers['x-duplicate'], 'first, second')
+    res.end()
+  })
+
+  const headers = {
+    * [Symbol.iterator] () {
+      yield ['x-duplicate', 'first']
+      yield ['x-duplicate', 'second']
+    }
+  }
+
+  await request(serverUrl, { dispatcher: proxyAgent, headers })
+
+  server.close()
+  proxy.close()
+  proxyAgent.close()
+})
+
 test('sending proxy-authorization in request headers should throw', async (t) => {
   t = tspl(t, { plan: 5 })
   const server = await buildServer()


### PR DESCRIPTION
Follow-up to #5758.

ProxyAgent converts iterable request headers to an object before checking for Proxy-Authorization. If the iterable contains the same header more than once, the conversion keeps only the last value.

Keep repeated values when building the headers used by the proxy request, and add a regression test for the case.

Tests:
- `npx borp --timeout 180000 test/proxy-agent.js`
- `npx eslint lib/dispatcher/proxy-agent.js test/proxy-agent.js`
