### PR TITLE
fix(fetch): treat U+0060 (`) as an HTTP token code point

### DIFF
--- a/lib/web/fetch/data-url.js
+++ b/lib/web/fetch/data-url.js
@@ -8,7 +8,7 @@ const encoder = new TextEncoder()
 /**
  * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
  */
-const HTTP_TOKEN_CODEPOINTS = /^[-!#$%&'*+.^_|~A-Za-z0-9]+$/u
+const HTTP_TOKEN_CODEPOINTS = /^[-!#$%&'*+.^_`|~A-Za-z0-9]+$/u
 const HTTP_WHITESPACE_REGEX = /[\u000A\u000D\u0009\u0020]/u // eslint-disable-line
 
 /**

--- a/test/fetch/data-uri.js
+++ b/test/fetch/data-uri.js
@@ -5,7 +5,9 @@ const {
   URLSerializer,
   stringPercentDecode,
   parseMIMEType,
-  collectAnHTTPQuotedString
+  collectAnHTTPQuotedString,
+  serializeAMimeType,
+  HTTP_TOKEN_CODEPOINTS
 } = require('../../lib/web/fetch/data-url')
 const { fetch } = require('../..')
 
@@ -99,6 +101,50 @@ test('https://mimesniff.spec.whatwg.org/#parse-a-mime-type', (t) => {
     subtype: 'javascript',
     parameters: new Map(),
     essence: 'application/javascript'
+  })
+})
+
+// https://mimesniff.spec.whatwg.org/#http-token-code-point
+// The HTTP token code points include the range U+005E (^) to U+0060 (`),
+// so the backtick is a token code point just like ^ and _.
+test('U+0060 (`) is an HTTP token code point', async (t) => {
+  await t.test('is allowed in a type and a subtype', (t) => {
+    t.assert.deepStrictEqual(parseMIMEType('te`xt/plain'), {
+      type: 'te`xt',
+      subtype: 'plain',
+      parameters: new Map(),
+      essence: 'te`xt/plain'
+    })
+
+    t.assert.deepStrictEqual(parseMIMEType('text/pl`ain'), {
+      type: 'text',
+      subtype: 'pl`ain',
+      parameters: new Map(),
+      essence: 'text/pl`ain'
+    })
+  })
+
+  await t.test('is allowed in a parameter name', (t) => {
+    t.assert.deepStrictEqual(parseMIMEType('text/plain;a`b=1'), {
+      type: 'text',
+      subtype: 'plain',
+      parameters: new Map([['a`b', '1']]),
+      essence: 'text/plain'
+    })
+  })
+
+  await t.test('does not force a parameter value to be quoted when serialized', (t) => {
+    const mimeType = parseMIMEType('text/plain;x="a`b"')
+
+    t.assert.notStrictEqual(mimeType, 'failure')
+    t.assert.strictEqual(serializeAMimeType(mimeType), 'text/plain;x=a`b')
+  })
+
+  await t.test('is matched by HTTP_TOKEN_CODEPOINTS', (t) => {
+    // ^ and _ are the other two code points in the same range.
+    t.assert.ok(HTTP_TOKEN_CODEPOINTS.test('^'))
+    t.assert.ok(HTTP_TOKEN_CODEPOINTS.test('_'))
+    t.assert.ok(HTTP_TOKEN_CODEPOINTS.test('`'))
   })
 })
 


### PR DESCRIPTION
## This relates to...

No open issue — found by auditing `lib/web/fetch/data-url.js` against the MIME Sniffing standard.

## Rationale

[HTTP token code points](https://mimesniff.spec.whatwg.org/#http-token-code-point) are defined as:

> U+0021 (!), U+0023 (#) to U+0027 ('), U+002A (\*), U+002B (+), U+002D (-), U+002E (.), **U+005E (^) to U+0060 (\`)**, U+007C (|), U+007E (~), or an ASCII alphanumeric.

`HTTP_TOKEN_CODEPOINTS` covers `^` and `_` but stops one code point short of U+0060:

```js
const HTTP_TOKEN_CODEPOINTS = /^[-!#$%&'*+.^_|~A-Za-z0-9]+$/u
```

The regex is used in four places, which gives three distinct wrong results:

| | current | expected |
|---|---|---|
| ``parseMIMEType('text/pl`ain')`` | `'failure'` | a valid MIME type |
| ``parseMIMEType('text/plain;a`b=1')`` | parameter silently dropped | parameter kept |
| ``serializeAMimeType`` with value ``a`b`` | ``x="a`b"`` | ``x=a`b`` |

The giveaway is that `^` and `_` — the other two code points in that same range — parse fine.

Node's own `MIMEType` in `node:util` accepts the backtick in all three positions, so undici is the outlier within the project:

```js
> new (require('node:util').MIMEType)('text/plain;x="a`b"').toString()
'text/plain;x=a`b'
```

I checked whether #4483 (*improve regexes in data-uri.js*) introduced this. It did not — that PR moved the `-` and added the `u` flag; the backtick was already missing beforehand. This is long-standing, not a regression.

## Changes

One code point added to the character class, plus tests covering each of the three affected positions.

### Features

N/A

### Bug Fixes

- `U+0060` (`` ` ``) is now treated as an HTTP token code point, so it is accepted in a type, a subtype, and a parameter name, and is not quoted when serializing a parameter value.

### Breaking Changes and Deprecations

N/A

## Status

- [x] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested — 5 new tests, all failing before the change; `npm run test:fetch` green (481 fetch + 28 webidl + 47 busboy, 0 failures); `npm run lint` clean
- [ ] Benchmarked (**optional**) — S
- [ ] Documented — S, no public API change
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
