### PR TITLE
fix(websocket): add brand-checks to WebSocket kRef/kUnref

### DIFF
--- a/lib/web/websocket/websocket.js
+++ b/lib/web/websocket/websocket.js
@@ -202,12 +202,14 @@ class WebSocket extends EventTarget {
 
   // TODO: remove this
   [kRef] () {
+    webidl.brandCheck(this, webidl.is.WebSocket)
     this.#refed = true
     this.#handler.socket?.ref?.()
   }
 
   // TODO: remove this
   [kUnref] () {
+    webidl.brandCheck(this, webidl.is.WebSocket)
     this.#refed = false
     this.#handler.socket?.unref?.()
   }

--- a/test/websocket/process-ref.js
+++ b/test/websocket/process-ref.js
@@ -38,11 +38,22 @@ test('process.unref allows the process to exit with an open WebSocket', async (t
   const undici = join(__dirname, '../..')
   const child = spawn(process.execPath, ['-e', `
     const { WebSocket } = require(${JSON.stringify(undici)})
+    const { throws } = require('node:assert');
     const ws = new WebSocket(${JSON.stringify(url)})
-    if (typeof ws[Symbol.for('nodejs.ref')] !== 'function' ||
-        typeof ws[Symbol.for('nodejs.unref')] !== 'function') {
+
+    const kRef = Symbol.for('nodejs.ref')
+    const kUnref = Symbol.for('nodejs.unref')
+
+    const refFn = ws[kRef]
+    const unrefFn = ws[kUnref]
+
+    if (typeof refFn !== 'function' ||
+        typeof unrefFn !== 'function') {
       throw new Error('WebSocket does not implement the Refable protocol')
     }
+    throws(() => refFn(), { message: 'Illegal invocation' })
+    throws(() => unrefFn(), { message: 'Illegal invocation' })
+
     ws.addEventListener('open', () => {
       process.unref(ws)
       process.ref(ws)


### PR DESCRIPTION
These were missed in the brandcheck update.


