### PR TITLE
fix(h2): do not replay a request whose response already started after GOAWAY

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -193,6 +193,11 @@ function canReplayRequest (request) {
   return body == null || util.isBuffer(body) || util.isBlobLike(body)
 }
 
+function hasResponseStarted (request) {
+  const state = request[kRequestStream]?.[kRequestStreamState]
+  return state?.responseReceived === true
+}
+
 // Count a GOAWAY refusal against the request's replay budget. A peer that
 // refuses every connection must eventually surface an error to the caller
 // rather than being retried forever. Kept separate from canReplayRequest so
@@ -640,9 +645,12 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
     const request = client[kQueue][i]
 
     if (request != null) {
+      // Read before detaching, which drops the stream state.
+      const responseStarted = hasResponseStarted(request)
+
       streamsToClose.push(detachRequestStreamForClose(request))
 
-      if (canReplayRequest(request) && registerGoAwayRefusal(request)) {
+      if (!responseStarted && canReplayRequest(request) && registerGoAwayRefusal(request)) {
         retriableRequests.push(request)
       } else {
         util.errorRequest(client, request, err)

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -445,3 +445,56 @@ test('#5453 - request onto a GOAWAY-rejected session is requeued on a fresh sess
 
   await t.completed
 })
+
+test('a request whose response already started fails instead of being replayed after GOAWAY', { timeout: 10000 }, async (t) => {
+  const p = tspl(t, { plan: 4 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  let secondStream = null
+  let secondRequests = 0
+
+  server.on('stream', (stream, headers) => {
+    stream.on('error', () => {})
+
+    if (headers[':path'] === '/second') {
+      secondRequests++
+      secondStream = stream
+      // Respond without ending, so the GOAWAY below arrives mid-response.
+      stream.respond({ ':status': 200 })
+      return
+    }
+
+    stream.respond({ ':status': 200 })
+    stream.end('ok')
+  })
+
+  t.after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    allowH2: true,
+    connect: { rejectUnauthorized: false }
+  })
+  t.after(() => client.close())
+
+  // Stream 1 completes, so the GOAWAY below can name a lower stream id.
+  const first = await client.request({ path: '/first', method: 'GET' })
+  p.strictEqual(await first.body.text(), 'ok')
+
+  // Stream 3 has received its response headers when this resolves.
+  const second = await client.request({ path: '/second', method: 'GET' })
+
+  // A misbehaving peer names stream 1 as the last processed, even though it
+  // already responded on stream 3. undici must fail the request with the
+  // GOAWAY error rather than replay a response it has already started.
+  secondStream.session.goaway(constants.NGHTTP2_NO_ERROR, 1)
+
+  await p.rejects(second.body.text(), { code: 'UND_ERR_INFO' })
+  p.strictEqual(secondRequests, 1)
+
+  // After the GOAWAY, a new request still succeeds on a fresh connection.
+  const third = await client.request({ path: '/third', method: 'GET' })
+  p.strictEqual(await third.body.text(), 'ok')
+
+  await p.completed
+})


### PR DESCRIPTION
## This relates to...

## Rationale

The `onHttp2SessionGoAway()` never check the response already started. 
if the peer server broke the rules([RFC 9113 §8.7][rfc9113-8.7]), and send a `lastStreamId` lower than a stream it already responded,undici resend the in-flight request. 

<details>
<summary>Repro — <code>client.request()</code> and <code>fetch()</code>, <code>main</code> vs this PR</summary>

Save `repro.mjs` in the root, run with `node --no-warnings repro.mjs`.

```js
// Run from the undici repository root: node --no-warnings repro.mjs
// Shows how the second request settles under client.request() and fetch() when
// the server sends a GOAWAY whose lastStreamID is below a stream it has
// already responded on.
import { readFileSync } from 'node:fs'
import { createSecureServer, constants } from 'node:http2'
import { once } from 'node:events'
import { Client, fetch } from './index.js'

const SETTLE_TIMEOUT = 3000

const server = createSecureServer({
  key: readFileSync('./test/fixtures/key.pem'),
  cert: readFileSync('./test/fixtures/cert.pem')
})
// On main the replay leaves a stream nobody closes, so track sessions to tear
// the server down explicitly at the end.
const sessions = new Set()
server.on('session', session => {
  sessions.add(session)
  session.once('close', () => sessions.delete(session))
})
let secondHits = 0
server.on('stream', (stream, headers) => {
  stream.on('error', () => {})
  if (headers[':path'] === '/first') {
    stream.respond({ ':status': 200 })
    stream.end('ok')
    return
  }
  // /second: send the response headers, keep the stream open, then send a
  // GOAWAY naming stream 1 as last-processed even though stream 3 was answered.
  secondHits++
  stream.respond({ ':status': 200 })
  setTimeout(() => stream.session.goaway(constants.NGHTTP2_NO_ERROR, 1), 50)
})
await once(server.listen(0), 'listening')

const origin = `https://localhost:${server.address().port}`
const options = { allowH2: true, connect: { rejectUnauthorized: false } }

// Describes how a body promise settles, or reports a hang after SETTLE_TIMEOUT.
function describe (bodyPromise) {
  let timer
  const hang = new Promise(resolve => {
    timer = setTimeout(() => resolve(`no settle within ${SETTLE_TIMEOUT}ms (hang)`), SETTLE_TIMEOUT)
  })
  const settled = bodyPromise.then(
    text => `resolved ${JSON.stringify(text)}`,
    err => `rejected ${err.code ?? err.name}${err.cause ? ` (cause ${err.cause.code})` : ''}`
  )
  return Promise.race([settled, hang]).finally(() => clearTimeout(timer))
}

// 1. client.request()
{
  secondHits = 0
  const client = new Client(origin, options)
  await (await client.request({ path: '/first', method: 'GET' })).body.text()
  const res = await client.request({ path: '/second', method: 'GET' })
  console.log(`client.request(): ${await describe(res.body.text())}; server handled /second ${secondHits}x`)
  await client.destroy()
}

// 2. fetch()
{
  secondHits = 0
  const client = new Client(origin, options)
  await (await fetch(`${origin}/first`, { dispatcher: client })).text()
  const res = await fetch(`${origin}/second`, { dispatcher: client })
  console.log(`fetch():          ${await describe(res.text())}; server handled /second ${secondHits}x`)
  await client.destroy()
}

for (const session of sessions) session.destroy()
server.close()
```

`main`:

```
client.request(): rejected ERR_ASSERTION; server handled /second 1x
fetch():          no settle within 3000ms (hang); server handled /second 2x
```

This PR:

```
client.request(): rejected UND_ERR_INFO; server handled /second 1x
fetch():          rejected TypeError (cause UND_ERR_INFO); server handled /second 1x
```

</details>

## Changes

- `lib/dispatcher/client-h2.js`: read the stream's `responseReceived` and skip resend  when the response started
- `test/http2-goaway.js`: checks that the req failed and is not resent with the invalid `GoAway` with lower `lastStreamId`

### Features

N/A

### Bug Fixes

- Now h2 request isn't resend with already started response. and it fails with the `GoAway` error  

### Breaking Changes and Deprecations

N/A

## Test results (Node 24.20.0)

- `npm run lint` clean
- `test/http2-goaway.js` 7/7
- `test:h2:core` (`test/http2*.js` + `test/h2*.js`) 110/110
- `test/websocket/**/*.js` (`npm run test:websocket`) 147/147

The new test failed on `main` and passes with this pr

Assisted by: claude code

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional** — error path only, N/A)
- [S] Documented (no public API change)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
[rfc9113-8.7]: https://www.rfc-editor.org/rfc/rfc9113.html#section-8.7