### PR TITLE
docs(errors): document ProxyConnectionError (UND_ERR_PRX_CONN)

### DIFF
--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -446,6 +446,31 @@ The response returned an error status code. This is raised, for example, when th
   * `headers` {Object|string[]|null} The response headers. (optional)
   * `body` {Object|string|null} The response body. (optional)
 
+## Class: `ProxyConnectionError`
+
+<!-- YAML
+added: v8.10.1
+changes:
+  - version: v8.10.1
+    pr-url: https://github.com/nodejs/undici/pull/5707
+    description: Added to fail the request instead of retrying forever when the proxy connection is torn down.
+-->
+
+* Extends: {UndiciError}
+
+A connection to the proxy failed in a way that cannot be recovered on the
+same connection, so the request fails instead of being retried.
+
+* `name` {string} Always `'ProxyConnectionError'`.
+* `code` {string} Always `'UND_ERR_PRX_CONN'`.
+* `cause` {Error} The underlying error that caused the proxy connection to fail.
+
+### `new ProxyConnectionError(cause[, message[, options]])`
+
+* `cause` {Error} The underlying error. (optional)
+* `message` {string} The error message. (optional)
+* `options` {Object} Additional `Error` options merged with `cause`. (optional)
+
 ## Class: `SecureProxyConnectionError`
 
 <!-- YAML


### PR DESCRIPTION
## This relates to...

Follow-up documentation for #5707, which introduced `ProxyConnectionError` (`UND_ERR_PRX_CONN`) in v8.10.1. No existing issue tracks this documentation gap — found by comparing `lib/core/errors.js` exports and `types/errors.d.ts` against `docs/docs/api/Errors.md`.

## Rationale

`ProxyConnectionError` is public API: it is exported from the `errors` namespace (`lib/core/errors.js`), declared in `types/errors.d.ts`, and thrown by `lib/dispatcher/proxy-agent.js` when the proxy connection is torn down so the request fails instead of retrying forever. Its sibling `SecureProxyConnectionError` (`UND_ERR_PRX_TLS`) is documented in full, but `ProxyConnectionError` has no class section and no row in the error-code documentation, so users cannot discover or match on a public error class that their proxies can produce at runtime.

While auditing I also verified the only other code absent from the docs table, `UND_ERR_HTTP_PARSER`, is intentionally different (documented as an `HPE_`-prefixed `code` on the `HTTPParserError` class, which extends `Error` directly) — so this is the single genuine documentation gap.

## Changes

- Adds a `ProxyConnectionError` class section to `docs/docs/api/Errors.md`, mirroring the structure of the sibling `SecureProxyConnectionError` section: YAML `added`/`changes` block (v8.10.1, #5707), `Extends: {UndiciError}`, the `name`/`code`/`cause` field list matching the implementation, and the `new ProxyConnectionError(cause[, message[, options]])` constructor signature matching both the implementation and the type declaration.
- Places the section directly before `SecureProxyConnectionError` (base class before its subclass).

### Features

N/A

### Bug Fixes

N/A (documentation only)

### Breaking Changes and Deprecations

None

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested (S — documentation-only change; docs are not covered by the test suites)
- [x] Benchmarked (S — not applicable)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
