### PR TITLE
fix(decompress): treat inherited Object.prototype names as unsupported encodings

### DIFF
--- a/lib/interceptor/decompress.js
+++ b/lib/interceptor/decompress.js
@@ -11,6 +11,7 @@ const DecoratorHandler = require('../handler/decorator-handler')
 
 /** @type {Record<string, () => DecompressorStream>} */
 const supportedEncodings = {
+  __proto__: null,
   gzip: createGunzip,
   'x-gzip': createGunzip,
   br: createBrotliDecompress,

--- a/test/interceptors/decompress.js
+++ b/test/interceptors/decompress.js
@@ -373,6 +373,49 @@ test('should pass through unsupported encoding', async t => {
   await t.completed
 })
 
+// `constructor` and `__proto__` are the only Object.prototype member names that
+// survive the toLowerCase() in onResponseStart, so they are the two an origin
+// can actually put on the wire.
+for (const encoding of ['constructor', '__proto__', 'gzip, constructor']) {
+  test(`should pass through an Object.prototype name as an encoding: ${encoding}`, async t => {
+    t = tspl(t, { plan: 3 })
+
+    const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain',
+        'Content-Encoding': encoding
+      })
+      res.end('This has unsupported encoding')
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new Client(
+      `http://localhost:${server.address().port}`
+    ).compose(createDecompressInterceptor())
+
+    after(async () => {
+      await client.close()
+      server.close()
+      await once(server, 'close')
+    })
+
+    const response = await client.request({
+      method: 'GET',
+      path: '/'
+    })
+
+    const body = await response.body.text()
+
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers['content-encoding'], encoding)
+    t.equal(body, 'This has unsupported encoding')
+
+    await t.completed
+  })
+}
+
 test('should pass through error responses (4xx, 5xx)', async t => {
   t = tspl(t, { plan: 3 })
 


### PR DESCRIPTION
## Problem

`supportedEncodings` is a plain object literal, so the unsupported-encoding guard resolves inherited names through the prototype chain:

```js
const supportedEncodings = {
  gzip: createGunzip,
  ...
}
...
if (!supportedEncodings[encoding]) {
  decompressors.length = 0
  return decompressors           // unsupported -> pass through
}
decompressors.push(supportedEncodings[encoding]())
```

`onResponseStart` lowercases the header before the lookup, and exactly two `Object.prototype` own-property names survive lowercasing — `constructor` and `__proto__`. Both are truthy, so both walk past the guard and get *called*.

## Effect

Measured against `main` with a plain `node:http` origin and a client composed with `interceptors.decompress()`:

```
content-encoding: "identity"          -> ok: status=200 body=hello
content-encoding: "bogus-encoding"    -> ok: status=200 body=hello
content-encoding: "constructor"       -> HUNG - promise never settled
content-encoding: "__proto__"         -> threw: TypeError: supportedEncodings[encoding] is not a function
content-encoding: "gzip, constructor" -> HUNG - promise never settled
```

`constructor` is the bad one: `Object()` returns a plain object, that object is pushed into the decompressor chain as if it were a stream, and `client.request()` then neither resolves nor rejects. No `uncaughtException`, no teardown — the caller's await and the socket both leak. A remote origin (or any intermediary that rewrites `Content-Encoding`) can wedge a client with a single response header.

An unrecognised encoding is supposed to pass through untouched, which is what `bogus-encoding` shows.

## Fix

Give the lookup table a null prototype, so only its own entries can match. This matches the existing style in `lib/core/util.js:973`, `lib/util/runtime-features.js:7` and `lib/web/eventsource/eventsource.js:458`.

```js
const supportedEncodings = {
  __proto__: null,
  gzip: createGunzip,
  ...
}
```

All five cases above then pass through cleanly.

## Test plan

- Added three cases to `test/interceptors/decompress.js` beside the existing `should pass through unsupported encoding`, covering `constructor`, `__proto__` and `gzip, constructor`.
- Ran: `node --test test/interceptors/decompress.js` → **38 passing**.
- Checked: reverting only the `__proto__: null` line makes the `constructor` case hang rather than fail — the test run never terminates, which is the defect itself.
- Ran: `npx standard` on both touched files → clean.