### PR TITLE
fix issue #5715

### DIFF
--- a/lib/api/readable.js
+++ b/lib/api/readable.js
@@ -5,7 +5,6 @@ const { addAbortListener } = require('node:events')
 const { Readable } = require('node:stream')
 const { RequestAbortedError, NotSupportedError, InvalidArgumentError, AbortError } = require('../core/errors')
 const util = require('../core/util')
-const { ReadableStreamFrom } = require('../core/util')
 
 const kConsume = Symbol('kConsume')
 const kReading = Symbol('kReading')
@@ -246,7 +245,7 @@ class BodyReadable extends Readable {
    */
   get body () {
     if (!this[kBody]) {
-      this[kBody] = ReadableStreamFrom(this)
+      this[kBody] = ReadableStream.from(this)
       if (this[kConsume]) {
         // TODO: Is this the best way to force a lock?
         this[kBody].getReader() // Ensure stream is locked.

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -645,44 +645,6 @@ function getSocketInfo (socket) {
 }
 
 /**
- * @param {Iterable} iterable
- * @returns {ReadableStream}
- */
-function ReadableStreamFrom (iterable) {
-  // We cannot use ReadableStream.from here because it does not return a byte stream.
-
-  let iterator
-  return new ReadableStream(
-    {
-      start () {
-        iterator = iterable[Symbol.asyncIterator]()
-      },
-      pull (controller) {
-        return iterator.next().then(({ done, value }) => {
-          if (done) {
-            return queueMicrotask(() => {
-              controller.close()
-              controller.byobRequest?.respond(0)
-            })
-          } else {
-            const buf = Buffer.isBuffer(value) ? value : Buffer.from(value)
-            if (buf.byteLength) {
-              return controller.enqueue(new Uint8Array(buf))
-            } else {
-              return this.pull(controller)
-            }
-          }
-        })
-      },
-      cancel () {
-        return iterator.return()
-      },
-      type: 'bytes'
-    }
-  )
-}
-
-/**
  * The object should be a FormData instance and contains all the required
  * methods.
  * @param {*} object
@@ -1026,7 +988,6 @@ module.exports = {
   destroy,
   bodyLength,
   deepClone,
-  ReadableStreamFrom,
   isBuffer,
   assertRequestHandler,
   getSocketInfo,

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -196,8 +196,16 @@ function extractBody (object, keepalive = false) {
       )
     }
 
-    stream =
-      webidl.is.ReadableStream(object) ? object : ReadableStream.from(object)
+    stream = webidl.is.ReadableStream(object)
+      ? object
+      : ReadableStream.from(object).pipeThrough(new TransformStream({
+        transform (chunk, controller) {
+          const bytes = isUint8Array(chunk) ? chunk : textEncoder.encode(chunk)
+          if (bytes.byteLength) {
+            controller.enqueue(bytes)
+          }
+        }
+      }))
   }
 
   // 11. If source is a byte sequence, then set action to a

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -200,7 +200,7 @@ function extractBody (object, keepalive = false) {
       ? object
       : ReadableStream.from(object).pipeThrough(new TransformStream({
         transform (chunk, controller) {
-          const bytes = isUint8Array(chunk) ? chunk : textEncoder.encode(chunk)
+          const bytes = isUint8Array(chunk) ? chunk : Buffer.from(chunk)
           if (bytes.byteLength) {
             controller.enqueue(bytes)
           }

--- a/lib/web/fetch/body.js
+++ b/lib/web/fetch/body.js
@@ -2,7 +2,6 @@
 
 const util = require('../../core/util')
 const {
-  ReadableStreamFrom,
   readableStreamClose,
   fullyReadBody,
   extractMimeType
@@ -198,7 +197,7 @@ function extractBody (object, keepalive = false) {
     }
 
     stream =
-      webidl.is.ReadableStream(object) ? object : ReadableStreamFrom(object)
+      webidl.is.ReadableStream(object) ? object : ReadableStream.from(object)
   }
 
   // 11. If source is a byte sequence, then set action to a

--- a/lib/web/fetch/util.js
+++ b/lib/web/fetch/util.js
@@ -6,7 +6,7 @@ const { redirectStatusSet, referrerPolicyTokens, badPortsSet } = require('./cons
 const { getGlobalOrigin } = require('./global')
 const { collectAnHTTPQuotedString, parseMIMEType } = require('./data-url')
 const { performance } = require('node:perf_hooks')
-const { ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = require('../../core/util')
+const { isValidHTTPToken, normalizedMethodRecordsBase } = require('../../core/util')
 const assert = require('node:assert')
 const { isUint8Array } = require('node:util/types')
 const { webidl } = require('../webidl')
@@ -1484,7 +1484,6 @@ module.exports = {
   isAborted,
   isCancelled,
   isValidEncodedURL,
-  ReadableStreamFrom,
   tryUpgradeRequestToAPotentiallyTrustworthyURL,
   clampAndCoarsenConnectionTimingInfo,
   coarsenedSharedCurrentTime,

--- a/test/fetch/issue-5715.js
+++ b/test/fetch/issue-5715.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { test } = require('node:test')
+const { Response } = require('../..')
+
+// https://github.com/nodejs/undici/issues/5715
+test('ReadableStream cancellation while iterator.next() is in flight', async (t) => {
+  let resolveNext
+  let startNext
+  const nextStarted = new Promise((resolve) => {
+    startNext = resolve
+  })
+  const iterable = {
+    [Symbol.asyncIterator] () {
+      return {
+        next () {
+          startNext()
+          return new Promise((resolve) => {
+            resolveNext = resolve
+          })
+        },
+        return () {
+          return Promise.resolve({ done: true, value: undefined })
+        }
+      }
+    }
+  }
+
+  const reader = new Response(iterable).body.getReader()
+  const read = reader.read()
+  await nextStarted
+  await reader.cancel()
+  resolveNext({ done: true, value: undefined })
+  t.assert.deepStrictEqual(await read, { done: true, value: undefined })
+
+  // Let the microtask that closes the controller run. It must not throw if
+  // cancellation already closed the stream.
+  await new Promise((resolve) => setImmediate(resolve))
+})


### PR DESCRIPTION
ReadableStream.from has been supported since node v20.6.0. There is no reason to have the helper function anymore. Unfortunately ai doesn't understand nuance, so ai cannot be trusted to fix this bug.

closes #5716
fixes #5715

<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

<!-- List the issues this resolves or relates to here (if applicable) -->

## Rationale

<!-- Briefly explain the purpose of this pull request, if not already
justifiable with the above section. If it is, you may omit this section. -->

## Changes

<!-- Write a summary or list of changes here -->

### Features

<!-- List the new features here (if applicable), or write N/A if not -->

### Bug Fixes

<!-- List the fixed bugs here (if applicable), or write N/A if not -->

### Breaking Changes and Deprecations

<!-- List the breaking changes (changes that modify the existing API) and
deprecations (removed features) here -->

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
