### PR TITLE
test: skip HTTP/2 churn test on Node.js 25 on all platforms

### DIFF
--- a/test/http2-request-never-settles.js
+++ b/test/http2-request-never-settles.js
@@ -11,7 +11,9 @@ const pem = require('@metcoder95/https-pem')
 const { Agent } = require('..')
 
 const nodeMajor = Number(process.versions.node.split('.')[0])
-const skipForMemoryCorruption = process.platform === 'linux' && (nodeMajor === 24 || nodeMajor === 25)
+const skipForMemoryCorruption =
+  (process.platform === 'linux' && nodeMajor === 24) ||
+  nodeMajor === 25
 const skipForOnreadAssertion = nodeMajor === 26
 
 // completeRequestStream() runs on an h2 stream's 'close':


### PR DESCRIPTION
## This relates to...

- nodejs/node#64841 (issue)
- Extends the Linux-only skip from #5742
- Failing CI
  - macOS, Node.js 25: https://github.com/nodejs/undici/actions/runs/33722014592/job/100542932871
  - Windows, Node.js 25: https://github.com/nodejs/undici/actions/runs/34121099898/job/101739055458

## Rationale

`test/http2-request-never-settles.js` sometimes fails in CI.
It is already skipped on Linux with Node.js 24, 25 but the same issue occurred on other platforms (macOS, Windows)

This issue will never be fixed on Node.js 25 because it reached EOL on 2026-06-01 (https://github.com/nodejs/Release/blob/main/schedule.json) so the test should be skipped with Node.js 25 on all platforms

Reproduced it on a clean windows-latest runner with Node.js 25 (6 parallel processes per iteration, up to 60 iterations)

- default: crashed at iteration 24 with `exit 0xC0000005`
  (https://github.com/kjsik11/undici/actions/runs/34326717539/job/102385562474#step:6:48)
- with `--no-maglev`: no crash
  (https://github.com/kjsik11/undici/actions/runs/34326717539/job/102385562816#step:6:48)

## Changes

- `test/http2-request-never-settles.js`: Skipped test with Node.js 25 on all platforms

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [S] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
