### PR TITLE
fix(fetch): drain followed 3xx redirect bodies

### DIFF
--- a/lib/web/fetch/index.js
+++ b/lib/web/fetch/index.js
@@ -2266,6 +2266,11 @@ async function httpNetworkFetch (
             const willFollow = location && request.redirect === 'follow' &&
               redirectStatusSet.has(status)
 
+            // When this 3xx response will be followed, its body is discarded and
+            // never exposed to the caller. Remember that so onResponseData can
+            // drain without pausing (see below). https://github.com/nodejs/undici/issues/5728
+            this.willFollow = willFollow
+
             const decoders = []
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
@@ -2335,7 +2340,10 @@ async function httpNetworkFetch (
           },
 
           onResponseData (controller, chunk) {
-            if (fetchParams.controller.dump) {
+            // Discard the body of a 3xx response that is about to be followed,
+            // but keep reading (do not pause) so the connection drains and is
+            // released back to the pool. https://github.com/nodejs/undici/issues/5728
+            if (fetchParams.controller.dump || this.willFollow) {
               return
             }
 

--- a/test/issue-5728.js
+++ b/test/issue-5728.js
@@ -1,0 +1,37 @@
+'use strict'
+
+// Repro for https://github.com/nodejs/undici/issues/5728
+// fetch({ redirect: 'follow' }) must drain a large 3xx redirect body so a
+// connection-limited Agent can reuse the socket for the follow-up request.
+
+const { test } = require('node:test')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { fetch, Agent } = require('..')
+
+test('fetch follow does not pin the keep-alive socket on a 301 with a large body', { timeout: 15_000 }, async (t) => {
+  t.plan(3)
+  // Larger than the default 64 KiB highWaterMark so the body is not fully
+  // buffered/drained implicitly.
+  const redirectBody = Buffer.alloc(128 * 1024, 0x78)
+  const server = createServer((req, res) => {
+    if (req.url === '/redirect') {
+      res.writeHead(301, { Location: '/final' })
+      res.end(redirectBody)
+      return
+    }
+    res.end('ok')
+  })
+  const dispatcher = new Agent({ connections: 1, keepAliveTimeout: 10_000 })
+  t.after(async () => {
+    await dispatcher.destroy()
+    server.close()
+  })
+  server.listen(0)
+  await once(server, 'listening')
+  const url = `http://127.0.0.1:${server.address().port}/redirect`
+  const first = await fetch(url, { dispatcher, redirect: 'follow' })
+  t.assert.strictEqual(first.status, 200)
+  t.assert.strictEqual(await first.text(), 'ok')
+  t.assert.ok(first.redirected)
+})


### PR DESCRIPTION
## This relates to...

Fixes #5728

## Rationale

`fetch({ redirect: 'follow' })` was buffering redirect response bodies into an internal `Readable` and pausing on backpressure. A 3xx body larger than the stream highWaterMark could leave the keep-alive socket `running`, so a connection-limited `Agent` could never hand the socket to the follow-up request and `fetch` hung.

## Changes

### Features

N/A

### Bug Fixes

- Remember when a response will be followed (`this.willFollow`).
- In `onResponseData`, discard those chunks (same as `controller.dump`) without pausing so the connection drains and returns to the pool.
- Add a regression test with `Agent({ connections: 1 })` and a 128 KiB 301 body.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

## Test

```bash
node --test test/issue-5728.js
```

Passes locally (1/1).