### PR TITLE
test(h2): stabilize http2-connection

### DIFF
--- a/test/h2-disconnect-guard.js
+++ b/test/h2-disconnect-guard.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const assert = require('node:assert')
+const { test } = require('node:test')
+const { createSecureServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client } = require('..')
+const { guardAgainstUnexpectedDisconnect } = require('./utils/h2-disconnect-guard')
+
+async function setup (t, clientOpts = {}) {
+  const server = createSecureServer(pem)
+  const sessions = []
+
+  server.on('session', session => sessions.push(session))
+  server.on('stream', stream => {
+    stream.respond({ ':status': 200 })
+    stream.end('hello h2!')
+  })
+
+  let client = null
+  t.after(async () => {
+    if (client != null && !client.destroyed) {
+      await client.close()
+    }
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+
+  client = new Client(`https://127.0.0.1:${server.address().port}`, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    ...clientOpts
+  })
+
+  const failures = []
+  guardAgainstUnexpectedDisconnect({ fail: message => failures.push(message) }, client)
+
+  return { client, sessions, failures, get: () => client.request({ path: '/', method: 'GET' }) }
+}
+
+test('ignores the client tearing down its own idle session', async t => {
+  // A saturated CI runner can stretch the gap between two requests past
+  // keepAliveTimeout; the client then drops the idle socket itself and
+  // reconnects transparently on the next request. That is not a disconnect the
+  // test did not ask for.
+  const { client, failures, get } = await setup(t, { keepAliveTimeout: 100 })
+
+  const disconnected = once(client, 'disconnect')
+  await (await get()).body.text()
+  await disconnected
+
+  assert.deepStrictEqual(failures, [])
+})
+
+test('flags a disconnect forced by the peer', async t => {
+  const { client, sessions, failures, get } = await setup(t)
+
+  const disconnected = once(client, 'disconnect')
+  await (await get()).body.text()
+  sessions[0].destroy()
+  await disconnected
+
+  assert.strictEqual(failures.length, 1)
+  assert.match(failures[0], /^unexpected disconnect/)
+})
+
+test('stays quiet once the client is closing', async t => {
+  const { client, failures, get } = await setup(t)
+
+  await (await get()).body.text()
+  await client.close()
+
+  assert.deepStrictEqual(failures, [])
+})

--- a/test/http2-connection.js
+++ b/test/http2-connection.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { tspl } = require('@matteo.collina/tspl')
-const { test, after } = require('node:test')
+const { test } = require('node:test')
 const { createSecureServer } = require('node:http2')
 const { once } = require('node:events')
 const { Readable } = require('node:stream')
@@ -9,20 +9,34 @@ const { Readable } = require('node:stream')
 const pem = require('@metcoder95/https-pem')
 
 const { Client } = require('..')
+const { guardAgainstUnexpectedDisconnect } = require('./utils/h2-disconnect-guard')
+
+// Tears the client down before the server, so the client never has to react to
+// a GOAWAY it did not ask for, and waits for both.
+function teardown (t, server, getClient) {
+  t.after(async () => {
+    const client = getClient()
+    if (client != null && !client.destroyed) {
+      await client.close()
+    }
+    await new Promise(resolve => server.close(resolve))
+  })
+}
 
 test('Should support H2 connection', async t => {
-  t = tspl(t, { plan: 9 })
+  const assert = tspl(t, { plan: 9 })
 
   const body = []
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createSecureServer(pem)
   let authority = ''
+  let client = null
 
   server.on('stream', (stream, headers, _flags, rawHeaders) => {
-    t.strictEqual(headers['x-my-header'], 'foo')
-    t.strictEqual(headers[':method'], 'GET')
-    t.strictEqual(headers[':scheme'], 'https')
-    t.strictEqual(headers[':path'], '/')
-    t.strictEqual(headers[':authority'], authority)
+    assert.strictEqual(headers['x-my-header'], 'foo')
+    assert.strictEqual(headers[':method'], 'GET')
+    assert.strictEqual(headers[':scheme'], 'https')
+    assert.strictEqual(headers[':path'], '/')
+    assert.strictEqual(headers[':authority'], authority)
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
       'x-custom-h2': 'hello',
@@ -31,24 +45,19 @@ test('Should support H2 connection', async t => {
     stream.end('hello h2!')
   })
 
-  after(() => server.close())
+  teardown(t, server, () => client)
 
-  await once(server.listen(0), 'listening')
+  await once(server.listen(0, '127.0.0.1'), 'listening')
 
-  authority = `localhost:${server.address().port}`
-  const client = new Client(`https://${authority}`, {
+  authority = `127.0.0.1:${server.address().port}`
+  client = new Client(`https://${authority}`, {
     connect: {
       rejectUnauthorized: false
     },
     allowH2: true
   })
-  after(() => client.close())
 
-  client.on('disconnect', () => {
-    if (!client.closed && !client.destroyed) {
-      t.fail('unexpected disconnect')
-    }
-  })
+  guardAgainstUnexpectedDisconnect(assert, client)
 
   const response = await client.request({
     path: '/',
@@ -64,27 +73,28 @@ test('Should support H2 connection', async t => {
 
   await once(response.body, 'end')
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
-  t.strictEqual(response.headers['x-custom-h2'], 'hello')
-  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(response.headers['x-custom-h2'], 'hello')
+  assert.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
 
-  await t.completed
+  await assert.completed
 })
 
 test('Should support H2 connection(multiple requests)', async t => {
-  t = tspl(t, { plan: 21 })
+  const assert = tspl(t, { plan: 21 })
 
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createSecureServer(pem)
+  let client = null
 
   server.on('stream', async (stream, headers, _flags, rawHeaders) => {
-    t.strictEqual(headers['x-my-header'], 'foo')
-    t.strictEqual(headers[':method'], 'POST')
+    assert.strictEqual(headers['x-my-header'], 'foo')
+    assert.strictEqual(headers[':method'], 'POST')
     const reqData = []
     stream.on('data', chunk => reqData.push(chunk.toString()))
     await once(stream, 'end')
     const reqBody = reqData.join('')
-    t.strictEqual(reqBody.length > 0, true)
+    assert.strictEqual(reqBody.length > 0, true)
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
       'x-custom-h2': 'hello',
@@ -93,22 +103,18 @@ test('Should support H2 connection(multiple requests)', async t => {
     stream.end(`hello h2! ${reqBody}`)
   })
 
-  after(() => server.close())
-  await once(server.listen(0), 'listening')
+  teardown(t, server, () => client)
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+
+  client = new Client(`https://127.0.0.1:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
     allowH2: true
   })
-  after(() => client.close())
 
-  client.on('disconnect', () => {
-    if (!client.closed && !client.destroyed) {
-      t.fail('unexpected disconnect')
-    }
-  })
+  guardAgainstUnexpectedDisconnect(assert, client)
 
   for (let i = 0; i < 3; i++) {
     const sendBody = `seq ${i}`
@@ -129,26 +135,27 @@ test('Should support H2 connection(multiple requests)', async t => {
 
     await once(response.body, 'end')
 
-    t.strictEqual(response.statusCode, 200)
-    t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
-    t.strictEqual(response.headers['x-custom-h2'], 'hello')
-    t.strictEqual(Buffer.concat(body).toString('utf8'), `hello h2! ${sendBody}`)
+    assert.strictEqual(response.statusCode, 200)
+    assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+    assert.strictEqual(response.headers['x-custom-h2'], 'hello')
+    assert.strictEqual(Buffer.concat(body).toString('utf8'), `hello h2! ${sendBody}`)
   }
 
-  await t.completed
+  await assert.completed
 })
 
 test('Should support H2 connection (headers as array)', async t => {
-  t = tspl(t, { plan: 8 })
+  const assert = tspl(t, { plan: 8 })
 
   const body = []
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createSecureServer(pem)
+  let client = null
 
   server.on('stream', (stream, headers) => {
-    t.strictEqual(headers['x-my-header'], 'foo, bar')
-    t.strictEqual(headers['x-my-drink'], 'coffee, tea, water')
-    t.strictEqual(headers['x-other'], 'value')
-    t.strictEqual(headers[':method'], 'GET')
+    assert.strictEqual(headers['x-my-header'], 'foo, bar')
+    assert.strictEqual(headers['x-my-drink'], 'coffee, tea, water')
+    assert.strictEqual(headers['x-other'], 'value')
+    assert.strictEqual(headers[':method'], 'GET')
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
       'x-custom-h2': 'hello',
@@ -157,22 +164,18 @@ test('Should support H2 connection (headers as array)', async t => {
     stream.end('hello h2!')
   })
 
-  after(() => server.close())
-  await once(server.listen(0), 'listening')
+  teardown(t, server, () => client)
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+
+  client = new Client(`https://127.0.0.1:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
     allowH2: true
   })
-  after(() => client.close())
 
-  client.on('disconnect', () => {
-    if (!client.closed && !client.destroyed) {
-      t.fail('unexpected disconnect')
-    }
-  })
+  guardAgainstUnexpectedDisconnect(assert, client)
 
   const response = await client.request({
     path: '/',
@@ -192,52 +195,53 @@ test('Should support H2 connection (headers as array)', async t => {
 
   await once(response.body, 'end')
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
-  t.strictEqual(response.headers['x-custom-h2'], 'hello')
-  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(response.headers['x-custom-h2'], 'hello')
+  assert.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
 
-  await t.completed
+  await assert.completed
 })
 
 test('Should support multiple header values with semicolon separator', async t => {
-  t = tspl(t, { plan: 9 * 2 })
+  const assert = tspl(t, { plan: 9 * 2 })
 
   const body = []
   const body2 = []
   const expectedCookieHeaders = ['a=b', 'c=d', 'e=f']
-  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const server = createSecureServer(pem)
+  let client = null
 
+  // The two requests carry the same headers by design, so tell their responses
+  // apart to keep each assertion pinned to its own response.
+  let seq = 0
   server.on('stream', (stream, headers) => {
-    t.strictEqual(headers['x-my-header'], 'foo, bar')
-    t.strictEqual(headers['x-my-drink'], 'coffee, tea, water')
-    t.strictEqual(headers['x-other'], 'value')
-    t.strictEqual(headers['cookie'], expectedCookieHeaders.join('; '))
-    t.strictEqual(headers[':method'], 'GET')
+    const n = ++seq
+    assert.strictEqual(headers['x-my-header'], 'foo, bar')
+    assert.strictEqual(headers['x-my-drink'], 'coffee, tea, water')
+    assert.strictEqual(headers['x-other'], 'value')
+    assert.strictEqual(headers.cookie, expectedCookieHeaders.join('; '))
+    assert.strictEqual(headers[':method'], 'GET')
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
       'x-custom-h2': 'hello',
       ':status': 200
     })
-    stream.end('hello h2!')
+    stream.end(`hello h2! ${n}`)
   })
 
-  after(() => server.close())
-  await once(server.listen(0), 'listening')
+  teardown(t, server, () => client)
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+
+  client = new Client(`https://127.0.0.1:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
     allowH2: true
   })
-  after(() => client.close())
 
-  client.on('disconnect', () => {
-    if (!client.closed && !client.destroyed) {
-      t.fail('unexpected disconnect')
-    }
-  })
+  guardAgainstUnexpectedDisconnect(assert, client)
 
   const response = await client.request({
     path: '/',
@@ -258,10 +262,10 @@ test('Should support multiple header values with semicolon separator', async t =
 
   await once(response.body, 'end')
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
-  t.strictEqual(response.headers['x-custom-h2'], 'hello')
-  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(response.headers['x-custom-h2'], 'hello')
+  assert.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2! 1')
 
   const response2 = await client.request({
     path: '/',
@@ -284,25 +288,26 @@ test('Should support multiple header values with semicolon separator', async t =
 
   await once(response2.body, 'end')
 
-  t.strictEqual(response2.statusCode, 200)
-  t.strictEqual(response2.headers['content-type'], 'text/plain; charset=utf-8')
-  t.strictEqual(response2.headers['x-custom-h2'], 'hello')
-  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+  assert.strictEqual(response2.statusCode, 200)
+  assert.strictEqual(response2.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(response2.headers['x-custom-h2'], 'hello')
+  assert.strictEqual(Buffer.concat(body2).toString('utf8'), 'hello h2! 2')
 
-  await t.completed
+  await assert.completed
 })
 
 test('Should support H2 connection(POST Buffer)', async t => {
-  t = tspl(t, { plan: 6 })
+  const assert = tspl(t, { plan: 6 })
 
-  const server = createSecureServer({ ...await pem.generate({ opts: { keySize: 2048 } }), allowHTTP1: false })
+  const server = createSecureServer({ key: pem.key, cert: pem.cert, allowHTTP1: false })
+  let client = null
 
   server.on('stream', async (stream, headers, _flags, rawHeaders) => {
-    t.strictEqual(headers[':method'], 'POST')
+    assert.strictEqual(headers[':method'], 'POST')
     const reqData = []
     stream.on('data', chunk => reqData.push(chunk.toString()))
     await once(stream, 'end')
-    t.strictEqual(reqData.join(''), 'hello!')
+    assert.strictEqual(reqData.join(''), 'hello!')
     stream.respond({
       'content-type': 'text/plain; charset=utf-8',
       'x-custom-h2': 'hello',
@@ -311,22 +316,18 @@ test('Should support H2 connection(POST Buffer)', async t => {
     stream.end('hello h2!')
   })
 
-  after(() => server.close())
-  await once(server.listen(0), 'listening')
+  teardown(t, server, () => client)
 
-  const client = new Client(`https://localhost:${server.address().port}`, {
+  await once(server.listen(0, '127.0.0.1'), 'listening')
+
+  client = new Client(`https://127.0.0.1:${server.address().port}`, {
     connect: {
       rejectUnauthorized: false
     },
     allowH2: true
   })
-  after(() => client.close())
 
-  client.on('disconnect', () => {
-    if (!client.closed && !client.destroyed) {
-      t.fail('unexpected disconnect')
-    }
-  })
+  guardAgainstUnexpectedDisconnect(assert, client)
 
   const sendBody = 'hello!'
   const body = []
@@ -342,10 +343,10 @@ test('Should support H2 connection(POST Buffer)', async t => {
 
   await once(response.body, 'end')
 
-  t.strictEqual(response.statusCode, 200)
-  t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
-  t.strictEqual(response.headers['x-custom-h2'], 'hello')
-  t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
+  assert.strictEqual(response.statusCode, 200)
+  assert.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
+  assert.strictEqual(response.headers['x-custom-h2'], 'hello')
+  assert.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')
 
-  await t.completed
+  await assert.completed
 })

--- a/test/utils/h2-disconnect-guard.js
+++ b/test/utils/h2-disconnect-guard.js
@@ -1,0 +1,31 @@
+'use strict'
+
+// The client drops an idle h2 socket itself once keepAliveTimeout elapses and
+// reconnects transparently on the next request. A saturated CI runner can
+// stretch the gap between two requests past that deadline, so this is a
+// disconnect the test caused, not one the peer forced on it.
+const SELF_INFLICTED_DISCONNECTS = new Set([
+  'socket idle timeout'
+])
+
+// Fails `t` when the client loses its connection for a reason the test did not
+// ask for. Returns a function that removes the guard.
+function guardAgainstUnexpectedDisconnect (t, client) {
+  const onDisconnect = (_url, _targets, err) => {
+    if (client.closed || client.destroyed) {
+      return
+    }
+
+    if (err != null && SELF_INFLICTED_DISCONNECTS.has(err.message)) {
+      return
+    }
+
+    t.fail(`unexpected disconnect: ${err?.message ?? 'no error'}`)
+  }
+
+  client.on('disconnect', onDisconnect)
+
+  return () => client.off('disconnect', onDisconnect)
+}
+
+module.exports = { guardAgainstUnexpectedDisconnect }


### PR DESCRIPTION
Fixes #5266

`test/http2-connection.js` is the last of the `[flaky] test\http2-*.js` batch filed in the same week that still had none of the hardening its siblings got (#5219 → 123db796, #5212 → 9dfff73f, #5195 → f33a6cb6, #5216 → dd1e50a0). This applies the same treatment.

The CI log referenced in the issue has expired (HTTP 410), so the exact assertion that failed is not recoverable. What follows is what the file can fail on, with the reproductions I could build.

## 1. The unexpected-disconnect guard fires on the client's own idle teardown

The guard added by #5533 is:

```js
client.on('disconnect', () => {
  if (!client.closed && !client.destroyed) {
    t.fail('unexpected disconnect')
  }
})
```

When `keepAliveTimeout` (4s by default) elapses on an idle h2 session, the client destroys the socket itself — `setHttp2IdleTimeout` at `lib/dispatcher/client-h2.js:514`, `onHttp2SessionIdleTimeout` at `:529` — and emits `disconnect` with `closed` and `destroyed` both `false`. The reconnect is transparent to the next request, but the guard reports it as a failure:

```
UNEXPECTED DISCONNECT -> socket idle timeout
```

Tests 2 and 4 in this file issue several sequential requests on one client, so a runner that deschedules the process for >4s between two of them trips this. It also arrives after `await t.completed`, where an extra tspl assertion throws an `AssertionError` out of the listener rather than just failing a plan.

The guard now lives in `test/utils/h2-disconnect-guard.js`, ignores `socket idle timeout`, still flags a disconnect the peer forced, and reports the error message instead of a bare string. `test/h2-disconnect-guard.js` covers all three cases; it uses `keepAliveTimeout: 100` so the idle case runs in ~115ms instead of 4s.

Note this vector post-dates the issue (#5533 landed 2026-07-16) and would show up as a file duration over 4s, so it does not explain the 570ms run in the report — but it is a live flake today.

## 2. Per-test RSA-2048 keygen

The file called `await pem.generate({ opts: { keySize: 2048 } })` five times. `@metcoder95/https-pem` delegates to `selfsigned` → `forge.pki.rsa.generateKeyPair`, a pure-JS keygen measuring 34–83ms per call here (2.4x spread). This is the same call that produced a hard failure on a Windows job in #5195:

```
Error: error:068000DD:asn1 encoding routines::illegal padding
    at Http2SecureServer (node:internal/http2/core:3431:5)
    at createSecureServer (node:internal/http2/core:3660:10)
    at TestContext.<anonymous> (D:\a\undici\undici\test\http2-dispatcher.js:617:18)
```

I fuzzed 2400 generations across 6 processes on Linux without reproducing a bad PEM, so it is rare and/or specific to Windows/OpenSSL — but it was observed in CI, it fails fast, and it is consistent with the 570ms duration of the run in the report. Switching to the static `pem`, as dd1e50a0 did for the trailers test, removes the vector.

## 3. Teardown order

`after(() => server.close())` was registered before `after(() => client.close())`, and `Http2SecureServer.prototype.close` calls `closeAllSessions()` — so the server sent a GOAWAY to a client that was still open. I measured 320 runs looking for the race and `client.close()` always won (the boundary between two hooks is only a microtask), so this was not the failure. It is still the wrong order: the client now closes first and both are awaited, via per-test `t.after` rather than the module-level `after`.

## 4. `localhost` → `127.0.0.1`

Same as dd1e50a0, to keep the IPv4/IPv6 resolution out of the picture on Windows.

## 5. A real assertion bug

`test/http2-connection.js:290` validated the second response against the first response's buffer:

```js
t.strictEqual(Buffer.concat(body).toString('utf8'), 'hello h2!')  // body2
```

Both responses were `hello h2!`, so the mistake was invisible. The server now numbers them, which makes it observable, and the assertion reads `body2`. This is not a flake — the second request's payload was simply never checked.

## Verification

|  | before | after |
| --- | --- | --- |
| file duration | 375ms | 99ms |
| per test | 40–85ms | 3–15ms |

- `npm run test:h2:core` — 112 tests, 0 failures
- eslint clean
- 360 runs of both files under 12-way parallel load, 0 failures

## Suggested follow-up

The inline guard is still duplicated across **32 other test files** (`test/http2-*.js`, `test/h2-*.js`) from #5533 and #5686, all carrying the same idle-timeout vector. Migrating them to `test/utils/h2-disconnect-guard.js` is mechanical and would close the whole class rather than this one file. I kept it out of this PR to keep the diff reviewable, and I am happy to do it here or in a follow-up — whichever the maintainers prefer.
