### PR TITLE
fix(cookies): keep an Expires of 0 when serializing a cookie

### DIFF
--- a/lib/web/cookies/util.js
+++ b/lib/web/cookies/util.js
@@ -315,7 +315,9 @@ function stringify (cookie) {
     out.push(`Path=${cookie.path}`)
   }
 
-  if (cookie.expires && cookie.expires.toString() !== 'Invalid Date') {
+  // A numeric 0 is the Unix epoch, not an absent value -- the same reason the
+  // Max-Age check above tests the type rather than truthiness.
+  if (cookie.expires != null && cookie.expires.toString() !== 'Invalid Date') {
     out.push(`Expires=${toIMFDate(cookie.expires)}`)
   }
 

--- a/test/cookie/cookies.js
+++ b/test/cookie/cookies.js
@@ -397,6 +397,27 @@ test('Cookie Set', () => {
     'Space=Cat; Expires=Fri, 07 Jan 1983 15:32:00 GMT'
   )
 
+  // A numeric 0 is the Unix epoch, the canonical "expire now" value, not an
+  // absent option.
+  headers = new Headers()
+  setCookie(headers, {
+    name: 'Space',
+    value: 'Cat',
+    expires: 0
+  })
+  assert.equal(
+    headers.get('Set-Cookie'),
+    'Space=Cat; Expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  )
+
+  headers = new Headers()
+  setCookie(headers, {
+    name: 'Space',
+    value: 'Cat',
+    expires: null
+  })
+  assert.equal(headers.get('Set-Cookie'), 'Space=Cat')
+
   headers = new Headers()
   setCookie(headers, { name: '__Secure-Kitty', value: 'Meow' })
   assert.equal(headers.get('Set-Cookie'), '__Secure-Kitty=Meow; Secure')


### PR DESCRIPTION
## Problem

`stringify` tests `expires` for truthiness:

```js
if (cookie.expires && cookie.expires.toString() !== 'Invalid Date') {
  out.push(`Expires=${toIMFDate(cookie.expires)}`)
}
```

`expires` is typed `Date | number`, and a numeric `0` is the Unix epoch — the canonical way to say *expire this cookie now*. It is falsy, so the attribute is silently dropped.

The `Max-Age` branch a few lines above already avoids exactly this:

```js
if (typeof cookie.maxAge === 'number') {   // 0 is a real value
```

## Effect

```
expires: 0             -> "a=b"                                            <- attribute lost
expires: new Date(0)   -> "a=b; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
expires: 1000          -> "a=b; Expires=Thu, 01 Jan 1970 00:00:01 GMT"
maxAge: 0              -> "a=b; Max-Age=0"
```

Only the numeric-zero case, and only for `expires`. No error is raised — a caller asking for immediate expiry gets a session cookie instead, which is the unsafe direction for the usual purpose (clearing a cookie on logout).

## Fix

Treat `null`/`undefined` as absent instead of treating every falsy value that way. After the change:

```
expires: 0            -> "a=b; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
expires: null         -> "a=b"
no expires            -> "a=b"
expires: new Date(0)  -> "a=b; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
expires: invalid Date -> "a=b"
```

## Test plan

- Added two cases to `test/cookie/cookies.js` beside the existing numeric-`expires` test: `expires: 0` serializes the epoch, and `expires: null` still omits the attribute.
- Ran: `node --test test/cookie/*.js` → **93 passing**.
- Checked: reverting only `util.js` fails the new test with `'Space=Cat' == 'Space=Cat; Expires=Thu, 01 Jan 1970 00:00:00 GMT'`.
- Ran: `npx standard` on both touched files → clean.