### PR TITLE
feat(util): expose request header normalization

### DIFF
--- a/docs/docs/api/Util.md
+++ b/docs/docs/api/Util.md
@@ -14,13 +14,13 @@ and parse raw header lists exactly the way undici does.
 ```mjs
 import { util } from 'undici'
 
-const { parseHeaders, headerNameToString } = util
+const { parseHeaders, headerNameToString, normalizeHeaders } = util
 ```
 
 ```cjs
 const { util } = require('undici')
 
-const { parseHeaders, headerNameToString } = util
+const { parseHeaders, headerNameToString, normalizeHeaders } = util
 ```
 
 ## `parseHeaders(headers[, obj])`
@@ -76,6 +76,28 @@ console.log(util.headerNameToString('Content-Type'))
 
 console.log(util.headerNameToString(Buffer.from('X-Custom-Header')))
 // 'x-custom-header'
+```
+
+## `normalizeHeaders(headers)`
+
+* `headers` {Object|Array|Iterable|null|undefined} A supported request headers value.
+* Returns: {Object} An object keyed by lowercased header name.
+
+Normalizes request headers for dispatchers and interceptors that need to inspect
+them. Flat arrays, arrays of name/value pairs, `Headers` objects, custom
+iterables, and plain objects are accepted. Repeated names are collected into an
+array. The input is not modified.
+
+```mjs
+import { util } from 'undici'
+
+const headers = util.normalizeHeaders([
+  ['X-Trace-Id', 'one'],
+  ['x-trace-id', 'two']
+])
+
+console.log(headers)
+// { 'x-trace-id': [ 'one', 'two' ] }
 ```
 
 [`Dispatcher`]: Dispatcher.md#class-dispatcher

--- a/index.js
+++ b/index.js
@@ -68,7 +68,8 @@ module.exports.buildConnector = buildConnector
 module.exports.errors = errors
 module.exports.util = {
   parseHeaders: util.parseHeaders,
-  headerNameToString: util.headerNameToString
+  headerNameToString: util.headerNameToString,
+  normalizeHeaders: util.normalizeHeaders
 }
 
 function makeDispatcher (fn) {

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -417,6 +417,94 @@ function bufferToLowerCasedHeaderName (value) {
   return tree.lookup(value) ?? value.toString('latin1').toLowerCase()
 }
 
+function appendHeader (headers, key, value) {
+  if (value === undefined) {
+    return
+  }
+
+  const name = headerNameToString(key)
+  const current = Object.hasOwn(headers, name) ? headers[name] : undefined
+  const values = Array.isArray(value) ? value : [value]
+
+  if (current === undefined) {
+    const headerValue = Array.isArray(value) ? value.slice() : value
+    if (name === '__proto__') {
+      Object.defineProperty(headers, name, {
+        value: headerValue,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      })
+    } else {
+      headers[name] = headerValue
+    }
+  } else if (Array.isArray(current)) {
+    current.push(...values)
+  } else {
+    headers[name] = [current, ...values]
+  }
+}
+
+/**
+ * @param {import('../../types/dispatcher.d.ts').UndiciHeaders | undefined} input
+ * @returns {Record<string, number | string | string[]>}
+ */
+function normalizeHeaders (input) {
+  const headers = {}
+
+  if (input == null) {
+    return headers
+  }
+
+  if (typeof input !== 'object') {
+    throw new TypeError('headers must be an object')
+  }
+
+  if (!hasSafeIterator(input)) {
+    for (const key of Object.keys(input)) {
+      appendHeader(headers, key, input[key])
+    }
+    return headers
+  }
+
+  if (Array.isArray(input) && (input.length === 0 || !Array.isArray(input[0]))) {
+    if (input.length % 2 !== 0) {
+      throw new TypeError('headers must be a valid header map')
+    }
+    for (let i = 0; i < input.length; i += 2) {
+      const key = input[i]
+      const value = input[i + 1]
+      if (typeof key !== 'string' || (typeof value !== 'string' && !Array.isArray(value))) {
+        throw new TypeError('headers must be a valid header map')
+      }
+      if (Array.isArray(value)) {
+        const mapped = []
+        for (let j = 0; j < value.length; j++) {
+          const entry = value[j]
+          mapped.push(typeof entry === 'string' ? entry : entry.toString('latin1'))
+        }
+        appendHeader(headers, key, mapped)
+      } else {
+        appendHeader(headers, key, value)
+      }
+    }
+    return headers
+  }
+
+  for (const entry of input) {
+    if (!Array.isArray(entry) || entry.length !== 2) {
+      throw new TypeError('headers must be a valid header map')
+    }
+    const [key, value] = entry
+    if (typeof key !== 'string' || (value !== undefined && typeof value !== 'string' && !Array.isArray(value))) {
+      throw new TypeError('headers must be a valid header map')
+    }
+    appendHeader(headers, key, value)
+  }
+
+  return headers
+}
+
 /**
  * @param {(Buffer | string)[]} headers
  * @param {Record<string, string | string[]>} [obj]
@@ -1014,6 +1102,7 @@ module.exports = {
   isAsyncIterable,
   isDestroyed,
   headerNameToString,
+  normalizeHeaders,
   bufferToLowerCasedHeaderName,
   addListener,
   removeAllListeners,

--- a/lib/dispatcher/dispatcher.js
+++ b/lib/dispatcher/dispatcher.js
@@ -1,77 +1,6 @@
 'use strict'
 const EventEmitter = require('node:events')
 const { kOriginless, kUrl } = require('../core/symbols')
-const { hasSafeIterator } = require('../core/util')
-
-function appendHeader (headers, key, value) {
-  if (value === undefined) {
-    return
-  }
-
-  key = key.toLowerCase()
-  const current = headers[key]
-  const values = Array.isArray(value) ? value : [value]
-
-  if (current === undefined) {
-    headers[key] = Array.isArray(value) ? value.slice() : value
-  } else if (Array.isArray(current)) {
-    current.push(...values)
-  } else {
-    headers[key] = [current, ...values]
-  }
-}
-
-function normalizeHeaders (headers) {
-  if (headers == null || typeof headers !== 'object') {
-    return headers
-  }
-
-  const prototype = Object.getPrototypeOf(headers)
-  if ((prototype === Object.prototype || prototype === null) && !Object.hasOwn(headers, Symbol.iterator)) {
-    let normalized = true
-    for (const key of Object.keys(headers)) {
-      if (key !== key.toLowerCase()) {
-        normalized = false
-        break
-      }
-    }
-    if (normalized) {
-      return headers
-    }
-  }
-
-  const normalized = {}
-
-  if (Array.isArray(headers)) {
-    if (headers.length > 0 && Array.isArray(headers[0])) {
-      for (let i = 0; i < headers.length; i++) {
-        if (!Array.isArray(headers[i]) || headers[i].length !== 2) {
-          return headers
-        }
-      }
-      for (const [key, value] of headers) {
-        appendHeader(normalized, key, value)
-      }
-    } else {
-      if (headers.length % 2 !== 0) {
-        return headers
-      }
-      for (let i = 0; i < headers.length; i += 2) {
-        appendHeader(normalized, headers[i], headers[i + 1])
-      }
-    }
-  } else if (typeof headers === 'object' && hasSafeIterator(headers)) {
-    for (const [key, value] of headers) {
-      appendHeader(normalized, key, value)
-    }
-  } else {
-    for (const key of Object.keys(headers)) {
-      appendHeader(normalized, key, headers[key])
-    }
-  }
-
-  return normalized
-}
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -114,15 +43,8 @@ class Dispatcher extends EventEmitter {
     const originalDispatch = dispatch
     const self = this
     dispatch = function (opts, handler) {
-      if (opts && typeof opts === 'object') {
-        const origin = !opts.origin && self[kUrl] ? self[kUrl].origin : undefined
-        const headers = opts.headers == null ? opts.headers : normalizeHeaders(opts.headers)
-
-        if (origin || headers !== opts.headers) {
-          opts = Object.assign({}, opts)
-          if (origin) opts.origin = origin
-          if (headers !== opts.headers) opts.headers = headers
-        }
+      if (opts && typeof opts === 'object' && !opts.origin && self[kUrl]) {
+        opts = Object.assign({}, opts, { origin: self[kUrl].origin })
       }
       return originalDispatch(opts, handler)
     }

--- a/lib/dispatcher/dispatcher.js
+++ b/lib/dispatcher/dispatcher.js
@@ -1,6 +1,75 @@
 'use strict'
 const EventEmitter = require('node:events')
 const { kOriginless, kUrl } = require('../core/symbols')
+const { hasSafeIterator } = require('../core/util')
+
+function appendHeader (headers, key, value) {
+  if (value === undefined) {
+    return
+  }
+
+  key = key.toLowerCase()
+  const current = headers[key]
+  const values = Array.isArray(value) ? value : [value]
+
+  if (current === undefined) {
+    headers[key] = Array.isArray(value) ? value.slice() : value
+  } else if (Array.isArray(current)) {
+    current.push(...values)
+  } else {
+    headers[key] = [current, ...values]
+  }
+}
+
+function normalizeHeaders (headers) {
+  if (headers == null || typeof headers !== 'object') {
+    return headers
+  }
+
+  const prototype = Object.getPrototypeOf(headers)
+  if ((prototype === Object.prototype || prototype === null) && !Object.hasOwn(headers, Symbol.iterator)) {
+    let normalized = true
+    for (const key of Object.keys(headers)) {
+      if (key !== key.toLowerCase()) {
+        normalized = false
+        break
+      }
+    }
+    if (normalized) {
+      return headers
+    }
+  }
+
+  const normalized = {}
+
+  if (Array.isArray(headers)) {
+    if (headers.length > 0 && Array.isArray(headers[0])) {
+      if (headers.some(header => !Array.isArray(header) || header.length !== 2)) {
+        return headers
+      }
+      for (const [key, value] of headers) {
+        appendHeader(normalized, key, value)
+      }
+    } else {
+      if (headers.length % 2 !== 0) {
+        return headers
+      }
+      for (let i = 0; i < headers.length; i += 2) {
+        appendHeader(normalized, headers[i], headers[i + 1])
+      }
+    }
+  } else if (typeof headers === 'object' && hasSafeIterator(headers)) {
+    for (const [key, value] of headers) {
+      appendHeader(normalized, key, value)
+    }
+  } else {
+    for (const key of Object.keys(headers)) {
+      appendHeader(normalized, key, headers[key])
+    }
+  }
+
+  return normalized
+}
 
 class Dispatcher extends EventEmitter {
   dispatch () {
@@ -43,8 +112,15 @@ class Dispatcher extends EventEmitter {
     const originalDispatch = dispatch
     const self = this
     dispatch = function (opts, handler) {
-      if (opts && typeof opts === 'object' && !opts.origin && self[kUrl]) {
-        opts = Object.assign({}, opts, { origin: self[kUrl].origin })
+      if (opts && typeof opts === 'object') {
+        const origin = !opts.origin && self[kUrl] ? self[kUrl].origin : undefined
+        const headers = opts.headers == null ? opts.headers : normalizeHeaders(opts.headers)
+
+        if (origin || headers !== opts.headers) {
+          opts = Object.assign({}, opts)
+          if (origin) opts.origin = origin
+          if (headers !== opts.headers) opts.headers = headers
+        }
       }
       return originalDispatch(opts, handler)
     }

--- a/lib/dispatcher/dispatcher.js
+++ b/lib/dispatcher/dispatcher.js
@@ -44,8 +44,10 @@ function normalizeHeaders (headers) {
 
   if (Array.isArray(headers)) {
     if (headers.length > 0 && Array.isArray(headers[0])) {
-      if (headers.some(header => !Array.isArray(header) || header.length !== 2)) {
-        return headers
+      for (let i = 0; i < headers.length; i++) {
+        if (!Array.isArray(headers[i]) || headers[i].length !== 2) {
+          return headers
+        }
       }
       for (const [key, value] of headers) {
         appendHeader(normalized, key, value)

--- a/lib/interceptor/cache.js
+++ b/lib/interceptor/cache.js
@@ -11,7 +11,6 @@ const {
   assertCacheMethods,
   getInterceptorOrigin,
   makeCacheKey,
-  normalizeHeaders,
   parseCacheControlHeader,
   isInvalidOrWildcardVaryHeader,
   parseVaryHeader
@@ -621,7 +620,7 @@ module.exports = (opts = {}) => {
 
       opts = {
         ...opts,
-        headers: normalizeHeaders(opts)
+        headers: util.normalizeHeaders(opts.headers)
       }
 
       const reqCacheControl = opts.headers?.['cache-control']

--- a/lib/interceptor/deduplicate.js
+++ b/lib/interceptor/deduplicate.js
@@ -3,7 +3,7 @@
 const diagnosticsChannel = require('node:diagnostics_channel')
 const util = require('../core/util')
 const DeduplicationHandler = require('../handler/deduplication-handler')
-const { getInterceptorOrigin, normalizeHeaders, makeCacheKey, makeDeduplicationKey } = require('../util/cache.js')
+const { getInterceptorOrigin, makeCacheKey, makeDeduplicationKey } = require('../util/cache.js')
 
 const pendingRequestsChannel = diagnosticsChannel.channel('undici:request:pending-requests')
 
@@ -66,7 +66,7 @@ module.exports = (opts = {}) => {
 
       opts = {
         ...opts,
-        headers: normalizeHeaders(opts)
+        headers: util.normalizeHeaders(opts.headers)
       }
 
       // Skip deduplication if request contains any of the specified headers

--- a/lib/util/cache.js
+++ b/lib/util/cache.js
@@ -3,7 +3,6 @@
 const {
   safeHTTPMethods,
   pathHasQueryOrFragment,
-  hasSafeIterator,
   isValidHTTPToken
 } = require('../core/util')
 
@@ -202,96 +201,6 @@ function makeCacheKey (opts, origin = getRequestOrigin(opts)) {
     path: fullPath,
     headers: opts.headers
   }
-}
-
-function appendHeader (headers, key, val) {
-  const headerName = key.toLowerCase()
-  const current = headers[headerName]
-  const values = Array.isArray(val) ? val : [val]
-
-  if (current === undefined) {
-    headers[headerName] = Array.isArray(val) ? val.slice() : val
-  } else if (Array.isArray(current)) {
-    current.push(...values)
-  } else {
-    headers[headerName] = [current, ...values]
-  }
-}
-
-/**
- * @param {Record<string, string[] | string>}
- * @returns {Record<string, string[] | string>}
- */
-function normalizeHeaders (opts) {
-  let headers
-  if (opts.headers == null) {
-    headers = {}
-  } else if (typeof opts.headers === 'object') {
-    headers = {}
-
-    if (hasSafeIterator(opts.headers)) {
-      if (Array.isArray(opts.headers)) {
-        // Array format: could be flat alternating [k, v, k, v, ...]
-        // or array-of-pairs [[k, v], ...]
-        const first = opts.headers[0]
-        if (Array.isArray(first)) {
-          for (const x of opts.headers) {
-            if (!Array.isArray(x)) {
-              throw new Error('opts.headers is not a valid header map')
-            }
-            const [key, val] = x
-            if (typeof key !== 'string' || typeof val !== 'string') {
-              throw new Error('opts.headers is not a valid header map')
-            }
-            appendHeader(headers, key, val)
-          }
-        } else {
-          // Flat alternating array [k, v, k, v, ...]
-          const len = opts.headers.length
-          if (len % 2 !== 0) {
-            throw new Error('opts.headers is not a valid header map')
-          }
-          for (let i = 0; i < len; i += 2) {
-            const key = opts.headers[i]
-            const val = opts.headers[i + 1]
-            if (typeof key !== 'string' || (typeof val !== 'string' && !Array.isArray(val))) {
-              throw new Error('opts.headers is not a valid header map')
-            }
-            if (typeof val === 'string') {
-              appendHeader(headers, key, val)
-            } else {
-              const mapped = []
-              for (let j = 0; j < val.length; j++) {
-                const v = val[j]
-                mapped.push(typeof v === 'string' ? v : v.toString('latin1'))
-              }
-              appendHeader(headers, key, mapped)
-            }
-          }
-        }
-      } else {
-        // Non-array iterable (e.g. Map) — use original iteration logic
-        for (const x of opts.headers) {
-          if (!Array.isArray(x)) {
-            throw new Error('opts.headers is not a valid header map')
-          }
-          const [key, val] = x
-          if (typeof key !== 'string' || typeof val !== 'string') {
-            throw new Error('opts.headers is not a valid header map')
-          }
-          appendHeader(headers, key, val)
-        }
-      }
-    } else {
-      for (const key of Object.keys(opts.headers)) {
-        appendHeader(headers, key, opts.headers[key])
-      }
-    }
-  } else {
-    throw new Error('opts.headers is not an object')
-  }
-
-  return headers
 }
 
 /**
@@ -743,7 +652,6 @@ module.exports = {
   getInterceptorOrigin,
   getRequestOrigin,
   makeCacheKey,
-  normalizeHeaders,
   assertCacheKey,
   assertCacheValue,
   parseCacheControlHeader,

--- a/test/cache-interceptor/cache-utils.js
+++ b/test/cache-interceptor/cache-utils.js
@@ -2,7 +2,7 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { test } = require('node:test')
-const { normalizeHeaders } = require('../../lib/util/cache')
+const { normalizeHeaders } = require('../../lib/core/util')
 
 test('normalizeHeaders handles plain object headers with polluted Object.prototype[Symbol.iterator]', (t) => {
   const { strictEqual } = tspl(t, { plan: 2 })
@@ -13,10 +13,8 @@ test('normalizeHeaders handles plain object headers with polluted Object.prototy
 
   try {
     const headers = normalizeHeaders({
-      headers: {
-        Authorization: 'Bearer token',
-        'X-Test': 'ok'
-      }
+      Authorization: 'Bearer token',
+      'X-Test': 'ok'
     })
 
     strictEqual(headers.authorization, 'Bearer token')
@@ -34,11 +32,9 @@ test('normalizeHeaders handles plain object headers with polluted Object.prototy
 test('normalizeHeaders handles headers from Map', (t) => {
   const { strictEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({
-    headers: new Map([
-      ['X-Test', 'ok']
-    ])
-  })
+  const headers = normalizeHeaders(new Map([
+    ['X-Test', 'ok']
+  ]))
 
   strictEqual(headers['x-test'], 'ok')
 })
@@ -46,12 +42,10 @@ test('normalizeHeaders handles headers from Map', (t) => {
 test('normalizeHeaders preserves repeated iterable headers', (t) => {
   const { ok, strictEqual } = tspl(t, { plan: 4 })
 
-  const headers = normalizeHeaders({
-    headers: [
-      ['Cache-Control', 'no-store'],
-      ['cache-control', 'max-age=60']
-    ]
-  })
+  const headers = normalizeHeaders([
+    ['Cache-Control', 'no-store'],
+    ['cache-control', 'max-age=60']
+  ])
 
   ok(Array.isArray(headers['cache-control']))
   strictEqual(headers['cache-control'][0], 'no-store')
@@ -63,10 +57,8 @@ test('normalizeHeaders preserves repeated plain-object headers with different ca
   const { ok, strictEqual } = tspl(t, { plan: 4 })
 
   const headers = normalizeHeaders({
-    headers: {
-      'Cache-Control': 'no-store',
-      'cache-control': 'max-age=60'
-    }
+    'Cache-Control': 'no-store',
+    'cache-control': 'max-age=60'
   })
 
   ok(Array.isArray(headers['cache-control']))
@@ -78,7 +70,7 @@ test('normalizeHeaders preserves repeated plain-object headers with different ca
 test('normalizeHeaders handles empty array', (t) => {
   const { deepEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({ headers: [] })
+  const headers = normalizeHeaders([])
 
   deepEqual(headers, {})
 })
@@ -86,9 +78,7 @@ test('normalizeHeaders handles empty array', (t) => {
 test('normalizeHeaders handles flat alternating array (single header)', (t) => {
   const { strictEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({
-    headers: ['host', 'localhost']
-  })
+  const headers = normalizeHeaders(['host', 'localhost'])
 
   strictEqual(headers.host, 'localhost')
 })
@@ -96,9 +86,7 @@ test('normalizeHeaders handles flat alternating array (single header)', (t) => {
 test('normalizeHeaders handles flat alternating array (multiple headers)', (t) => {
   const { deepEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({
-    headers: ['host', 'localhost', 'content-type', 'application/json']
-  })
+  const headers = normalizeHeaders(['host', 'localhost', 'content-type', 'application/json'])
 
   deepEqual(headers, { host: 'localhost', 'content-type': 'application/json' })
 })
@@ -106,9 +94,7 @@ test('normalizeHeaders handles flat alternating array (multiple headers)', (t) =
 test('normalizeHeaders handles flat alternating array with array values', (t) => {
   const { deepEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({
-    headers: ['accept', ['application/json', 'text/plain']]
-  })
+  const headers = normalizeHeaders(['accept', ['application/json', 'text/plain']])
 
   deepEqual(headers, { accept: ['application/json', 'text/plain'] })
 })
@@ -116,9 +102,7 @@ test('normalizeHeaders handles flat alternating array with array values', (t) =>
 test('normalizeHeaders handles array-of-pairs (existing behavior)', (t) => {
   const { strictEqual } = tspl(t, { plan: 1 })
 
-  const headers = normalizeHeaders({
-    headers: [['host', 'localhost']]
-  })
+  const headers = normalizeHeaders([['host', 'localhost']])
 
   strictEqual(headers.host, 'localhost')
 })
@@ -126,15 +110,15 @@ test('normalizeHeaders handles array-of-pairs (existing behavior)', (t) => {
 test('normalizeHeaders throws on odd-length flat array', (t) => {
   const { throws } = require('node:assert')
 
-  throws(() => normalizeHeaders({ headers: ['host'] }), {
-    message: 'opts.headers is not a valid header map'
+  throws(() => normalizeHeaders(['host']), {
+    message: 'headers must be a valid header map'
   })
 })
 
 test('normalizeHeaders throws on non-string key in flat array', (t) => {
   const { throws } = require('node:assert')
 
-  throws(() => normalizeHeaders({ headers: [42, 'value'] }), {
-    message: 'opts.headers is not a valid header map'
+  throws(() => normalizeHeaders([42, 'value']), {
+    message: 'headers must be a valid header map'
   })
 })

--- a/test/interceptors/interceptors-on-client.js
+++ b/test/interceptors/interceptors-on-client.js
@@ -7,7 +7,7 @@
 
 const { test } = require('node:test')
 const { createServer } = require('node:http')
-const { Client, Pool, interceptors } = require('../../')
+const { Agent, Client, Pool, Headers, interceptors, request } = require('../../')
 
 function listen (server) {
   return new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
@@ -16,6 +16,38 @@ function listen (server) {
 function close (server) {
   return new Promise(resolve => server.close(resolve))
 }
+
+test('compose() normalizes request headers before invoking interceptors', async (t) => {
+  const server = createServer((req, res) => res.end('ok'))
+  await listen(server)
+  t.after(() => close(server))
+
+  const seen = []
+  const dispatcher = new Agent().compose(dispatch => (opts, handler) => {
+    seen.push(opts.headers)
+    return dispatch(opts, handler)
+  })
+  t.after(() => dispatcher.close())
+
+  const origin = `http://127.0.0.1:${server.address().port}`
+  const inputs = [
+    ['x-a', '1', 'x-b', '2'],
+    { 'X-A': '1', 'x-b': '2' },
+    new Headers([['x-a', '1'], ['x-b', '2']]),
+    { * [Symbol.iterator] () { yield ['x-a', '1']; yield ['x-a', '2']; yield ['x-b', '2'] } }
+  ]
+
+  for (const headers of inputs) {
+    await request(origin, { dispatcher, headers })
+  }
+
+  t.assert.deepStrictEqual(seen, [
+    { 'x-a': '1', 'x-b': '2' },
+    { 'x-a': '1', 'x-b': '2' },
+    { 'x-a': '1', 'x-b': '2' },
+    { 'x-a': ['1', '2'], 'x-b': '2' }
+  ])
+})
 
 // ---------------------------------------------------------------------------
 // cache() on Client

--- a/test/interceptors/interceptors-on-client.js
+++ b/test/interceptors/interceptors-on-client.js
@@ -7,7 +7,7 @@
 
 const { test } = require('node:test')
 const { createServer } = require('node:http')
-const { Agent, Client, Pool, Headers, interceptors, request } = require('../../')
+const { Agent, Client, Pool, Headers, interceptors, request, util } = require('../../')
 
 function listen (server) {
   return new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
@@ -17,15 +17,16 @@ function close (server) {
   return new Promise(resolve => server.close(resolve))
 }
 
-test('compose() normalizes request headers before invoking interceptors', async (t) => {
+test('custom interceptors can normalize request headers', async (t) => {
   const server = createServer((req, res) => res.end('ok'))
   await listen(server)
   t.after(() => close(server))
 
   const seen = []
   const dispatcher = new Agent().compose(dispatch => (opts, handler) => {
-    seen.push(opts.headers)
-    return dispatch(opts, handler)
+    const headers = util.normalizeHeaders(opts.headers)
+    seen.push(headers)
+    return dispatch({ ...opts, headers }, handler)
   })
   t.after(() => dispatcher.close())
 

--- a/test/node-test/util.js
+++ b/test/node-test/util.js
@@ -124,6 +124,34 @@ test('parseHeaders', () => {
   assert.deepEqual(util.parseHeaders([Buffer.from('key'), [Buffer.from('value1'), Buffer.from('value2'), Buffer.from('value3')]]), { key: ['value1', 'value2', 'value3'] })
 })
 
+test('normalizeHeaders treats object prototype names as header names', () => {
+  const input = JSON.parse('{"__proto__":"value","constructor":"other"}')
+  const headers = util.normalizeHeaders(input)
+
+  assert.strictEqual(Object.getPrototypeOf(headers), Object.prototype)
+  assert.strictEqual(Object.hasOwn(headers, '__proto__'), true)
+  assert.strictEqual(Object.getOwnPropertyDescriptor(headers, '__proto__').value, 'value')
+  assert.strictEqual(headers.constructor, 'other')
+})
+
+test('normalizeHeaders does not modify its input', () => {
+  const input = { 'X-Test': 'one', 'x-test': 'two' }
+  const headers = util.normalizeHeaders(input)
+
+  assert.deepStrictEqual(input, { 'X-Test': 'one', 'x-test': 'two' })
+  assert.deepStrictEqual(headers, { 'x-test': ['one', 'two'] })
+  assert.notStrictEqual(headers, input)
+})
+
+test('normalizeHeaders handles missing and invalid input', () => {
+  assert.deepStrictEqual(util.normalizeHeaders(), {})
+  assert.deepStrictEqual(util.normalizeHeaders(null), {})
+  assert.throws(() => util.normalizeHeaders('x-test: value'), {
+    name: 'TypeError',
+    message: 'headers must be an object'
+  })
+})
+
 test('parseHeaders decodes values as latin1, not utf8', () => {
   // These bytes (0xE2, 0x80, 0xA6) are the UTF-8 encoding of U+2026 (ellipsis)
   // When decoded as latin1, they should be 3 separate characters: â, €, ¦

--- a/test/types/util.test-d.ts
+++ b/test/types/util.test-d.ts
@@ -23,3 +23,11 @@ expectAssignable<Record<string, string | string[]>>(
 expectAssignable<string>(util.headerNameToString('content-type'))
 
 expectAssignable<string>(util.headerNameToString(Buffer.from('content-type')))
+
+expectAssignable<Record<string, number | string | string[]>>(
+  util.normalizeHeaders([['content-type', 'text/plain']])
+)
+
+expectAssignable<Record<string, number | string | string[]>>(
+  util.normalizeHeaders({ 'content-type': 'text/plain' })
+)

--- a/types/util.d.ts
+++ b/types/util.d.ts
@@ -1,3 +1,5 @@
+import type { UndiciHeaders } from './dispatcher'
+
 export namespace util {
   /**
    * Retrieves a header name and returns its lowercase value.
@@ -15,4 +17,11 @@ export namespace util {
     headers: (Buffer | string | (Buffer | string)[])[],
     obj?: Record<string, string | string[]>
   ): Record<string, string | string[]>
+
+  /**
+   * Normalizes supported request header inputs into an object with lowercase names.
+   */
+  export function normalizeHeaders (
+    headers?: UndiciHeaders
+  ): Record<string, number | string | string[]>
 }


### PR DESCRIPTION
Refs #4336.

Request headers can reach composed interceptors as an object, flat array, `Headers` instance, or another iterable. This adds `util.normalizeHeaders()` so interceptors that inspect headers can convert those inputs to a lower-case object while preserving repeated values.

The cache and deduplicate interceptors now use the same helper. `compose()` no longer normalizes every request, avoiding extra header work for interceptors that do not inspect them.

Tests:

- `npm run lint`
- `npm run test:typescript`
- `borp --timeout 180000 test/interceptors/interceptors-on-client.js test/interceptors/cache-query-params.js test/interceptors/redirect.js test/cache-interceptor/cache-utils.js test/node-test/util.js`
- `node --test --test-name-pattern '#5522' test/interceptors/dns.js`
