### PR TITLE
fix(dns): handle a null pick, and stop failing over to an expired record

### DIFF
--- a/lib/interceptor/dns.js
+++ b/lib/interceptor/dns.js
@@ -190,6 +190,16 @@ class DNSInstance {
           newOpts.affinity
         )
 
+        // The lookup succeeded, but nothing it returned is usable here: with
+        // dualStack disabled and an affinity set, records of the other family
+        // cannot be picked. Running the lookup again would return the same
+        // records, so report it the way an empty result is reported.
+        if (ip == null) {
+          this.storage.delete(origin.hostname)
+          cb(new InformationalError('No DNS entries found'))
+          return
+        }
+
         let port
         if (typeof ip.port === 'number') {
           port = `:${ip.port}`
@@ -346,6 +356,7 @@ class DNSInstance {
       // We delete expired records
       // It is possible that they have different TTL, so we manage them individually
       family.ips.splice(position, 1)
+      return this.pickFamily(origin, ipFamily)
     }
 
     return ip

--- a/test/interceptors/dns.js
+++ b/test/interceptors/dns.js
@@ -2397,3 +2397,103 @@ test('#4234 - Should pass Pool requests without origin through', async t => {
   t.equal(await response.body.text(), 'hello world!')
   t.equal(lookupCount, 1)
 })
+
+test('Should not fail over to a TTL-expired address (dual stack)', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const clock = FakeTimers.install()
+  const attempts = []
+  const server = createServer({ joinDuplicateHeaders: true })
+
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Agent().compose([
+    dispatch => (opts, handler) => {
+      attempts.push(new URL(opts.origin).hostname)
+      return dispatch(opts, handler)
+    },
+    dns({
+      affinity: 4,
+      maxTTL: 100000,
+      lookup (origin, opts, cb) {
+        cb(null, [
+          { address: '127.0.0.1', family: 4, ttl: 100000 },
+          { address: '::1', family: 6, ttl: 10 }
+        ])
+      }
+    })
+  ])
+
+  after(async () => {
+    clock.uninstall()
+    await client.close()
+  })
+
+  const requestOptions = {
+    method: 'GET',
+    path: '/',
+    origin: `http://localhost:${server.address().port}`
+  }
+
+  // Warm the cache while the server is still up.
+  const response = await client.request(requestOptions)
+  t.equal(await response.body.text(), 'hello world!')
+
+  // The IPv6 record goes stale; the IPv4 one this request will use stays fresh.
+  clock.tick(50)
+
+  // Take the server away, so the IPv4 attempt is refused and the dual-stack
+  // fail-over asks for the other family.
+  server.close()
+  await once(server, 'close')
+  attempts.length = 0
+
+  await t.rejects(client.request(requestOptions), { code: 'ECONNREFUSED' })
+
+  // Only the IPv4 attempt. pickFamily drops the expired IPv6 record, and a
+  // record it has just evicted as stale must not be handed back to retry with.
+  t.equal(attempts.length, 1)
+  t.equal(attempts[0], '127.0.0.1')
+})
+
+test('Should report an unusable lookup result instead of crashing (dual stack disabled)', async t => {
+  t = tspl(t, { plan: 1 })
+
+  const server = createServer({ joinDuplicateHeaders: true })
+
+  server.on('request', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello world!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  // A host with no AAAA record, asked for over IPv6 only. pick() has nothing to
+  // return, and the fresh-lookup branch has to say so rather than dereference it.
+  const client = new Agent().compose(dns({
+    dualStack: false,
+    affinity: 6,
+    lookup (origin, opts, cb) {
+      cb(null, [{ address: '127.0.0.1', family: 4, ttl: 100000 }])
+    }
+  }))
+
+  after(async () => {
+    await client.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  await t.rejects(client.request({
+    method: 'GET',
+    path: '/',
+    origin: `http://localhost:${server.address().port}`
+  }), { code: 'UND_ERR_INFO', message: 'No DNS entries found' })
+})


### PR DESCRIPTION
## This relates to...

Nothing filed — found by reading `lib/interceptor/dns.js` and reproduced through the public API.

## Rationale

Two places where the DNS interceptor mishandles a record it should not use. Each has a sibling in the same file that gets it right, which is what makes them look like oversights rather than choices.

**1. `runLookup`'s fresh-lookup branch dereferences `pick()` without checking it.**

```js
const ip = this.pick(origin, records, newOpts.affinity)

let port
if (typeof ip.port === 'number') {
```

The cached branch twenty lines below *does* check, and recovers. `pick()` returns `null` whenever nothing it holds matches the request — no custom `pick` needed: with `dualStack: false` and an affinity set, `#defaultPick` takes `records[affinity]` with no fallback. So a host with no AAAA record, requested over IPv6 only, gives:

```
TypeError: Cannot read properties of null (reading 'port')
```

thrown inside the DNS callback, where the dispatch error path cannot catch it, instead of the `InformationalError('No DNS entries found')` raised two lines above for an empty result.

Reproduced on `main` through the public API:

```js
const client = new Agent().compose(dns({
  dualStack: false,
  affinity: 6,
  lookup (origin, opts, cb) { cb(null, [{ address: '127.0.0.1', family: 4, ttl: 100000 }]) }
}))
await client.request({ method: 'GET', path: '/', origin })
// caught : TypeError |  | Cannot read properties of null (reading 'port')
```

The fix reports the same error as the empty-result case. It deliberately does not re-run the lookup the way the cached branch does: the records were just fetched, so a second lookup would return the same ones.

**2. `pickFamily` evicts a TTL-expired record and returns it anyway.**

```js
if (Date.now() - ip.timestamp > ip.ttl) { // record TTL is already in ms
  // We delete expired records
  // It is possible that they have different TTL, so we manage them individually
  family.ips.splice(position, 1)
}

return ip
```

`#defaultPick` carries the identical comment and, after the same splice, re-picks. `pickFamily` backs the dual-stack fail-over in `DNSDispatchHandler.onResponseError`, so an `ETIMEDOUT`/`ECONNREFUSED` gets retried against an address the interceptor has just dropped as stale.

Worth noting because it changes how reachable this is: the default `DNSStorage.set(hostname, records)` takes two parameters and drops the `{ ttl }` it is given, and `get()` never checks expiry. These per-record checks are the only expiry there is, so this is reachable with the default storage — it just needs two records of the same host with different TTLs, which is the normal case for a dual-stack host.

Reproduced on `main`, warming the cache while the server is up, then letting the IPv6 record go stale and taking the server away:

```
attempts: ["127.0.0.1","[::1]"]     <- the second is the record just evicted as expired
```

With the fix, `["127.0.0.1"]`, and the original `ECONNREFUSED` surfaces.

## Changes

### Features

N/A

### Bug Fixes

- `runLookup` reports `No DNS entries found` when a fresh lookup yields nothing the request can use, instead of throwing a `TypeError` on `null`.
- `pickFamily` re-picks after evicting an expired record, so the dual-stack fail-over cannot retry at a stale address.

### Breaking Changes and Deprecations

None. Both paths currently end in a crash or a doomed retry.

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

Two tests in `test/interceptors/dns.js`, both through the public API. Reverting only `lib/interceptor/dns.js` and keeping them fails both, exactly where it should:

```
✖ Should not fail over to a TTL-expired address (dual stack)
    actual: 2, expected: 1
✖ Should report an unusable lookup result instead of crashing (dual stack disabled)
    actual:   TypeError: Cannot read properties of null (reading 'port')
    expected: { code: 'UND_ERR_INFO', message: 'No DNS entries found' }
```

`node --test test/interceptors/dns.js`: **31 passed, 1 failed**. That one failure, `Should respect DNS origin hostname for SNI on TLS`, is pre-existing on this machine — it fails identically with the patch reverted (`ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE`, a local OpenSSL/cert issue on Windows). `eslint` is clean on both changed files.

Nothing user-facing changed, so I marked Documented as skipped — happy to add something to `docs/docs/api/Interceptors.md` if you would rather the `null` contract for a custom `pick` were written down there.

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
