### PR TITLE
types: mark DecoratorHandler as @deprecated

### DIFF
--- a/docs/docs/api/Errors.md
+++ b/docs/docs/api/Errors.md
@@ -446,6 +446,31 @@ The response returned an error status code. This is raised, for example, when th
   * `headers` {Object|string[]|null} The response headers. (optional)
   * `body` {Object|string|null} The response body. (optional)
 
+## Class: `ProxyConnectionError`
+
+<!-- YAML
+added: v8.10.1
+changes:
+  - version: v8.10.1
+    pr-url: https://github.com/nodejs/undici/pull/5707
+    description: Added to fail the request instead of retrying forever when the proxy connection is torn down.
+-->
+
+* Extends: {UndiciError}
+
+A connection to the proxy failed in a way that cannot be recovered on the
+same connection, so the request fails instead of being retried.
+
+* `name` {string} Always `'ProxyConnectionError'`.
+* `code` {string} Always `'UND_ERR_PRX_CONN'`.
+* `cause` {Error} The underlying error that caused the proxy connection to fail.
+
+### `new ProxyConnectionError(cause[, message[, options]])`
+
+* `cause` {Error} The underlying error. (optional)
+* `message` {string} The error message. (optional)
+* `options` {Object} Additional `Error` options merged with `cause`. (optional)
+
 ## Class: `SecureProxyConnectionError`
 
 <!-- YAML

--- a/types/handlers.d.ts
+++ b/types/handlers.d.ts
@@ -11,6 +11,9 @@ export declare class RedirectHandler implements Dispatcher.DispatchHandler {
   )
 }
 
+/**
+ * @deprecated Use a plain handler object instead.
+ */
 export declare class DecoratorHandler implements Dispatcher.DispatchHandler {
   constructor (handler: Dispatcher.DispatchHandler)
 }


### PR DESCRIPTION
## This relates to...

Follow-up to #5707, which added `@deprecated` to `lib/handler/decorator-handler.js` (shipped in v8.10.1). No existing issue or PR tracks this — found by comparing the runtime deprecation against `types/handlers.d.ts`.

## Rationale

`DecoratorHandler` is marked `@deprecated` at runtime since v8.10.1, but the type declaration in `types/handlers.d.ts` carries no `@deprecated` JSDoc tag and no deprecation marker anywhere in `docs/`. TypeScript consumers importing `DecoratorHandler` (or using it through the `globalThis` install) get no deprecation signal in their editors — the runtime and the types currently disagree about the class's status.

## Changes

- Adds a `@deprecated` JSDoc tag with migration guidance (`Use a plain handler object instead.`) to `DecoratorHandler` in `types/handlers.d.ts`, matching the runtime annotation. The tag propagates to the `index.d.ts` re-export and the `globalThis` install, so editors will show the deprecation for all import paths.

### Features

N/A

### Bug Fixes

N/A (types annotation only — aligns the published types with the already-shipped runtime deprecation)

### Breaking Changes and Deprecations

None — this change documents an already-existing deprecation; it does not deprecate anything new or alter any runtime behavior.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested (`npx tsd`, `tsc test/imports/undici-import.ts --noEmit`, `tsc types/*.d.ts --noEmit` — all pass; `test:typescript` glob step verified equivalent)
- [x] Benchmarked (S — not applicable)
- [x] Documented (S — the deprecation note itself is the change; no `DecoratorHandler` doc page exists, and adding one for a deprecated class seemed out of scope)
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
