### PR TITLE
perf(websocket): unroll client frame masking

### DIFF
--- a/lib/web/websocket/frame.js
+++ b/lib/web/websocket/frame.js
@@ -20,6 +20,31 @@ function generateMask () {
   return [buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++], buffer[bufIdx++]]
 }
 
+function maskPayload (source, target, targetOffset, maskKey) {
+  const length = source.byteLength
+  const mask0 = maskKey[0]
+  const mask1 = maskKey[1]
+  const mask2 = maskKey[2]
+  const mask3 = maskKey[3]
+  const unrolledEnd = length & ~7
+
+  let i = 0
+  for (; i < unrolledEnd; i += 8) {
+    target[targetOffset + i] = source[i] ^ mask0
+    target[targetOffset + i + 1] = source[i + 1] ^ mask1
+    target[targetOffset + i + 2] = source[i + 2] ^ mask2
+    target[targetOffset + i + 3] = source[i + 3] ^ mask3
+    target[targetOffset + i + 4] = source[i + 4] ^ mask0
+    target[targetOffset + i + 5] = source[i + 5] ^ mask1
+    target[targetOffset + i + 6] = source[i + 6] ^ mask2
+    target[targetOffset + i + 7] = source[i + 7] ^ mask3
+  }
+
+  for (; i < length; ++i) {
+    target[targetOffset + i] = source[i] ^ maskKey[i & 3]
+  }
+}
+
 class WebsocketFrameSend {
   /**
    * @param {Buffer|undefined} data
@@ -71,8 +96,8 @@ class WebsocketFrameSend {
     buffer[1] |= 0x80 // MASK
 
     // mask body
-    for (let i = 0; i < bodyLength; ++i) {
-      buffer[offset + i] = frameData[i] ^ maskKey[i & 3]
+    if (bodyLength !== 0) {
+      maskPayload(frameData, buffer, offset, maskKey)
     }
 
     return buffer
@@ -87,9 +112,7 @@ class WebsocketFrameSend {
     const bodyLength = buffer.length
 
     // mask body
-    for (let i = 0; i < bodyLength; ++i) {
-      buffer[i] ^= maskKey[i & 3]
-    }
+    maskPayload(buffer, buffer, 0, maskKey)
 
     let payloadLength = bodyLength
     let offset = 6

--- a/test/websocket/frame.js
+++ b/test/websocket/frame.js
@@ -37,3 +37,29 @@ test('Writing 16-bit frame length value at correct offset when buffer has a non-
   t.assert.strictEqual(frame[3], payloadLength & 0xff)
   t.assert.strictEqual(smallBuffer.length, 1) // ensure smallBuffer can't be garbage-collected too soon
 })
+
+test('Masks aligned and unaligned payloads without changing frame semantics', (t) => {
+  for (const length of [0, 1, 3, 4, 5, 7, 8, 9, 125, 126, 127, 65535, 65536]) {
+    const payload = Buffer.alloc(length)
+    for (let i = 0; i < payload.length; ++i) payload[i] = i & 0xff
+    const originalPayload = Buffer.from(payload)
+    const frame = new WebsocketFrameSend(payload).createFrame(opcodes.BINARY)
+    const offset = length > 65535 ? 14 : length > 125 ? 8 : 6
+    const mask = frame.subarray(offset - 4, offset)
+    const decoded = Buffer.alloc(length)
+    for (let i = 0; i < length; ++i) decoded[i] = frame[offset + i] ^ mask[i & 3]
+    t.assert.deepStrictEqual(decoded, originalPayload)
+    t.assert.deepStrictEqual(payload, originalPayload)
+  }
+
+  const text = Buffer.from('héllo websocket 🌍'.repeat(2))
+  const backing = Buffer.alloc(text.length + 1)
+  text.copy(backing, 1)
+  const view = backing.subarray(1)
+  const original = Buffer.from(view)
+  const [head, body] = WebsocketFrameSend.createFastTextFrame(view)
+  const mask = head.subarray(head.length - 4)
+  const decoded = Buffer.alloc(body.length)
+  for (let i = 0; i < body.length; ++i) decoded[i] = body[i] ^ mask[i & 3]
+  t.assert.deepStrictEqual(decoded, original)
+})


### PR DESCRIPTION
## This relates to...

Existing issues [#3201](https://github.com/nodejs/undici/issues/3201) and [#2927](https://github.com/nodejs/undici/issues/2927).

## Rationale

Client WebSocket frames are masked before they are written. The masking path currently performs one loop iteration per byte. This change keeps the existing mask generation and wire format, while processing eight bytes per iteration and handling the remaining bytes with the existing byte-wise semantics.

## Changes

- Unroll the masking loop with four preloaded mask bytes.
- Keep the existing mask generation, frame headers, caller-buffer behavior, and byte tail unchanged.
- Add coverage for short, boundary, aligned, unaligned, binary, and UTF-8 text payloads.

### Features

N/A

### Bug Fixes

Reduces the CPU work in the maintained WebSocket masking path without changing frame semantics.

### Breaking Changes and Deprecations

N/A

## Validation

- `node --test test/websocket/frame.js`: 3 passed.
- `npm run lint`: passed.
- The WebSocket suite reported 132 passed, 5 failed, and 2 cancelled. The H2 failures and 180-second timeouts reproduce on the clean base and are retained as baseline/environment failures; the suite is not presented as fully green.
- Independent correctness-checking echo measurements used the maintained 256 KiB WebSocket workload with Node v22.23.1, `ws` 8.20.1, loopback, no compression, one connection, and one in-flight message. The five paired runs used AB BA AB BA AB order, with two seconds of warmup and one second of measurement per cell. The primary binary median of per-run p50 values changed from 876.749 µs to 797.448 µs (-9.045%). All five paired rows improved; median p99 improved 3.915%, CPU time improved 9.426%, and the small-payload controls were flat.
- These are short-window measurements on a shared host and cover the WebSocket masking path only; they do not claim an improvement for HTTP or Fetch.
- [Weco trajectory](https://dashboard.weco.ai/share/FxmhE3XvJnpUvtmX-ZFNcwgZfJFDnFva)

## Status

<!-- KEY: S = Skipped, x = complete -->

- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [x] Tested
- [x] Benchmarked
- [ ] Documented
- [x] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
