### PR TITLE
feat(h2): honor maxRequestsPerClient

### DIFF
--- a/docs/docs/api/Client.md
+++ b/docs/docs/api/Client.md
@@ -49,6 +49,8 @@ added: v1.0.0
   * `headersTimeout` {number|null} The timeout, in milliseconds, the parser
     waits to receive the complete HTTP headers before the request times out. Use
     `0` to disable it entirely. **Default:** `300e3`.
+    Over HTTP/2 this also bounds how long a session retired by
+    `maxRequestsPerClient` may wait for its active streams to close.
     HTTP/1.1 headers/body parser timeouts are not guaranteed to fire with exact
     millisecond precision: delays up to 1000ms use native timers, while larger
     delays use undici's lower-overhead fast timers with a target resolution
@@ -78,9 +80,9 @@ added: v1.0.0
     Over HTTP/1.1 a request is counted per message and the socket is reset once
     the limit is reached. Over HTTP/2 a request is counted per successfully
     opened stream: the session is retired once the limit is reached, meaning it
-    accepts no further streams and the streams it already accepted are allowed
-    to complete before the connection is closed. Queued and subsequent requests
-    are dispatched on a new session.
+    accepts no further streams. Streams it already accepted are allowed to
+    complete for up to `headersTimeout` before the connection is reset. Queued
+    and subsequent requests are then dispatched on a new session.
   * `localAddress` {string|null} The local IP address the socket should connect
     from. **Default:** `null`.
   * `pipelining` {number|null} The number of concurrent requests sent over the

--- a/docs/docs/api/Client.md
+++ b/docs/docs/api/Client.md
@@ -75,6 +75,12 @@ added: v1.0.0
   * `maxRequestsPerClient` {number|null} The maximum number of requests to send
     over a single connection before the socket is reset. Use `0` to disable this
     limit. **Default:** `null`.
+    Over HTTP/1.1 a request is counted per message and the socket is reset once
+    the limit is reached. Over HTTP/2 a request is counted per successfully
+    opened stream: the session is retired once the limit is reached, meaning it
+    accepts no further streams and the streams it already accepted are allowed
+    to complete before the connection is closed. Queued and subsequent requests
+    are dispatched on a new session.
   * `localAddress` {string|null} The local IP address the socket should connect
     from. **Default:** `null`.
   * `pipelining` {number|null} The number of concurrent requests sent over the

--- a/docs/docs/api/H2CClient.md
+++ b/docs/docs/api/H2CClient.md
@@ -64,7 +64,9 @@ added: v7.7.0
   * `maxHeaderSize` {number} The maximum length of request headers in bytes.
     **Default:** Node.js' `--max-http-header-size` or `16384` (16 KiB).
   * `headersTimeout` {number} The amount of time, in milliseconds, the parser
-    waits to receive the complete HTTP headers. **Default:** `300e3`.
+    waits to receive the complete HTTP headers. This also bounds how long a
+    session retired by `maxRequestsPerClient` may wait for its active streams
+    to close. **Default:** `300e3`.
   * `connectTimeout` {number} The timeout for establishing a socket connection,
     in milliseconds. Use `0` to disable it entirely. **Default:** `10e3`.
   * `bodyTimeout` {number} The timeout, in milliseconds, after which a request
@@ -93,9 +95,10 @@ added: v7.7.0
     a single connection before it is reset. Use `0` to disable this limit.
     **Default:** `null`.
     A request is counted per successfully opened HTTP/2 stream. Once the limit
-    is reached the session is retired: it accepts no further streams and the
-    streams it already accepted are allowed to complete before the connection is
-    closed. Queued and subsequent requests are dispatched on a new session.
+    is reached the session is retired: it accepts no further streams. Streams
+    it already accepted are allowed to complete for up to `headersTimeout`
+    before the connection is reset. Queued and subsequent requests are
+    dispatched on a new session.
   * `localAddress` {string} The local IP address the socket should connect from.
   * `maxResponseSize` {number} The maximum allowed response body size in bytes.
     Use `-1` to disable. **Default:** `-1`.

--- a/docs/docs/api/H2CClient.md
+++ b/docs/docs/api/H2CClient.md
@@ -92,6 +92,10 @@ added: v7.7.0
   * `maxRequestsPerClient` {number} The maximum number of requests to send over
     a single connection before it is reset. Use `0` to disable this limit.
     **Default:** `null`.
+    A request is counted per successfully opened HTTP/2 stream. Once the limit
+    is reached the session is retired: it accepts no further streams and the
+    streams it already accepted are allowed to complete before the connection is
+    closed. Queued and subsequent requests are dispatched on a new session.
   * `localAddress` {string} The local IP address the socket should connect from.
   * `maxResponseSize` {number} The maximum allowed response body size in bytes.
     Use `-1` to disable. **Default:** `-1`.

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -41,7 +41,9 @@ const {
   kHTTP2Stream,
   kHTTP2SessionState,
   kHTTP2Options,
-  kMaxResponseSize
+  kMaxResponseSize,
+  kMaxRequests,
+  kCounter
 } = require('../core/symbols.js')
 const { channels } = require('../core/diagnostics.js')
 
@@ -53,6 +55,7 @@ const kRequestStreamState = Symbol('request stream state')
 const kReceivedGoAway = Symbol('received goaway')
 const kGoAwayReplayAttempts = Symbol('goaway replay attempts')
 const kRefusedStreamRetry = Symbol('refused stream retry')
+const kRetiringSession = Symbol('retiring session')
 
 // RFC 9113 section 8.7: a client SHOULD NOT automatically retry a request more
 // than once. Without a budget a peer that keeps refusing turns one request into
@@ -271,6 +274,17 @@ function connectH2 (client, socket) {
     // Armed while the peer advertises MAX_CONCURRENT_STREAMS = 0 and we have
     // work that cannot start. See setNoStreamsTimeout.
     noStreamsTimeout: null,
+    // Set once the session has opened maxRequestsPerClient streams. A retired
+    // session never accepts another stream; it drains and is then torn down.
+    // See trackH2Stream.
+    retired: false,
+    // Number of streams counted against maxRequestsPerClient that have not
+    // physically closed yet. Only maintained when the limit is enabled.
+    countedStreams: 0,
+    // Set when closeRetiredH2Session has already emitted 'disconnect' and
+    // resumed the queue, so that the trailing socket close does not do it
+    // again. See onHttp2SocketClose.
+    disconnectAnnounced: false,
     // Sockets start out ref'd. Session ref/unref proxies to the socket, so a
     // single cached flag lets us skip redundant uv ref/unref calls, provided
     // every ref/unref of the session or its socket goes through
@@ -351,6 +365,13 @@ function connectH2 (client, socket) {
      * @returns {boolean}
     */
     busy (request) {
+      // A session that has reached maxRequestsPerClient is draining: it must
+      // not receive another stream, so queued work waits here until the session
+      // is torn down and a fresh one replaces it.
+      if (session[kHTTP2SessionState].retired === true) {
+        return true
+      }
+
       if (session[kRemoteSettings] === false && client[kRunning] > 0) {
         return true
       }
@@ -406,6 +427,13 @@ function resumeH2 (client) {
   const session = client[kHTTP2Session]
 
   if (socket?.destroyed === false) {
+    if (session[kHTTP2SessionState].retired === true) {
+      // A retired session must not be unref'ed or given an idle timeout: the
+      // streams it already accepted may still be uploading. Teardown happens
+      // in onCountedStreamClose once the last of them is physically closed.
+      return
+    }
+
     // After an upgrade the queue is empty but its stream is still in use, so never unref while a stream is open.
     if (session[kOpenStreams] === 0 && (client[kSize] === 0 || client[kMaxConcurrentStreams] === 0)) {
       unrefH2Session(session)
@@ -529,6 +557,99 @@ function onHttp2SessionIdleTimeout (session) {
   const err = new InformationalError('socket idle timeout')
   socket[kError] = err
   util.destroy(socket, err)
+}
+
+// Called once for every stream that session.request() successfully opened.
+// Besides the shared bookkeeping (an open stream cancels the idle timeout and
+// keeps the session alive) this is where maxRequestsPerClient is enforced: for
+// HTTP/2 one request is one opened stream, so a stream that never made it past
+// session.request() must not consume the budget.
+function trackH2Stream (session, stream) {
+  clearHttp2IdleTimeout(session)
+  ++session[kOpenStreams]
+
+  const maxRequests = session[kClient][kMaxRequests]
+
+  // `null`, `undefined` and `0` all disable the limit, as in HTTP/1.1.
+  if (!maxRequests) {
+    return
+  }
+
+  // kOpenStreams is released as soon as the response is complete, which for
+  // HTTP/2 can happen while the request body is still being uploaded. Track the
+  // physical stream separately so that retiring the session cannot truncate
+  // that upload.
+  session[kHTTP2SessionState].countedStreams += 1
+  stream[kRetiringSession] = session
+  stream.once('close', onCountedStreamClose)
+
+  const socket = session[kSocket]
+  const counter = (socket[kCounter] ?? 0) + 1
+  socket[kCounter] = counter
+
+  // `>=` mirrors client-h1.js: the stream that reaches the limit is served,
+  // the next one is not.
+  if (counter >= maxRequests) {
+    // Retire synchronously so that a resume loop dispatching several requests
+    // in one pass cannot slip stream N+1 onto this session: busy() reads the
+    // flag before every write. Teardown is left to onCountedStreamClose, which
+    // runs once every stream this session accepted has physically closed.
+    session[kHTTP2SessionState].retired = true
+  }
+}
+
+function onCountedStreamClose () {
+  const session = this[kRetiringSession]
+
+  if (session == null) {
+    return
+  }
+
+  this[kRetiringSession] = null
+
+  const state = session[kHTTP2SessionState]
+  state.countedStreams -= 1
+
+  if (state.retired === true && state.countedStreams === 0) {
+    closeRetiredH2Session(session)
+  }
+}
+
+// Tearing the session down is deliberately deferred until it has drained.
+// Doing it in the same tick as session.request() makes nghttp2 refuse the very
+// stream that triggered retirement, and a locally initiated graceful
+// session.close() can leave the socket half-open indefinitely when the peer
+// keeps its side open (for example when it sent a GOAWAY of its own). Once no
+// stream is left there is nothing to be graceful about, so reuse the standard
+// reset path. The error is informational so that onError() in client.js leaves
+// queued requests in place; they are replayed on a fresh session.
+function closeRetiredH2Session (session) {
+  clearHttp2IdleTimeout(session)
+  clearNoStreamsTimeout(session)
+
+  if (session.destroyed) {
+    return
+  }
+
+  const client = session[kClient]
+  const state = session[kHTTP2SessionState]
+  const err = new InformationalError('HTTP/2: session retired after reaching maxRequestsPerClient')
+
+  // Only the attached session owns the client's connection state, so only it
+  // may announce the disconnect. The flag tells onHttp2SocketClose that this
+  // has already been taken care of; it is deliberately not `state.retired`,
+  // because a retired session can also be torn down by the peer, and that path
+  // still needs onHttp2SocketClose to flush the client state.
+  const announce = client[kHTTP2Session] === session
+  state.disconnectAnnounced = announce
+
+  session[kError] = err
+  resetHttp2Session(session, err)
+
+  if (announce) {
+    client.emit('disconnect', client[kUrl], [client], err)
+    client[kResume]()
+  }
 }
 
 function applyConnectionWindowSize (connectionWindowSize) {
@@ -721,11 +842,16 @@ function onHttp2SocketClose () {
   const client = session[kClient]
 
   if (client[kSocket] !== this) {
-    // Ignore stale socket closes from a detached GOAWAY session and from any
-    // session that has already been replaced. If the session was detached
-    // without a GOAWAY and there is no replacement yet, we still need the
+    // Ignore stale socket closes from a detached GOAWAY session, from a
+    // retired session that has already announced its own disconnect and from
+    // any session that has already been replaced. If the session was detached
+    // without any of those and there is no replacement yet, we still need the
     // close event to flush the client state.
-    if (session[kReceivedGoAway] || (client[kHTTP2Session] != null && client[kHTTP2Session] !== session)) {
+    if (
+      session[kReceivedGoAway] ||
+      session[kHTTP2SessionState].disconnectAnnounced === true ||
+      (client[kHTTP2Session] != null && client[kHTTP2Session] !== session)
+    ) {
       return
     }
   }
@@ -775,6 +901,13 @@ function closeStreamSession (stream) {
   stream[kHTTP2Session] = null
   session[kOpenStreams] -= 1
   if (session[kOpenStreams] === 0) {
+    if (session[kHTTP2SessionState].retired === true) {
+      // Teardown is driven by onCountedStreamClose once every counted stream
+      // has physically closed. Until then keep the session ref'd and leave the
+      // idle timeout disarmed so it cannot cut an in-progress upload short.
+      return
+    }
+
     unrefH2Session(session)
     setHttp2IdleTimeout(session)
   }
@@ -963,8 +1096,7 @@ function setupUpgradeStream (stream, state) {
   stream.on('timeout', onUpgradeStreamTimeout)
   stream.once('close', onUpgradeStreamClose)
 
-  clearHttp2IdleTimeout(session)
-  ++session[kOpenStreams]
+  trackH2Stream(session, stream)
   stream.setTimeout(headersTimeout)
 }
 
@@ -1251,16 +1383,17 @@ function writeH2 (client, request) {
   stream[kRequestStreamState] = state
   state.stream = stream
 
-  // Increment counter as we have new streams open
-  clearHttp2IdleTimeout(session)
-  ++session[kOpenStreams]
-
   if (headersTimeout) {
     stream.setTimeout(headersTimeout)
   }
 
   stream[kHTTP2Session] = session
   stream.on('close', completeRequestStream)
+
+  // Registered after the request's own 'close' handler so that request
+  // completion always runs before a session retirement can tear the
+  // connection down.
+  trackH2Stream(session, stream)
 
   bindRequestToStream(request, stream, releaseRequestStream)
   if (expectContinue) {

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -100,6 +100,8 @@ function resetHttp2Session (session, err) {
   const client = session[kClient]
   const socket = session[kSocket]
 
+  clearRetiredSessionTimeout(session)
+
   if (client[kHTTP2Session] === session) {
     client[kSocket] = null
     client[kHTTPContext] = null
@@ -278,6 +280,9 @@ function connectH2 (client, socket) {
     // session never accepts another stream; it drains and is then torn down.
     // See trackH2Stream.
     retired: false,
+    // Bounds how long a retired session may wait for its accepted streams to
+    // close before they are destroyed so queued work can reconnect.
+    retiredSessionTimeout: null,
     // Number of streams counted against maxRequestsPerClient that have not
     // physically closed yet. Only maintained when the limit is enabled.
     countedStreams: 0,
@@ -464,6 +469,51 @@ function clearNoStreamsTimeout (session) {
   }
 }
 
+function clearRetiredSessionTimeout (session) {
+  const state = session[kHTTP2SessionState]
+
+  if (state?.retiredSessionTimeout != null) {
+    clearTimeout(state.retiredSessionTimeout)
+    state.retiredSessionTimeout = null
+  }
+}
+
+function setRetiredSessionTimeout (session) {
+  const client = session[kClient]
+  const state = session[kHTTP2SessionState]
+  const timeout = client[kHeadersTimeout]
+
+  if (!timeout || state.retiredSessionTimeout != null) {
+    return
+  }
+
+  state.retiredSessionTimeout = setTimeout(onRetiredSessionTimeout, timeout, session).unref()
+}
+
+function onRetiredSessionTimeout (session) {
+  const client = session[kClient]
+  const state = session[kHTTP2SessionState]
+
+  state.retiredSessionTimeout = null
+
+  if (
+    client[kHTTP2Session] !== session ||
+    state.retired !== true ||
+    state.countedStreams === 0 ||
+    session.closed ||
+    session.destroyed
+  ) {
+    return
+  }
+
+  closeRetiredH2Session(
+    session,
+    new InformationalError(
+      `HTTP/2: retired session did not drain within ${client[kHeadersTimeout]}`
+    )
+  )
+}
+
 // A peer is allowed to advertise SETTINGS_MAX_CONCURRENT_STREAMS = 0 to refuse
 // new streams (RFC 9113 §6.5.2), and is expected to raise it again later. Until
 // it does, busy() reports the client as permanently busy and queued requests
@@ -595,6 +645,7 @@ function trackH2Stream (session, stream) {
     // flag before every write. Teardown is left to onCountedStreamClose, which
     // runs once every stream this session accepted has physically closed.
     session[kHTTP2SessionState].retired = true
+    setRetiredSessionTimeout(session)
   }
 }
 
@@ -621,11 +672,15 @@ function onCountedStreamClose () {
 // session.close() can leave the socket half-open indefinitely when the peer
 // keeps its side open (for example when it sent a GOAWAY of its own). Once no
 // stream is left there is nothing to be graceful about, so reuse the standard
-// reset path. The error is informational so that onError() in client.js leaves
-// queued requests in place; they are replayed on a fresh session.
-function closeRetiredH2Session (session) {
+// reset path. The error is informational so queued requests remain available
+// to replay on a fresh session, including when the drain deadline expires.
+function closeRetiredH2Session (
+  session,
+  err = new InformationalError('HTTP/2: session retired after reaching maxRequestsPerClient')
+) {
   clearHttp2IdleTimeout(session)
   clearNoStreamsTimeout(session)
+  clearRetiredSessionTimeout(session)
 
   if (session.destroyed) {
     return
@@ -633,7 +688,6 @@ function closeRetiredH2Session (session) {
 
   const client = session[kClient]
   const state = session[kHTTP2SessionState]
-  const err = new InformationalError('HTTP/2: session retired after reaching maxRequestsPerClient')
 
   // Only the attached session owns the client's connection state, so only it
   // may announce the disconnect. The flag tells onHttp2SocketClose that this
@@ -790,6 +844,7 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
 
   clearHttp2IdleTimeout(this)
   clearNoStreamsTimeout(this)
+  clearRetiredSessionTimeout(this)
 
   if (!this.closed && !this.destroyed) {
     this.close()
@@ -815,6 +870,7 @@ function onHttp2SessionClose () {
 
   clearHttp2IdleTimeout(this)
   clearNoStreamsTimeout(this)
+  clearRetiredSessionTimeout(this)
 
   if (state.ping.interval != null) {
     clearInterval(state.ping.interval)

--- a/test/http2-max-requests-per-client.js
+++ b/test/http2-max-requests-per-client.js
@@ -1,0 +1,548 @@
+'use strict'
+
+// Regression coverage for https://github.com/nodejs/undici/issues/5787
+// `maxRequestsPerClient` must retire an HTTP/2 session once it has opened the
+// configured number of streams, letting accepted streams finish before the
+// session closes and queued work moves to a fresh session.
+
+const { tspl } = require('@matteo.collina/tspl')
+const { test, after } = require('node:test')
+const { createSecureServer, createServer } = require('node:http2')
+const { once } = require('node:events')
+
+const pem = require('@metcoder95/https-pem')
+
+const { Client, H2CClient, Pool, errors } = require('..')
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// Records how many streams each physical HTTP/2 session accepted, in the order
+// the sessions first saw a stream.
+function trackSessions (server) {
+  const counts = new Map()
+
+  server.on('stream', (stream) => {
+    counts.set(stream.session, (counts.get(stream.session) ?? 0) + 1)
+  })
+
+  return {
+    get perSession () {
+      return [...counts.values()]
+    },
+    get sessionCount () {
+      return counts.size
+    }
+  }
+}
+
+function respond (stream, delay = 0) {
+  if (delay === 0) {
+    stream.respond({ ':status': 200 })
+    stream.end('hello')
+    return
+  }
+
+  setTimeout(() => {
+    if (stream.closed || stream.destroyed) return
+    stream.respond({ ':status': 200 })
+    stream.end('hello')
+  }, delay)
+}
+
+async function startSecureServer (t, onStream) {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const sessions = trackSessions(server)
+
+  server.on('session', (session) => session.on('error', () => {}))
+  server.on('stream', onStream)
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  return { server, sessions, origin: `https://localhost:${server.address().port}` }
+}
+
+async function startCleartextServer (t, onStream) {
+  const server = createServer()
+  const sessions = trackSessions(server)
+
+  server.on('session', (session) => session.on('error', () => {}))
+  server.on('stream', onStream)
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  return { server, sessions, origin: `http://localhost:${server.address().port}` }
+}
+
+function h2Client (origin, opts) {
+  return new Client(origin, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    ...opts
+  })
+}
+
+test('h2 sequential requests rotate the session at maxRequestsPerClient', async t => {
+  t = tspl(t, { plan: 7 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  for (let i = 0; i < 5; i++) {
+    const response = await client.request({ path: '/', method: 'GET' })
+    t.strictEqual(response.statusCode, 200)
+    await response.body.text()
+  }
+
+  t.deepStrictEqual(sessions.perSession, [2, 2, 1])
+  t.strictEqual(sessions.sessionCount, 3)
+})
+
+test('h2 concurrent requests never exceed maxRequestsPerClient per session', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream, 50))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  // Warm the session up so that the remote SETTINGS have been received and the
+  // client is genuinely allowed to multiplex the burst below.
+  await (await client.request({ path: '/', method: 'GET' })).body.text()
+
+  const responses = await Promise.all(
+    Array.from({ length: 9 }, () => client.request({ path: '/', method: 'GET' }))
+  )
+
+  for (const response of responses) {
+    await response.body.text()
+  }
+
+  t.strictEqual(responses.length, 9)
+  t.ok(responses.every(response => response.statusCode === 200))
+  t.ok(
+    sessions.perSession.every(count => count <= 2),
+    `expected no session above 2 streams, got ${JSON.stringify(sessions.perSession)}`
+  )
+})
+
+test('h2 maxRequestsPerClient of 1 opens a session per request', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 1 })
+  after(() => client.close())
+
+  for (let i = 0; i < 3; i++) {
+    const response = await client.request({ path: '/', method: 'GET' })
+    await response.body.text()
+  }
+
+  t.deepStrictEqual(sessions.perSession, [1, 1, 1])
+  t.strictEqual(sessions.sessionCount, 3)
+})
+
+test('h2 maxRequestsPerClient of 0 disables the limit', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 0 })
+  after(() => client.close())
+
+  for (let i = 0; i < 4; i++) {
+    const response = await client.request({ path: '/', method: 'GET' })
+    await response.body.text()
+  }
+
+  t.strictEqual(sessions.sessionCount, 1)
+  t.deepStrictEqual(sessions.perSession, [4])
+})
+
+test('h2 without maxRequestsPerClient keeps sharing a single session', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin)
+  after(() => client.close())
+
+  for (let i = 0; i < 4; i++) {
+    const response = await client.request({ path: '/', method: 'GET' })
+    await response.body.text()
+  }
+
+  t.strictEqual(sessions.sessionCount, 1)
+  t.deepStrictEqual(sessions.perSession, [4])
+})
+
+test('h2c honours maxRequestsPerClient', async t => {
+  t = tspl(t, { plan: 6 })
+
+  const { sessions, origin } = await startCleartextServer(t, (stream) => respond(stream))
+
+  const client = new H2CClient(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  for (let i = 0; i < 5; i++) {
+    const response = await client.request({ path: '/', method: 'GET' })
+    t.strictEqual(response.statusCode, 200)
+    await response.body.text()
+  }
+
+  t.deepStrictEqual(sessions.perSession, [2, 2, 1])
+})
+
+test('h2 pool resumes queued work after a session is retired', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream, 25))
+
+  const pool = new Pool(origin, {
+    connect: { rejectUnauthorized: false },
+    allowH2: true,
+    connections: 1,
+    maxRequestsPerClient: 2
+  })
+  after(() => pool.close())
+
+  const responses = await Promise.all(
+    Array.from({ length: 7 }, () => pool.request({ path: '/', method: 'GET' }))
+  )
+
+  const bodies = await Promise.all(responses.map(response => response.body.text()))
+
+  t.ok(responses.every(response => response.statusCode === 200))
+  t.ok(bodies.every(body => body === 'hello'))
+  t.ok(
+    sessions.perSession.every(count => count <= 2),
+    `expected no session above 2 streams, got ${JSON.stringify(sessions.perSession)}`
+  )
+})
+
+test('h2 lets streams accepted before retirement finish gracefully', async t => {
+  t = tspl(t, { plan: 5 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream, 150))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  await (await client.request({ path: '/warmup', method: 'GET' })).body.text()
+
+  // The first of these two lands on the warmed-up session as its second (and
+  // limit-reaching) stream, so it must still complete after retirement starts.
+  const inFlight = Promise.all([
+    client.request({ path: '/slow-a', method: 'GET' }),
+    client.request({ path: '/slow-b', method: 'GET' })
+  ])
+
+  const [a, b] = await inFlight
+
+  t.strictEqual(a.statusCode, 200)
+  t.strictEqual(b.statusCode, 200)
+  t.strictEqual(await a.body.text(), 'hello')
+  t.strictEqual(await b.body.text(), 'hello')
+
+  t.ok(
+    sessions.perSession.every(count => count <= 2),
+    `expected no session above 2 streams, got ${JSON.stringify(sessions.perSession)}`
+  )
+})
+
+test('h2 requests that never open a stream do not consume the budget', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  await (await client.request({ path: '/a', method: 'GET' })).body.text()
+
+  // Rejected by writeH2 before session.request() is ever reached.
+  await t.rejects(
+    client.upgrade({ path: '/', protocol: 'not-websocket' }),
+    errors.InvalidArgumentError
+  )
+
+  await (await client.request({ path: '/b', method: 'GET' })).body.text()
+  await (await client.request({ path: '/c', method: 'GET' })).body.text()
+
+  t.deepStrictEqual(sessions.perSession, [2, 1])
+  t.strictEqual(sessions.sessionCount, 2)
+})
+
+test('h2 counts an accepted stream that is later aborted', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let onServerStream = null
+  const serverSawStream = new Promise(resolve => { onServerStream = resolve })
+
+  const { sessions, origin } = await startSecureServer(t, (stream, headers) => {
+    if (headers[':path'] === '/aborted') {
+      stream.on('error', () => {})
+      onServerStream()
+      return
+    }
+
+    respond(stream)
+  })
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  const controller = new AbortController()
+  const aborted = client.request({ path: '/aborted', method: 'GET', signal: controller.signal })
+  const abortResult = aborted.then(() => null, err => err)
+
+  await serverSawStream
+  controller.abort()
+
+  t.strictEqual((await abortResult)?.name, 'AbortError')
+
+  await (await client.request({ path: '/b', method: 'GET' })).body.text()
+  await (await client.request({ path: '/c', method: 'GET' })).body.text()
+
+  t.deepStrictEqual(sessions.perSession, [2, 1])
+  t.strictEqual(sessions.sessionCount, 2)
+})
+
+test('h2 counts a websocket upgrade stream and waits for it to close', async t => {
+  t = tspl(t, { plan: 5 })
+
+  const server = createSecureServer({
+    ...(await pem.generate({ opts: { keySize: 2048 } })),
+    settings: { enableConnectProtocol: true }
+  })
+  const sessions = trackSessions(server)
+
+  server.on('stream', (stream, headers) => {
+    stream.on('error', () => {})
+
+    if (headers[':method'] === 'CONNECT') {
+      stream.respond({ ':status': 200 }, { endStream: false })
+      stream.resume()
+      stream.once('end', () => stream.end())
+      return
+    }
+
+    respond(stream)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = h2Client(`https://localhost:${server.address().port}`, { maxRequestsPerClient: 1 })
+  after(() => client.close())
+
+  const { socket } = await client.upgrade({ path: '/', protocol: 'websocket' })
+  socket.on('error', () => {})
+
+  // The upgrade stream consumed the whole budget, so this must wait for a new
+  // session rather than joining the retired one.
+  const queued = client.request({ path: '/queued', method: 'GET' })
+
+  t.strictEqual(await Promise.race([queued, sleep(300).then(() => 'pending')]), 'pending')
+  t.strictEqual(sessions.sessionCount, 1)
+
+  socket.end()
+
+  const response = await queued
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(await response.body.text(), 'hello')
+  t.deepStrictEqual(sessions.perSession, [1, 1])
+})
+
+test('h2 settles every request when the peer sends GOAWAY while retiring', async t => {
+  t = tspl(t, { plan: 2 })
+
+  const seen = new Map()
+  const { sessions, origin } = await startSecureServer(t, (stream) => {
+    const session = stream.session
+    const count = (seen.get(session) ?? 0) + 1
+    seen.set(session, count)
+
+    stream.respond({ ':status': 200 })
+    stream.end('hello')
+
+    // Race a peer GOAWAY against the client's own retirement of this session.
+    if (count === 2) {
+      stream.once('close', () => {
+        if (!session.closed && !session.destroyed) {
+          session.goaway()
+        }
+      })
+    }
+  })
+
+  const client = h2Client(origin, { maxRequestsPerClient: 2 })
+  after(() => client.close())
+
+  const results = []
+  for (let i = 0; i < 6; i++) {
+    const response = await client.request({ path: `/${i}`, method: 'GET' })
+    results.push(await response.body.text())
+  }
+
+  t.deepStrictEqual(results, Array.from({ length: 6 }, () => 'hello'))
+  t.ok(
+    sessions.perSession.every(count => count <= 2),
+    `expected no session above 2 streams, got ${JSON.stringify(sessions.perSession)}`
+  )
+})
+
+test('h2 destroy while a retired session is draining rejects everything', async t => {
+  t = tspl(t, { plan: 3 })
+
+  let releaseFirstStream
+  const firstStreamSeen = new Promise(resolve => { releaseFirstStream = resolve })
+
+  const { origin } = await startSecureServer(t, (stream) => {
+    stream.on('error', () => {})
+    releaseFirstStream()
+    // Never responds, so the stream is still open when the client is destroyed.
+  })
+
+  const client = h2Client(origin, { maxRequestsPerClient: 1 })
+
+  // Attach the rejection handlers up-front: both requests reject while
+  // client.destroy() is still settling.
+  const inFlight = client.request({ path: '/slow', method: 'GET' }).then(() => null, err => err)
+
+  // Only once the session has accepted (and been retired by) the first stream
+  // does the second request end up queued behind a draining session.
+  await firstStreamSeen
+  const queued = client.request({ path: '/queued', method: 'GET' }).then(() => null, err => err)
+
+  await client.destroy()
+
+  t.ok((await inFlight) instanceof errors.ClientDestroyedError)
+  t.ok((await queued) instanceof errors.ClientDestroyedError)
+  t.ok(true, 'destroy resolved')
+})
+
+test('h2 uploads the whole request body when retirement happens mid-upload', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const chunk = Buffer.alloc(1024, 0x61)
+  const chunks = 5
+
+  const { sessions, origin } = await startSecureServer(t, (stream, headers) => {
+    let received = 0
+    let ended = false
+
+    stream.on('data', (data) => { received += data.length })
+    stream.on('end', () => { ended = true })
+    stream.on('close', () => {
+      if (headers[':path'] === '/upload') {
+        t.strictEqual(received, chunk.length * chunks, 'server received the whole body')
+        t.ok(ended, 'server saw the end of the body')
+      }
+    })
+
+    // Respond before the body has been fully uploaded. HTTP/2 allows this, and
+    // it releases the response side of the stream while the request side is
+    // still open.
+    stream.respond({ ':status': 200 })
+    stream.end('hello')
+  })
+
+  const client = h2Client(origin, { maxRequestsPerClient: 1 })
+  after(() => client.close())
+
+  async function * body () {
+    for (let i = 0; i < chunks; i++) {
+      await sleep(10)
+      yield chunk
+    }
+  }
+
+  const response = await client.request({ path: '/upload', method: 'POST', body: body() })
+  t.strictEqual(response.statusCode, 200)
+  await response.body.text()
+
+  // The next request must land on a fresh session, proving the first one really
+  // was retired rather than simply never reaching the limit.
+  const next = await client.request({ path: '/next', method: 'GET' })
+  await next.body.text()
+
+  t.strictEqual(sessions.sessionCount, 2)
+})
+
+test('h2 emits exactly one disconnect per retired session', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const { sessions, origin } = await startSecureServer(t, (stream) => respond(stream))
+
+  const client = h2Client(origin, { maxRequestsPerClient: 1 })
+  after(() => client.close())
+
+  let disconnects = 0
+  client.on('disconnect', () => { disconnects += 1 })
+
+  for (let i = 0; i < 3; i++) {
+    const response = await client.request({ path: `/${i}`, method: 'GET' })
+    await response.body.text()
+  }
+
+  t.strictEqual(sessions.sessionCount, 3)
+  t.deepStrictEqual(sessions.perSession, [1, 1, 1])
+
+  // Three sessions were used; the first two were retired and must each have
+  // announced their disconnect exactly once. The third is still open.
+  t.strictEqual(disconnects, 2)
+})
+
+test('h2 recovers when the peer destroys the socket while a retired session drains', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const sockets = []
+  let releaseFirstStream
+  const firstStreamSeen = new Promise(resolve => { releaseFirstStream = resolve })
+
+  const { server, origin } = await startCleartextServer(t, (stream, headers) => {
+    stream.on('error', () => {})
+
+    if (headers[':path'] === '/slow') {
+      // Never responds: the stream is still open (and the session retired)
+      // when the peer rips the transport away.
+      releaseFirstStream()
+      return
+    }
+
+    respond(stream)
+  })
+
+  // The raw sockets are only reachable through 'connection'; http2 forbids
+  // manipulating session.socket directly.
+  server.on('connection', (socket) => {
+    socket.on('error', () => {})
+    sockets.push(socket)
+  })
+
+  const client = new H2CClient(origin, { maxRequestsPerClient: 1 })
+  after(() => client.close())
+
+  let disconnects = 0
+  client.on('disconnect', () => { disconnects += 1 })
+
+  const inFlight = client.request({ path: '/slow', method: 'GET' }).then(() => null, err => err)
+
+  await firstStreamSeen
+
+  // Queued behind the now-retired session.
+  const queued = client.request({ path: '/queued', method: 'GET' })
+
+  // Abrupt transport failure, with no GOAWAY.
+  for (const socket of sockets) socket.destroy()
+
+  t.ok((await inFlight) instanceof Error, 'the in-flight request is rejected')
+
+  const response = await queued
+  t.strictEqual(response.statusCode, 200, 'the queued request runs on a new session')
+  t.strictEqual(await response.body.text(), 'hello')
+  t.strictEqual(disconnects, 1, 'the broken connection announced exactly one disconnect')
+})

--- a/test/http2-max-requests-per-client.js
+++ b/test/http2-max-requests-per-client.js
@@ -356,6 +356,50 @@ test('h2 counts a websocket upgrade stream and waits for it to close', async t =
   t.deepStrictEqual(sessions.perSession, [1, 1])
 })
 
+test('h2 bounds retired session draining with headersTimeout', async t => {
+  t = tspl(t, { plan: 6 })
+
+  let interval
+  const { sessions, origin } = await startSecureServer(t, (stream, headers) => {
+    stream.on('error', () => {})
+
+    if (headers[':path'] === '/events') {
+      stream.respond({
+        ':status': 200,
+        'content-type': 'text/event-stream'
+      })
+      stream.write('data: started\n\n')
+      interval = setInterval(() => stream.write('data: keepalive\n\n'), 25).unref()
+      stream.once('close', () => clearInterval(interval))
+      return
+    }
+
+    respond(stream)
+  })
+
+  const client = h2Client(origin, {
+    maxRequestsPerClient: 1,
+    headersTimeout: 100,
+    bodyTimeout: 1000
+  })
+  after(() => client.close())
+
+  const events = await client.request({ path: '/events', method: 'GET' })
+  t.strictEqual(events.statusCode, 200)
+  const eventsError = events.body.text().then(() => null, err => err)
+
+  const queued = client.request({ path: '/queued', method: 'GET' })
+  t.strictEqual(await Promise.race([queued, sleep(50).then(() => 'pending')]), 'pending')
+
+  const response = await queued
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(await response.body.text(), 'hello')
+
+  const err = await eventsError
+  t.strictEqual(err?.code, 'UND_ERR_INFO')
+  t.deepStrictEqual(sessions.perSession, [1, 1])
+})
+
 test('h2 settles every request when the peer sends GOAWAY while retiring', async t => {
   t = tspl(t, { plan: 2 })
 

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -38,7 +38,7 @@ export declare namespace Client {
   export interface Options {
     /** The maximum length of request headers in bytes. Default: Node.js' `--max-http-header-size` or `16384` (16KiB). */
     maxHeaderSize?: number;
-    /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers (Node 14 and above only). Default: `300e3` milliseconds (300s). HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
+    /** The amount of time, in milliseconds, the parser will wait to receive the complete HTTP headers (Node 14 and above only). Over HTTP/2 this also bounds how long a session retired by `maxRequestsPerClient` may wait for its active streams to close. Default: `300e3` milliseconds (300s). HTTP/1.1 parser timeouts are not guaranteed to fire with exact millisecond precision: delays up to 1000ms use native timers, while larger delays use lower-overhead fast timers with a target resolution around 500ms. */
     headersTimeout?: number;
     /** @deprecated unsupported socketTimeout, use headersTimeout & bodyTimeout instead */
     socketTimeout?: never;


### PR DESCRIPTION
## This relates to...

Closes #5787

## Rationale

`maxRequestsPerClient` was only honored by the HTTP/1.1 dispatcher. A `Client` created with `allowH2: true`, or an `H2CClient`, ignored the option and kept a single HTTP/2 session alive indefinitely. The option is important for rotating
connections so load balancers can rebalance and clients do not remain pinned to one backend.

HTTP/2 also requires bounded retirement. Once a client has reached its request limit and we mark it as such, we must wait for existing streams to close. Waiting indefinitely for accepted streams to close lets a long-lived SSE, CONNECT, WebSocket, long-polling, gRPC, or stalled upload would block all queued work if we didn't implement a bound. 

## Changes

- Count successfully opened HTTP/2 streams against `maxRequestsPerClient`.
- Retire a session synchronously when it reaches the limit so no additional stream can slip through the same resume loop.
- Allow accepted streams to drain without truncating ordinary responses or request uploads.
- Bound retirement draining with `headersTimeout`. If accepted streams remain open at the deadline, reset the retired session with an informational error so queued requests remain replayable on a fresh connection.
- Cancel the retirement timer during normal drain, GOAWAY, reset, and session close paths.
- Preserve the existing `0`, `null`, and `undefined` disabled behavior.
- Document the HTTP/1.1 message-counting and HTTP/2 stream-counting behavior for `Client`, `H2CClient`, and TypeScript consumers.

The implementation tracks physical stream closure separately from `kOpenStreams`. A response may finish while its request body is still uploading, so response completion alone is not sufficient to safely retire the session.

## Tests

`test/http2-max-requests-per-client.js` contains 17 tests covering:

- sequential and concurrent session rotation
- limits of `1` and disabled limits
- `Client`, `H2CClient`, and `Pool`
- graceful drain and complete request-body uploads
- failed, aborted, upgrade, and WebSocket streams
- GOAWAY and abrupt peer disconnect races
- client destruction during retirement
- exactly one disconnect notification
- an endless SSE stream being terminated after `headersTimeout` while queued work reconnects successfully

Validation:

- Focused HTTP/2 suite: 17/17 passed
- ESLint passed for the changed JavaScript files
- Syntax and whitespace checks passed

## Commits

- `12ac5172 feat(h2): honor maxRequestsPerClient`
- `41ba964e fix(h2): bound retired session draining`

## Breaking Changes and Deprecations

None. HTTP/1.1 behavior is unchanged. HTTP/2 users who do not configure `maxRequestsPerClient`, or set it to `0`, see no change. Setting `headersTimeout: 0` explicitly disables the retirement drain deadline.

## Status

<!-- KEY: S = Skipped, x = complete -->

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [S] Benchmarked (**optional**)
- [x] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
