### PR TITLE
fix(h2): do not unref a session with open streams

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -406,7 +406,8 @@ function resumeH2 (client) {
   const session = client[kHTTP2Session]
 
   if (socket?.destroyed === false) {
-    if (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0) {
+    // After an upgrade the queue is empty but its stream is still in use, so never unref while a stream is open.
+    if (session[kOpenStreams] === 0 && (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0)) {
       unrefH2Session(session)
     } else {
       refH2Session(session)

--- a/test/fixtures/websocket-h2-client.js
+++ b/test/fixtures/websocket-h2-client.js
@@ -1,0 +1,17 @@
+'use strict'
+
+// Client for test/websocket/h2-keep-process-alive.js. Nothing else here may keep
+// the event loop alive: the test checks that the WebSocket alone does.
+const { Agent, WebSocket } = require('../..')
+
+const dispatcher = new Agent({
+  allowH2: true,
+  connect: { rejectUnauthorized: false }
+})
+
+const ws = new WebSocket(`wss://localhost:${process.argv[2]}`, { dispatcher })
+
+ws.onopen = () => process.send('open')
+ws.onmessage = ({ data }) => process.send(data)
+ws.onclose = ({ code, wasClean }) => process.send({ code, wasClean })
+ws.onerror = ({ error }) => { throw error }

--- a/test/websocket/h2-keep-process-alive.js
+++ b/test/websocket/h2-keep-process-alive.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { test } = require('node:test')
+const { fork } = require('node:child_process')
+const { once } = require('node:events')
+const { createSecureServer } = require('node:http2')
+const { join } = require('node:path')
+const { WebSocket: WSWebSocket } = require('ws')
+const { key, cert } = require('@metcoder95/https-pem')
+const { uid } = require('../../lib/web/websocket/constants')
+const { runtimeFeatures } = require('../../lib/util/runtime-features')
+
+const crypto = runtimeFeatures.has('crypto')
+  ? require('node:crypto')
+  : null
+
+// An open WebSocket over h2 must keep the process alive even though the handshake
+// completed its request and left the queue empty. The server sends only after the
+// child reports 'open': an unref'd session would let the child exit before that.
+async function runClient (t, beforeSend = (stream, send) => send()) {
+  const server = createSecureServer({ key, cert, settings: { enableConnectProtocol: true } })
+  t.after(() => server.close())
+
+  let serverStream
+  let serverWs
+  server.on('stream', (stream, headers) => {
+    stream.respond({
+      ':status': 200,
+      'sec-websocket-accept': crypto.hash('sha1', `${headers['sec-websocket-key']}${uid}`, 'base64')
+    })
+
+    serverStream = stream
+    serverWs = new WSWebSocket(null, null, { autoPong: true })
+    serverWs.setSocket(stream, Buffer.alloc(0), {
+      maxPayload: 104857600,
+      skipUTF8Validation: false
+    })
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const child = fork(join(__dirname, '../fixtures/websocket-h2-client.js'), [String(server.address().port)])
+  t.after(() => child.kill())
+
+  const messages = []
+  child.on('message', (message) => {
+    messages.push(message)
+
+    if (message === 'open') {
+      beforeSend(serverStream, () => {
+        serverWs.send('hello')
+        serverWs.close(1000)
+      })
+    }
+  })
+
+  const [code, signal] = await once(child, 'close')
+
+  t.assert.strictEqual(signal, null)
+  t.assert.strictEqual(code, 0)
+  t.assert.deepStrictEqual(messages, ['open', 'hello', { code: 1000, wasClean: true }])
+}
+
+const options = { skip: crypto == null, timeout: 10000 }
+
+test('an open WebSocket over H2 keeps the process alive', options, async (t) => {
+  await runClient(t)
+})
+
+// SETTINGS_MAX_CONCURRENT_STREAMS = 0 leaves the open stream alone, so it must not
+// unref the session either. The settings callback fires on the child's ACK.
+test('an open WebSocket over H2 keeps the process alive after the peer stops allowing new streams', options, async (t) => {
+  await runClient(t, (stream, send) => stream.session.settings({ maxConcurrentStreams: 0 }, send))
+})


### PR DESCRIPTION
## This relates to...

## Rationale

Once the h2 WebSocket handshake completes, `onUpgradeResponse()` completes the request and resumes the client.
At that point the queue is empty (`client[kSize] === 0`), and `resumeH2()` unrefs the session.
But the WebSocket is still using that stream (`session[kOpenStreams]` is still 1).
A program with nothing else holding the event loop therefore exits with status 0 right after `open`.

The fix adds `session[kOpenStreams] === 0` to the unref condition — the same rule that `closeStreamSession()` and the idle-timeout gate already use.

<details>
<summary>Repro — <code>main</code>: exits right after <code>open</code>; this PR: exits after receiving the message</summary>

Save as `repro.mjs` in the repository root and run `node --no-warnings repro.mjs`.

```js
// Save as repro.mjs in the undici repository root: it imports ./index.js and reads test/fixtures/*.pem.
import { fork } from "node:child_process";
import { hash } from "node:crypto";
import { readFileSync } from "node:fs";
import { createSecureServer } from "node:http2";
import { Agent, WebSocket } from "./index.js";

if (process.argv[2] === "server") {
  // The server runs in a child process so its handles cannot keep the client alive.
  const server = createSecureServer({
    key: readFileSync("./test/fixtures/key.pem"),
    cert: readFileSync("./test/fixtures/cert.pem"),
    settings: { enableConnectProtocol: true },
  });
  server.on("stream", (stream, headers) => {
    const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
    stream.respond({
      ":status": 200,
      "sec-websocket-accept": hash(
        "sha1",
        headers["sec-websocket-key"] + guid,
        "base64",
      ),
    });
    // Once the client is idle, send the text frame "hi" and end the stream.
    setTimeout(() => stream.end(Buffer.from([0x81, 0x02, 0x68, 0x69])), 500);
  });
  server.listen(0, () => process.send(server.address().port));
} else {
  const child = fork(process.argv[1], ["server"]);
  process.on("exit", () => child.kill());
  child.once("message", (port) => {
    // From here on only the WebSocket may keep this process alive.
    child.unref();
    child.channel.unref();
    const dispatcher = new Agent({
      allowH2: true,
      connect: { rejectUnauthorized: false },
    });
    const ws = new WebSocket(`wss://localhost:${port}`, { dispatcher });
    ws.onopen = () => console.log("open");
    ws.onmessage = ({ data }) => console.log("message:", data);
    process.on("beforeExit", () =>
      console.log("beforeExit, readyState =", ws.readyState),
    );
  });
}
```

`main`:

```
open
beforeExit, readyState = 1
```

This PR:

```
open
message: hi
beforeExit, readyState = 3
```

</details>

## Changes

- `lib/dispatcher/client-h2.js`: the unref condition in `resumeH2()` becomes `session[kOpenStreams] === 0 && (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0)` — the same rule as `closeStreamSession()` and the idle-timeout gate.
- `test/websocket/h2-keep-process-alive.js` + `test/fixtures/websocket-h2-client.js`: a child process opens an h2 WebSocket and reports events over IPC. The parent sends a message and `close(1000)` only after the child has reported `open`; the test passes when the child receives both and exits with 0. Two cases: the default one, and one where, after the `open` report, the server sends `SETTINGS_MAX_CONCURRENT_STREAMS = 0` and sends the message only once the settings ACK callback fires. Both fail on `main` and pass with this patch.

### Features

N/A

### Bug Fixes

- The process no longer exits silently while an h2 upgraded stream (WebSocket, CONNECT) is open.

### Breaking Changes and Deprecations

N/A

## Test results (Node 24.20.0)

- `npm run lint` clean
- `test/websocket/**/*.js` 149/149
- `test/http2*.js` + `test/client-unref.js` + `test/issue-5137.js` + `test/node-test/keep-alive-reuse.js` 102/102

Assisted-by: Claude Code

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
