### PR TITLE
fix(cache): preserve 304 response event order with async stores

### DIFF
--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -150,6 +150,12 @@ class CacheHandler {
   #handler
 
   /**
+   * Pending 304 resolution (async store lookup or cached body replay).
+   * @type {Promise<void> | null}
+   */
+  #pending304 = null
+
+  /**
    * @type {import('node:stream').Writable | undefined}
    */
   #writeStream
@@ -345,59 +351,67 @@ class CacheHandler {
         }
 
         if (typeof cachedValue.body.values === 'function') {
-          const bodyIterator = cachedValue.body.values()
+          return new Promise((resolve) => {
+            const bodyIterator = cachedValue.body.values()
 
-          const streamCachedBody = () => {
-            for (const chunk of bodyIterator) {
-              const full = this.#writeStream.write(chunk) === false
-              this.#handler.onResponseData?.(controller, chunk)
-              // when stream is full stop writing until we get a 'drain' event
-              if (full) {
-                break
+            const streamCachedBody = () => {
+              for (const chunk of bodyIterator) {
+                const full = this.#writeStream?.write(chunk) === false
+                this.#handler.onResponseData?.(controller, chunk)
+                // when stream is full stop writing until we get a 'drain' event
+                if (full) {
+                  return
+                }
               }
+              resolve()
             }
-          }
 
-          this.#writeStream
-            .on('error', function () {
-              handler.#writeStream = undefined
-              handler.#store.delete(handler.#cacheKey)
-            })
-            .on('drain', () => {
-              streamCachedBody()
-            })
-            .on('close', function () {
-              if (handler.#writeStream === this) {
+            this.#writeStream
+              .on('error', function () {
                 handler.#writeStream = undefined
-              }
-            })
+                handler.#store.delete(handler.#cacheKey)
+                resolve()
+              })
+              .on('drain', () => {
+                streamCachedBody()
+              })
+              .on('close', function () {
+                if (handler.#writeStream === this) {
+                  handler.#writeStream = undefined
+                }
+              })
 
-          streamCachedBody()
+            streamCachedBody()
+          })
         } else if (typeof cachedValue.body.on === 'function') {
           // Readable stream body (e.g. from async/remote cache stores)
-          cachedValue.body
-            .on('data', (chunk) => {
-              this.#writeStream.write(chunk)
-              this.#handler.onResponseData?.(controller, chunk)
-            })
-            .on('end', () => {
-              this.#writeStream.end()
-            })
-            .on('error', () => {
-              this.#writeStream = undefined
-              this.#store.delete(this.#cacheKey)
-            })
+          return new Promise((resolve) => {
+            cachedValue.body
+              .on('data', (chunk) => {
+                this.#writeStream?.write(chunk)
+                this.#handler.onResponseData?.(controller, chunk)
+              })
+              .on('end', () => {
+                this.#writeStream?.end()
+                resolve()
+              })
+              .on('error', () => {
+                this.#writeStream = undefined
+                this.#store.delete(this.#cacheKey)
+                resolve()
+              })
 
-          this.#writeStream
-            .on('error', function () {
-              handler.#writeStream = undefined
-              handler.#store.delete(handler.#cacheKey)
-            })
-            .on('close', function () {
-              if (handler.#writeStream === this) {
+            this.#writeStream
+              .on('error', function () {
                 handler.#writeStream = undefined
-              }
-            })
+                handler.#store.delete(handler.#cacheKey)
+              })
+              .on('close', function () {
+                if (handler.#writeStream === this) {
+                  handler.#writeStream = undefined
+                }
+              })
+          })
         }
       }
 
@@ -406,9 +420,15 @@ class CacheHandler {
        */
       const result = this.#store.get(this.#cacheKey)
       if (result && typeof result.then === 'function') {
-        result.then(handle304)
+        // The 304 ends before the lookup settles; hold the end until then.
+        this.#pending304 = result
+          .then(handle304, () => handle304(undefined))
+          .then(() => { this.#pending304 = null })
       } else {
-        handle304(result)
+        const replay = handle304(result)
+        if (replay) {
+          this.#pending304 = replay.then(() => { this.#pending304 = null })
+        }
       }
     } else {
       if (typeof resHeaders.etag === 'string' && isEtagUsable(resHeaders.etag)) {
@@ -445,6 +465,11 @@ class CacheHandler {
   }
 
   onResponseData (controller, chunk) {
+    if (this.#pending304) {
+      this.#pending304 = this.#pending304.then(() => this.onResponseData(controller, chunk))
+      return
+    }
+
     if (this.#writeStream?.write(chunk) === false) {
       controller.pause()
     }
@@ -453,11 +478,21 @@ class CacheHandler {
   }
 
   onResponseEnd (controller, trailers) {
+    if (this.#pending304) {
+      this.#pending304 = this.#pending304.then(() => this.onResponseEnd(controller, trailers))
+      return
+    }
+
     this.#writeStream?.end()
     this.#handler.onResponseEnd?.(controller, trailers)
   }
 
   onResponseError (controller, err) {
+    if (this.#pending304) {
+      this.#pending304 = this.#pending304.then(() => this.onResponseError(controller, err))
+      return
+    }
+
     this.#writeStream?.destroy(err)
     this.#writeStream = undefined
     this.#handler.onResponseError?.(controller, err)

--- a/lib/handler/cache-handler.js
+++ b/lib/handler/cache-handler.js
@@ -370,7 +370,8 @@ class CacheHandler {
               .on('error', function () {
                 handler.#writeStream = undefined
                 handler.#store.delete(handler.#cacheKey)
-                resolve()
+                // Keep replaying downstream without the store
+                streamCachedBody()
               })
               .on('drain', () => {
                 streamCachedBody()

--- a/test/interceptors/cache-async-store.js
+++ b/test/interceptors/cache-async-store.js
@@ -5,7 +5,7 @@ const { strictEqual, notStrictEqual } = require('node:assert')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
 const { Readable } = require('node:stream')
-const { request, Client, interceptors } = require('../../index')
+const { request, Client, Dispatcher, interceptors } = require('../../index')
 const MemoryCacheStore = require('../../lib/cache/memory-cache-store')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { setTimeout } = require('node:timers/promises')
@@ -48,6 +48,113 @@ class AsyncCacheStore {
 }
 
 describe('cache interceptor with async store', () => {
+  // Delivers start, data and end synchronously inside dispatch(), so an
+  // empty 304 ends before an async store lookup settles.
+  class SyncDispatcher extends Dispatcher {
+    requests = 0
+
+    dispatch (opts, handler) {
+      this.requests++
+      const controller = {
+        paused: false,
+        aborted: false,
+        reason: null,
+        pause () {},
+        resume () {},
+        abort () {}
+      }
+      handler.onRequestStart?.(controller, {})
+      if (opts.headers?.['if-none-match'] === '"abc"') {
+        // Without cache-control the 304 is passed through untouched.
+        handler.onResponseStart?.(controller, 304, { etag: '"abc"', 'cache-control': 'public, max-age=60' }, 'Not Modified')
+        handler.onResponseEnd?.(controller, {})
+        return true
+      }
+      const body = Buffer.from('cached body')
+      handler.onResponseStart?.(controller, 200, {
+        'cache-control': 'public, max-age=60',
+        etag: '"abc"',
+        'content-length': String(body.length)
+      }, 'OK')
+      handler.onResponseData?.(controller, body)
+      handler.onResponseEnd?.(controller, {})
+      return true
+    }
+  }
+
+  test('a 304 to a conditional request that missed the cache reaches the client intact', async () => {
+    const store = new AsyncCacheStore()
+    const client = new SyncDispatcher().compose(interceptors.cache({ store }))
+
+    const response = await client.request({
+      origin: 'http://localhost',
+      method: 'GET',
+      path: '/',
+      headers: { 'if-none-match': '"abc"' }
+    })
+    strictEqual(response.statusCode, 304)
+    strictEqual(await response.body.text(), '')
+  })
+
+  // Misses on the interceptor's lookup and hits on the lookup CacheHandler
+  // makes after the 304, so handle304 runs with a cached value to replay.
+  class MissThenHitStore {
+    #inner = new MemoryCacheStore()
+    #asStream
+    misses = 0
+
+    constructor ({ asStream = false } = {}) {
+      this.#asStream = asStream
+    }
+
+    async get (key) {
+      if (this.misses > 0) {
+        this.misses--
+        return undefined
+      }
+      const result = this.#inner.get(key)
+      if (!result || !this.#asStream) return result
+      const { body, ...rest } = result
+      return { ...rest, body: Readable.from(body ?? []) }
+    }
+
+    createWriteStream (key, value) {
+      return this.#inner.createWriteStream(key, value)
+    }
+
+    delete (key) {
+      return this.#inner.delete(key)
+    }
+  }
+
+  for (const [name, asStream] of [['an array of Buffers', false], ['a Readable', true]]) {
+    test(`a 304 resolved against an async store replays a cached body that is ${name} before the end`, async () => {
+      const store = new MissThenHitStore({ asStream })
+      const dispatcher = new SyncDispatcher()
+      const client = dispatcher.compose(interceptors.cache({ store }))
+
+      {
+        const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/' })
+        strictEqual(response.statusCode, 200)
+        strictEqual(await response.body.text(), 'cached body')
+      }
+
+      // The origin's 304 goes downstream, followed by the cached body, then the end.
+      store.misses = 1
+      {
+        const response = await client.request({
+          origin: 'http://localhost',
+          method: 'GET',
+          path: '/',
+          headers: { 'if-none-match': '"abc"' }
+        })
+        strictEqual(response.statusCode, 304)
+        strictEqual(await response.body.text(), 'cached body')
+      }
+      strictEqual(dispatcher.requests, 2)
+    })
+  }
+
   test('stale-while-revalidate 304 refreshes cache with async store', async () => {
     const clock = FakeTimers.install({ now: 1 })
     after(() => clock.uninstall())

--- a/test/interceptors/cache-async-store.js
+++ b/test/interceptors/cache-async-store.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const { test, after, describe } = require('node:test')
-const { strictEqual, notStrictEqual } = require('node:assert')
+const { strictEqual, notStrictEqual, rejects } = require('node:assert')
 const { createServer } = require('node:http')
 const { once } = require('node:events')
-const { Readable } = require('node:stream')
+const { Readable, Writable } = require('node:stream')
 const { request, Client, Dispatcher, interceptors } = require('../../index')
 const MemoryCacheStore = require('../../lib/cache/memory-cache-store')
 const FakeTimers = require('@sinonjs/fake-timers')
@@ -53,6 +53,12 @@ describe('cache interceptor with async store', () => {
   class SyncDispatcher extends Dispatcher {
     requests = 0
 
+    constructor ({ dataOn304, errorOn304 } = {}) {
+      super()
+      this.dataOn304 = dataOn304
+      this.errorOn304 = errorOn304
+    }
+
     dispatch (opts, handler) {
       this.requests++
       const controller = {
@@ -67,16 +73,23 @@ describe('cache interceptor with async store', () => {
       if (opts.headers?.['if-none-match'] === '"abc"') {
         // Without cache-control the 304 is passed through untouched.
         handler.onResponseStart?.(controller, 304, { etag: '"abc"', 'cache-control': 'public, max-age=60' }, 'Not Modified')
+        if (this.errorOn304) {
+          handler.onResponseError?.(controller, this.errorOn304)
+          return true
+        }
+        if (this.dataOn304) {
+          handler.onResponseData?.(controller, this.dataOn304)
+        }
         handler.onResponseEnd?.(controller, {})
         return true
       }
-      const body = Buffer.from('cached body')
       handler.onResponseStart?.(controller, 200, {
         'cache-control': 'public, max-age=60',
         etag: '"abc"',
-        'content-length': String(body.length)
+        'content-length': '11'
       }, 'OK')
-      handler.onResponseData?.(controller, body)
+      handler.onResponseData?.(controller, Buffer.from('cached '))
+      handler.onResponseData?.(controller, Buffer.from('body'))
       handler.onResponseEnd?.(controller, {})
       return true
     }
@@ -101,10 +114,15 @@ describe('cache interceptor with async store', () => {
   class MissThenHitStore {
     #inner = new MemoryCacheStore()
     #asStream
+    #bodyError
     misses = 0
+    deletes = 0
+    // 'slow' or 'error': the write stream handed out from now on
+    writeStream = null
 
-    constructor ({ asStream = false } = {}) {
+    constructor ({ asStream = false, bodyError = null } = {}) {
       this.#asStream = asStream
+      this.#bodyError = bodyError
     }
 
     async get (key) {
@@ -115,14 +133,29 @@ describe('cache interceptor with async store', () => {
       const result = this.#inner.get(key)
       if (!result || !this.#asStream) return result
       const { body, ...rest } = result
-      return { ...rest, body: Readable.from(body ?? []) }
+      const bodyError = this.#bodyError
+      const readable = Readable.from(body ?? [])
+      if (bodyError) {
+        readable.push = readable.push.bind(readable)
+        readable.once('data', () => readable.destroy(bodyError))
+      }
+      return { ...rest, body: readable }
     }
 
     createWriteStream (key, value) {
+      if (this.writeStream === 'slow') {
+        // Each write exceeds the high water mark: write() returns false and
+        // the replay has to wait for 'drain'.
+        return new Writable({ highWaterMark: 1, write (chunk, encoding, callback) { setImmediate(callback) } })
+      }
+      if (this.writeStream === 'error') {
+        return new Writable({ write (chunk, encoding, callback) { callback(new Error('write failed')) } })
+      }
       return this.#inner.createWriteStream(key, value)
     }
 
     delete (key) {
+      this.deletes++
       return this.#inner.delete(key)
     }
   }
@@ -154,6 +187,65 @@ describe('cache interceptor with async store', () => {
       strictEqual(dispatcher.requests, 2)
     })
   }
+
+  test('the replay of an array body waits for the write stream to drain', async () => {
+    const store = new MissThenHitStore()
+    const client = new SyncDispatcher().compose(interceptors.cache({ store }))
+    await (await client.request({ origin: 'http://localhost', method: 'GET', path: '/' })).body.text()
+
+    store.misses = 1
+    store.writeStream = 'slow'
+    const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/', headers: { 'if-none-match': '"abc"' } })
+    strictEqual(response.statusCode, 304)
+    strictEqual(await response.body.text(), 'cached body')
+  })
+
+  for (const [name, asStream] of [['an array of Buffers', false], ['a Readable', true]]) {
+    test(`a failing write stream during the replay of ${name} drops the entry and still ends the response`, async () => {
+      const store = new MissThenHitStore({ asStream })
+      const client = new SyncDispatcher().compose(interceptors.cache({ store }))
+      await (await client.request({ origin: 'http://localhost', method: 'GET', path: '/' })).body.text()
+
+      store.misses = 1
+      store.writeStream = 'error'
+      const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/', headers: { 'if-none-match': '"abc"' } })
+      strictEqual(response.statusCode, 304)
+      strictEqual(await response.body.text(), 'cached body')
+      strictEqual(store.deletes, 1)
+    })
+  }
+
+  test('a cached body stream that errors during the replay drops the entry and still ends the response', async () => {
+    const store = new MissThenHitStore({ asStream: true, bodyError: new Error('body failed') })
+    const client = new SyncDispatcher().compose(interceptors.cache({ store }))
+    await (await client.request({ origin: 'http://localhost', method: 'GET', path: '/' })).body.text()
+
+    store.misses = 1
+    const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/', headers: { 'if-none-match': '"abc"' } })
+    strictEqual(response.statusCode, 304)
+    await response.body.text()
+    strictEqual(store.deletes, 1)
+  })
+
+  test('data from the origin after a pending 304 is delivered after the cached body', async () => {
+    const store = new MissThenHitStore()
+    const client = new SyncDispatcher({ dataOn304: Buffer.from('+extra') }).compose(interceptors.cache({ store }))
+    await (await client.request({ origin: 'http://localhost', method: 'GET', path: '/' })).body.text()
+
+    store.misses = 1
+    const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/', headers: { 'if-none-match': '"abc"' } })
+    strictEqual(response.statusCode, 304)
+    strictEqual(await response.body.text(), 'cached body+extra')
+  })
+
+  test('an error from the origin after a pending 304 is delivered after the start', async () => {
+    const store = new AsyncCacheStore()
+    const client = new SyncDispatcher({ errorOn304: new Error('origin failed') }).compose(interceptors.cache({ store }))
+
+    const response = await client.request({ origin: 'http://localhost', method: 'GET', path: '/', headers: { 'if-none-match': '"abc"' } })
+    strictEqual(response.statusCode, 304)
+    await rejects(response.body.text(), { message: 'origin failed' })
+  })
 
   test('stale-while-revalidate 304 refreshes cache with async store', async () => {
     const clock = FakeTimers.install({ now: 1 })


### PR DESCRIPTION
## This relates to...

N/A

## Rationale

A cache revalidation can receive a 304 before an asynchronous store has returned the cached response. The 304 itself has no body, but the cached body must be replayed before downstream receives the response end.

## Changes

- Pause a reusable 304 while the cache lookup and cached-body replay complete.
- Use a private controller wrapper so downstream backpressure cannot release that internal pause early.
- Resume the origin response only after replay completes, preserving start, cached data, then end ordering.
- Handle failed cache lookups as misses and abort cleanly if asynchronous 304 handling throws.
- Add coverage for synchronous and asynchronous stores, replay backpressure, write-stream failures, closed streams, and the asynchronous abort path.

### Features

N/A

### Bug Fixes

- Preserve response event ordering when a 304 is revalidated through an asynchronous cache store.
- Prevent cached-body replay from being cut short by an early 304 end.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [S] Documented
- [x] Review ready
- [x] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
